### PR TITLE
docs: make owner & local run docs executable and consistent

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,13 +1,13 @@
 # Getting Started (Owner)
 
 ## A. Purpose
-This guide provides the single authoritative path for owners to start and access the application locally. Follow the steps in order to verify the API is running and then stop it cleanly.
+This guide provides the single authoritative path for owners to start and access the application locally. Follow the steps in order to verify the API is running and then stop/reset it cleanly.
 
 ## B. Prerequisites
 - Python 3.10+
 - `pip`
 
-## C. Single Authoritative Start Method
+## C. Single Authoritative Start Method (canonical)
 From the repository root, run exactly:
 
 ```bash
@@ -17,30 +17,45 @@ pip install -r requirements.txt
 PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
-## D. Single Access Endpoint
+## D. Secondary / utility entrypoints (not canonical)
+- `PYTHONPATH=src python -m api.main`
+- `docker compose up --build`
+
+Use these only as alternatives. The canonical owner startup path is Section C.
+
+## E. Single Access Endpoint
 Use this endpoint to access the running application:
 
 - http://127.0.0.1:8000/health
 
-## E. Success Indicator
+## F. Success Indicator
 The application is running when the endpoint returns exactly:
 
 ```json
 {"status":"ok"}
 ```
 
-## F. Clean Stop Procedure
+## G. Clean Stop Procedure
 1. In the terminal where `uvicorn` is running, press `Ctrl+C` once.
-2. Wait until the shutdown completes and the terminal prompt returns.
+2. Wait until shutdown completes and the terminal prompt returns.
 3. Optional confirmation:
 
 ```bash
-curl http://127.0.0.1:8000/health
+curl --fail http://127.0.0.1:8000/health
 ```
 
-After stopping `uvicorn`, the endpoint is no longer reachable.
+After stopping `uvicorn`, the command exits non-zero because the endpoint is unreachable.
 
-## G. Troubleshooting
+## H. Reset Local Runtime State
+Run from repository root (local development only):
+
+```bash
+rm -f cilly_trading.db
+```
+
+On next API start, SQLite tables are recreated automatically.
+
+## I. Troubleshooting
 - If `uvicorn: command not found` appears, activate the virtual environment again:
 
   ```bash

--- a/docs/OWNER_RUNBOOK.md
+++ b/docs/OWNER_RUNBOOK.md
@@ -7,35 +7,65 @@ This runbook gives owners a short, safe checklist to run, stop, monitor, and res
 - Perform these steps only in your local environment.
 - Keep commands and outputs visible while you operate.
 
-## Start
-Action:
+## Canonical startup path (owner default)
+Run from the repository root:
+
 ```bash
-<<START_COMMAND>>
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
-What happens: The local service starts and becomes available for owner use.
+What happens: FastAPI starts locally on port `8000`, and SQLite tables are initialized in `cilly_trading.db`.
 
-Expected success signal: `<<HEALTH_CHECK_COMMAND>>` shows the service is available.
+Expected success signal (run in a second terminal):
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+## Secondary / utility entrypoints (not the default owner path)
+- Module start (same API app, without typing the uvicorn target):
+  ```bash
+  PYTHONPATH=src python -m api.main
+  ```
+- Docker Compose start:
+  ```bash
+  docker compose up --build
+  ```
+
+These are valid utility paths, but the canonical owner path is `PYTHONPATH=src uvicorn api.main:app --reload`.
 
 ## Stop
-Action:
+Action (terminal where the server is running):
+- Press `Ctrl+C` once.
+
+Expected success signal (from another terminal):
+
 ```bash
-<<STOP_COMMAND>>
+curl --fail http://127.0.0.1:8000/health
 ```
 
-What happens: The running local service shuts down cleanly.
-
-Expected success signal: `<<STOP_SIGNAL>>` confirms the service is no longer running.
+The command exits non-zero because the service is no longer reachable.
 
 ## Logs
 Action:
+- Read the terminal where `uvicorn` runs; runtime logs are written there.
+
+Optional follow mode:
+
 ```bash
-<<LOG_ACCESS_COMMAND>>
+PYTHONPATH=src uvicorn api.main:app --reload 2>&1 | tee local-api.log
 ```
 
-What happens: Recent runtime output is displayed so you can verify current behavior.
-
-Expected success signal: New log output appears and includes recent activity timestamps.
+What happens: logs stream to terminal and also to `local-api.log`.
 
 ## Reset / Cleanup
 > ⚠ WARNING — LOCAL DEVELOPMENT ONLY
@@ -43,16 +73,19 @@ Expected success signal: New log output appears and includes recent activity tim
 > NEVER run this on production or shared systems.
 
 Action:
+
 ```bash
-<<RESET_COMMAND>>
+rm -f cilly_trading.db
 ```
 
 What happens: Local runtime state is cleared for a fresh local start.
 
-Expected success signal: `<<LOCAL_DATA_FILE>>` is removed or re-created cleanly after the next start.
+Expected success signal:
+- `cilly_trading.db` is removed.
+- After the next API start, `cilly_trading.db` is created again.
 
 ## Troubleshooting
-- If start fails, re-run `<<START_COMMAND>>` exactly and check the returned error line.
-- If stop fails, run `<<STOP_COMMAND>>` again and verify `<<STOP_SIGNAL>>`.
-- If logs are empty, re-run `<<LOG_ACCESS_COMMAND>>` and confirm you are targeting the active log source.
-- If reset fails, stop first, run `<<RESET_COMMAND>>`, then start again with `<<START_COMMAND>>`.
+- If start fails, rerun the canonical startup command and read the first error line.
+- If `/health` fails while server is running, confirm the process uses `127.0.0.1:8000`.
+- If logs look empty, ensure you are looking at the terminal where `uvicorn` is running.
+- If reset appears ineffective, stop the API first, run `rm -f cilly_trading.db`, then start again.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -54,7 +54,7 @@ A change is considered DONE only if:
 ### Prerequisites
 - Python 3 available in your environment.
 - Run from the repository root so the default fixtures path (`fixtures/smoke-run/`) is available.
-- Ensure the package is importable by setting `PYTHONPATH=src` (there is no CLI entrypoint).
+- Ensure the package is importable by setting `PYTHONPATH=src`. There is no installed top-level CLI command, so use the documented Python module command.
 
 ### Command (exact)
 ```bash
@@ -133,4 +133,4 @@ python -m pytest
 - A red check blocks merge until tests pass.
 
 ### Run Paper Trading (Simulation)
-Not available — Blocker: no paper-trading/simulation entrypoint is documented or implemented in the repo without touching `src/**`. No live trading, broker keys, or real orders are used.
+No dedicated CLI endpoint is documented for paper-trading simulation in this runbook. The repository contains a simulator module (`src/cilly_trading/engine/paper_trading.py`), but no owner-facing run command is defined here. No live trading, broker keys, or real orders are used.


### PR DESCRIPTION
### Motivation
- Owners need runnable, unambiguous run/stop/reset instructions that reflect the repository's real behavior so local onboarding is deterministic and repeatable.
- Several docs contained placeholders or outdated claims (e.g. “no CLI entrypoint yet”) which caused guessing and prevented a clean local run.
- The goal is to provide a single canonical startup path plus clearly labeled secondary/utility entrypoints and explicit start/stop/reset/log steps so the Acceptance Criteria are satisfied.

### Description
- Replaced placeholder tokens and non-executable text with concrete commands and examples in `docs/OWNER_RUNBOOK.md`, `docs/local_run.md`, `docs/GETTING_STARTED.md`, and corrected wording in `docs/RUNBOOK.md`.
- Declared the canonical owner startup path as `PYTHONPATH=src uvicorn api.main:app --reload` and listed secondary entrypoints (`python -m api.main`, `docker compose up --build`, and the deterministic run module) with explicit labels.
- Added an executable demo snapshot creation step using `python scripts/create_demo_snapshot.py` and showed how to capture `ingestion_run_id`, call `POST /strategy/analyze`, and verify persisted signals with `GET /signals`.
- Made start/stop/log/reset instructions explicit and truthful: `Ctrl+C` to stop, `curl --fail http://127.0.0.1:8000/health` for verification, `rm -f cilly_trading.db` to reset locally, and an optional `tee` log capture example.

### Testing
- Executed an end-to-end local smoke sequence: `python -m venv .venv`, `source .venv/bin/activate`, `pip install -r requirements.txt`, and started the API with `PYTHONPATH=src uvicorn api.main:app --reload`, which started successfully (health endpoint returned `{"status":"ok"}`).
- Created a demo snapshot with `python scripts/create_demo_snapshot.py` to obtain an `ingestion_run_id`, performed `POST /strategy/analyze` with that ID, and verified `GET /signals?strategy=RSI2&ingestion_run_id=<id>&limit=10`; all commands returned expected shapes and the API responded as documented.
- Confirmed stop semantics by sending `Ctrl+C` to the server and verifying `curl --fail http://127.0.0.1:8000/health` failed as expected; all automated/CLI checks in the PR transcript succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987890e6a908333b44c7aa174686d42)