### PR TITLE
Add numeric precision guard and deterministic serialization tests

### DIFF
--- a/docs/numeric_output_precision.md
+++ b/docs/numeric_output_precision.md
@@ -1,0 +1,20 @@
+# Numeric Output Precision Rules
+
+## Rule Summary
+
+All floating-point values emitted in analysis output payloads must be stable under a fixed precision
+rule:
+
+- **Precision:** values must round to **4 decimal places** using standard half-up rounding.
+- **Tolerance:** the absolute delta between the stored float and its 4-decimal rounded value must be
+  less than or equal to `1e-9`.
+- **Serialization:** deterministic JSON serialization is required (sorted keys, no NaN/Infinity, and
+  compact separators) to keep payloads byte-stable across runs.
+
+These rules prevent floating-point drift from causing silent regressions while preserving the
+current runtime behavior.
+
+## Tests
+
+The numeric precision guard is enforced in `tests/numeric/test_numeric_precision_guard.py`, and
+serialization stability is validated by comparing stable JSON outputs across repeated runs.

--- a/tests/numeric/test_numeric_precision_guard.py
+++ b/tests/numeric/test_numeric_precision_guard.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.utils.golden_master import prepare_snapshot_db, run_fixed_analysis, stable_json_dumps
+from tests.utils.numeric_precision import find_numeric_precision_violations
+
+
+def _build_payload(tmp_path: Path) -> dict:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    db_path = tmp_path / "analysis.db"
+    prepare_snapshot_db(db_path)
+    return run_fixed_analysis(db_path)
+
+
+def test_numeric_precision_rule(tmp_path: Path) -> None:
+    payload = _build_payload(tmp_path / "precision")
+    violations = find_numeric_precision_violations(payload)
+    assert not violations, (
+        "Numeric precision drift detected:\n"
+        + "\n".join(
+            f"- {violation.path}: value={violation.value} rounded={violation.rounded} delta={violation.delta}"
+            for violation in violations
+        )
+    )
+
+
+def test_numeric_output_stable_across_runs(tmp_path: Path) -> None:
+    payload_a = _build_payload(tmp_path / "run_a")
+    payload_b = _build_payload(tmp_path / "run_b")
+
+    json_a = stable_json_dumps(payload_a)
+    json_b = stable_json_dumps(payload_b)
+
+    assert json_a == json_b

--- a/tests/utils/numeric_precision.py
+++ b/tests/utils/numeric_precision.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Iterable, List, Sequence
+
+
+PRECISION_PLACES = 4
+PRECISION_EPSILON = Decimal("1e-9")
+
+
+@dataclass(frozen=True)
+class NumericViolation:
+    path: str
+    value: float
+    rounded: str
+    delta: str
+
+
+def _decimal_quantize(value: float) -> tuple[Decimal, Decimal]:
+    raw = Decimal(str(value))
+    quantum = Decimal(f"1.{('0' * PRECISION_PLACES)}")
+    rounded = raw.quantize(quantum, rounding=ROUND_HALF_UP)
+    return raw, rounded
+
+
+def _format_path(path: Sequence[str | int]) -> str:
+    rendered: List[str] = []
+    for part in path:
+        if isinstance(part, int):
+            rendered.append(f"[{part}]")
+        else:
+            rendered.append(f".{part}" if rendered else str(part))
+    return "".join(rendered)
+
+
+def _collect_paths(value: Any, *, prefix: Sequence[str | int] = ()) -> Iterable[tuple[Sequence[str | int], Any]]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from _collect_paths(child, prefix=(*prefix, key))
+        return
+    if isinstance(value, list):
+        for idx, child in enumerate(value):
+            yield from _collect_paths(child, prefix=(*prefix, idx))
+        return
+    yield prefix, value
+
+
+def find_numeric_precision_violations(payload: Any) -> List[NumericViolation]:
+    violations: List[NumericViolation] = []
+    for path, value in _collect_paths(payload):
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, float):
+            raw, rounded = _decimal_quantize(value)
+            delta = abs(raw - rounded)
+            if delta > PRECISION_EPSILON:
+                violations.append(
+                    NumericViolation(
+                        path=_format_path(path),
+                        value=value,
+                        rounded=str(rounded),
+                        delta=str(delta),
+                    )
+                )
+    return violations


### PR DESCRIPTION
### Motivation

- Prevent silent regressions caused by tiny floating-point drift by enforcing a stable numeric formatting and deterministic serialization rule.
- Provide automated detection so test suites fail with clear field-level reporting when numeric outputs violate the precision rule.

### Description

- Add a numeric precision detection helper in `tests/utils/numeric_precision.py` that walks payloads, rounds floats to 4 decimal places using half-up rounding, and reports violations when delta > 1e-9. 
- Add tests in `tests/numeric/test_numeric_precision_guard.py` that assert the precision rule for a fixed analysis payload and verify stable JSON serialization across repeated runs using existing golden-master helpers. 
- Document the numeric precision and serialization rules in `docs/numeric_output_precision.md` (4 decimal places, half-up rounding, tolerance <= 1e-9, deterministic JSON serialization). 

### Testing

- Executed `pytest tests/numeric/test_numeric_precision_guard.py` which ran 2 tests and both passed (2 passed in ~2.30s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976849cf154833384fbf624317c7eea)