### PR TITLE
Persist Phase-6 snapshot audit on snapshot-only runs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -829,6 +829,7 @@ def manual_analysis(req: ManualAnalysisRequest) -> ManualAnalysisResponse:
         signal_repo=signal_repo,
         ingestion_run_id=req.ingestion_run_id,
         db_path=_resolve_analysis_db_path(),
+        run_id=computed_run_id,
     )
 
     filtered_signals = [

--- a/data/phase6_snapshots/test-snapshot-0001/metadata.json
+++ b/data/phase6_snapshots/test-snapshot-0001/metadata.json
@@ -1,0 +1,9 @@
+{
+  "snapshot_id": "test-snapshot-0001",
+  "provider": "test-provider",
+  "source": "unit-test",
+  "created_at_utc": "2025-01-01T00:00:00Z",
+  "payload_checksum": "b4b37477b804e86423a01e738b552a101f2fd8647d745f0263e0ef32bcac8272",
+  "schema_version": "1",
+  "notes": "Test fixture for Phase-6 snapshot contract"
+}

--- a/data/phase6_snapshots/test-snapshot-0001/payload.json
+++ b/data/phase6_snapshots/test-snapshot-0001/payload.json
@@ -1,0 +1,1 @@
+{"dataset":"phase6-test","rows":[{"timestamp":"2025-01-01T00:00:00Z","open":100,"high":110,"low":90,"close":105,"volume":1000,"symbol":"AAPL","timeframe":"D1"}]}

--- a/docs/architecture/phase6_snapshot_contract.md
+++ b/docs/architecture/phase6_snapshot_contract.md
@@ -1,0 +1,42 @@
+# Phase-6 Deterministic Snapshot Contract
+
+## Snapshot ID rules
+
+- Phase-6 runs **must** provide a `snapshot_id`.
+- In this system, `snapshot_id` is the `ingestion_run_id` used by snapshot-only engine runs.
+- The snapshot resolves to the SQLite snapshot store (`ingestion_runs` + `ohlcv_snapshots`) using that `ingestion_run_id`.
+
+## Metadata fields
+
+Snapshot metadata is immutable and stored in `metadata.json` with the following fields:
+
+- `snapshot_id` (string)
+- `provider` (string)
+- `source` (string, endpoint or dataset name)
+- `created_at_utc` (ISO-8601 string)
+- `payload_checksum` (string, SHA-256 of payload bytes)
+- `schema_version` (string or int)
+- `notes` (optional string)
+
+## Audit persistence
+
+Every Phase-6 run persists a deterministic audit record to:
+
+```
+runs/phase6/<run_id>/audit.json
+```
+
+The audit record includes:
+
+- `run_id`
+- `snapshot_id`
+- `snapshot_metadata` (full metadata object)
+- `engine_version` (if `CILLY_ENGINE_VERSION` is set)
+
+Audit JSON serialization uses sorted keys for stable byte output.
+
+## Deterministic replay
+
+- Replays resolve snapshot payload bytes directly from `payload.json`.
+- Snapshot payload bytes are verified against the stored checksum.
+- Result artifacts are serialized with sorted keys to ensure byte-identical output when reusing the same snapshot.

--- a/src/cilly_trading/engine/phase6_snapshot_contract.py
+++ b/src/cilly_trading/engine/phase6_snapshot_contract.py
@@ -1,0 +1,309 @@
+"""Phase-6 deterministic snapshot contract utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+SnapshotId = str
+SchemaVersion = str | int
+
+DEFAULT_SNAPSHOT_DIR = Path("data/phase6_snapshots")
+DEFAULT_RUN_DIR = Path("runs/phase6")
+SNAPSHOT_METADATA_FILENAME = "metadata.json"
+SNAPSHOT_PAYLOAD_FILENAME = "payload.json"
+
+
+class SnapshotContractError(RuntimeError):
+    """Raised when Phase-6 snapshot contract requirements are violated."""
+
+
+class SnapshotNotFoundError(SnapshotContractError):
+    """Raised when a snapshot ID cannot be resolved."""
+
+
+class SnapshotMetadataError(SnapshotContractError):
+    """Raised when snapshot metadata is invalid or incomplete."""
+
+
+class SnapshotChecksumError(SnapshotContractError):
+    """Raised when snapshot payload checksum does not match metadata."""
+
+
+@dataclass(frozen=True)
+class SnapshotMetadata:
+    """Immutable metadata describing a deterministic snapshot.
+
+    Args:
+        snapshot_id: Stable snapshot identifier.
+        provider: Snapshot data provider.
+        source: Source descriptor (endpoint, dataset name, etc.).
+        created_at_utc: ISO-8601 creation timestamp in UTC.
+        payload_checksum: SHA-256 checksum of the snapshot payload bytes.
+        schema_version: Snapshot schema version string or integer.
+        notes: Optional notes about the snapshot.
+    """
+
+    snapshot_id: SnapshotId
+    provider: str
+    source: str
+    created_at_utc: str
+    payload_checksum: str
+    schema_version: SchemaVersion
+    notes: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation.
+
+        Returns:
+            Dictionary representation with stable key names.
+        """
+        payload: dict[str, Any] = {
+            "snapshot_id": self.snapshot_id,
+            "provider": self.provider,
+            "source": self.source,
+            "created_at_utc": self.created_at_utc,
+            "payload_checksum": self.payload_checksum,
+            "schema_version": self.schema_version,
+        }
+        if self.notes is not None:
+            payload["notes"] = self.notes
+        return payload
+
+
+@dataclass(frozen=True)
+class ResolvedSnapshot:
+    """Resolved snapshot payload and metadata.
+
+    Args:
+        snapshot_id: Snapshot identifier.
+        metadata: Immutable snapshot metadata.
+        payload_path: Local path to the deterministic snapshot payload.
+        payload_bytes: Raw payload bytes used for deterministic replay.
+    """
+
+    snapshot_id: SnapshotId
+    metadata: SnapshotMetadata
+    payload_path: Path
+    payload_bytes: bytes
+
+
+@dataclass(frozen=True)
+class Phase6RunResult:
+    """Result metadata for a Phase-6 deterministic run.
+
+    Args:
+        run_id: Persisted run identifier.
+        audit_path: Path to the persisted audit record.
+        result_path: Path to the deterministic result artifact.
+        result_bytes: Raw bytes of the deterministic result artifact.
+    """
+
+    run_id: str
+    audit_path: Path
+    result_path: Path
+    result_bytes: bytes
+
+
+def resolve_snapshot(
+    snapshot_id: SnapshotId,
+    *,
+    snapshot_dir: Optional[Path] = None,
+) -> ResolvedSnapshot:
+    """Resolve a snapshot ID into deterministic local payload bytes.
+
+    Args:
+        snapshot_id: Snapshot identifier to resolve.
+        snapshot_dir: Optional base directory for snapshot payloads.
+
+    Returns:
+        ResolvedSnapshot with metadata and payload bytes.
+
+    Raises:
+        SnapshotNotFoundError: If the snapshot metadata or payload is missing.
+        SnapshotMetadataError: If metadata is invalid or mismatched.
+        SnapshotChecksumError: If payload checksum does not match metadata.
+    """
+    base_dir = snapshot_dir or DEFAULT_SNAPSHOT_DIR
+    snapshot_root = base_dir / snapshot_id
+    metadata_path = snapshot_root / SNAPSHOT_METADATA_FILENAME
+    payload_path = snapshot_root / SNAPSHOT_PAYLOAD_FILENAME
+
+    if not metadata_path.exists():
+        raise SnapshotNotFoundError(f"snapshot_metadata_missing snapshot_id={snapshot_id}")
+    if not payload_path.exists():
+        raise SnapshotNotFoundError(f"snapshot_payload_missing snapshot_id={snapshot_id}")
+
+    metadata = _load_snapshot_metadata(metadata_path)
+    if metadata.snapshot_id != snapshot_id:
+        raise SnapshotMetadataError(
+            "snapshot_id_mismatch "
+            f"expected={snapshot_id} metadata={metadata.snapshot_id}"
+        )
+
+    payload_bytes = payload_path.read_bytes()
+    checksum = _sha256_bytes(payload_bytes)
+    if checksum != metadata.payload_checksum:
+        raise SnapshotChecksumError(
+            "snapshot_checksum_mismatch "
+            f"expected={metadata.payload_checksum} actual={checksum}"
+        )
+
+    return ResolvedSnapshot(
+        snapshot_id=snapshot_id,
+        metadata=metadata,
+        payload_path=payload_path,
+        payload_bytes=payload_bytes,
+    )
+
+
+def run_phase6_snapshot(
+    snapshot_id: SnapshotId,
+    *,
+    snapshot_dir: Optional[Path] = None,
+    run_output_dir: Optional[Path] = None,
+    run_id: Optional[str] = None,
+) -> Phase6RunResult:
+    """Execute a deterministic Phase-6 run backed by a snapshot.
+
+    Args:
+        snapshot_id: Snapshot identifier (required).
+        snapshot_dir: Optional base directory for snapshots.
+        run_output_dir: Optional output directory for run artifacts.
+        run_id: Optional run identifier to persist.
+
+    Returns:
+        Phase6RunResult containing artifact paths and bytes.
+
+    Raises:
+        ValueError: If snapshot_id is missing.
+        SnapshotContractError: If snapshot resolution fails.
+    """
+    if not snapshot_id or not str(snapshot_id).strip():
+        raise ValueError("snapshot_id is required for Phase-6 runs")
+
+    resolved = resolve_snapshot(snapshot_id, snapshot_dir=snapshot_dir)
+    run_identifier = run_id or str(uuid.uuid4())
+    output_root = run_output_dir or DEFAULT_RUN_DIR
+    run_dir = output_root / run_identifier
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    audit_path = persist_phase6_audit(
+        run_id=run_identifier,
+        snapshot_id=snapshot_id,
+        metadata=resolved.metadata,
+        output_dir=run_dir,
+    )
+
+    result_payload = {
+        "snapshot_id": snapshot_id,
+        "payload_checksum": resolved.metadata.payload_checksum,
+        "provider": resolved.metadata.provider,
+        "source": resolved.metadata.source,
+        "created_at_utc": resolved.metadata.created_at_utc,
+        "schema_version": resolved.metadata.schema_version,
+    }
+    result_json = json.dumps(result_payload, sort_keys=True, separators=(",", ":"))
+    result_path = run_dir / "result.json"
+    result_path.write_text(result_json, encoding="utf-8")
+
+    return Phase6RunResult(
+        run_id=run_identifier,
+        audit_path=audit_path,
+        result_path=result_path,
+        result_bytes=result_json.encode("utf-8"),
+    )
+
+
+def persist_phase6_audit(
+    *,
+    run_id: str,
+    snapshot_id: SnapshotId,
+    metadata: SnapshotMetadata,
+    output_dir: Path,
+) -> Path:
+    """Persist a Phase-6 audit record with snapshot metadata.
+
+    Args:
+        run_id: Unique run identifier.
+        snapshot_id: Snapshot identifier used for the run.
+        metadata: Snapshot metadata.
+        output_dir: Directory to store audit artifacts.
+
+    Returns:
+        Path to the persisted audit JSON file.
+    """
+    payload: dict[str, Any] = {
+        "run_id": run_id,
+        "snapshot_id": snapshot_id,
+        "snapshot_metadata": metadata.to_dict(),
+    }
+    engine_version = _get_engine_version()
+    if engine_version is not None:
+        payload["engine_version"] = engine_version
+
+    audit_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    audit_path = output_dir / "audit.json"
+    audit_path.write_text(audit_json, encoding="utf-8")
+    return audit_path
+
+
+def _load_snapshot_metadata(metadata_path: Path) -> SnapshotMetadata:
+    raw = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise SnapshotMetadataError("snapshot_metadata_invalid")
+
+    required = {
+        "snapshot_id",
+        "provider",
+        "source",
+        "created_at_utc",
+        "payload_checksum",
+        "schema_version",
+    }
+    missing = sorted(required - set(raw.keys()))
+    if missing:
+        raise SnapshotMetadataError(f"snapshot_metadata_missing_fields {','.join(missing)}")
+
+    return SnapshotMetadata(
+        snapshot_id=_coerce_str(raw["snapshot_id"], field="snapshot_id"),
+        provider=_coerce_str(raw["provider"], field="provider"),
+        source=_coerce_str(raw["source"], field="source"),
+        created_at_utc=_coerce_str(raw["created_at_utc"], field="created_at_utc"),
+        payload_checksum=_coerce_str(raw["payload_checksum"], field="payload_checksum"),
+        schema_version=_coerce_schema_version(raw["schema_version"]),
+        notes=_coerce_optional_str(raw.get("notes"), field="notes"),
+    )
+
+
+def _coerce_str(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise SnapshotMetadataError(f"snapshot_metadata_invalid_{field}")
+    return value
+
+
+def _coerce_optional_str(value: Any, *, field: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SnapshotMetadataError(f"snapshot_metadata_invalid_{field}")
+    return value
+
+
+def _coerce_schema_version(value: Any) -> SchemaVersion:
+    if isinstance(value, (str, int)):
+        return value
+    raise SnapshotMetadataError("snapshot_metadata_invalid_schema_version")
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _get_engine_version() -> Optional[str]:
+    return os.getenv("CILLY_ENGINE_VERSION")

--- a/tests/test_phase6_snapshot_audit.py
+++ b/tests/test_phase6_snapshot_audit.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.db import init_db
+from cilly_trading.engine.core import EngineConfig, run_watchlist_analysis
+from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
+
+
+class _NoopStrategy:
+    name = "NOOP"
+
+    def generate_signals(self, df, config):
+        return []
+
+
+def _insert_ingestion_run(db_path: Path, ingestion_run_id: str) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO ingestion_runs (
+            ingestion_run_id,
+            created_at,
+            source,
+            symbols_json,
+            timeframe,
+            fingerprint_hash
+        )
+        VALUES (?, ?, ?, ?, ?, ?);
+        """,
+        (
+            ingestion_run_id,
+            "2025-01-01T00:00:00+00:00",
+            "internal",
+            json.dumps(["AAPL"]),
+            "D1",
+            "checksum-123",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_snapshot_row(db_path: Path, ingestion_run_id: str) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO ohlcv_snapshots (
+            ingestion_run_id,
+            symbol,
+            timeframe,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            ingestion_run_id,
+            "AAPL",
+            "D1",
+            1735689600000,
+            100.0,
+            110.0,
+            90.0,
+            105.0,
+            1000.0,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _prepare_snapshot_db(db_path: Path, ingestion_run_id: str) -> None:
+    init_db(db_path)
+    _insert_ingestion_run(db_path, ingestion_run_id)
+    _insert_snapshot_row(db_path, ingestion_run_id)
+
+
+def test_phase6_snapshot_requires_ingestion_run_id(tmp_path: Path) -> None:
+    signal_repo = SqliteSignalRepository(db_path=tmp_path / "signals.db")
+    with pytest.raises(ValueError, match="snapshot_only requires ingestion_run_id"):
+        run_watchlist_analysis(
+            symbols=["AAPL"],
+            strategies=[_NoopStrategy()],
+            engine_config=EngineConfig(),
+            strategy_configs={},
+            signal_repo=signal_repo,
+            snapshot_only=True,
+        )
+
+
+def test_phase6_audit_persisted_for_snapshot_run(tmp_path: Path) -> None:
+    db_path = tmp_path / "analysis.db"
+    ingestion_run_id = "11111111-1111-4111-8111-111111111111"
+    _prepare_snapshot_db(db_path, ingestion_run_id)
+
+    signal_repo = SqliteSignalRepository(db_path=tmp_path / "signals.db")
+    run_id = "run-0001"
+    audit_dir = tmp_path / "audits"
+
+    run_watchlist_analysis(
+        symbols=["AAPL"],
+        strategies=[_NoopStrategy()],
+        engine_config=EngineConfig(),
+        strategy_configs={},
+        signal_repo=signal_repo,
+        ingestion_run_id=ingestion_run_id,
+        db_path=db_path,
+        run_id=run_id,
+        audit_dir=audit_dir,
+        snapshot_only=True,
+    )
+
+    audit_path = audit_dir / run_id / "audit.json"
+    audit_payload = json.loads(audit_path.read_text(encoding="utf-8"))
+
+    assert audit_payload["run_id"] == run_id
+    assert audit_payload["snapshot_id"] == ingestion_run_id
+    assert audit_payload["snapshot_metadata"]["snapshot_id"] == ingestion_run_id
+
+
+def test_phase6_replay_produces_identical_audit_bytes(tmp_path: Path) -> None:
+    db_path = tmp_path / "analysis.db"
+    ingestion_run_id = "11111111-1111-4111-8111-111111111111"
+    _prepare_snapshot_db(db_path, ingestion_run_id)
+
+    signal_repo = SqliteSignalRepository(db_path=tmp_path / "signals.db")
+    run_id = "run-0002"
+    audit_dir = tmp_path / "audits"
+
+    run_watchlist_analysis(
+        symbols=["AAPL"],
+        strategies=[_NoopStrategy()],
+        engine_config=EngineConfig(),
+        strategy_configs={},
+        signal_repo=signal_repo,
+        ingestion_run_id=ingestion_run_id,
+        db_path=db_path,
+        run_id=run_id,
+        audit_dir=audit_dir,
+        snapshot_only=True,
+    )
+    first_bytes = (audit_dir / run_id / "audit.json").read_bytes()
+
+    run_watchlist_analysis(
+        symbols=["AAPL"],
+        strategies=[_NoopStrategy()],
+        engine_config=EngineConfig(),
+        strategy_configs={},
+        signal_repo=signal_repo,
+        ingestion_run_id=ingestion_run_id,
+        db_path=db_path,
+        run_id=run_id,
+        audit_dir=audit_dir,
+        snapshot_only=True,
+    )
+    second_bytes = (audit_dir / run_id / "audit.json").read_bytes()
+
+    assert first_bytes == second_bytes
+    assert hashlib.sha256(first_bytes).hexdigest() == hashlib.sha256(second_bytes).hexdigest()

--- a/tests/test_phase6_snapshot_contract.py
+++ b/tests/test_phase6_snapshot_contract.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.engine.phase6_snapshot_contract import (
+    SnapshotNotFoundError,
+    run_phase6_snapshot,
+)
+
+
+SNAPSHOT_ID = "test-snapshot-0001"
+SNAPSHOT_DIR = Path("data/phase6_snapshots")
+
+
+def test_phase6_snapshot_id_required() -> None:
+    with pytest.raises(ValueError, match="snapshot_id is required"):
+        run_phase6_snapshot("")
+
+
+def test_phase6_unknown_snapshot_id_fails(tmp_path: Path) -> None:
+    with pytest.raises(SnapshotNotFoundError, match="snapshot_metadata_missing"):
+        run_phase6_snapshot("missing-snapshot", snapshot_dir=tmp_path)
+
+
+def test_phase6_snapshot_audit_persisted(tmp_path: Path) -> None:
+    result = run_phase6_snapshot(
+        SNAPSHOT_ID,
+        snapshot_dir=SNAPSHOT_DIR,
+        run_output_dir=tmp_path,
+    )
+
+    audit_payload = json.loads(result.audit_path.read_text(encoding="utf-8"))
+    assert audit_payload["run_id"] == result.run_id
+    assert audit_payload["snapshot_id"] == SNAPSHOT_ID
+
+    metadata = audit_payload["snapshot_metadata"]
+    assert metadata["snapshot_id"] == SNAPSHOT_ID
+    assert metadata["provider"] == "test-provider"
+    assert metadata["source"] == "unit-test"
+    assert metadata["created_at_utc"] == "2025-01-01T00:00:00Z"
+    assert metadata["payload_checksum"]
+    assert metadata["schema_version"] == "1"
+
+
+def test_phase6_replay_is_deterministic(tmp_path: Path) -> None:
+    first = run_phase6_snapshot(
+        SNAPSHOT_ID,
+        snapshot_dir=SNAPSHOT_DIR,
+        run_output_dir=tmp_path,
+    )
+    second = run_phase6_snapshot(
+        SNAPSHOT_ID,
+        snapshot_dir=SNAPSHOT_DIR,
+        run_output_dir=tmp_path,
+    )
+
+    first_hash = hashlib.sha256(first.result_bytes).hexdigest()
+    second_hash = hashlib.sha256(second.result_bytes).hexdigest()
+
+    assert first.result_bytes == second.result_bytes
+    assert first_hash == second_hash


### PR DESCRIPTION
### Motivation

- Enforce Phase‑6 (snapshot-only) auditability by ensuring all Phase‑6 executions record the snapshot reference and metadata at run start. 
- Treat the existing `ingestion_run_id` as the Phase‑6 `snapshot_id` so no new user-facing identifier is required. 
- Produce deterministic, replayable run artifacts and surface snapshot metadata/checksum information early to avoid live-data drift.

### Description

- Wire audit persistence into the real Phase‑6 execution path by invoking `_persist_phase6_audit` from `run_watchlist_analysis` when `snapshot_only=True`. The audit is persisted under `runs/phase6/<run_id>/audit.json` (configurable via `audit_dir`).
- Add a small snapshot metadata helper `load_snapshot_metadata` in `src/cilly_trading/engine/data.py` that reads `ingestion_runs` (and `fingerprint_hash`) from the SQLite store and returns a deterministic metadata dict.
- Implement deterministic audit serialization using `json.dumps(..., sort_keys=True, separators=(",",":"))` and include `run_id`, `snapshot_id` (== `ingestion_run_id`) and `snapshot_metadata` (provider, source, created_at_utc, payload_checksum when available, `schema_version`).
- Pass the computed run id from `api/main.py` into the snapshot-only engine path for manual analysis runs so audits can be bound to existing deterministic run identifiers.
- Add utilities and documentation: `src/cilly_trading/engine/phase6_snapshot_contract.py` (Phase‑6 helpers) and update `docs/architecture/phase6_snapshot_contract.md` to state `snapshot_id` ⇔ `ingestion_run_id` mapping and store locations.
- Add tests `tests/test_phase6_snapshot_audit.py` to validate: missing `ingestion_run_id` fails fast, audit artifact is written for snapshot runs, and repeated runs produce identical audit bytes.

### Testing

- Ran `pytest tests/test_phase6_snapshot_audit.py` which executed 3 tests and all passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979eff7abb8833388614338fc9957af)