### PR TITLE
Add external readiness checklist

### DIFF
--- a/docs/governance/external-readiness-checklist.md
+++ b/docs/governance/external-readiness-checklist.md
@@ -1,0 +1,23 @@
+# External Readiness Checklist (Binary)
+
+Instructions:
+1) Answer every item with YES or NO.
+2) If any item is NO, External Ready = NO.
+3) Only if all items are YES, External Ready = YES.
+
+## Checklist
+
+| # | Item | Answer (YES/NO) |
+| --- | --- | --- |
+| 1 | `docs/local_run.md` includes a command to start the API server with `uvicorn`. | |
+| 2 | `docs/local_run.md` includes a `/health` request example for verifying the API is up. | |
+| 3 | `README.md` links to at least one run/start guide in `docs/`. | |
+| 4 | `docs/api/usage_contract.md` exists and is titled "API Usage Contract". | |
+| 5 | `docs/api/usage_contract.md` documents snapshot-only behavior under "Common Conventions". | |
+| 6 | `docs/api/usage_contract.md` includes a section titled "Error semantics". | |
+| 7 | `docs/api/usage_contract.md` lists snapshot readiness/validation errors with status codes. | |
+| 8 | `docs/api/external_api_happy_path.md` exists. | |
+
+## Final decision rule
+
+External Ready = YES only if every item above is YES; otherwise External Ready = NO.


### PR DESCRIPTION
### Motivation
- Add a deterministic, binary checklist document for assessing whether the system is safe to expose to external users, covering API startability, documentation, contract references, and failure-mode documentation.

### Description
- Create `docs/governance/external-readiness-checklist.md` containing a copy-pasteable binary (YES/NO) checklist and an explicit final decision rule; the modified/new file is listed below and its full content is included verbatim.

Modified/created files:
- `docs/governance/external-readiness-checklist.md`

Full file content:
```
# External Readiness Checklist (Binary)

Instructions:
1) Answer every item with YES or NO.
2) If any item is NO, External Ready = NO.
3) Only if all items are YES, External Ready = YES.

## Checklist

| # | Item | Answer (YES/NO) |
| --- | --- | --- |
| 1 | `docs/local_run.md` includes a command to start the API server with `uvicorn`. | |
| 2 | `docs/local_run.md` includes a `/health` request example for verifying the API is up. | |
| 3 | `README.md` links to at least one run/start guide in `docs/`. | |
| 4 | `docs/api/usage_contract.md` exists and is titled "API Usage Contract". | |
| 5 | `docs/api/usage_contract.md` documents snapshot-only behavior under "Common Conventions". | |
| 6 | `docs/api/usage_contract.md` includes a section titled "Error semantics". | |
| 7 | `docs/api/usage_contract.md` lists snapshot readiness/validation errors with status codes. | |
| 8 | `docs/api/external_api_happy_path.md` exists. | |

## Final decision rule

External Ready = YES only if every item above is YES; otherwise External Ready = NO.
```

### Testing
- No automated tests were run because this is a documentation-only change (file added and committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793138be308333b8f049fa28e0c30e)