### PR TITLE
Add Phase 9 exit MVP declaration

### DIFF
--- a/docs/phase-9-exit.md
+++ b/docs/phase-9-exit.md
@@ -1,0 +1,24 @@
+# Phase 9 Exit – MVP State Declaration
+
+## Decision
+Phase 9 is formally closed.
+
+## Effective Date
+2025-09-10
+
+## MVP Capabilities
+- View market price data in the application.
+- Review historical price data in the application.
+- Run paper trading simulations in the application.
+- View stored signals and alerts in the application.
+- Manage strategies and related settings in the application.
+
+## Explicit Non-Goals / Exclusions
+- No live trading.
+- No broker integrations.
+- No backtesting.
+- No AI decision-making.
+- No automated execution of real orders.
+
+## Scope Boundary Statement
+Anything not listed above is out of scope for the MVP state declared here.


### PR DESCRIPTION
### Motivation
- Formalize the closure of Phase 9 and declare the current MVP state and explicit exclusions to satisfy the project acceptance criteria.

### Description
- Added a new documentation file `docs/phase-9-exit.md` containing the required sections: Title, Decision (Phase 9 formally closed), Effective Date (`2025-09-10`), plain-language MVP Capabilities, Explicit Non-Goals / Exclusions (including no live trading, no broker integrations, no backtesting, no AI decision-making), and a Scope Boundary Statement.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f68ccb3483338b8192f4d0c72b65)