### PR TITLE
Screener V2 — remove JSON tie-breaker and normalize missing numeric values

### DIFF
--- a/tests/test_screener_v2.py
+++ b/tests/test_screener_v2.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from api import main
+
+
+def test_screener_response_schema_and_ordering(monkeypatch) -> None:
+    signals = [
+        {
+            "symbol": "BBB",
+            "stage": "setup",
+            "score": 50,
+            "signal_strength": 0.5,
+            "strategy": "RSI2",
+        },
+        {
+            "symbol": "AAA",
+            "stage": "setup",
+            "score": 50,
+            "signal_strength": 0.7,
+            "strategy": "RSI2",
+        },
+        {
+            "symbol": "AAC",
+            "stage": "setup",
+            "score": 50,
+            "signal_strength": 0.7,
+            "strategy": "TURTLE",
+        },
+        {
+            "symbol": "CCC",
+            "stage": "setup",
+            "score": None,
+            "signal_strength": 0.9,
+            "strategy": "RSI2",
+        },
+        {
+            "symbol": "DDD",
+            "stage": "setup",
+            "score": None,
+            "signal_strength": None,
+            "strategy": "RSI2",
+        },
+        {
+            "symbol": "AAA",
+            "stage": "setup",
+            "score": 40,
+            "signal_strength": 0.4,
+            "strategy": "TURTLE",
+        },
+    ]
+
+    def fake_run_watchlist_analysis(*args, **kwargs):
+        return signals
+
+    monkeypatch.setattr(main, "run_watchlist_analysis", fake_run_watchlist_analysis)
+
+    request = main.ScreenerRequest(
+        symbols=["AAA", "AAC", "BBB", "CCC", "DDD"],
+        market_type="stock",
+        lookback_days=200,
+        min_score=0,
+    )
+    response = main.basic_screener(request)
+
+    payload = response.model_dump()
+    assert payload["market_type"] == "stock"
+
+    items = payload["symbols"]
+    assert [item["symbol"] for item in items] == ["AAA", "AAC", "BBB", "CCC", "DDD"]
+
+    for item in items:
+        assert set(["symbol", "score", "signal_strength", "setups"]).issubset(item.keys())
+
+    top_item = items[0]
+    assert top_item["symbol"] == "AAA"
+    assert top_item["score"] == 50
+    assert top_item["signal_strength"] == 0.7


### PR DESCRIPTION
### Motivation
- Ensure deterministic ordering without relying on JSON serialization of nested `setups` which can be non-deterministic or fail on non-serializable values.
- Keep the Screener V2 stable response schema with explicit numeric fields so clients have a predictable DTO.
- Handle missing or malformed numeric values safely so sorting never raises and remains stable.

### Description
- Remove JSON-based tie-breaker from the sort key and implement a deterministic three-level sort key of `score` (desc), `signal_strength` (desc), and `symbol` (asc) via `_sorting_key`.
- Normalize missing numeric values to `float("-inf")` in the sort key and document this behavior in a comment to guarantee deterministic ordering.
- Add explicit optional fields `score` and `signal_strength` to `ScreenerSymbolResult` and compute per-symbol maxima using `_coerce_float` and `_max_numeric` when building results.
- Replace inline numeric coercion/filtering with `_coerce_float` and iterate signals to build `symbol_results` before sorting with the new key.

### Testing
- Ran `pytest -q tests/test_screener_v2.py`, which executed the screener schema and ordering unit test and passed (`1 passed`).
- The unit test verifies presence of `symbol`, `score`, `signal_strength`, and `setups` and asserts deterministic ordering for tied scores and missing values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694feab27eb883339bbc5443acddf913)