### PR TITLE
Add GitHub Actions CI to run pytest on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+      - name: Run tests
+        run: python -m pytest


### PR DESCRIPTION
### Motivation

- Prevent merging code with failing tests by running the existing test suite on pull requests.
- Provide a minimal, low-maintenance CI pipeline using GitHub Actions and existing project commands.
- Ensure failing tests cause the CI job to fail and thus block merges.
- Keep changes minimal and constrained to workflow configuration only.

### Description

- Add a GitHub Actions workflow that triggers on `pull_request` and runs the existing test suite with `pytest`.
- The workflow sets up Python `3.11` on `ubuntu-latest`, installs dependencies from `requirements.txt`, and installs `pytest` before running `python -m pytest`.
- This change only creates a single workflow file and does not modify application or test source files.

Files added:
- `.github/workflows/ci.yml`

Full contents of `.github/workflows/ci.yml`:

```yaml
name: CI

on:
  pull_request:

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4
      - name: Set up Python
        uses: actions/setup-python@v5
        with:
          python-version: '3.11'
      - name: Install dependencies
        run: |
          python -m pip install --upgrade pip
          python -m pip install -r requirements.txt
          python -m pip install pytest
      - name: Run tests
        run: python -m pytest
```

### Testing

- No automated tests were run locally as this change only adds a CI workflow file.
- The workflow is configured to run the full test suite with `pytest` on every pull request.
- A failing test in the suite will cause the CI job to fail and thus block merging.
- No other automated tests or toolchains were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69519a9039c48333bd22c4453bdd03dd)