### PR TITLE
Enforce snapshot readiness for analysis endpoints

### DIFF
--- a/tests/test_screener_v2.py
+++ b/tests/test_screener_v2.py
@@ -103,6 +103,7 @@ def test_screener_response_schema_and_ordering(monkeypatch) -> None:
 
     monkeypatch.setattr(main, "run_watchlist_analysis", fake_run_watchlist_analysis)
     monkeypatch.setattr(main, "_require_ingestion_run", lambda *_: None)
+    monkeypatch.setattr(main, "_require_snapshot_ready", lambda *_args, **_kwargs: None)
 
     request = main.ScreenerRequest(
         ingestion_run_id="test-ingestion-run",


### PR DESCRIPTION
### Motivation
- Ensure all analysis execution paths run only against persisted OHLCV snapshots so analyses are deterministic and snapshot-first semantics are enforced.

### Description
- Added `ingestion_run_is_ready(ingestion_run_id, *, symbols, timeframe)` to `SqliteAnalysisRunRepository` which returns False if the ingestion_run is missing or if any (symbol, timeframe) pair has no row in `ohlcv_snapshots`, and otherwise returns True while catching sqlite errors.
- Added `_require_snapshot_ready(ingestion_run_id, *, symbols, timeframe="D1")` helper in `api/main.py` that calls the repository method and raises `HTTPException(status_code=422, detail="ingestion_run_not_ready")` when not ready.
- Enforced snapshot readiness in `POST /strategy/analyze` (per-request symbol) and `POST /screener/basic` (resolved symbol list) by calling the new helper before running analysis.
- Updated tests to cover snapshot readiness semantics and to prevent external loaders from being invoked by patching them to fail when called, and made test DB inserts deterministic (timestamps) where needed.

### Testing
- Ran the full test suite with `pytest`; all tests passed: `87 passed`.
- Exercised snapshot-first tests: `tests/test_api_snapshot_first_enforcement.py` additions verify rejection when snapshots are missing/partial and acceptance when snapshots exist for all symbols.
- Updated existing preset and screener tests (`tests/test_api_strategy_analyze_presets.py`, `tests/test_screener_v2.py`) to insert snapshots or stub the readiness check and ensure deterministic behavior; these tests passed under the suite run.
- Confirmed external data loaders are not called in snapshot-ready paths by patching them to raise and observing no failures during tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f8943d308333a85d8c66dcc7a43e)