### PR TITLE
Document local deterministic smoke-run execution

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -49,9 +49,41 @@ A change is considered DONE only if:
 - No scope creep beyond the linked Issue
 - Phase 6 gilt nur als abgeschlossen, wenn die Exit-Kriterien und die Exit-Checklist vollständig erfüllt sind: [docs/phase-6-exit-criteria.md](docs/phase-6-exit-criteria.md), [docs/checklists/phase-6-exit-checklist.md](docs/checklists/phase-6-exit-checklist.md)
 
-## Deterministic Smoke-Run Specification
-- A deterministic smoke-run specification exists and is NOT IMPLEMENTED.
-- Reference: [docs/smoke-run.md](docs/smoke-run.md)
+## Deterministic Smoke Run – Local Execution
+
+### Prerequisites
+- Python 3 available in your environment.
+- Run from the repository root so the default fixtures path (`fixtures/smoke-run/`) is available.
+- Ensure the package is importable by setting `PYTHONPATH=src` (there is no CLI entrypoint).
+
+### Command (exact)
+```bash
+PYTHONPATH=src python -c 'from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())'
+```
+
+### Expected stdout on success (exact, line-by-line)
+```
+SMOKE_RUN:START
+SMOKE_RUN:FIXTURES_OK
+SMOKE_RUN:CHECKS_OK
+SMOKE_RUN:END
+```
+
+### Artifacts
+- `artifacts/smoke-run/result.json`
+
+### Exit code semantics
+- `0` — success.
+- `10` — fixtures missing (`input.json`, `expected.csv`, `config.yaml`).
+- `11` — fixtures invalid (format, missing required keys/columns, or parse errors).
+- `12` — constraints failed (validation errors or determinism guard triggered).
+- `13` — output mismatch (artifact write/read mismatch).
+
+### Determinism note
+The smoke-run is deterministic: no time access, no randomness, and no network access are permitted during execution. Any attempt to access these will fail the run via the determinism guard.
+
+### Reference
+- [docs/smoke-run.md](docs/smoke-run.md)
 
 ## Remote (Codespaces)
 

--- a/docs/repo-snapshot.md
+++ b/docs/repo-snapshot.md
@@ -2,11 +2,11 @@
 
 ## Purpose of the Repository
 
-This repository describes a trading analysis engine intended to support a website-based trading analysis tool with deterministic strategy outputs, persistence, and an API layer. The project targets market data ingestion, indicator calculation, strategy-based signal generation, and storage of results for retrieval through an API. The scope explicitly excludes live trading, broker integrations, order execution, portfolio management, backtesting frameworks, and AI-based signal generation in the current MVP definition. The deterministic smoke-run is specified but explicitly not implemented in the repository.
+This repository describes a trading analysis engine intended to support a website-based trading analysis tool with deterministic strategy outputs, persistence, and an API layer. The project targets market data ingestion, indicator calculation, strategy-based signal generation, and storage of results for retrieval through an API. The scope explicitly excludes live trading, broker integrations, order execution, portfolio management, backtesting frameworks, and AI-based signal generation in the current MVP definition. The deterministic smoke-run is implemented and documented in the runbook/spec.
 
 ## High-Level Project State
 
-Current materials include detailed scope, architecture, workflow, and deterministic contracts captured in markdown files. The documentation defines what the MVP should cover and what it excludes, while the deterministic smoke-run is defined as a spec-only contract with no implementation. Documentation states that paper trading/simulation is not available and that no smoke-run execution exists. Trading, simulation, and smoke-run execution are explicitly not implemented.
+Current materials include detailed scope, architecture, workflow, and deterministic contracts captured in markdown files. The documentation defines what the MVP should cover and what it excludes, while the deterministic smoke-run is defined and implemented. Documentation states that paper trading/simulation is not available. Trading and simulation execution are explicitly not implemented.
 
 ## Repository Structure Overview
 
@@ -30,8 +30,8 @@ Work is structured around a single active Issue with an explicit execution workf
 
 ## Key Documents
 
-- `RUNBOOK.md`: Working SOP that defines the end-to-end workflow, review gate, Definition of Done, and the statement that the deterministic smoke-run exists only as a spec. It also states that paper trading/simulation is not available.
-- `docs/smoke-run.md`: Deterministic smoke-run specification with exact fixtures, output, and exit codes, explicitly marked as not implemented.
+- `RUNBOOK.md`: Working SOP that defines the end-to-end workflow, review gate, Definition of Done, and the local deterministic smoke-run execution steps. It also states that paper trading/simulation is not available.
+- `docs/smoke-run.md`: Deterministic smoke-run specification with exact fixtures, output, and exit codes.
 - `docs/MVP_SPEC.md`: Product scope and exclusions for MVP v1, including explicit exclusions such as live trading, broker integrations, backtesting, and AI-based signal generation.
 - `docs/mvp_v1.md`: Detailed MVP v1 system overview and component breakdown (engine, persistence, API, and trading desk) with scope and non-goals.
 - `docs/local_run.md`: Local development steps and API usage expectations, including the note that there is no CLI entrypoint and that the API is used directly.
@@ -45,19 +45,19 @@ A new developer can start with:
 2. `docs/MVP_SPEC.md` and `docs/mvp_v1.md` for scope, architecture, and MVP boundaries.
 3. `RUNBOOK.md` and `docs/governance/*` for workflow, review gates, and test/merge rules.
 4. `docs/local_run.md` for how the API is invoked in local development.
-5. `docs/smoke-run.md` to understand the deterministic smoke-run contract that exists only as a spec.
+5. `docs/smoke-run.md` to understand the deterministic smoke-run contract and its implementation details.
 
-They should not expect to run a smoke-run command, a paper-trading or simulation entrypoint, or a live trading workflow, because these are explicitly not implemented. There is also no CLI entrypoint documented; API usage via `uvicorn` is the described path. The documentation provides the scope and operational workflow; implementation specifics are in `src/` and `api/` and are outside the scope of this snapshot.
+They should not expect to run a paper-trading or simulation entrypoint, or a live trading workflow, because these are explicitly not implemented. There is no CLI entrypoint documented; API usage via `uvicorn` is the described path, and the smoke-run is executed via the documented local command. The documentation provides the scope and operational workflow; implementation specifics are in `src/` and `api/` and are outside the scope of this snapshot.
 
 ## Known Gaps / Non-Implemented Areas
 
 The following components are explicitly absent or described as not implemented in the current repository state:
 
-- Deterministic smoke-run execution (specification exists; implementation does not).
 - Paper trading or simulation execution.
 - Live trading, broker integrations, or order execution.
 - Backtesting frameworks.
 - AI-based signal generation or automated decision-making.
 - A CLI entrypoint for running the engine; API-only invocation is documented.
 
+Deterministic smoke-run execution is implemented and documented in the runbook/spec.
 These are documented as out of scope or not yet implemented, and are part of the current state rather than defects.

--- a/docs/smoke-run.md
+++ b/docs/smoke-run.md
@@ -1,7 +1,7 @@
-# Deterministic Smoke-Run Specification (SPEC ONLY)
+# Deterministic Smoke-Run Specification
 
 ## Status
-NOT IMPLEMENTED. This document defines a deterministic smoke-run contract only; no implementation exists in this repository.
+Implemented in `src/cilly_trading/smoke_run.py` via `run_smoke_run`.
 
 ## Purpose
 Define a deterministic, offline smoke-run contract that validates fixed fixtures and produces fixed outputs so another developer can implement it without ambiguity.
@@ -19,9 +19,8 @@ Define a deterministic, offline smoke-run contract that validates fixed fixtures
 - No network: do not open sockets or make HTTP requests.
 - Input-only: results must be derived solely from the fixture files described below.
 
-## Reserved Invocation (Not Implemented)
-- Name only: `smoke-run`.
-- This is a reserved invocation name and is not implemented.
+## Invocation
+- There is no CLI entrypoint; execute via `run_smoke_run` (see `RUNBOOK.md` for the exact local command).
 
 ## Fixture Contract (Exact)
 
@@ -112,4 +111,4 @@ A UTF-8 JSON object with the following exact keys and types:
 - Any nonzero exit code not listed above.
 
 ## Implementation Note
-This is a SPEC only. It is NOT IMPLEMENTED in this repository.
+The implementation is deterministic and intentionally uses only local fixtures and artifacts.


### PR DESCRIPTION
### Motivation
- Make RUNBOOK actionable by adding a copy-paste local invocation and exact expected outputs so the documented smoke-run matches the implemented behavior. 
- Remove stale statements that claimed the smoke-run was unimplemented and align `docs/smoke-run.md` and the repository snapshot with the actual implementation in `src/cilly_trading/smoke_run.py`.

### Description
- Add a new "Deterministic Smoke Run – Local Execution" section to `RUNBOOK.md` with prerequisites, the exact command to run (`PYTHONPATH=src python -c 'from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())'`), exact stdout expected, artifact path (`artifacts/smoke-run/result.json`), and exit-code semantics (0, 10, 11, 12, 13) and a determinism note.
- Update `docs/smoke-run.md` to mark the spec as implemented, add invocation guidance, and update the implementation note to reflect the deterministic local implementation.
- Update `docs/repo-snapshot.md` to reflect that the deterministic smoke-run is implemented and documented in the runbook/spec and adjust related references.
- Files changed: `RUNBOOK.md`, `docs/smoke-run.md`, `docs/repo-snapshot.md`.

### Testing
- No automated tests were run because this is a documentation-only change (tests unaffected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981352e6c5483338dcd23aee89be6ba)