### PR TITLE
Tighten local run docs to verified commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ MVP v1 – Engine → SQLite → API → Trading Desk
 
 - Core architecture and scope: `docs/mvp_v1.md`
 - Strategy configuration schema (RSI2, Turtle): `docs/strategy-configs.md`
+- Local run & test commands: `docs/local_run.md`

--- a/docs/local_run.md
+++ b/docs/local_run.md
@@ -1,0 +1,40 @@
+# Local Development: Run & Test
+
+## Prerequisites
+
+- Python 3.10+
+- `pip`
+
+## Local setup
+
+```bash
+python -m venv .venv
+```
+
+```bash
+source .venv/bin/activate
+```
+
+```bash
+pip install -r requirements.txt
+```
+
+## Run the engine
+
+No CLI entrypoint yet; see Issue #15.
+
+## Run the API
+
+```bash
+uvicorn api.main:app --reload
+```
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+## Run tests
+
+```bash
+python -m pytest
+```


### PR DESCRIPTION
### Motivation
- Provide reliable, repo-verified local run and test commands without assumptions like `PYTHONPATH` hacks.
- Remove inline Python scripts and unverified DB/health assumptions and present only documented entrypoints.
- Make onboarding copy/paste-ready and map directly to real entrypoints in the repository.
- Explicitly state the absence of an engine CLI when none exists.

### Description
- Add `docs/local_run.md` with verified commands: `python -m venv .venv`, `source .venv/bin/activate`, `pip install -r requirements.txt`, `uvicorn api.main:app --reload`, `curl http://127.0.0.1:8000/health`, and `python -m pytest`.
- Remove the previous inline Python snippet and `PYTHONPATH` manipulation from the local run documentation.
- Update `README.md` to reference `docs/local_run.md`.
- Document that there is no engine CLI entrypoint yet and point to Issue `#15`.

### Testing
- No automated tests were executed because this is a documentation-only change.
- Verified by inspection that the API entrypoint `uvicorn api.main:app --reload` and the `/health` endpoint are documented in the repo.
- Confirmed `requirements.txt` and the `tests/` directory align with the `pip install -r requirements.txt` and `python -m pytest` commands by file inspection.
- No test failures occurred because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a170a4308333855208f20ba4c3ff)