### PR TITLE
Add Codespaces devcontainer and document remote run steps in RUNBOOK

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Trading Engine",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  }
+}

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -48,3 +48,18 @@ A change is considered DONE only if:
 - Codex A review gate result is recorded (APPROVED or CHANGES REQUIRED)
 - No scope creep beyond the linked Issue
 - Phase 6 gilt nur als abgeschlossen, wenn die Exit-Kriterien und die Exit-Checklist vollständig erfüllt sind: [docs/phase-6-exit-criteria.md](docs/phase-6-exit-criteria.md), [docs/checklists/phase-6-exit-checklist.md](docs/checklists/phase-6-exit-checklist.md)
+
+## Remote (Codespaces)
+
+### Start Codespace
+1) Open the repository on GitHub.
+2) Select **Code → Codespaces → Create codespace on main**.
+3) Wait for the devcontainer to finish provisioning and dependency install.
+
+### Run Tests
+```bash
+python -m pytest
+```
+
+### Run Paper Trading (Simulation)
+Not available — Blocker: no paper-trading/simulation entrypoint is documented or implemented in the repo without touching `src/**`. No live trading, broker keys, or real orders are used.


### PR DESCRIPTION
### Motivation
- Provide a minimal Codespaces devcontainer so the repository can be opened and dependencies installed automatically in GitHub Codespaces. 
- Document how to start a Codespace and how to run the test-suite remotely, and clearly call out that a paper-trading/simulation entrypoint is not available without touching `src/**`.

### Description
- Add `.devcontainer/devcontainer.json` that uses the `mcr.microsoft.com/devcontainers/python:3.11` image and runs `pip install -r requirements.txt` on container creation, and recommends VS Code Python extensions. 
- Update `RUNBOOK.md` to include a `Remote (Codespaces)` section with step-by-step instructions to create a Codespace and the command to run tests (`python -m pytest`), and a note that paper-trading/simulation is a blocker because no documented entrypoint exists without modifying `src/**`.
- Files changed: added `.devcontainer/devcontainer.json` and modified `RUNBOOK.md`.

### Testing
- Ran `python -m pytest` in the repository and the full test-suite completed successfully with `158 passed in 6.76s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8f42462883339eb86870457e1cb9)