### PR TITLE
Document and gate golden master snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ MVP v1 – Engine → SQLite → API → Trading Desk
 - Core architecture and scope: `docs/mvp_v1.md`
 - Strategy configuration schema (RSI2, Turtle): `docs/strategy-configs.md`
 - Local run & test commands: `docs/local_run.md`
+- Canonical output snapshots (golden masters): `docs/snapshot-testing.md`
 
 ## Local CI checks
 

--- a/docs/snapshot-testing.md
+++ b/docs/snapshot-testing.md
@@ -1,0 +1,43 @@
+# Canonical output snapshots (golden masters)
+
+This repository uses **canonical output snapshots** (golden masters) to protect the deterministic analysis contract. A snapshot is a committed JSON file that represents the canonical engine output for a fixed snapshot database input.
+
+## Rules of use
+
+### When snapshots are required
+- Any change that affects the **contracted analysis output payload** (fields, ordering, canonicalization, schema versioning, or deterministic computation logic) must be reflected in the golden master snapshot so that drift is visible and reviewed.  
+- Any contract change that is intended to be **breaking or observable** must be captured by an updated snapshot and the related schema versioning rules.
+
+### When snapshots are allowed
+- Updating a snapshot is allowed **only** when a contract change is intentional, reviewed, and accompanied by the explicit update action described below.
+- Snapshot updates are allowed only inside `tests/golden/**` and must be committed as part of the change.
+
+### When snapshots are forbidden
+- Snapshots must **not** be updated to "make tests pass" when output drift is unexpected or unintended.
+- Snapshots must **not** be updated for runtime-only changes that do not impact the canonical analysis output.
+- Snapshots must **not** be removed. Removal is out of scope and forbidden.
+
+## Contract changes that require snapshot updates
+Update the golden master snapshot when any of the following are changed intentionally:
+- Output fields or field names in the canonical analysis payload.
+- Canonical ordering, stable JSON formatting, or serialization rules.
+- Deterministic output computation that affects signal payload contents.
+- Schema version updates or schema enum changes that are tied to the output payload.
+
+## Snapshot lifecycle and retention
+- Golden master snapshots are **versioned** and stored in `tests/golden/**`.
+- Snapshot files are retained indefinitely to make output drift visible in history.
+- Each snapshot file must have an explicit version suffix (example: `analysis_output_golden_v1.json`) and is treated as immutable history.
+
+## Enforcement (tests + CI)
+- Tests compare computed output bytes against the committed snapshot. Any drift fails the test and therefore CI.
+- Tests do **not** auto-update snapshots. Updates require an explicit developer action.
+
+## Explicit snapshot update action
+To intentionally update the golden master snapshot, run the golden master test with the environment flag below. This is the **only** documented update mechanism:
+
+```bash
+UPDATE_GOLDEN_SNAPSHOTS=1 pytest tests/golden/test_analysis_golden_master.py
+```
+
+This action rewrites the snapshot file and produces an explicit diff that must be reviewed and committed.

--- a/tests/golden/test_analysis_golden_master.py
+++ b/tests/golden/test_analysis_golden_master.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-from tests.utils.golden_master import build_canonical_output_bytes, prepare_snapshot_db
+from tests.utils.golden_master import (
+    build_canonical_output_bytes,
+    prepare_snapshot_db,
+    write_canonical_output_snapshot,
+)
 
 
 def _format_byte(value: int | None) -> str:
@@ -58,6 +63,9 @@ def test_analysis_golden_master_snapshot(tmp_path: Path) -> None:
     db_path = tmp_path / "analysis.db"
     prepare_snapshot_db(db_path)
     actual_bytes = build_canonical_output_bytes(db_path)
+
+    if os.environ.get("UPDATE_GOLDEN_SNAPSHOTS") == "1":
+        expected_bytes = write_canonical_output_snapshot(snapshot_path, db_path)
 
     if actual_bytes != expected_bytes:
         details = _describe_first_diff(expected_bytes, actual_bytes)

--- a/tests/utils/golden_master.py
+++ b/tests/utils/golden_master.py
@@ -177,3 +177,14 @@ def build_canonical_output_bytes(db_path: Path, *, schema_version: Optional[str]
     response_payload = run_fixed_analysis(db_path, schema_version=schema_version)
     output_json = stable_json_dumps(response_payload)
     return output_json.encode("utf-8")
+
+
+def write_canonical_output_snapshot(
+    snapshot_path: Path,
+    db_path: Path,
+    *,
+    schema_version: Optional[str] = None,
+) -> bytes:
+    output_bytes = build_canonical_output_bytes(db_path, schema_version=schema_version)
+    snapshot_path.write_bytes(output_bytes)
+    return output_bytes


### PR DESCRIPTION
### Motivation
- Define and enforce a clear, reviewable strategy for canonical output snapshots (golden masters) so snapshot changes are intentional and visible.
- Ensure CI detects unexpected output drift by keeping tests that compare computed output against committed snapshots.
- Provide an explicit, documented developer action to update snapshots so tests do not silently mutate golden masters.

### Description
- Add `docs/snapshot-testing.md` documenting when snapshots are required, allowed, forbidden, lifecycle/retention, and the explicit update action. 
- Link the new snapshot policy from `README.md` for discoverability.
- Add `write_canonical_output_snapshot` helper to `tests/utils/golden_master.py` to create/update the canonical snapshot file programmatically. 
- Gate snapshot updates in `tests/golden/test_analysis_golden_master.py` behind the explicit environment flag `UPDATE_GOLDEN_SNAPSHOTS=1`, preserving default test behavior that fails on drift.

### Testing
- No automated test suite was executed as part of this change. 
- The existing golden-master test (`tests/golden/test_analysis_golden_master.py`) continues to compare computed bytes to the checked-in snapshot and will fail in CI on unexpected drift, while snapshot updates require the documented `UPDATE_GOLDEN_SNAPSHOTS=1` action.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c66c8314833392d07a45da0af678)