### PR TITLE
docs: add explicit local-only access policy

### DIFF
--- a/docs/access-policy.md
+++ b/docs/access-policy.md
@@ -1,0 +1,17 @@
+# Access Policy
+
+## Decision
+The application is accessed locally only. This decision is exclusive and final.
+
+## Supported Access Mode
+- Local execution on the user's own machine only.
+
+## Explicitly Unsupported Access Modes
+- Hosted access is unsupported.
+- Cloud access is unsupported.
+- Web access is unsupported.
+- SaaS access is unsupported.
+- Remote access is unsupported.
+
+## Rationale
+This document establishes one explicit access policy and removes ambiguity by defining exactly one supported mode and listing all unsupported modes in direct terms.


### PR DESCRIPTION
### Motivation
- Create a single authoritative decision document that defines the application access mode as local only and removes any ambiguity about supported access modes.

### Description
- Add `docs/access-policy.md` containing `Decision`, `Supported Access Mode`, `Explicitly Unsupported Access Modes`, and `Rationale` sections with unambiguous, declarative wording that the application is accessed locally only and that hosted, cloud, web, SaaS, and remote access modes are unsupported.

### Testing
- Run `git add docs/access-policy.md` and `git commit` and verify with `git status --short`, all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698655d329b083339f6a8089481246fe)