### PR TITLE
Replace Pydantic `Config` with `ConfigDict` to remove v2 deprecation warnings

### DIFF
--- a/src/cilly_trading/models.py
+++ b/src/cilly_trading/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Literal, Optional, TypedDict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 Stage = Literal["setup", "entry_confirmed"]
@@ -62,9 +62,7 @@ class EntryZoneDTO(BaseModel):
     from_: float = Field(..., alias="from_")
     to: float
 
-    class Config:
-        extra = "forbid"
-        allow_population_by_field_name = True
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
 class SignalReadItemDTO(BaseModel):
@@ -80,8 +78,7 @@ class SignalReadItemDTO(BaseModel):
     market_type: MarketType
     data_source: DataSource
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 class SignalReadResponseDTO(BaseModel):
@@ -90,5 +87,4 @@ class SignalReadResponseDTO(BaseModel):
     offset: int
     total: int
 
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")


### PR DESCRIPTION
### Motivation
- Remove Pydantic v2 deprecation warnings by replacing legacy `Config` inner classes with the v2-compatible `ConfigDict` settings.
- Preserve existing validation semantics and API surface so there are no behavior or schema changes.
- Limit changes to files that currently trigger Pydantic v2 warnings.

### Description
- Added `ConfigDict` import and replaced inner `class Config` usages with `model_config = ConfigDict(...)` on Pydantic models.
- Updated `EntryZoneDTO` to use `model_config = ConfigDict(extra="forbid", populate_by_name=True)` to preserve field alias population behavior.
- Updated `SignalReadItemDTO` and `SignalReadResponseDTO` to use `model_config = ConfigDict(extra="forbid")` to preserve `extra` handling.
- Modified files: `src/cilly_trading/models.py`.

### Testing
- No automated tests were executed as part of this change.
- Existing test suite was not run and therefore test status is unknown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ccfe41a483338c798d9f8758dbab)