### PR TITLE
docs(local_run): add quick start, analysis trigger, verification, reset, and common errors

### DIFF
--- a/docs/local_run.md
+++ b/docs/local_run.md
@@ -1,25 +1,11 @@
-# Local Development: Run & Test
+# Local Development: Run & Analyze
 
-## Prerequisites
-
-- Python 3.10+
-- `pip`
-
-## Local setup
+## TL;DR Quick Start
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-```
-
-## Run the engine
-
-No CLI entrypoint yet; see Issue #15.
-
-## Run the API
-
-```bash
 uvicorn api.main:app --reload
 ```
 
@@ -27,7 +13,97 @@ uvicorn api.main:app --reload
 curl http://127.0.0.1:8000/health
 ```
 
-## Run the API with Docker
+Expected output:
+
+```json
+{"status":"ok"}
+```
+
+## Prerequisites
+
+- Python 3.10+
+- `pip`
+
+## Step-by-step (fresh clone → signals stored)
+
+1) **Create and activate a virtual environment**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
+2) **Install dependencies**
+
+```bash
+pip install -r requirements.txt
+```
+
+3) **Run the API**
+
+No CLI entrypoint yet; use API endpoints.
+
+```bash
+uvicorn api.main:app --reload
+```
+
+4) **Verify the API is up**
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Expected output:
+
+```json
+{"status":"ok"}
+```
+
+5) **Trigger signal generation**
+
+Supported strategies: `RSI2`, `TURTLE`.
+
+```bash
+curl -X POST "http://127.0.0.1:8000/strategy/analyze" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "symbol": "AAPL",
+    "strategy": "RSI2",
+    "market_type": "stock",
+    "lookback_days": 200
+  }'
+```
+
+Expected output (example):
+
+```json
+{
+  "symbol": "AAPL",
+  "strategy": "RSI2",
+  "signals": []
+}
+```
+
+6) **Verify signals were stored**
+
+```bash
+curl -X GET "http://127.0.0.1:8000/signals?strategy=RSI2&limit=10" \
+  -H "Accept: application/json"
+```
+
+Expected output (example):
+
+```json
+{
+  "items": [],
+  "limit": 10,
+  "offset": 0,
+  "total": 0
+}
+```
+
+## Run the API with Docker (alternative)
 
 ```bash
 docker compose up --build
@@ -37,21 +113,64 @@ docker compose up --build
 curl http://127.0.0.1:8000/health
 ```
 
-SQLite persistence is handled via a named Docker volume. Stopping and starting
-the container will keep the data:
+Expected output:
 
-```bash
-docker compose down
-docker compose up
+```json
+{"status":"ok"}
 ```
 
-To reset the local SQLite database, remove the volume:
+## Results: where data is stored and how to read it
+
+- SQLite file: `cilly_trading.db` (project root)
+- Key tables: `signals`, `analysis_runs`
+
+Read results via API:
+
+```bash
+curl -X GET "http://127.0.0.1:8000/signals?strategy=RSI2&limit=10" \
+  -H "Accept: application/json"
+```
+
+## Reset local state (SQLite)
+
+**Docker:**
 
 ```bash
 docker compose down -v
 ```
 
-## Run tests
+**Non-Docker (local venv run):**
+
+1) Stop `uvicorn`
+2) Delete the SQLite file in the project root:
+   - `cilly_trading.db`
+3) Restart `uvicorn` (DB re-initializes on startup)
+
+Safety note: this deletes all local signals and analysis runs.
+
+## Common setup errors & fixes
+
+1) **No CLI entrypoint**
+   - Symptom: Looking for a `run` or `engine` command.
+   - Fix: Run the API with `uvicorn api.main:app --reload` and use the HTTP endpoints.
+
+2) **Unknown strategy (400)**
+   - Symptom: `{"detail":"Unknown strategy: <strategy>"}`
+   - Fix: Use supported strategies: `RSI2` or `TURTLE`.
+
+3) **Missing required field (422)**
+   - Symptom: `422 Unprocessable Entity` with missing field details (e.g., missing `symbol`).
+   - Fix: Provide all required fields for `/strategy/analyze` and `/analysis/run`.
+
+4) **invalid_ingestion_run_id (422)**
+   - Symptom: `{"detail":"invalid_ingestion_run_id"}`
+   - Fix: When using `ingestion_run_id`, provide a valid UUIDv4 string.
+
+5) **ingestion_run_not_found (422)**
+   - Symptom: `{"detail":"ingestion_run_not_found"}`
+   - Fix: Use an existing ingestion run ID or omit `ingestion_run_id` for endpoints where it is optional.
+
+## Run tests (optional)
 
 ```bash
 python -m pytest


### PR DESCRIPTION
### Motivation

- Enable a minimal, reproducible local path from a fresh clone to signal generation within ~10–15 minutes. 
- Provide clear, API-first instructions to trigger analyses and verify stored signals using `curl`. 
- Document how to reset local SQLite state both with Docker and without Docker. 
- Surface common setup errors and pragmatic fixes to speed onboarding and troubleshooting. 

### Description

- Updated `docs/local_run.md` to include a TL;DR Quick Start with `python -m venv`, `pip install -r requirements.txt`, `uvicorn api.main:app --reload`, and a `curl` health check. 
- Added `curl` examples to trigger analysis via `POST /strategy/analyze` and to verify stored signals via `GET /signals`, and noted supported strategies `RSI2` and `TURTLE`. 
- Documented results location (`cilly_trading.db` in project root) and key tables (`signals`, `analysis_runs`), as well as Docker (`docker compose down -v`) and non-Docker (stop `uvicorn`, delete `cilly_trading.db`, restart) reset procedures. 
- Added a concise list of five common errors (`No CLI entrypoint`, `Unknown strategy (400)`, `Missing required field (422)`, `invalid_ingestion_run_id (422)`, `ingestion_run_not_found (422)`) with recommended fixes. 

### Testing

- No automated tests were executed because this change is documentation-only. 
- `python -m pytest` is listed as an optional verification step in the doc but was not run as part of this update. 
- The modified file is `docs/local_run.md` and the updated content is intended to be copy-paste runnable on a fresh environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965661370a08333972daf5023b99536)