### PR TITLE
Document strategy config skip semantics and analyst guidance

### DIFF
--- a/docs/analyst-workflow.md
+++ b/docs/analyst-workflow.md
@@ -43,6 +43,9 @@ Signals produced by the run are retrieved from the run’s results. When the sna
 # Inspect Results
 The results are inspected as the authoritative record of the run. They include the signals and any metadata produced by the engine during execution.
 
+# Interpret Missing or Empty Signals
+Empty or missing signals do not automatically indicate an error. A strategy may be skipped if its configuration is invalid, and skipped strategies emit no signals. Determinism includes skip behavior: identical invalid configurations result in identical skips across runs.
+
 # Reason About Output
 Reasoning about the output is based solely on the snapshot and the deterministic run semantics. Identical snapshots yield identical signals and results, assuming the snapshot-only path is used.
 

--- a/docs/api/usage_contract.md
+++ b/docs/api/usage_contract.md
@@ -78,6 +78,21 @@ These errors are emitted by `/strategy/analyze`, `/analysis/run`, and `/screener
 - If both a canonical key and its alias are provided, the engine raises an error and skips the strategy.
 - Invalid types or out-of-range values for known keys raise an error and skip the strategy (no signals for that strategy).
 
+### Strategy config invalidation and skip semantics (as implemented)
+
+Invalid `strategy_config` values do **not** fail the request. The API still returns `200 OK`, and the affected strategy is **skipped** with **no signals produced** for that strategy.
+
+**Skip causes (exactly as implemented):**
+
+- Invalid types for known strategy keys.
+- Out-of-range values for known strategy keys.
+- Alias and canonical key conflicts (both provided).
+
+**Boundary clarification:**
+
+- Snapshot/ingestion validation errors fail the request (see Error semantics).
+- Strategy config errors only skip the affected strategy; the request remains successful.
+
 ### Market types
 
 - `stock`


### PR DESCRIPTION
### Motivation
- Make the runtime behavior explicit when a provided `strategy_config` is invalid so callers and analysts can interpret results unambiguously.
- Clarify the boundary between snapshot/ingestion validation (which fails the request) and per-strategy config errors (which skip the strategy) without introducing any new behavior or semantics.

### Description
- Added a new section to `docs/api/usage_contract.md` that documents that invalid `strategy_config` values do **not** fail the request, that the API still returns `200 OK`, and that the affected strategy is skipped with no signals produced.
- Explicitly enumerated the exact skip causes implemented: invalid types for known keys, out-of-range values for known keys, and alias + canonical key conflicts.
- Clarified the boundary that snapshot/ingestion validation errors fail the request (see `422` errors) while strategy config errors only skip the affected strategy.
- Added analyst-facing guidance to `docs/analyst-workflow.md` stating that empty or missing signals do not necessarily indicate an error, that strategies may be skipped due to invalid config, and that skip behavior is deterministic for identical invalid configs.

### Testing
- No automated tests were run because this is a documentation-only change; behavior documented matches the existing runtime implementation.
- Files modified: `docs/api/usage_contract.md`, `docs/analyst-workflow.md`.
- PR summary: Documented strategy config invalidation skip semantics and clarified analyst interpretation of empty signals.

## Summary
Documents invalid `strategy_config` handling as implemented: invalid configs skip the affected strategy (no signals) while the request remains `200 OK`. Clarifies boundary to snapshot/ingestion validation failures.

## Changes
- docs/api/usage_contract.md: add explicit invalid-config skip semantics + boundary to request-level failures
- docs/analyst-workflow.md: analyst guidance for interpreting empty/missing signals and deterministic skip behavior

## Testing
Not run (docs-only change).

Closes #141

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b806dd200833395ab148b38062d2c)