### PR TITLE
Add Phase 6 operational overview documentation

### DIFF
--- a/docs/phase-6/PHASE_6_OPERATIONAL_OVERVIEW.md
+++ b/docs/phase-6/PHASE_6_OPERATIONAL_OVERVIEW.md
@@ -1,0 +1,104 @@
+# Phase 6 – Operational Overview
+**Scope:** Controlled External Exposure  
+**Status:** Governance-Enforced / Non-Production  
+**Audience:** Project Owner, Review, Onboarding
+
+---
+
+## Purpose
+
+Phase 6 defines a **strictly controlled operational environment** that allows
+limited exposure to real external data **without enabling trading,
+execution, or decision autonomy**.
+
+This phase is exploratory and observational only.
+
+---
+
+## What Phase 6 Allows
+
+Phase 6 explicitly allows:
+
+- Consumption of **real market data** for observation and inspection only  
+- Manual, human-triggered data pulls  
+- Read-only processing and transformation of external data  
+- Documentation, validation, and inspection of data pipelines  
+- Deterministic, non-decision-support logic  
+- Offline analysis that cannot trigger actions
+
+All allowed actions must remain:
+- Non-automated
+- Non-persistent beyond defined scope
+- Non-actionable
+
+Reference:
+- Phase 6 Entry Declaration (#196)
+- Real Market Data Usage Declaration (#198)
+
+---
+
+## What Phase 6 Explicitly Forbids
+
+Phase 6 strictly forbids:
+
+- Any form of live trading or order execution  
+- Broker, exchange, or wallet integrations  
+- Automated or scheduled data ingestion  
+- Decision-making, scoring, or signal generation  
+- Backtesting or performance simulation  
+- AI-based inference or recommendations  
+- Feedback loops of any kind  
+- State accumulation intended for later execution
+
+**Any violation is considered a hard stop.**
+
+Reference:
+- Phase 6 Guardrails & Stop Conditions (#197)
+
+---
+
+## Stop Conditions
+
+Phase 6 must stop immediately if any of the following occurs:
+
+- External data is used beyond read-only inspection  
+- Data is consumed automatically or on a schedule  
+- Outputs could be interpreted as trading signals  
+- Any execution-capable interface is introduced  
+- Scope ambiguity or interpretation is required to proceed  
+
+On stop:
+- Work halts
+- A blocking governance issue must be raised
+- No continuation without explicit approval
+
+---
+
+## Governance Enforcement
+
+Governance in Phase 6 is enforced through:
+
+- Issue-first workflow (no work without an active Issue)  
+- Explicit phase labeling and guardrails  
+- Mandatory review gates  
+- Binary approval decisions only  
+- Immediate stop authority on guardrail breach  
+
+Phase 6 is **not a transition to production**  
+and provides **no implicit permission** for Phase 7 activities.
+
+---
+
+## Summary
+
+Phase 6 is:
+- Observational
+- Read-only
+- Human-controlled
+- Non-executing
+
+Phase 6 is **not**:
+- Autonomous
+- Actionable
+- Persistent
+- Tradable


### PR DESCRIPTION
### Motivation
- Provide a single, normative operational overview for Phase 6 that defines clear boundaries and governance for controlled external data exposure. 
- Separate allowed and forbidden actions unambiguously and define stop conditions to prevent inadvertent escalation toward execution or production. 
- Supply an onboarding and reference document that is Phase-6-conform and avoids procedural examples or implementation details. 

### Description
- Add a new markdown file at `docs/phase-6/PHASE_6_OPERATIONAL_OVERVIEW.md` containing the required sections: What Phase 6 Allows, What Phase 6 Explicitly Forbids, Stop Conditions, and Governance Enforcement. 
- The document is normative and unambiguous, explicitly references `Phase 6 Entry Declaration (#196)`, `Phase 6 Guardrails & Stop Conditions (#197)`, and `Real Market Data Usage Declaration (#198)`, and avoids any transition to Phase 7. 
- No other files were modified; the change is limited to adding the single documentation file. 
- Closes #202

### Testing
- No automated tests were run because this is a documentation-only change and does not modify code or configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2af6aa28833382ff0f572b627c3f)