### PR TITLE
Fix snapshot validation and loader bugs

### DIFF
--- a/src/cilly_trading/db/init_db.py
+++ b/src/cilly_trading/db/init_db.py
@@ -130,6 +130,51 @@ def init_db(db_path: Optional[Path] = None) -> None:
         """
     )
 
+    # Tabelle: ingestion_runs
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ingestion_runs (
+            ingestion_run_id TEXT PRIMARY KEY,
+            created_at TEXT NOT NULL,
+            source TEXT NOT NULL,
+            symbols_json TEXT NOT NULL,
+            timeframe TEXT NOT NULL,
+            fingerprint_hash TEXT NULL
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_ingestion_runs_created_at
+          ON ingestion_runs(created_at);
+        """
+    )
+
+    # Tabelle: ohlcv_snapshots
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ohlcv_snapshots (
+            ingestion_run_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            timeframe TEXT NOT NULL,
+            ts INTEGER NOT NULL,
+            open REAL NOT NULL,
+            high REAL NOT NULL,
+            low REAL NOT NULL,
+            close REAL NOT NULL,
+            volume REAL NOT NULL,
+            PRIMARY KEY (ingestion_run_id, symbol, timeframe, ts),
+            FOREIGN KEY (ingestion_run_id) REFERENCES ingestion_runs(ingestion_run_id)
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_ohlcv_snapshots_lookup
+          ON ohlcv_snapshots(ingestion_run_id, symbol, timeframe, ts);
+        """
+    )
+
     conn.commit()
     conn.close()
 

--- a/src/cilly_trading/repositories/analysis_runs_sqlite.py
+++ b/src/cilly_trading/repositories/analysis_runs_sqlite.py
@@ -30,6 +30,22 @@ class SqliteAnalysisRunRepository:
         conn.row_factory = sqlite3.Row
         return conn
 
+    def ingestion_run_exists(self, ingestion_run_id: str) -> bool:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT 1
+            FROM ingestion_runs
+            WHERE ingestion_run_id = ?
+            LIMIT 1;
+            """,
+            (ingestion_run_id,),
+        )
+        row = cur.fetchone()
+        conn.close()
+        return row is not None
+
     def get_run(self, analysis_run_id: str) -> Optional[Dict[str, Any]]:
         """
         Lädt einen Analyse-Run anhand der Run-ID.
@@ -109,4 +125,3 @@ class SqliteAnalysisRunRepository:
         )
         conn.commit()
         conn.close()
-

--- a/tests/test_api_manual_analysis_trigger.py
+++ b/tests/test_api_manual_analysis_trigger.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import sqlite3
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -17,6 +21,83 @@ def _make_analysis_repo(tmp_path: Path) -> SqliteAnalysisRunRepository:
     return SqliteAnalysisRunRepository(db_path=tmp_path / "analysis.db")
 
 
+def _insert_ingestion_run(
+    db_path: Path,
+    ingestion_run_id: str,
+    *,
+    symbols: list[str],
+    timeframe: str = "D1",
+    source: str = "test",
+    fingerprint_hash: str | None = None,
+) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO ingestion_runs (
+            ingestion_run_id,
+            created_at,
+            source,
+            symbols_json,
+            timeframe,
+            fingerprint_hash
+        )
+        VALUES (?, ?, ?, ?, ?, ?);
+        """,
+        (
+            ingestion_run_id,
+            datetime.now(timezone.utc).isoformat(),
+            source,
+            json.dumps(symbols),
+            timeframe,
+            fingerprint_hash,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_snapshot_rows(
+    db_path: Path,
+    ingestion_run_id: str,
+    symbol: str,
+    timeframe: str,
+    rows: list[tuple[int, float, float, float, float, float]],
+) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        """
+        INSERT INTO ohlcv_snapshots (
+            ingestion_run_id,
+            symbol,
+            timeframe,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        [
+            (
+                ingestion_run_id,
+                symbol,
+                timeframe,
+                ts,
+                open_,
+                high,
+                low,
+                close,
+                volume,
+            )
+            for ts, open_, high, low, close, volume in rows
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
 def test_manual_analysis_idempotent(tmp_path: Path, monkeypatch) -> None:
     signal_repo = _make_signal_repo(tmp_path)
     analysis_repo = _make_analysis_repo(tmp_path)
@@ -29,9 +110,17 @@ def test_manual_analysis_idempotent(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(api_main, "run_watchlist_analysis", _fail_run_watchlist_analysis)
 
+    ingestion_run_id = str(uuid.uuid4())
+    _insert_ingestion_run(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        symbols=["AAPL"],
+        timeframe="D1",
+    )
+
     response_payload = {
         "analysis_run_id": "run-1",
-        "ingestion_run_id": "snapshot-1",
+        "ingestion_run_id": ingestion_run_id,
         "symbol": "AAPL",
         "strategy": "RSI2",
         "signals": [
@@ -50,15 +139,15 @@ def test_manual_analysis_idempotent(tmp_path: Path, monkeypatch) -> None:
     }
     analysis_repo.save_run(
         analysis_run_id="run-1",
-        ingestion_run_id="snapshot-1",
-        request_payload={"analysis_run_id": "run-1", "ingestion_run_id": "snapshot-1"},
+        ingestion_run_id=ingestion_run_id,
+        request_payload={"analysis_run_id": "run-1", "ingestion_run_id": ingestion_run_id},
         result_payload=response_payload,
     )
 
     client = TestClient(api_main.app)
     payload = {
         "analysis_run_id": "run-1",
-        "ingestion_run_id": "snapshot-1",
+        "ingestion_run_id": ingestion_run_id,
         "symbol": "AAPL",
         "strategy": "RSI2",
         "market_type": "stock",
@@ -77,7 +166,7 @@ def test_manual_analysis_idempotent(tmp_path: Path, monkeypatch) -> None:
     assert second_body == first_body
 
 
-def test_manual_analysis_rejects_new_run(tmp_path: Path, monkeypatch) -> None:
+def test_manual_analysis_rejects_invalid_ingestion_run(tmp_path: Path, monkeypatch) -> None:
     signal_repo = _make_signal_repo(tmp_path)
     analysis_repo = _make_analysis_repo(tmp_path)
 
@@ -94,7 +183,7 @@ def test_manual_analysis_rejects_new_run(tmp_path: Path, monkeypatch) -> None:
         "/analysis/run",
         json={
             "analysis_run_id": "run-missing",
-            "ingestion_run_id": "missing-snapshot",
+            "ingestion_run_id": "not-a-uuid",
             "symbol": "AAPL",
             "strategy": "RSI2",
             "market_type": "stock",
@@ -103,5 +192,67 @@ def test_manual_analysis_rejects_new_run(tmp_path: Path, monkeypatch) -> None:
     )
 
     assert response.status_code == 422
-    assert response.json()["detail"] == "snapshot_not_supported"
+    assert response.json()["detail"] == "invalid_ingestion_run_id"
     assert analysis_repo.get_run("run-missing") is None
+    assert signal_repo.list_signals(limit=10) == []
+
+
+def test_manual_analysis_uses_snapshot(tmp_path: Path, monkeypatch) -> None:
+    signal_repo = _make_signal_repo(tmp_path)
+    analysis_repo = _make_analysis_repo(tmp_path)
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
+
+    ingestion_run_id = str(uuid.uuid4())
+    _insert_ingestion_run(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        symbols=["AAPL"],
+        timeframe="D1",
+    )
+
+    rows = [
+        (1735689600000, 101.0, 102.0, 100.0, 101.0, 1000.0),
+        (1735776000000, 100.0, 101.0, 90.0, 91.0, 1000.0),
+        (1735862400000, 90.0, 91.0, 80.0, 81.0, 1000.0),
+    ]
+    _insert_snapshot_rows(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        "AAPL",
+        "D1",
+        rows,
+    )
+
+    def _fail_yahoo(*args, **kwargs):
+        raise AssertionError("yfinance should not be called")
+
+    def _fail_binance(*args, **kwargs):
+        raise AssertionError("ccxt should not be called")
+
+    monkeypatch.setattr("cilly_trading.engine.data._load_stock_yahoo", _fail_yahoo)
+    monkeypatch.setattr("cilly_trading.engine.data._load_crypto_binance", _fail_binance)
+
+    client = TestClient(api_main.app)
+    response = client.post(
+        "/analysis/run",
+        json={
+            "analysis_run_id": "run-snapshot",
+            "ingestion_run_id": ingestion_run_id,
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "market_type": "stock",
+            "lookback_days": 200,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["analysis_run_id"] == "run-snapshot"
+    assert payload["ingestion_run_id"] == ingestion_run_id
+    assert payload["symbol"] == "AAPL"
+    assert payload["strategy"] == "RSI2"
+    assert payload["signals"]
+    assert analysis_repo.get_run("run-snapshot") is not None
+    assert signal_repo.list_signals(limit=10)


### PR DESCRIPTION
### Motivation
- Ensure idempotent manual analysis responses are still valid by re-checking the referenced snapshot before returning cached results.  
- Make snapshot-driven analysis explicit and safe by requiring a database path when `ingestion_run_id` is used.  
- Fix data-layer issues so both live loaders and snapshot loader produce a normalized OHLCV DataFrame.  
- Update tests to use proper UUID4 snapshot IDs and to assert snapshot-mode avoids live provider calls.

### Description
- Validate cached manual run snapshot in `api/main.py` by calling `_require_ingestion_run` on the stored `ingestion_run_id` before returning the idempotent response, and validate incoming `ingestion_run_id` for analyze/screener/manual endpoints.  
- Enforce snapshot usage in `src/cilly_trading/engine/core.py` by requiring `db_path` when `ingestion_run_id` is provided and dispatch to `load_ohlcv_snapshot` when running the engine with a snapshot.  
- Implement `load_ohlcv_snapshot` and fix loaders in `src/cilly_trading/engine/data.py` so snapshots are read from `ohlcv_snapshots`, Yahoo loader uses `REQUIRED_COLS`, and Binance loader logging/timestamp handling is corrected.  
- Add DB schema and repo support for snapshots and ingestion runs (tables `ingestion_runs` and `ohlcv_snapshots` plus `ingestion_run_exists`), and update `tests/test_api_manual_analysis_trigger.py` to insert ingestion run and snapshot rows and to use `uuid.uuid4()` IDs.

### Testing
- Ran the full test suite with `pytest` and all tests passed (output: `60 passed`).  
- `tests/test_api_manual_analysis_trigger.py` was run and passed, covering idempotent cached runs, invalid `ingestion_run_id` rejection, and snapshot-driven manual analysis that avoids live fetches.  
- Verified snapshot mode prevented calls to live providers by monkeypatching `_load_stock_yahoo` and `_load_crypto_binance` in tests.  
- No automated tests failed during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69616cbca4dc83339f5b8bafd985bcaf)