### PR TITLE
Drop all-NaN OHLC rows after numeric coercion

### DIFF
--- a/src/data_layer/normalization.py
+++ b/src/data_layer/normalization.py
@@ -55,5 +55,9 @@ def normalize_ohlcv(
     for col in TARGET_COLUMNS[1:]:
         out[col] = pd.to_numeric(out[col], errors="coerce")
 
+    out = out.dropna(subset=["open", "high", "low", "close"], how="all")
+    if out.empty:
+        return _empty_result()
+
     out = out.sort_values("timestamp").reset_index(drop=True)
     return NormalizationResult(df=out, empty=out.empty)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -57,3 +57,22 @@ def test_normalize_timestamp_alias_is_supported() -> None:
     assert result.empty is False
     assert list(result.df.columns) == list(TARGET_COLUMNS)
     assert result.df["timestamp"].is_monotonic_increasing
+
+
+def test_normalize_drops_all_nan_ohlc_rows() -> None:
+    df = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01"],
+            "open": ["N/A"],
+            "high": ["N/A"],
+            "low": ["N/A"],
+            "close": ["N/A"],
+            "volume": ["1000"],
+        }
+    )
+
+    result = normalize_ohlcv(df, symbol="TEST", source="pytest")
+
+    assert result.empty is True
+    assert list(result.df.columns) == list(TARGET_COLUMNS)
+    assert result.df.empty is True


### PR DESCRIPTION
### Motivation
- After `pd.to_numeric(..., errors="coerce")` non-numeric OHLC values become `NaN` and rows with all-NaN OHLC must not be treated as valid data downstream.
- If the all-NaN OHLC filter removes every row the normalization should return `_empty_result()` and `NormalizationResult.empty == True`.
- The change must only apply to OHLC columns (not `volume`) and preserve existing behavior for valid data.
- Add a minimal unit test that covers a non-numeric OHLC input (e.g., "N/A") producing an empty result.

### Description
- Added `out = out.dropna(subset=["open", "high", "low", "close"], how="all")` and an early `return _empty_result()` when no rows remain after coercion inside `normalize_ohlcv`.
- Added a unit test `test_normalize_drops_all_nan_ohlc_rows` to `tests/test_normalization.py` that verifies the empty result for non-numeric OHLC values.

Modified files and full contents:

src/data_layer/normalization.py
```python
from __future__ import annotations

from dataclasses import dataclass
from typing import Final

import pandas as pd

TARGET_COLUMNS: Final[tuple[str, ...]] = (
    "timestamp",
    "open",
    "high",
    "low",
    "close",
    "volume",
)


@dataclass(frozen=True)
class NormalizationResult:
    df: pd.DataFrame
    empty: bool


def _empty_result() -> NormalizationResult:
    empty_df = pd.DataFrame(columns=list(TARGET_COLUMNS))
    return NormalizationResult(df=empty_df, empty=True)


def _normalize_timestamp_column(df: pd.DataFrame) -> pd.DataFrame:
    if "timestamp" not in df.columns and "timeStamp" in df.columns:
        return df.rename(columns={"timeStamp": "timestamp"})
    return df


def normalize_ohlcv(
    df: pd.DataFrame,
    *,
    symbol: str,
    source: str,
) -> NormalizationResult:
    if df is None or df.empty:
        return _empty_result()

    working = _normalize_timestamp_column(df)
    missing = [col for col in TARGET_COLUMNS if col not in working.columns]
    if missing:
        return _empty_result()

    out = working[list(TARGET_COLUMNS)].copy()
    out["timestamp"] = pd.to_datetime(out["timestamp"], utc=True, errors="coerce")
    out = out.dropna(subset=["timestamp"])
    if out.empty:
        return _empty_result()

    for col in TARGET_COLUMNS[1:]:
        out[col] = pd.to_numeric(out[col], errors="coerce")

    out = out.dropna(subset=["open", "high", "low", "close"], how="all")
    if out.empty:
        return _empty_result()

    out = out.sort_values("timestamp").reset_index(drop=True)
    return NormalizationResult(df=out, empty=out.empty)
```

tests/test_normalization.py
```python
import pandas as pd

from src.data_layer.normalization import TARGET_COLUMNS, normalize_ohlcv


def test_normalize_columns_and_order() -> None:
    df = pd.DataFrame(
        {
            "timestamp": ["2024-01-02", "2024-01-01"],
            "open": [101, 100],
            "high": [106, 105],
            "low": [100, 99],
            "close": [105, 104],
            "volume": [1100, 1000],
        }
    )

    result = normalize_ohlcv(df, symbol="TEST", source="pytest")

    assert result.empty is False
    assert list(result.df.columns) == list(TARGET_COLUMNS)
    assert result.df["timestamp"].is_monotonic_increasing


def test_normalize_empty_input_is_safe() -> None:
    empty = pd.DataFrame()
    result = normalize_ohlcv(empty, symbol="TEST", source="pytest")

    assert result.empty is True
    assert list(result.df.columns) == list(TARGET_COLUMNS)
    assert result.df.empty is True


def test_normalize_missing_columns_returns_empty() -> None:
    df = pd.DataFrame({"timestamp": ["2024-01-01"], "open": [1]})  # missing others
    result = normalize_ohlcv(df, symbol="TEST", source="pytest")

    assert result.empty is True
    assert list(result.df.columns) == list(TARGET_COLUMNS)
    assert result.df.empty is True


def test_normalize_timestamp_alias_is_supported() -> None:
    df = pd.DataFrame(
        {
            "timeStamp": ["2024-01-01", "2024-01-02"],  # alias, mixed case
            "open": [100, 101],
            "high": [105, 106],
            "low": [99, 100],
            "close": [104, 105],
            "volume": [1000, 1100],
        }
    )

    result = normalize_ohlcv(df, symbol="TEST", source="pytest")

    assert result.empty is False
    assert list(result.df.columns) == list(TARGET_COLUMNS)
    assert result.df["timestamp"].is_monotonic_increasing


def test_normalize_drops_all_nan_ohlc_rows() -> None:
    df = pd.DataFrame(
        {
            "timestamp": ["2024-01-01"],
            "open": ["N/A"],
            "high": ["N/A"],
            "low": ["N/A"],
            "close": ["N/A"],
            "volume": ["1000"],
        }
    )

    result = normalize_ohlcv(df, symbol="TEST", source="pytest")

    assert result.empty is True
    assert list(result.df.columns) == list(TARGET_COLUMNS)
    assert result.df.empty is True
```

### Testing
- Ran `pytest` and the full test suite passed: `43 passed`.
- The new test `test_normalize_drops_all_nan_ohlc_rows` is included and passed as part of the suite.
- No test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d6ba59548333a196222e9eda41d3)