### PR TITLE
docs: fix local uvicorn command in local run guide

### DIFF
--- a/docs/local_run.md
+++ b/docs/local_run.md
@@ -6,7 +6,7 @@
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn api.main:app --reload
+PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
 ```bash
@@ -44,8 +44,10 @@ pip install -r requirements.txt
 No CLI entrypoint yet; use API endpoints.
 
 ```bash
-uvicorn api.main:app --reload
+PYTHONPATH=src uvicorn api.main:app --reload
 ```
+
+The code uses a `src/` layout; `PYTHONPATH=src` makes `cilly_trading` importable.
 
 4) **Verify the API is up**
 


### PR DESCRIPTION
### Motivation
- The documented `uvicorn api.main:app --reload` command fails on a fresh virtualenv because the package uses a `src/` layout and `src` is not on `PYTHONPATH` by default.
- Update the quick-start so a single copy/paste command works without undocumented steps.
- Keep changes minimal and confined to the local run documentation.

### Description
- Replaced `uvicorn api.main:app --reload` with `PYTHONPATH=src uvicorn api.main:app --reload` in the TL;DR Quick Start block.
- Replaced the same command in the step-by-step "Run the API" section.
- Added a one-line note explaining that the code uses a `src/` layout and that `PYTHONPATH=src` makes `cilly_trading` importable. 
- Modified file: `docs/local_run.md`.

### Testing
- This is a documentation-only change so no automated tests were executed. 
- No tests were required to validate the docs change and none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656c6f84ac833393b5a7668b7419a4)