### PR TITLE
Align strategy config docs with implemented parameter specs

### DIFF
--- a/docs/api/usage_contract.md
+++ b/docs/api/usage_contract.md
@@ -67,6 +67,17 @@ These errors are emitted by `/strategy/analyze`, `/analysis/run`, and `/screener
 - `RSI2`
 - `TURTLE`
 
+### Strategy configuration normalization (as implemented)
+
+- Strategy configs are optional; `null` or `{}` resolves to an empty config.
+- Configs must be mappings; non-mapping values are logged and treated as empty configs.
+- Only implemented parameters are accepted; unknown keys are ignored and logged.
+- Supported aliases:
+  - `RSI2`: `oversold` → `oversold_threshold`
+  - `TURTLE`: `entry_lookback` → `breakout_lookback`, `proximity_threshold` → `proximity_threshold_pct`
+- If both a canonical key and its alias are provided, the engine raises an error and skips the strategy.
+- Invalid types or out-of-range values for known keys raise an error and skip the strategy (no signals for that strategy).
+
 ### Market types
 
 - `stock`
@@ -641,7 +652,7 @@ curl -s -X POST http://localhost:8000/screener/basic \
 
 - `ingestion_run_id` (snapshot reference ID)
 - Request payload (symbol(s), strategy, market_type, lookback_days, strategy_config/presets)
-- Strategy configuration used (defaults + overrides)
+- Strategy configuration used (normalized config after alias resolution; unknown keys removed)
 - Timeframe (`D1` in MVP)
 
 ### Outputs to store/log

--- a/docs/strategy-configs.md
+++ b/docs/strategy-configs.md
@@ -10,24 +10,27 @@ Dieses Dokument beschreibt das **offizielle Strategy-Config-Schema** für den **
 
 ### Wichtige Regeln (verbindlich)
 
-- Alle Strategy-Configs sind **optional**
-- `None` oder `{}` → es werden **vollständige Defaults** verwendet
-- Fehlende Keys → **Default pro Key**
-- Ungültige Typen oder Werte → **deterministischer Fallback auf Default**
-- Unbekannte Keys → **werden ignoriert**
-- Das Verhalten ist **backward compatible**
-- Strategy-Configs dürfen **niemals** einen Engine-Crash verursachen
+- Strategy-Configs sind **optional**.
+- `None` oder `{}` → leere Config (`{}`).
+- Fehlende Keys → bleiben **ungesetzt** (keine Defaults pro Key aus der Config-Normalisierung).
+- Unbekannte Keys → werden **ignoriert** und als Warning geloggt.
+- Ungültige Typen oder Werte bei bekannten Keys → **Fehler**; die Strategie wird im Engine-Lauf **übersprungen**.
+- Konflikt zwischen Alias und Canonical-Key → **Fehler**; die Strategie wird im Engine-Lauf **übersprungen**.
+- Ungültiger Config-Typ (kein Mapping) → Warning, es wird eine **leere Config** verwendet.
 
 ---
 
 ## Allgemeines Config-Verhalten
 
-- Strategy-Configs werden **vor der Strategy-Ausführung normalisiert**
-- Jede Strategie arbeitet intern immer mit einer:
-  - vollständigen
-  - typsicheren
-  - validierten Konfiguration
-- Strategien enthalten **keine I/O-Logik** und **keine eigene Config-Validierung**
+- Strategy-Configs werden **vor der Strategy-Ausführung normalisiert und validiert**.
+- Aliases werden auf Canonical-Keys aufgelöst (siehe pro Strategie).
+- Bekannte Parameter werden typisiert und gegen Min/Max geprüft.
+- Die Normalisierung liefert **nur** die bekannten, validen Keys.
+
+### Typ-Normalisierung (für implementierte Parameter)
+
+- `int`: akzeptiert `int`, `float` mit ganzzahligem Wert (z. B. `2.0`) und numerische Strings (z. B. `"2"`).
+- `float`: akzeptiert `int`, `float` und numerische Strings (z. B. `"2.5"`).
 
 ---
 
@@ -35,24 +38,20 @@ Dieses Dokument beschreibt das **offizielle Strategy-Config-Schema** für den **
 
 ### Beschreibung
 
-RSI2 ist eine kurzfristige Mean-Reversion-Strategie basierend auf einem sehr kurzen RSI-Indikator, optional kombiniert mit einem Trendfilter.
+RSI2 ist eine kurzfristige Mean-Reversion-Strategie basierend auf einem sehr kurzen RSI-Indikator.
 
 ### Konfigurations-Keys
 
-| Key | Typ | Default | Beschreibung | Constraints |
-|---|---|---:|---|---|
-| rsi_period | int | 2 | RSI-Periode | >= 2 |
-| oversold | float | 10.0 | Buy-Trigger | 0 ≤ oversold < overbought ≤ 100 |
-| overbought | float | 70.0 | Exit-Trigger | 0 ≤ oversold < overbought ≤ 100 |
-| trend_filter | bool | true | Trendfilter aktiv | – |
-| trend_ma_period | int | 200 | MA-Periode | >= 1 |
-| trend_filter_mode | str | price_above_ma | Trendfilter-Modus | intern definiert |
-| min_bars | int | 250 | Mindestanzahl Bars | >= max(rsi, ma) |
+| Key | Typ | Alias | Beschreibung | Constraints |
+|---|---|---|---|---|
+| `rsi_period` | int | – | RSI-Periode | `>= 1` |
+| `oversold_threshold` | float | `oversold` | Oversold-Schwelle | `0.0 .. 100.0` |
+| `min_score` | float | – | Mindest-Score | `0.0 .. 100.0` |
 
 ### Minimal-Beispiel
 
 ```json
-{ "oversold": 5, "overbought": 80 }
+{ "oversold": 5, "min_score": 40 }
 ```
 
 ---
@@ -61,33 +60,26 @@ RSI2 ist eine kurzfristige Mean-Reversion-Strategie basierend auf einem sehr kur
 
 ### Beschreibung
 
-Turtle ist eine klassische Breakout-Trendfolge-Strategie auf Basis von Donchian-Kanälen.
+Turtle ist eine klassische Breakout-Trendfolge-Strategie.
 
 ### Konfigurations-Keys
 
-| Key | Typ | Default | Beschreibung | Constraints |
-|---|---|---:|---|---|
-| entry_lookback | int | 20 | Entry-Lookback | >= 2 |
-| exit_lookback | int | 10 | Exit-Lookback | >= 2 |
-| atr_period | int | 20 | ATR-Periode | >= 2 |
-| stop_atr_mult | float | 2.0 | Stop-Distanz | > 0 |
-| risk_per_trade | float | 0.01 | Risiko pro Trade | 0 < v ≤ 0.05 |
-| max_units | int | 4 | Max Units | >= 1 |
-| unit_add_atr | float | 0.5 | Unit-Abstand | > 0 |
-| allow_short | bool | false | Shorts erlaubt | – |
-| min_bars | int | 60 | Mindestanzahl Bars | >= max(entry, exit, atr) |
+| Key | Typ | Alias | Beschreibung | Constraints |
+|---|---|---|---|---|
+| `breakout_lookback` | int | `entry_lookback` | Breakout-Lookback | `>= 1` |
+| `proximity_threshold_pct` | float | `proximity_threshold` | Nähe zum Breakout-Level (Prozent) | `0.0 .. 1.0` |
+| `min_score` | float | – | Mindest-Score | `0.0 .. 100.0` |
 
 ### Minimal-Beispiel
 
 ```json
-{ "entry_lookback": 55, "exit_lookback": 20, "allow_short": true }
+{ "entry_lookback": 55, "proximity_threshold": 0.2 }
 ```
 
 ---
 
 ## Kompatibilität
 
-- Alle Keys optional
-- Fehlende / ungültige Werte werden ersetzt
-- Unbekannte Keys werden ignoriert
-- Vollständig backward compatible
+- Nur die oben gelisteten Keys sind implementiert.
+- Unbekannte Keys werden ignoriert; bekannte Keys werden strikt validiert.
+- Es gibt keine stillen Defaults oder Fallbacks in der Config-Normalisierung.


### PR DESCRIPTION
### Motivation

- Ensure the public strategy configuration documentation exactly reflects the engine's implemented parameter specifications, aliases, and validation behavior without changing runtime logic.
- Remove misleading statements about silent defaults and fallback behavior so users know how the engine will treat unknown, invalid, or aliased config keys.

### Description

- Updated `docs/strategy-configs.md` to list only the parameters implemented in `STRATEGY_PARAMETER_SPECS` and to document their names, types, ranges, and aliases (RSI2: `rsi_period`, `oversold_threshold` (alias `oversold`), `min_score`; TURTLE: `breakout_lookback` (alias `entry_lookback`), `proximity_threshold_pct` (alias `proximity_threshold`), `min_score`).
- Replaced prior doc text that implied per-key defaults and automatic fallbacks with precise wording: `None`/`{}` resolves to an empty config, missing keys remain unset, unknown keys are ignored and logged, and canonical/alias conflicts or invalid types/ranges raise errors that cause the strategy to be skipped during a run.
- Added `Strategy configuration normalization (as implemented)` to `docs/api/usage_contract.md` documenting alias resolution, unknown-key handling, error behavior, and the supported alias mappings used by the engine.
- This PR is documentation-only and makes no changes to any files under `src/` or to runtime validation logic.

### Testing

- Automated tests: none executed because this change only updates documentation files. All changes are descriptive and mirror the existing implementation.`}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b784238588333b9f8d8630fa1e308)