### PR TITLE
Clarify omitted strategy_config handling in usage contract

### DIFF
--- a/docs/api/usage_contract.md
+++ b/docs/api/usage_contract.md
@@ -69,7 +69,7 @@ These errors are emitted by `/strategy/analyze`, `/analysis/run`, and `/screener
 
 ### Strategy configuration normalization (as implemented)
 
-- Strategy configs are optional; `null` or `{}` resolves to an empty config.
+- Strategy configs are optional; omitted, `null`, or `{}` resolves to an empty config.
 - Configs must be mappings; non-mapping values are logged and treated as empty configs.
 - Only implemented parameters are accepted; unknown keys are ignored and logged.
 - Supported aliases:


### PR DESCRIPTION
### Motivation
- Clarify that omitting `strategy_config` is treated the same as providing `null` or `{}` in the documented API behavior so the usage contract matches the implemented behavior.

### Description
- Update `docs/api/usage_contract.md` by changing the bullet under `### Strategy configuration normalization (as implemented)` to: "- Strategy configs are optional; omitted, `null`, or `{}` resolves to an empty config." (modified file: `docs/api/usage_contract.md`).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69791ef6a8cc83339e55ac7c02e10017)