### PR TITLE
Add minimal CI quality gates (compileall + pytest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,28 @@
 name: CI
 
 on:
+  push:
   pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install pytest
+          pip install -r requirements.txt pytest
+
+      - name: Compile all Python files
+        run: python -m compileall .
+
       - name: Run tests
-        run: python -m pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ MVP v1 – Engine → SQLite → API → Trading Desk
 - Core architecture and scope: `docs/mvp_v1.md`
 - Strategy configuration schema (RSI2, Turtle): `docs/strategy-configs.md`
 - Local run & test commands: `docs/local_run.md`
+
+## Local CI checks
+
+```bash
+python -m compileall .
+pytest
+```


### PR DESCRIPTION
### Motivation

- Add lightweight CI quality gates to detect regressions early with minimal overhead.
- Ensure checks run on both `push` and `pull_request` using Python 3.10 and no new dependencies.
- Provide a simple way for contributors to run the same checks locally.

### Description

- Add a GitHub Actions workflow at `.github/workflows/ci.yml` which sets up Python 3.10, installs `requirements.txt` and `pytest`, runs `python -m compileall .`, and runs `pytest`.
- Update `README.md` to document local CI check commands using `python -m compileall .` and `pytest`.
- Changes are minimal and limited to the two files ` .github/workflows/ci.yml` and `README.md` only.

### Testing

- No automated tests were executed locally; the workflow is configured to run `pytest` and `python -m compileall .` on `push` and `pull_request`.
- The repository's existing test suite will be executed by the new CI workflow without adding new test frameworks.
- Installation step in the workflow installs `requirements.txt` and `pytest` to ensure tests can run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956c3cce7348333b6a5850ffc7c42d7)