### PR TITLE
Add smoke coverage for empty /signals response

### DIFF
--- a/tests/test_api_smoke_engine_db_api.py
+++ b/tests/test_api_smoke_engine_db_api.py
@@ -79,3 +79,16 @@ def test_api_smoke_engine_db_api(tmp_path: Path, monkeypatch) -> None:
         and item.get("created_at") == fixed_timestamp
         for item in items
     ), f"Expected signal not found in payload items: {items}"
+
+
+def test_api_smoke_signals_empty(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "signal_repo", repo)
+
+    client = TestClient(api_main.app)
+    response = client.get("/signals")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"] == []
+    assert payload["total"] == 0


### PR DESCRIPTION
### Motivation
- Ensure the `/signals` read-flow is explicitly covered by the API smoke suite to prevent regressions.
- Make the smoke check deterministic and CI-friendly by relying only on local test resources and no external DB access.
- Keep the smoke tests fast and minimal while validating both populated and empty-state behavior of the endpoint.

### Description
- Modified: `tests/test_api_smoke_engine_db_api.py` to add a new smoke test for an empty `GET /signals` response.
- Added `test_api_smoke_signals_empty` which uses the existing `_make_repo` helper and `monkeypatch` to set `api_main.signal_repo` to a local SQLite repo and then calls `GET /signals` with `TestClient`.
- The new test asserts a `200` response and that the payload contains an empty `items` list and `total == 0`, while leaving the existing engine-driven smoke test unchanged.

### Testing
- Ran `pytest -q tests/test_api_smoke_engine_db_api.py`.
- Result: `2 passed` (all smoke tests in the file succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d13b5515883338d151cdbd71a7725)