### PR TITLE
Fix breaking change gate behavior

### DIFF
--- a/documentation/breaking-change-regeln.md
+++ b/documentation/breaking-change-regeln.md
@@ -1,0 +1,25 @@
+# Breaking-Change-Regeln für versionierte Schemas
+
+Diese Regeln definieren, was als Breaking Change für versionierte Schemas gilt und wann ein Major-Version-Bump erforderlich ist.
+
+## Was ist ein Breaking Change?
+
+Ein Breaking Change liegt vor, wenn eine der folgenden Änderungen an einem versionierten Schema vorgenommen wird:
+
+- **Feld entfernt**: Ein bestehendes Feld ist im neuen Schema nicht mehr vorhanden.
+- **Typ geändert**: Der Datentyp eines bestehenden Feldes wird geändert.
+- **Requiredness geändert**: Ein Feld wechselt zwischen `required` und `optional`.
+
+## Wann ist ein Major-Version-Bump erforderlich?
+
+Wenn ein Breaking Change erkannt wird, muss die **Major-Version** des Schemas erhöht werden. Ein Breaking Change ohne Major-Version-Bump ist nicht zulässig.
+
+## Testbasierte Durchsetzung
+
+Die Tests simulieren Breaking Changes, indem sie ein Feld entfernen, den Typ ändern oder die Requiredness ändern, ohne die Major-Version zu erhöhen. Der Fehlerfall wird per erwarteter Assertion geprüft und muss eine Fehlermeldung liefern, die:
+
+- die verletzte Regel (z. B. „Field removed“),
+- den betroffenen Feldpfad (z. B. `$.signal.score`),
+- und den Hinweis „Major version bump required“
+
+enthält.

--- a/tests/schema/test_schema_breaking_change_gate.py
+++ b/tests/schema/test_schema_breaking_change_gate.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from tests.utils.schema_breaking_change_detector import (
+    assert_no_breaking_changes_without_major_bump,
+    detect_breaking_changes,
+    extract_major_version,
+)
+
+
+def _base_schema() -> Dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "schema_version": {"type": "string", "enum": ["1.0.0"]},
+            "signal": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "score": {"type": "number"},
+                },
+                "required": ["id", "score"],
+                "additionalProperties": False,
+            },
+        },
+        "required": ["schema_version", "signal"],
+        "additionalProperties": False,
+    }
+
+
+def _breaking_removed_field_schema() -> Dict[str, Any]:
+    schema = _base_schema()
+    schema["properties"]["signal"]["properties"].pop("score")
+    schema["properties"]["signal"]["required"] = ["id"]
+    return schema
+
+
+def _breaking_type_change_schema() -> Dict[str, Any]:
+    schema = _base_schema()
+    schema["properties"]["signal"]["properties"]["score"]["type"] = "string"
+    return schema
+
+
+def _breaking_requiredness_schema() -> Dict[str, Any]:
+    schema = _base_schema()
+    schema["properties"]["signal"]["required"] = ["id"]
+    return schema
+
+
+@pytest.mark.parametrize(
+    "schema_factory, expected_rule, expected_field",
+    [
+        (_breaking_removed_field_schema, "Field removed", "$.signal.score"),
+        (_breaking_type_change_schema, "Type changed", "$.signal.score"),
+        (_breaking_requiredness_schema, "Requiredness changed", "$.signal.score"),
+    ],
+)
+def test_breaking_change_requires_major_bump(schema_factory, expected_rule, expected_field) -> None:
+    old_schema = _base_schema()
+    new_schema = schema_factory()
+
+    changes = detect_breaking_changes(old_schema, new_schema)
+
+    assert changes, "Expected breaking changes to be detected"
+    assert changes[0].rule == expected_rule
+    assert changes[0].field_path == expected_field
+    old_major = extract_major_version(old_schema)
+    new_major = extract_major_version(new_schema)
+    assert old_major == new_major, "Expected no major version bump in test fixture"
+
+    with pytest.raises(AssertionError) as exc:
+        assert_no_breaking_changes_without_major_bump(old_schema, new_schema)
+    error_message = str(exc.value)
+    assert expected_rule in error_message
+    assert expected_field in error_message
+    assert "Major version bump required." in error_message
+
+
+def test_breaking_change_allows_major_bump() -> None:
+    old_schema = _base_schema()
+    new_schema = _breaking_removed_field_schema()
+    new_schema["properties"]["schema_version"]["enum"] = ["2.0.0"]
+
+    assert_no_breaking_changes_without_major_bump(old_schema, new_schema)

--- a/tests/utils/schema_breaking_change_detector.py
+++ b/tests/utils/schema_breaking_change_detector.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class BreakingChange:
+    rule: str
+    field_path: str
+    details: str
+
+
+def detect_breaking_changes(old_schema: Dict[str, Any], new_schema: Dict[str, Any]) -> List[BreakingChange]:
+    changes: List[BreakingChange] = []
+    _compare_schema(old_schema, new_schema, path="$", changes=changes, root_old=old_schema, root_new=new_schema)
+    return changes
+
+
+def extract_major_version(schema: Dict[str, Any]) -> Optional[int]:
+    version = _extract_schema_version(schema)
+    if version is None:
+        return None
+    major_text = version.split(".", 1)[0]
+    if not major_text.isdigit():
+        return None
+    return int(major_text)
+
+
+def assert_no_breaking_changes_without_major_bump(
+    old_schema: Dict[str, Any],
+    new_schema: Dict[str, Any],
+) -> None:
+    changes = detect_breaking_changes(old_schema, new_schema)
+    if not changes:
+        return
+    old_major = extract_major_version(old_schema)
+    new_major = extract_major_version(new_schema)
+    if old_major is not None and new_major is not None and new_major > old_major:
+        return
+    first_change = changes[0]
+    message = (
+        f"Breaking change detected: {first_change.rule} at {first_change.field_path}. "
+        "Major version bump required."
+    )
+    raise AssertionError(message)
+
+
+def _extract_schema_version(schema: Dict[str, Any]) -> Optional[str]:
+    properties = schema.get("properties", {})
+    version_schema = properties.get("schema_version")
+    if not isinstance(version_schema, dict):
+        return None
+    enum_values = version_schema.get("enum")
+    if not isinstance(enum_values, list) or not enum_values:
+        return None
+    version = enum_values[0]
+    return version if isinstance(version, str) else None
+
+
+def _compare_schema(
+    old_schema: Dict[str, Any],
+    new_schema: Dict[str, Any],
+    *,
+    path: str,
+    changes: List[BreakingChange],
+    root_old: Dict[str, Any],
+    root_new: Dict[str, Any],
+) -> None:
+    old_resolved = _resolve_ref(old_schema, root_old)
+    new_resolved = _resolve_ref(new_schema, root_new)
+
+    old_type = _normalized_type(old_resolved)
+    new_type = _normalized_type(new_resolved)
+
+    if old_type is not None and new_type is not None and old_type != new_type:
+        changes.append(
+            BreakingChange(
+                rule="Type changed",
+                field_path=path,
+                details=f"Expected {old_type} but got {new_type}",
+            )
+        )
+        return
+
+    if old_type == "object" and new_type == "object":
+        _compare_object(old_resolved, new_resolved, path=path, changes=changes, root_old=root_old, root_new=root_new)
+        return
+
+    if old_type == "array" and new_type == "array":
+        _compare_array(old_resolved, new_resolved, path=path, changes=changes, root_old=root_old, root_new=root_new)
+
+
+def _compare_object(
+    old_schema: Dict[str, Any],
+    new_schema: Dict[str, Any],
+    *,
+    path: str,
+    changes: List[BreakingChange],
+    root_old: Dict[str, Any],
+    root_new: Dict[str, Any],
+) -> None:
+    old_props = old_schema.get("properties", {})
+    new_props = new_schema.get("properties", {})
+    old_required = set(_as_sequence(old_schema.get("required")))
+    new_required = set(_as_sequence(new_schema.get("required")))
+
+    for key, old_prop in old_props.items():
+        field_path = f"{path}.{key}"
+        if key not in new_props:
+            changes.append(
+                BreakingChange(
+                    rule="Field removed",
+                    field_path=field_path,
+                    details="Field no longer present in schema",
+                )
+            )
+            continue
+
+        new_prop = new_props[key]
+        was_required = key in old_required
+        is_required = key in new_required
+        if was_required != is_required:
+            changes.append(
+                BreakingChange(
+                    rule="Requiredness changed",
+                    field_path=field_path,
+                    details=f"Required changed from {was_required} to {is_required}",
+                )
+            )
+
+        _compare_schema(
+            old_prop,
+            new_prop,
+            path=field_path,
+            changes=changes,
+            root_old=root_old,
+            root_new=root_new,
+        )
+
+
+def _compare_array(
+    old_schema: Dict[str, Any],
+    new_schema: Dict[str, Any],
+    *,
+    path: str,
+    changes: List[BreakingChange],
+    root_old: Dict[str, Any],
+    root_new: Dict[str, Any],
+) -> None:
+    old_items = old_schema.get("items")
+    new_items = new_schema.get("items")
+    if old_items is None or new_items is None:
+        return
+    _compare_schema(
+        old_items,
+        new_items,
+        path=f"{path}[]",
+        changes=changes,
+        root_old=root_old,
+        root_new=root_new,
+    )
+
+
+def _resolve_ref(schema: Dict[str, Any], root_schema: Dict[str, Any]) -> Dict[str, Any]:
+    if "$ref" not in schema:
+        return schema
+    ref = schema["$ref"]
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return schema
+    parts = [part for part in ref.lstrip("#/").split("/") if part]
+    resolved: Any = root_schema
+    for part in parts:
+        if not isinstance(resolved, dict) or part not in resolved:
+            return schema
+        resolved = resolved[part]
+    return resolved if isinstance(resolved, dict) else schema
+
+
+def _normalized_type(schema: Dict[str, Any]) -> Optional[str]:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        return "/".join(sorted(str(item) for item in schema_type))
+    if isinstance(schema_type, str):
+        return schema_type
+    return None
+
+
+def _as_sequence(value: Any) -> Sequence[str]:
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []


### PR DESCRIPTION
### Motivation

- The schema gate previously caused the test suite to fail unconditionally via `assert False`, which is unacceptable for CI and obscures the real failure condition.  
- Implement a proper gate that only fails when a breaking change is detected and the schema major version was not bumped.  
- Ensure tests assert the expected failure via `pytest.raises` and also verify the success path when the major version is bumped.

### Description

- Add `assert_no_breaking_changes_without_major_bump(old_schema: Dict[str, Any], new_schema: Dict[str, Any]) -> None` in `tests/utils/schema_breaking_change_detector.py` which calls `detect_breaking_changes`, extracts majors via `extract_major_version`, returns on no changes or a major bump, and otherwise raises `AssertionError` with a message containing the first change's `rule`, `field_path`, and the text "Major version bump required.".  
- Update `tests/schema/test_schema_breaking_change_gate.py` to import and use `assert_no_breaking_changes_without_major_bump`, test the failure case with `with pytest.raises(AssertionError)` for each breaking-change fixture, and add a passing test that sets the new schema to major `2.0.0` and calls the gate without expecting an exception.  
- Clarify `documentation/breaking-change-regeln.md` to state that the error case is verified by an expected assertion and list the required contents of the error message.

### Testing

- Ran `pytest tests/schema/test_schema_breaking_change_gate.py`, which executed `4` tests and all passed (`4 passed`).  
- The gate now raises `AssertionError` only in the intended scenario and the tests verify both the expected failure message contents and the allowed major-bump success path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c0fda1bc8333804bed2ff72768ce)