### PR TITLE
Add deterministic smoke-run fixtures

### DIFF
--- a/fixtures/smoke-run/config.yaml
+++ b/fixtures/smoke-run/config.yaml
@@ -1,0 +1,3 @@
+engine_name: cilly-trading-engine
+engine_version: 0.0.0
+precision: 2

--- a/fixtures/smoke-run/expected.csv
+++ b/fixtures/smoke-run/expected.csv
@@ -1,0 +1,4 @@
+run_id,tick_index,price
+smoke-0001,0,100.00
+smoke-0001,1,100.50
+smoke-0001,2,101.00

--- a/fixtures/smoke-run/input.json
+++ b/fixtures/smoke-run/input.json
@@ -1,0 +1,8 @@
+{
+  "run_id": "smoke-0001",
+  "base_currency": "EUR",
+  "quote_currency": "USD",
+  "start_price": 100.0,
+  "end_price": 101.0,
+  "ticks": 3
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic smoke-run fixture set required for Issue #224 so smoke tests can run reproducibly.

### Description
- Add three files under `fixtures/smoke-run/`: `input.json` (run parameters), `config.yaml` (engine metadata and precision), and `expected.csv` (expected tick outputs) with the exact contents specified by the issue.

### Testing
- No automated tests were run because this is a fixtures-only change; basic content validation was performed to confirm header order, row count, run_id consistency, and two-decimal precision in `expected.csv`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980f30fe8d48333b11adf1b712d27f6)