### PR TITLE
fix: enforce single GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+﻿blank_issues_enabled: false


### PR DESCRIPTION
Adds .github/ISSUE_TEMPLATE/config.yml to disable blank issues and enforce the unified issue template.
