### PR TITLE
Add `preset_id`/`preset_ids` support and return `preset_results` in strategy analyze

### DIFF
--- a/tests/test_api_strategy_analyze_presets.py
+++ b/tests/test_api_strategy_analyze_presets.py
@@ -57,10 +57,8 @@ def test_strategy_analyze_multi_presets_returns_results(tmp_path: Path, monkeypa
         "strategy": "RSI2",
         "market_type": "stock",
         "lookback_days": 30,
-        "presets": [
-            {"id": "fast", "params": {"oversold_threshold": 15.0}},
-            {"id": "slow", "params": {"oversold_threshold": 8.0}},
-        ],
+        "preset_ids": ["fast", "slow"],
+        "strategy_config": {"oversold_threshold": 15.0},
     }
 
     response = client.post("/strategy/analyze", json=payload)
@@ -73,6 +71,8 @@ def test_strategy_analyze_multi_presets_returns_results(tmp_path: Path, monkeypa
     assert list(data["results_by_preset"].keys()) == ["fast", "slow"]
     assert isinstance(data["results_by_preset"]["fast"], list)
     assert isinstance(data["results_by_preset"]["slow"], list)
+    assert data["preset_results"] is not None
+    assert [item["preset_id"] for item in data["preset_results"]] == ["fast", "slow"]
 
 
 def test_strategy_analyze_duplicate_preset_ids_rejected(
@@ -86,10 +86,7 @@ def test_strategy_analyze_duplicate_preset_ids_rejected(
         "strategy": "RSI2",
         "market_type": "stock",
         "lookback_days": 30,
-        "presets": [
-            {"id": "dup", "params": {"oversold_threshold": 15.0}},
-            {"id": "dup", "params": {"oversold_threshold": 8.0}},
-        ],
+        "preset_ids": ["dup", "dup"],
     }
 
     response = client.post("/strategy/analyze", json=payload)
@@ -108,7 +105,7 @@ def test_strategy_analyze_missing_preset_id_rejected(
         "strategy": "RSI2",
         "market_type": "stock",
         "lookback_days": 30,
-        "presets": [{"params": {"oversold_threshold": 15.0}}],
+        "preset_ids": [],
     }
 
     response = client.post("/strategy/analyze", json=payload)
@@ -124,10 +121,8 @@ def test_strategy_analyze_deterministic_output(tmp_path: Path, monkeypatch) -> N
         "strategy": "RSI2",
         "market_type": "stock",
         "lookback_days": 30,
-        "presets": [
-            {"id": "fast", "params": {"oversold_threshold": 15.0}},
-            {"id": "slow", "params": {"oversold_threshold": 8.0}},
-        ],
+        "preset_ids": ["fast", "slow"],
+        "strategy_config": {"oversold_threshold": 15.0},
     }
 
     response_one = client.post("/strategy/analyze", json=payload)


### PR DESCRIPTION
### Motivation
- Allow callers to request analyses by single `preset_id` or list `preset_ids` in addition to existing `presets` payloads. 
- Provide an explicit, ordered list of preset results alongside the compatibility `results_by_preset` mapping. 
- Validate and prevent ambiguous combinations of `presets`, `preset_id`, and `preset_ids` to avoid misuse. 
- Preserve deterministic processing order for preset comparisons.

### Description
- Added `preset_id` and `preset_ids` fields to `StrategyAnalyzeRequest` and validation in `_validate_presets` to forbid ambiguous combinations and duplicate ids. 
- Introduced `PresetAnalysisResult` model and `preset_results` field on `StrategyAnalyzeResponse` to return ordered results per preset. 
- Updated `analyze_strategy` to accept `presets`, `preset_ids`, or `preset_id`, build effective configs, call `run_watchlist_analysis` per preset, and populate both `results_by_preset` and `preset_results`. 
- Modified tests to exercise the new `preset_ids` input path and assert ordering and validation behavior.

### Testing
- Ran `pytest tests/test_api_strategy_analyze_presets.py` and all tests passed (5 passed). 
- No other automated test suites were modified or executed as part of this change. 
- Modified files: `api/main.py`, `tests/test_api_strategy_analyze_presets.py`. 
- The change maintained deterministic ordering of preset processing and output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655c99da608333b83de46eb456aa82)