### PR TITLE
Fix normalization module self-import

### DIFF
--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,59 @@
+import pandas as pd
+
+from src.data_layer.normalization import TARGET_COLUMNS, normalize_ohlcv
+
+
+def test_normalize_columns_and_order() -> None:
+    df = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-02", "2024-01-01"],
+            "open": [101, 100],
+            "high": [106, 105],
+            "low": [100, 99],
+            "close": [105, 104],
+            "volume": [1100, 1000],
+        }
+    )
+
+    result = normalize_ohlcv(df, symbol="TEST", source="pytest")
+
+    assert result.empty is False
+    assert list(result.df.columns) == list(TARGET_COLUMNS)
+    assert result.df["timestamp"].is_monotonic_increasing
+
+
+def test_normalize_empty_input_is_safe() -> None:
+    empty = pd.DataFrame()
+    result = normalize_ohlcv(empty, symbol="TEST", source="pytest")
+
+    assert result.empty is True
+    assert list(result.df.columns) == list(TARGET_COLUMNS)
+    assert result.df.empty is True
+
+
+def test_normalize_missing_columns_returns_empty() -> None:
+    df = pd.DataFrame({"timestamp": ["2024-01-01"], "open": [1]})  # missing others
+    result = normalize_ohlcv(df, symbol="TEST", source="pytest")
+
+    assert result.empty is True
+    assert list(result.df.columns) == list(TARGET_COLUMNS)
+    assert result.df.empty is True
+
+
+def test_normalize_timestamp_alias_is_supported() -> None:
+    df = pd.DataFrame(
+        {
+            "timeStamp": ["2024-01-01", "2024-01-02"],  # alias, mixed case
+            "open": [100, 101],
+            "high": [105, 106],
+            "low": [99, 100],
+            "close": [104, 105],
+            "volume": [1000, 1100],
+        }
+    )
+
+    result = normalize_ohlcv(df, symbol="TEST", source="pytest")
+
+    assert result.empty is False
+    assert list(result.df.columns) == list(TARGET_COLUMNS)
+    assert result.df["timestamp"].is_monotonic_increasing


### PR DESCRIPTION
### Motivation

- Remove a self-referential import from `src/data_layer/normalization.py` so the module contains only productive normalization logic.
- Ensure `TARGET_COLUMNS` and `normalize_ohlcv` are defined locally to avoid recursive imports while preserving runtime behavior.
- Keep the public normalization API stable so other engine components continue to work unchanged.

### Description

- Replace the self-import with a local `TARGET_COLUMNS` constant and a `NormalizationResult` dataclass to hold results.
- Implement `normalize_ohlcv` and helper `_normalize_timestamp_column` with identical normalization behavior and timestamp alias support for `timeStamp`.
- Provide an `_empty_result` helper that returns an empty DataFrame with the correct columns to preserve calling code expectations.
- Move tests into `tests/test_normalization.py` and adjust imports to import from `src.data_layer.normalization`.

### Testing

- Ran `pytest` after the changes.
- All tests completed successfully with `39 passed` and no failures.
- Normalization-specific tests in `tests/test_normalization.py` exercise empty input, missing columns, timestamp aliasing, and ordering.
- No other automated tests failed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b9d5b3888333918337241cf2fa19)