### PR TITLE
Normalize strategy_config for deterministic analysis_run_id

### DIFF
--- a/tests/test_api_manual_analysis_trigger.py
+++ b/tests/test_api_manual_analysis_trigger.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 import api.main as api_main
+from cilly_trading.engine.core import compute_analysis_run_id
 from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 
@@ -105,11 +106,6 @@ def test_manual_analysis_idempotent(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(api_main, "signal_repo", signal_repo)
     monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
 
-    def _fail_run_watchlist_analysis(*args, **kwargs):
-        raise AssertionError("run_watchlist_analysis should not be called")
-
-    monkeypatch.setattr(api_main, "run_watchlist_analysis", _fail_run_watchlist_analysis)
-
     ingestion_run_id = str(uuid.uuid4())
     _insert_ingestion_run(
         tmp_path / "analysis.db",
@@ -118,51 +114,59 @@ def test_manual_analysis_idempotent(tmp_path: Path, monkeypatch) -> None:
         timeframe="D1",
     )
 
-    response_payload = {
-        "analysis_run_id": "run-1",
-        "ingestion_run_id": ingestion_run_id,
-        "symbol": "AAPL",
-        "strategy": "RSI2",
-        "signals": [
-            {
-                "symbol": "AAPL",
-                "strategy": "RSI2",
-                "direction": "long",
-                "score": 42.0,
-                "timestamp": "2025-01-03T00:00:00+00:00",
-                "stage": "setup",
-                "timeframe": "D1",
-                "market_type": "stock",
-                "data_source": "yahoo",
-            }
-        ],
-    }
-    analysis_repo.save_run(
-        analysis_run_id="run-1",
-        ingestion_run_id=ingestion_run_id,
-        request_payload={"analysis_run_id": "run-1", "ingestion_run_id": ingestion_run_id},
-        result_payload=response_payload,
+    rows = [
+        (1735689600000, 101.0, 102.0, 100.0, 101.0, 1000.0),
+        (1735776000000, 100.0, 101.0, 90.0, 91.0, 1000.0),
+        (1735862400000, 90.0, 91.0, 80.0, 81.0, 1000.0),
+    ]
+    _insert_snapshot_rows(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        "AAPL",
+        "D1",
+        rows,
     )
+
+    def _fail_yahoo(*args, **kwargs):
+        raise AssertionError("yfinance should not be called")
+
+    def _fail_binance(*args, **kwargs):
+        raise AssertionError("ccxt should not be called")
+
+    monkeypatch.setattr("cilly_trading.engine.data._load_stock_yahoo", _fail_yahoo)
+    monkeypatch.setattr("cilly_trading.engine.data._load_crypto_binance", _fail_binance)
 
     client = TestClient(api_main.app)
     payload = {
-        "analysis_run_id": "run-1",
         "ingestion_run_id": ingestion_run_id,
         "symbol": "AAPL",
         "strategy": "RSI2",
         "market_type": "stock",
         "lookback_days": 200,
     }
+    run_request_payload = {
+        "ingestion_run_id": ingestion_run_id,
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "market_type": "stock",
+        "lookback_days": 200,
+    }
+    expected_run_id = compute_analysis_run_id(run_request_payload)
 
     response_first = client.post("/analysis/run", json=payload)
     assert response_first.status_code == 200
     first_body = response_first.json()
-    assert first_body["analysis_run_id"] == "run-1"
-    assert first_body == response_payload
+    assert first_body["analysis_run_id"] == expected_run_id
+
+    def _fail_run_watchlist_analysis(*args, **kwargs):
+        raise AssertionError("run_watchlist_analysis should not be called")
+
+    monkeypatch.setattr(api_main, "run_watchlist_analysis", _fail_run_watchlist_analysis)
 
     response_second = client.post("/analysis/run", json=payload)
     assert response_second.status_code == 200
     second_body = response_second.json()
+    assert second_body["analysis_run_id"] == expected_run_id
     assert second_body == first_body
 
 
@@ -182,7 +186,6 @@ def test_manual_analysis_rejects_invalid_ingestion_run(tmp_path: Path, monkeypat
     response = client.post(
         "/analysis/run",
         json={
-            "analysis_run_id": "run-missing",
             "ingestion_run_id": "not-a-uuid",
             "symbol": "AAPL",
             "strategy": "RSI2",
@@ -193,7 +196,15 @@ def test_manual_analysis_rejects_invalid_ingestion_run(tmp_path: Path, monkeypat
 
     assert response.status_code == 422
     assert response.json()["detail"] == "invalid_ingestion_run_id"
-    assert analysis_repo.get_run("run-missing") is None
+    run_request_payload = {
+        "ingestion_run_id": "not-a-uuid",
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "market_type": "stock",
+        "lookback_days": 200,
+    }
+    expected_run_id = compute_analysis_run_id(run_request_payload)
+    assert analysis_repo.get_run(expected_run_id) is None
     assert signal_repo.list_signals(limit=10) == []
 
 
@@ -238,7 +249,7 @@ def test_manual_analysis_uses_snapshot(tmp_path: Path, monkeypatch) -> None:
     response = client.post(
         "/analysis/run",
         json={
-            "analysis_run_id": "run-snapshot",
+            "analysis_run_id": "client-run",
             "ingestion_run_id": ingestion_run_id,
             "symbol": "AAPL",
             "strategy": "RSI2",
@@ -249,10 +260,161 @@ def test_manual_analysis_uses_snapshot(tmp_path: Path, monkeypatch) -> None:
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["analysis_run_id"] == "run-snapshot"
+    run_request_payload = {
+        "ingestion_run_id": ingestion_run_id,
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "market_type": "stock",
+        "lookback_days": 200,
+    }
+    expected_run_id = compute_analysis_run_id(run_request_payload)
+    assert payload["analysis_run_id"] == expected_run_id
+    assert payload["analysis_run_id"] != "client-run"
     assert payload["ingestion_run_id"] == ingestion_run_id
     assert payload["symbol"] == "AAPL"
     assert payload["strategy"] == "RSI2"
     assert payload["signals"]
-    assert analysis_repo.get_run("run-snapshot") is not None
+    assert analysis_repo.get_run(expected_run_id) is not None
     assert signal_repo.list_signals(limit=10)
+
+
+def test_manual_analysis_changes_id_for_different_payload(tmp_path: Path, monkeypatch) -> None:
+    signal_repo = _make_signal_repo(tmp_path)
+    analysis_repo = _make_analysis_repo(tmp_path)
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
+
+    ingestion_run_id = str(uuid.uuid4())
+    _insert_ingestion_run(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        symbols=["AAPL"],
+        timeframe="D1",
+    )
+
+    rows = [
+        (1735689600000, 101.0, 102.0, 100.0, 101.0, 1000.0),
+        (1735776000000, 100.0, 101.0, 90.0, 91.0, 1000.0),
+        (1735862400000, 90.0, 91.0, 80.0, 81.0, 1000.0),
+    ]
+    _insert_snapshot_rows(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        "AAPL",
+        "D1",
+        rows,
+    )
+
+    def _fail_yahoo(*args, **kwargs):
+        raise AssertionError("yfinance should not be called")
+
+    def _fail_binance(*args, **kwargs):
+        raise AssertionError("ccxt should not be called")
+
+    monkeypatch.setattr("cilly_trading.engine.data._load_stock_yahoo", _fail_yahoo)
+    monkeypatch.setattr("cilly_trading.engine.data._load_crypto_binance", _fail_binance)
+
+    client = TestClient(api_main.app)
+    payload_base = {
+        "ingestion_run_id": ingestion_run_id,
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "market_type": "stock",
+    }
+    response_first = client.post(
+        "/analysis/run",
+        json={**payload_base, "lookback_days": 200},
+    )
+    assert response_first.status_code == 200
+    first_body = response_first.json()
+
+    response_second = client.post(
+        "/analysis/run",
+        json={**payload_base, "lookback_days": 201},
+    )
+    assert response_second.status_code == 200
+    second_body = response_second.json()
+
+    assert first_body["analysis_run_id"] != second_body["analysis_run_id"]
+
+
+def test_manual_analysis_strategy_config_float_idempotent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    signal_repo = _make_signal_repo(tmp_path)
+    analysis_repo = _make_analysis_repo(tmp_path)
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
+
+    ingestion_run_id = str(uuid.uuid4())
+    _insert_ingestion_run(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        symbols=["AAPL"],
+        timeframe="D1",
+    )
+
+    rows = [
+        (1735689600000, 101.0, 102.0, 100.0, 101.0, 1000.0),
+        (1735776000000, 100.0, 101.0, 90.0, 91.0, 1000.0),
+        (1735862400000, 90.0, 91.0, 80.0, 81.0, 1000.0),
+    ]
+    _insert_snapshot_rows(
+        tmp_path / "analysis.db",
+        ingestion_run_id,
+        "AAPL",
+        "D1",
+        rows,
+    )
+
+    def _fail_yahoo(*args, **kwargs):
+        raise AssertionError("yfinance should not be called")
+
+    def _fail_binance(*args, **kwargs):
+        raise AssertionError("ccxt should not be called")
+
+    monkeypatch.setattr("cilly_trading.engine.data._load_stock_yahoo", _fail_yahoo)
+    monkeypatch.setattr("cilly_trading.engine.data._load_crypto_binance", _fail_binance)
+
+    client = TestClient(api_main.app)
+    payload = {
+        "ingestion_run_id": ingestion_run_id,
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "market_type": "stock",
+        "lookback_days": 200,
+        "strategy_config": {"oversold_threshold": 15.0},
+    }
+
+    original_run_watchlist_analysis = api_main.run_watchlist_analysis
+
+    response_first = client.post("/analysis/run", json=payload)
+    assert response_first.status_code == 200
+    first_body = response_first.json()
+    assert first_body["analysis_run_id"]
+
+    def _fail_run_watchlist_analysis(*args, **kwargs):
+        raise AssertionError("run_watchlist_analysis should not be called")
+
+    monkeypatch.setattr(api_main, "run_watchlist_analysis", _fail_run_watchlist_analysis)
+
+    response_second = client.post("/analysis/run", json=payload)
+    assert response_second.status_code == 200
+    second_body = response_second.json()
+    assert second_body["analysis_run_id"] == first_body["analysis_run_id"]
+
+    monkeypatch.setattr(api_main, "run_watchlist_analysis", original_run_watchlist_analysis)
+
+    response_third = client.post(
+        "/analysis/run",
+        json={
+            **payload,
+            "strategy_config": {"oversold_threshold": 16.0},
+        },
+    )
+    assert response_third.status_code == 200
+    third_body = response_third.json()
+    assert third_body["analysis_run_id"] != first_body["analysis_run_id"]


### PR DESCRIPTION
### Motivation
- `compute_analysis_run_id` previously failed when `strategy_config` contained floats because the canonical JSON used for hashing rejected unnormalized floats, causing 500 errors.
- The change aims to make the server-side `analysis_run_id` computation robust and deterministic even when `strategy_config` includes floats while keeping runtime behavior unchanged.

### Description
- Add a local helper `_normalize_for_hashing` that recursively converts `float` values to deterministic strings using `format(value, ".10g")` and preserves other primitive types, lists, and dicts.
- Build the `run_request_payload` for hashing with the normalized `strategy_config` only, then compute `computed_run_id` via `compute_analysis_run_id` and use it for lookup, persistence, and the response.
- Keep engine execution unchanged by merging and passing the original `req.strategy_config` into the engine (`run_watchlist_analysis`) so runtime behavior is not altered.
- Modified files: `api/main.py` (add helper and use normalized payload for hashing) and `tests/test_api_manual_analysis_trigger.py` (add float-config idempotency test and adapt existing tests to expected computed run id behavior).

### Testing
- Ran the full test suite with `pytest -q` and all tests passed: `84 passed`.
- New test `test_manual_analysis_strategy_config_float_idempotent` verifies no 500 on float `strategy_config`, deterministic idempotent `analysis_run_id` across repeated calls, and that changing a run-defining float produces a different `analysis_run_id`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967ea6945a48333bce9db04efda4a0f)