### PR TITLE
docs: Phase 11 kickoff runtime bootstrap scope declaration

### DIFF
--- a/docs/phase-11-kickoff.md
+++ b/docs/phase-11-kickoff.md
@@ -1,0 +1,59 @@
+# Phase 11 Kickoff: Runtime Bootstrap Scope Declaration
+
+## Phase 11 Scope
+Phase 11 defines the runtime bootstrap scope for system lifecycle coordination.
+
+Phase 11 includes only:
+- Conceptual lifecycle state model for runtime control: `init`, `start`, `running`, `shutdown`.
+- Conceptual ownership boundaries between engine lifecycle responsibility and API responsibility.
+- Scope guardrails that prevent lifecycle/API boundary drift during Phase 11 work.
+
+Phase 11 excludes any implementation, integration, or behavior changes.
+
+## Lifecycle States (Conceptual)
+- `init`: Runtime prerequisites are prepared and lifecycle control context is established.
+- `start`: Lifecycle transition from prepared state to active runtime operation is initiated.
+- `running`: Runtime operation is active and lifecycle supervision is in effect.
+- `shutdown`: Runtime operation is terminated through controlled lifecycle closure.
+
+State definitions are declarative scope markers only.
+
+## Ownership and Responsibility Boundaries
+
+### Engine Lifecycle Ownership
+The engine owns lifecycle state authority and lifecycle transitions.
+
+Engine responsibility is limited to:
+- Defining and maintaining lifecycle state continuity.
+- Executing lifecycle transitions across `init`, `start`, `running`, and `shutdown`.
+- Maintaining runtime lifecycle integrity independent of API request flow.
+
+### API Ownership
+The API owns external interaction surface and request/response orchestration.
+
+API responsibility is limited to:
+- Exposing interaction endpoints for external clients.
+- Relaying intent into lifecycle-aware engine interfaces without owning lifecycle state.
+- Reporting lifecycle-relevant status as provided by engine lifecycle authority.
+
+### Boundary Rule (Explicit)
+- The engine is the single conceptual owner of lifecycle state and transitions.
+- The API is not a lifecycle state owner and does not define lifecycle transitions.
+- Lifecycle control scope and API interaction scope are separate and non-overlapping.
+
+## Non-Goals (Explicit)
+Phase 11 does **not** include:
+- Lifecycle implementation details, orchestration mechanics, or control-flow design.
+- API contract redesign, endpoint additions, transport policy changes, or versioning changes.
+- Startup/shutdown performance targets, runtime tuning, or optimization work.
+- Observability design, logging schemas, metrics definitions, or alerting policy.
+- Error taxonomy design, retry strategy definition, or failure-recovery behavior design.
+- Dependency injection strategy, module wiring strategy, or package layout changes.
+- Deployment/runtime environment strategy, infra policy, or operations process updates.
+- Test strategy expansion, test-case design, or validation framework changes.
+- Any feature development outside lifecycle scope declaration and boundary definition.
+
+## Acceptance Mapping
+- Scope unambiguous: constrained to lifecycle scope declaration and boundary definition only.
+- Non-goals explicit and exhaustive: concrete exclusions listed across implementation, API, runtime, observability, failure handling, structure, deployment, testing, and out-of-scope feature work.
+- No implementation guidance: document remains conceptual and declarative without code or design instructions.


### PR DESCRIPTION
### Motivation
- Establish an unambiguous, documentation-only scope for Phase 11 focused on runtime bootstrap and lifecycle coordination to prevent scope drift. 
- Clarify ownership boundaries between the engine lifecycle authority and the API interaction surface so subsequent work remains within declared responsibilities.

### Description
- Added `docs/phase-11-kickoff.md` that declares Phase 11 scope limited to lifecycle concept definition and boundary guardrails. 
- Defined conceptual lifecycle states: `init`, `start`, `running`, and `shutdown` as declarative scope markers. 
- Specified engine vs API ownership and responsibility at a conceptual level, designating the engine as the lifecycle state owner and the API as the external interaction surface. 
- Included a comprehensive, explicit Non-Goals section enumerating excluded items (implementation details, API contract changes, performance tuning, observability, error/recovery design, DI/wiring, deployment/infra, and test strategy changes) and an Acceptance Mapping that ties the document to acceptance criteria.

### Testing
- No unit or integration tests were required for this documentation-only change. 
- Automated validation: presence and contents of `docs/phase-11-kickoff.md` were inspected using repository tooling and displayed successfully. 
- Repository index update and file addition were performed and verified using local repository commands (file listed and content lines confirmed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987909998f88333a7a2b99e6a65c17f)