### PR TITLE
Normalize Turtle strategy config usage

### DIFF
--- a/src/cilly_trading/strategies/turtle.py
+++ b/src/cilly_trading/strategies/turtle.py
@@ -23,6 +23,7 @@ import pandas as pd
 
 from cilly_trading.models import Signal
 from cilly_trading.engine.core import BaseStrategy
+from cilly_trading.strategies.config_schema import normalize_turtle_config
 
 
 @dataclass
@@ -59,6 +60,7 @@ class TurtleStrategy(BaseStrategy):
         df: pd.DataFrame,
         config: Dict[str, Any],
     ) -> List[Signal]:
+        config = normalize_turtle_config(config)
         cfg = TurtleConfig(
             breakout_lookback=int(config.get("breakout_lookback", 20)),
             proximity_threshold_pct=float(config.get("proximity_threshold_pct", 0.03)),


### PR DESCRIPTION
### Motivation
- Ensure the Turtle strategy receives a normalized configuration to prevent `KeyError`/`TypeError` from missing or malformed config values.
- Apply a minimal-invasive change that does not alter strategy logic or behavior.

### Description
- Import `normalize_turtle_config` from `cilly_trading.strategies.config_schema`.
- Call `config = normalize_turtle_config(config)` at the start of `TurtleStrategy.generate_signals` before any config access.
- Keep all existing logic and defaults intact and only adjust code to safely consume the normalized `config`.

### Testing
- No automated tests were executed as part of this change.
- Recommend running `pytest` to validate existing test-suite after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d90f7cbac8333b2553cb1af839c17)