### PR TITLE
docs: fix OWNER_RUNBOOK for architectural review gate

### DIFF
--- a/docs/OWNER_RUNBOOK.md
+++ b/docs/OWNER_RUNBOOK.md
@@ -1,0 +1,58 @@
+# Owner Runbook: Start / Stop / Logs / Reset Cheatsheet
+
+## Purpose & Safety Notes
+This runbook gives owners a short, safe checklist to run, stop, monitor, and reset the local system.
+
+- Use this checklist exactly as written.
+- Perform these steps only in your local environment.
+- Keep commands and outputs visible while you operate.
+
+## Start
+Action:
+```bash
+<<START_COMMAND>>
+```
+
+What happens: The local service starts and becomes available for owner use.
+
+Expected success signal: `<<HEALTH_CHECK_COMMAND>>` shows the service is available.
+
+## Stop
+Action:
+```bash
+<<STOP_COMMAND>>
+```
+
+What happens: The running local service shuts down cleanly.
+
+Expected success signal: `<<STOP_SIGNAL>>` confirms the service is no longer running.
+
+## Logs
+Action:
+```bash
+<<LOG_ACCESS_COMMAND>>
+```
+
+What happens: Recent runtime output is displayed so you can verify current behavior.
+
+Expected success signal: New log output appears and includes recent activity timestamps.
+
+## Reset / Cleanup
+> ⚠ WARNING — LOCAL DEVELOPMENT ONLY
+>
+> NEVER run this on production or shared systems.
+
+Action:
+```bash
+<<RESET_COMMAND>>
+```
+
+What happens: Local runtime state is cleared for a fresh local start.
+
+Expected success signal: `<<LOCAL_DATA_FILE>>` is removed or re-created cleanly after the next start.
+
+## Troubleshooting
+- If start fails, re-run `<<START_COMMAND>>` exactly and check the returned error line.
+- If stop fails, run `<<STOP_COMMAND>>` again and verify `<<STOP_SIGNAL>>`.
+- If logs are empty, re-run `<<LOG_ACCESS_COMMAND>>` and confirm you are targeting the active log source.
+- If reset fails, stop first, run `<<RESET_COMMAND>>`, then start again with `<<START_COMMAND>>`.


### PR DESCRIPTION
### Motivation
- Ensure the owner runbook meets the Architectural Review Gate by removing concrete architecture assumptions and replacing executable details with placeholders.

### Description
- Modified `docs/OWNER_RUNBOOK.md` to remove framework- and system-specific references and commands, replacing them with explicit uppercase placeholders such as `<<START_COMMAND>>`, `<<STOP_COMMAND>>`, `<<LOG_ACCESS_COMMAND>>`, `<<HEALTH_CHECK_COMMAND>>`, `<<STOP_SIGNAL>>`, `<<RESET_COMMAND>>`, and `<<LOCAL_DATA_FILE>>`, and added the required prominent reset safety warning; no other files were changed.

### Testing
- Inspected the updated file with `nl -ba docs/OWNER_RUNBOOK.md` to confirm placeholders and the reset safety warning are present; this is a docs-only change so no unit tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986510135e08333bea79abaf6ab4e03)