### PR TITLE
Enforce snapshot immutability in SQLite

### DIFF
--- a/src/cilly_trading/db/init_db.py
+++ b/src/cilly_trading/db/init_db.py
@@ -177,6 +177,24 @@ def init_db(db_path: Optional[Path] = None) -> None:
           ON ohlcv_snapshots(ingestion_run_id, symbol, timeframe, ts);
         """
     )
+    cur.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_ohlcv_snapshots_no_update
+        BEFORE UPDATE ON ohlcv_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'snapshot_immutable');
+        END;
+        """
+    )
+    cur.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS trg_ohlcv_snapshots_no_delete
+        BEFORE DELETE ON ohlcv_snapshots
+        BEGIN
+            SELECT RAISE(ABORT, 'snapshot_immutable');
+        END;
+        """
+    )
 
     conn.commit()
     conn.close()

--- a/tests/test_snapshot_immutability.py
+++ b/tests/test_snapshot_immutability.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.db.init_db import get_connection, init_db
+
+
+def _insert_ingestion_run(conn: sqlite3.Connection, ingestion_run_id: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO ingestion_runs (
+            ingestion_run_id,
+            created_at,
+            source,
+            symbols_json,
+            timeframe,
+            fingerprint_hash
+        )
+        VALUES (?, ?, ?, ?, ?, ?);
+        """,
+        (
+            ingestion_run_id,
+            datetime.now(timezone.utc).isoformat(),
+            "test",
+            json.dumps(["AAPL"]),
+            "D1",
+            None,
+        ),
+    )
+
+
+def _insert_snapshot_row(conn: sqlite3.Connection, ingestion_run_id: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO ohlcv_snapshots (
+            ingestion_run_id,
+            symbol,
+            timeframe,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            ingestion_run_id,
+            "AAPL",
+            "D1",
+            1735689600000,
+            101.0,
+            102.0,
+            100.0,
+            101.0,
+            1000.0,
+        ),
+    )
+
+
+def _snapshot_row_count(conn: sqlite3.Connection, ingestion_run_id: str) -> int:
+    cur = conn.execute(
+        """
+        SELECT COUNT(*) AS total
+        FROM ohlcv_snapshots
+        WHERE ingestion_run_id = ?;
+        """,
+        (ingestion_run_id,),
+    )
+    row = cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+def test_snapshot_rows_are_immutable(tmp_path: Path) -> None:
+    db_path = tmp_path / "analysis.db"
+    init_db(db_path)
+    conn = get_connection(db_path)
+    try:
+        ingestion_run_id = "00000000-0000-4000-8000-000000000000"
+        _insert_ingestion_run(conn, ingestion_run_id)
+        _insert_snapshot_row(conn, ingestion_run_id)
+        conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError) as update_error:
+            conn.execute(
+                """
+                UPDATE ohlcv_snapshots
+                SET close = 999.0
+                WHERE ingestion_run_id = ?;
+                """,
+                (ingestion_run_id,),
+            )
+        assert "snapshot_immutable" in str(update_error.value)
+
+        with pytest.raises(sqlite3.IntegrityError) as delete_error:
+            conn.execute(
+                """
+                DELETE FROM ohlcv_snapshots
+                WHERE ingestion_run_id = ?;
+                """,
+                (ingestion_run_id,),
+            )
+        assert "snapshot_immutable" in str(delete_error.value)
+
+        assert _snapshot_row_count(conn, ingestion_run_id) == 1
+    finally:
+        conn.close()


### PR DESCRIPTION
### Motivation
- Prevent UPDATE/DELETE against `ohlcv_snapshots` at the SQLite layer so snapshot rows remain immutable as documented. 
- Provide a minimal, deterministic enforcement that yields a stable error message for automated checks and tests.

### Description
- Add `trg_ohlcv_snapshots_no_update` and `trg_ohlcv_snapshots_no_delete` triggers in `src/cilly_trading/db/init_db.py` that perform `SELECT RAISE(ABORT, 'snapshot_immutable')` on `BEFORE UPDATE` and `BEFORE DELETE` respectively. 
- Ensure triggers are created during database initialization where the `ohlcv_snapshots` table is created. 
- Add `tests/test_snapshot_immutability.py` which inserts an ingestion and a snapshot row, asserts UPDATE and DELETE raise a `sqlite3.IntegrityError` containing `snapshot_immutable`, and confirms the row still exists. 
- Modified file: `src/cilly_trading/db/init_db.py` and added file: `tests/test_snapshot_immutability.py`.

### Testing
- Ran `pytest -q` and the test suite completed successfully with `105 passed in 6.84s`, including the new `test_snapshot_immutability.py` test. 
- The new test verifies INSERT still works and that UPDATE and DELETE fail deterministically with the `snapshot_immutable` error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b68c04c508333a4e024fd0b5c2011)