### PR TITLE
Refine API guarantees vs non-guarantees

### DIFF
--- a/docs/api/api_guarantees.md
+++ b/docs/api/api_guarantees.md
@@ -1,0 +1,21 @@
+# API Guarantees vs Non-Guarantees (MVP v1.1)
+
+This document separates what the API guarantees from what it explicitly does not guarantee. It is limited to the currently implemented behavior documented in `docs/api/usage_contract.md`.
+
+## Guaranteed
+
+- The API guarantees that analysis requests are snapshot-only and require an `ingestion_run_id`.
+- The API guarantees no implicit live data in analysis requests.
+- The API guarantees that the request and response shapes documented in `docs/api/usage_contract.md` define the MVP v1.1 contract.
+- The API guarantees that the documented field requirements, enums, and ranges in `docs/api/usage_contract.md` define the MVP v1.1 contract.
+
+## Not guaranteed
+
+- The API does not guarantee deterministic results for execution paths outside the snapshot-only analysis contract.
+- The API does not guarantee deterministic results when live data sources are used outside the snapshot-only analysis contract.
+- The API does not guarantee compatibility with request or response shapes not documented in `docs/api/usage_contract.md`.
+- The API does not guarantee schema stability outside the MVP v1.1 contract documented in `docs/api/usage_contract.md`.
+- The API does not guarantee profitability.
+- The API does not guarantee signal completeness.
+- The API does not guarantee complete snapshot coverage or more than one row per symbol and timeframe.
+- The API does not guarantee snapshot ingestion or population of snapshot tables.


### PR DESCRIPTION
### Motivation
- Align the API guarantees documentation with governance constraints by removing implementation details and error semantics.
- Present guarantees as strict, property-level statements so external users can clearly distinguish guaranteed behavior from explicit non-guarantees.

### Description
- Replace endpoint-specific and error-related language in `docs/api/api_guarantees.md` with property-level guarantee statements only.
- Remove references to error codes, failure reasons, and internal mechanics from the document and enforce binary phrasing.
- Ensure the file is organized into two clear sections: `Guaranteed` and `Not guaranteed` referencing the MVP v1.1 contract where appropriate.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69792ce6b0748333b29e924498c2f861)