### PR TITLE
Normalize RSI2 config before use

### DIFF
--- a/src/cilly_trading/strategies/rsi2.py
+++ b/src/cilly_trading/strategies/rsi2.py
@@ -21,6 +21,7 @@ import pandas as pd
 from cilly_trading.models import Signal
 from cilly_trading.engine.core import BaseStrategy
 from cilly_trading.indicators.rsi import rsi
+from cilly_trading.strategies.config_schema import normalize_rsi2_config
 
 
 @dataclass
@@ -58,15 +59,17 @@ class Rsi2Strategy(BaseStrategy):
         df: pd.DataFrame,
         config: Dict[str, Any],
     ) -> List[Signal]:
+        if df.empty:
+            return []
+
+        config = normalize_rsi2_config(config)
+
         # Konfiguration aus Dict in Rsi2Config überführen (mit Defaults)
         cfg = Rsi2Config(
             rsi_period=int(config.get("rsi_period", 2)),
             oversold_threshold=float(config.get("oversold_threshold", 10.0)),
             min_score=float(config.get("min_score", 20.0)),
         )
-
-        if df.empty:
-            return []
 
         # Sicherstellen, dass die notwendigen Spalten existieren
         if "close" not in df.columns:


### PR DESCRIPTION
### Motivation
- Prevent `KeyError`/`TypeError` from unnormalized config access by ensuring the strategy always operates on a normalized config.
- Keep the change minimal and avoid any behavioral changes to indicator computation or signal generation.

### Description
- Add import `from cilly_trading.strategies.config_schema import normalize_rsi2_config` to `rsi2.py`.
- Call `config = normalize_rsi2_config(config)` at the start of `generate_signals` so subsequent accesses use the normalized config.
- Preserve an early `if df.empty: return []` guard (moved before normalization) and remove the duplicated empty-DataFrame check later in the function.
- No modifications to indicator calculations, signal-generation logic, return format, or existing `config.get(...)` usages.

### Testing
- No automated tests were run after this change.
- Running `pytest` is recommended to verify behavior across the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d8ff77b2483338f28b882e505a875)