### PR TITLE
Add linkage-aware reason persistence and deterministic reconstruction

### DIFF
--- a/src/cilly_trading/db/init_db.py
+++ b/src/cilly_trading/db/init_db.py
@@ -49,6 +49,8 @@ def init_db(db_path: Optional[Path] = None) -> None:
         """
         CREATE TABLE IF NOT EXISTS signals (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            analysis_run_id TEXT,
+            ingestion_run_id TEXT,
             symbol TEXT NOT NULL,
             strategy TEXT NOT NULL,
             direction TEXT NOT NULL,
@@ -60,7 +62,8 @@ def init_db(db_path: Optional[Path] = None) -> None:
             confirmation_rule TEXT,
             timeframe TEXT NOT NULL,          -- z. B. "D1"
             market_type TEXT NOT NULL,        -- "stock" | "crypto"
-            data_source TEXT NOT NULL         -- "yahoo" | "binance"
+            data_source TEXT NOT NULL,        -- "yahoo" | "binance"
+            reasons_json TEXT
         );
         """
     )

--- a/tests/test_reason_persistence_and_reconstruction.py
+++ b/tests/test_reason_persistence_and_reconstruction.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.models import compute_signal_id, compute_signal_reason_id
+from cilly_trading.repositories.signals_sqlite import (
+    SignalReconstructionError,
+    SqliteSignalRepository,
+    reconstruct_signal_explanation,
+)
+
+
+def _make_repo(tmp_path: Path) -> SqliteSignalRepository:
+    db_path = tmp_path / "test_signals.db"
+    return SqliteSignalRepository(db_path=db_path)
+
+
+def _base_signal(**overrides):
+    base = {
+        "analysis_run_id": "analysis-run-1",
+        "ingestion_run_id": "ingestion-run-1",
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "direction": "long",
+        "score": 0.9,
+        "timestamp": "2025-01-01T00:00:00Z",
+        "stage": "setup",
+        "timeframe": "D1",
+        "market_type": "stock",
+        "data_source": "yahoo",
+    }
+    base.update(overrides)
+    return base
+
+
+def _build_reason(
+    *,
+    signal_id: str,
+    ordering_key: int,
+    rule_id: str,
+    data_id: str,
+    data_value: float,
+    timestamp: str,
+) -> dict:
+    reason = {
+        "reason_type": "STATE_TRANSITION",
+        "signal_id": signal_id,
+        "rule_ref": {
+            "rule_id": rule_id,
+            "rule_version": "1.0",
+        },
+        "data_refs": [
+            {
+                "data_type": "STATE_VALUE",
+                "data_id": data_id,
+                "value": data_value,
+                "timestamp": timestamp,
+            }
+        ],
+        "ordering_key": ordering_key,
+    }
+    reason["reason_id"] = compute_signal_reason_id(
+        signal_id=signal_id,
+        reason_type=reason["reason_type"],
+        rule_ref=reason["rule_ref"],
+        data_refs=reason["data_refs"],
+    )
+    return reason
+
+
+def _signal_with_reasons():
+    signal = _base_signal()
+    signal_id = compute_signal_id(signal)
+    reasons = [
+        _build_reason(
+            signal_id=signal_id,
+            ordering_key=10,
+            rule_id="rule-alpha",
+            data_id="state-1",
+            data_value=1.0,
+            timestamp="2025-01-01T00:00:00Z",
+        ),
+        _build_reason(
+            signal_id=signal_id,
+            ordering_key=20,
+            rule_id="rule-beta",
+            data_id="state-2",
+            data_value=2.0,
+            timestamp="2025-01-01T00:00:00Z",
+        ),
+    ]
+    signal["reasons"] = reasons
+    return signal
+
+
+def test_persist_reasons_roundtrip(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    signal = _signal_with_reasons()
+
+    repo.save_signals([signal])
+
+    rows = repo.list_signals(limit=1)
+    assert rows[0]["analysis_run_id"] == signal["analysis_run_id"]
+    assert rows[0]["ingestion_run_id"] == signal["ingestion_run_id"]
+    assert rows[0]["reasons"] == signal["reasons"]
+
+
+def test_reconstruct_signal_explanation_success() -> None:
+    signal = _signal_with_reasons()
+
+    explanation = reconstruct_signal_explanation(signal)
+
+    assert explanation["signal_id"] == compute_signal_id(signal)
+    assert explanation["symbol"] == signal["symbol"]
+    assert explanation["reasons"] == signal["reasons"]
+
+
+def test_reconstruct_signal_explanation_missing_reasons() -> None:
+    signal = _base_signal()
+
+    with pytest.raises(SignalReconstructionError, match="Signal reasons are missing"):
+        reconstruct_signal_explanation(signal)
+
+
+def test_reconstruct_signal_explanation_invalid_reason_id() -> None:
+    signal = _signal_with_reasons()
+    signal["reasons"][0]["reason_id"] = "sr_invalid"
+
+    with pytest.raises(SignalReconstructionError, match="Signal reason ID does not match"):
+        reconstruct_signal_explanation(signal)
+
+
+def test_reconstruct_signal_explanation_non_canonical_order() -> None:
+    signal = _signal_with_reasons()
+    signal["reasons"] = list(reversed(signal["reasons"]))
+
+    with pytest.raises(SignalReconstructionError, match="not in canonical order"):
+        reconstruct_signal_explanation(signal)
+
+
+def test_reconstruct_signal_explanation_missing_linkage() -> None:
+    signal = _signal_with_reasons()
+    signal.pop("analysis_run_id")
+
+    with pytest.raises(
+        SignalReconstructionError,
+        match="missing required fields for reconstruction",
+    ):
+        reconstruct_signal_explanation(signal)


### PR DESCRIPTION
### Motivation
- Persist the full reasons payload alongside signals and ensure deterministic, canonical serialization for auditability and reproducible analyst reconstruction.
- Enforce stable linkage between signals and runs via `analysis_run_id` and `ingestion_run_id` so reconstruction can be validated from stored data only.
- Remove repository dependency on engine internals to avoid layering/cycle risks and allow reconstruction without re-executing the engine.

### Description
- Add `analysis_run_id`, `ingestion_run_id` and `reasons_json` to the `signals` schema and migration logic in `src/cilly_trading/db/init_db.py` so these fields exist for new DBs.
- Move deterministic ID helpers into the neutral models layer by adding `canonical_json`, `sha256_hex`, `_signal_identity_payload`, and `compute_signal_id` to `src/cilly_trading/models.py` and keep `compute_signal_reason_id` there.
- Update `src/cilly_trading/repositories/signals_sqlite.py` to remove the `engine.core` dependency, ensure signal columns exist, persist and return `analysis_run_id`/`ingestion_run_id`, serialize reasons with canonical JSON (`json.dumps(..., separators=(",", ":"), ensure_ascii=False, sort_keys=True)`), and include rigorous `reconstruct_signal_explanation()` checks that require linkage and validate deterministic `signal_id` and `reason_id` and canonical ordering.
- Update tests in `tests/test_reason_persistence_and_reconstruction.py` to include linkage in the success case and to assert reconstruction fails when linkage is missing or reasons are malformed/non-canonical.

### Testing
- Ran the full test suite with `pytest -q` and all tests passed: `104 passed in 21.84s`.
- Ran the reasons persistence/reconstruction tests which exercise roundtrip persistence, canonical ordering and linkage failure modes and they passed as part of the full suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ab3a2de2c8333a887fe1022dbc566)