### PR TITLE
Manual analysis: reject new runs deterministically and remove snapshot registry

### DIFF
--- a/src/cilly_trading/db/init_db.py
+++ b/src/cilly_trading/db/init_db.py
@@ -2,7 +2,8 @@
 Init-Skript für die SQLite-Datenbank der Cilly Trading Engine.
 
 - Legt die Datei `cilly_trading.db` im Projektverzeichnis an (falls nicht vorhanden).
-- Erzeugt die Tabellen `signals` und `trades` entsprechend der MVP-Spezifikation.
+- Erzeugt die Tabellen `signals`, `trades` und `analysis_runs`
+  entsprechend der MVP-Spezifikation.
 """
 
 from __future__ import annotations
@@ -107,6 +108,25 @@ def init_db(db_path: Optional[Path] = None) -> None:
             market_type TEXT NOT NULL,
             data_source TEXT NOT NULL
         );
+        """
+    )
+
+    # Tabelle: analysis_runs
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS analysis_runs (
+            analysis_run_id TEXT PRIMARY KEY,
+            ingestion_run_id TEXT NOT NULL,
+            request_payload TEXT NOT NULL,
+            result_payload TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_analysis_runs_ingestion
+          ON analysis_runs(ingestion_run_id);
         """
     )
 

--- a/src/cilly_trading/repositories/analysis_runs_sqlite.py
+++ b/src/cilly_trading/repositories/analysis_runs_sqlite.py
@@ -1,0 +1,112 @@
+"""
+SQLite-Repository für Analyse-Runs.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from cilly_trading.db import DEFAULT_DB_PATH, init_db
+
+
+class SqliteAnalysisRunRepository:
+    """
+    Repository für Analyse-Run-Metadaten und Ergebnisse.
+    """
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        if db_path is None:
+            db_path = DEFAULT_DB_PATH
+
+        self._db_path = Path(db_path)
+        init_db(self._db_path)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def get_run(self, analysis_run_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Lädt einen Analyse-Run anhand der Run-ID.
+
+        Args:
+            analysis_run_id: Eindeutige ID für den Analyse-Run.
+
+        Returns:
+            Optionaler Dict mit gespeicherten Run-Daten.
+        """
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT
+                analysis_run_id,
+                ingestion_run_id,
+                request_payload,
+                result_payload,
+                created_at
+            FROM analysis_runs
+            WHERE analysis_run_id = ?;
+            """,
+            (analysis_run_id,),
+        )
+        row = cur.fetchone()
+        conn.close()
+
+        if row is None:
+            return None
+
+        return {
+            "analysis_run_id": row["analysis_run_id"],
+            "ingestion_run_id": row["ingestion_run_id"],
+            "request": json.loads(row["request_payload"]),
+            "result": json.loads(row["result_payload"]),
+            "created_at": row["created_at"],
+        }
+
+    def save_run(
+        self,
+        *,
+        analysis_run_id: str,
+        ingestion_run_id: str,
+        request_payload: Dict[str, Any],
+        result_payload: Dict[str, Any],
+    ) -> None:
+        """
+        Speichert einen Analyse-Run mit Request- und Result-Payload.
+
+        Args:
+            analysis_run_id: Eindeutige ID für den Analyse-Run.
+            ingestion_run_id: Referenz auf den Snapshot/Run der Ingestion.
+            request_payload: Request-Daten als JSON-serialisierbares Dict.
+            result_payload: Ergebnis-Daten als JSON-serialisierbares Dict.
+        """
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO analysis_runs (
+                analysis_run_id,
+                ingestion_run_id,
+                request_payload,
+                result_payload,
+                created_at
+            )
+            VALUES (?, ?, ?, ?, ?);
+            """,
+            (
+                analysis_run_id,
+                ingestion_run_id,
+                json.dumps(request_payload, sort_keys=True),
+                json.dumps(result_payload, sort_keys=True),
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+

--- a/tests/test_api_manual_analysis_trigger.py
+++ b/tests/test_api_manual_analysis_trigger.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
+from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
+
+
+def _make_signal_repo(tmp_path: Path) -> SqliteSignalRepository:
+    return SqliteSignalRepository(db_path=tmp_path / "signals.db")
+
+
+def _make_analysis_repo(tmp_path: Path) -> SqliteAnalysisRunRepository:
+    return SqliteAnalysisRunRepository(db_path=tmp_path / "analysis.db")
+
+
+def test_manual_analysis_idempotent(tmp_path: Path, monkeypatch) -> None:
+    signal_repo = _make_signal_repo(tmp_path)
+    analysis_repo = _make_analysis_repo(tmp_path)
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
+
+    def _fail_run_watchlist_analysis(*args, **kwargs):
+        raise AssertionError("run_watchlist_analysis should not be called")
+
+    monkeypatch.setattr(api_main, "run_watchlist_analysis", _fail_run_watchlist_analysis)
+
+    response_payload = {
+        "analysis_run_id": "run-1",
+        "ingestion_run_id": "snapshot-1",
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "signals": [
+            {
+                "symbol": "AAPL",
+                "strategy": "RSI2",
+                "direction": "long",
+                "score": 42.0,
+                "timestamp": "2025-01-03T00:00:00+00:00",
+                "stage": "setup",
+                "timeframe": "D1",
+                "market_type": "stock",
+                "data_source": "yahoo",
+            }
+        ],
+    }
+    analysis_repo.save_run(
+        analysis_run_id="run-1",
+        ingestion_run_id="snapshot-1",
+        request_payload={"analysis_run_id": "run-1", "ingestion_run_id": "snapshot-1"},
+        result_payload=response_payload,
+    )
+
+    client = TestClient(api_main.app)
+    payload = {
+        "analysis_run_id": "run-1",
+        "ingestion_run_id": "snapshot-1",
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "market_type": "stock",
+        "lookback_days": 200,
+    }
+
+    response_first = client.post("/analysis/run", json=payload)
+    assert response_first.status_code == 200
+    first_body = response_first.json()
+    assert first_body["analysis_run_id"] == "run-1"
+    assert first_body == response_payload
+
+    response_second = client.post("/analysis/run", json=payload)
+    assert response_second.status_code == 200
+    second_body = response_second.json()
+    assert second_body == first_body
+
+
+def test_manual_analysis_rejects_new_run(tmp_path: Path, monkeypatch) -> None:
+    signal_repo = _make_signal_repo(tmp_path)
+    analysis_repo = _make_analysis_repo(tmp_path)
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
+
+    def _fail_run_watchlist_analysis(*args, **kwargs):
+        raise AssertionError("run_watchlist_analysis should not be called")
+
+    monkeypatch.setattr(api_main, "run_watchlist_analysis", _fail_run_watchlist_analysis)
+
+    client = TestClient(api_main.app)
+    response = client.post(
+        "/analysis/run",
+        json={
+            "analysis_run_id": "run-missing",
+            "ingestion_run_id": "missing-snapshot",
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "market_type": "stock",
+            "lookback_days": 200,
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "snapshot_not_supported"
+    assert analysis_repo.get_run("run-missing") is None


### PR DESCRIPTION
### Motivation
- Ensure `POST /analysis/run` is deterministic and idempotent by returning stored results for an existing `analysis_run_id` and refusing to execute analysis for new runs within I-04.
- Prevent scope creep by removing the snapshot registry responsibility from this issue (snapshot ingestion/registry belongs to I-09).
- Guarantee that no analysis engine is invoked and no DB mutation occurs when a run is missing.

### Description
- Update the manual analysis endpoint so it returns the stored result when `analysis_run_id` exists and otherwise raises HTTP 422 with detail `"snapshot_not_supported"` (no execution); implemented in `api/main.py` via `manual_analysis` and `ManualAnalysisRequest/Response`.
- Remove snapshot registry usage and schema: dropped `analysis_snapshots` table creation from `src/cilly_trading/db/init_db.py` and removed `SqliteSnapshotRepository` from `src/cilly_trading/repositories/analysis_runs_sqlite.py`.
- Keep and simplify the analysis run persistence with `SqliteAnalysisRunRepository` that manages `analysis_runs` storage and retrieval in `src/cilly_trading/repositories/analysis_runs_sqlite.py`.
- Adjust tests in `tests/test_api_manual_analysis_trigger.py` to pre-seed an analysis run for the idempotent case and to assert deterministic 422 rejection for new runs while ensuring `run_watchlist_analysis` is not invoked.

### Testing
- Ran `pytest -q tests/test_api_manual_analysis_trigger.py` and the suite passed (`2 passed`).
- Tests verify idempotent behavior by pre-saving a run and asserting identical responses on repeated `POST /analysis/run` calls.
- Tests verify deterministic rejection by asserting a 422 with detail `"snapshot_not_supported"` for a new `analysis_run_id` and confirm no run was created.
- The test also asserts that `run_watchlist_analysis` is not called for both code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696162e6d41483338c934b750a8feffb)