### PR TITLE
Add RSI2 and Turtle strategy presets

### DIFF
--- a/strategy/presets/rsi2.presets.json
+++ b/strategy/presets/rsi2.presets.json
@@ -1,0 +1,21 @@
+{
+  "strategy": "RSI2",
+  "presets": [
+    {
+      "id": "rsi2.conservative.v1",
+      "params": {
+        "rsi_period": 2,
+        "oversold_threshold": 8.0,
+        "min_score": 30.0
+      }
+    },
+    {
+      "id": "rsi2.aggressive.v1",
+      "params": {
+        "rsi_period": 2,
+        "oversold_threshold": 15.0,
+        "min_score": 10.0
+      }
+    }
+  ]
+}

--- a/strategy/presets/turtle.presets.json
+++ b/strategy/presets/turtle.presets.json
@@ -1,0 +1,21 @@
+{
+  "strategy": "TURTLE",
+  "presets": [
+    {
+      "id": "turtle.conservative.v1",
+      "params": {
+        "breakout_lookback": 55,
+        "proximity_threshold_pct": 0.02,
+        "min_score": 40.0
+      }
+    },
+    {
+      "id": "turtle.aggressive.v1",
+      "params": {
+        "breakout_lookback": 20,
+        "proximity_threshold_pct": 0.05,
+        "min_score": 20.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide declarative, versioned presets for existing strategies to simplify analysis configuration and reduce free-form errors. 
- Cover at least two presets for the existing RSI2 and Turtle strategies without changing strategy logic. 
- Keep presets data-only and explicit so they can be consumed by the existing analysis flow.

### Description

- Added two new JSON preset files containing explicit parameter bundles for `RSI2` and `TURTLE` with versioned identifiers. 
- Files are purely declarative and only reuse existing strategy parameters without introducing logic changes or dependencies.

Files created/modified (all new):

- `strategy/presets/rsi2.presets.json`  
  Short explanation: Added two versioned RSI2 presets (`rsi2.conservative.v1` and `rsi2.aggressive.v1`) with explicit parameters.  
  Full contents:
  ```json
  {
    "strategy": "RSI2",
    "presets": [
      {
        "id": "rsi2.conservative.v1",
        "params": {
          "rsi_period": 2,
          "oversold_threshold": 8.0,
          "min_score": 30.0
        }
      },
      {
        "id": "rsi2.aggressive.v1",
        "params": {
          "rsi_period": 2,
          "oversold_threshold": 15.0,
          "min_score": 10.0
        }
      }
    ]
  }
  ```

- `strategy/presets/turtle.presets.json`  
  Short explanation: Added two versioned Turtle presets (`turtle.conservative.v1` and `turtle.aggressive.v1`) with explicit parameters.  
  Full contents:
  ```json
  {
    "strategy": "TURTLE",
    "presets": [
      {
        "id": "turtle.conservative.v1",
        "params": {
          "breakout_lookback": 55,
          "proximity_threshold_pct": 0.02,
          "min_score": 40.0
        }
      },
      {
        "id": "turtle.aggressive.v1",
        "params": {
          "breakout_lookback": 20,
          "proximity_threshold_pct": 0.05,
          "min_score": 20.0
        }
      }
    ]
  }
  ```

### Testing

- Ran the test suite with `pytest` against the repository.  
- Result: all tests passed (`48 passed in 3.58s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d7452eb508333b802042510b490cb)