### PR TITLE
Add Phase 5 exit criteria (External Ready)

### DIFF
--- a/docs/governance/phase-5-exit-criteria.md
+++ b/docs/governance/phase-5-exit-criteria.md
@@ -1,0 +1,20 @@
+# Phase 5 Exit Criteria (External Ready)
+
+Phase 5 confirms external readiness through a strictly binary checklist.
+Each item is answered YES or NO using evidence in the repository or review records.
+Phase 5 is complete only when every item is YES.
+
+## Phase 5 Exit Criteria
+
+- External readiness checklist is fully answered YES in `docs/governance/external-readiness-checklist.md`.
+- A review record exists that shows two independent reviewers each marked every item in the external readiness checklist as YES.
+- The review record includes the date of review and the reviewer identities for both reviewers.
+
+## Phase 6 Entry Permission
+
+Phase 6 is NOT allowed to begin unless ALL Phase 5 Exit Criteria are met.
+If any Phase 5 Exit Criteria item is NO, Phase 6 is blocked.
+
+## Verification Note
+
+Manual checklist verification by two independent reviewers.


### PR DESCRIPTION
### Motivation
- Provide explicit, binary, and testable exit criteria for Phase 5 and an unambiguous gate that prevents Phase 6 from starting until Phase 5 is complete.

### Description
- Add `docs/governance/phase-5-exit-criteria.md` containing a short context paragraph, a binary "Phase 5 Exit Criteria" checklist requiring the external readiness checklist to be fully YES and two independent reviewer verification with date and identities, an explicit "Phase 6 Entry Permission" statement that Phase 6 is NOT allowed unless ALL Phase 5 criteria are met, and a short verification note.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793338f9a483339e9681ef9edd80f0)