### PR TITLE
Add EngineRuntimeController lifecycle entrypoint with tests

### DIFF
--- a/src/cilly_trading/engine/runtime_controller.py
+++ b/src/cilly_trading/engine/runtime_controller.py
@@ -1,0 +1,112 @@
+"""Runtime lifecycle controller for the engine domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+
+class LifecycleTransitionError(RuntimeError):
+    """Raised when a runtime lifecycle transition is not allowed."""
+
+
+@dataclass
+class EngineRuntimeController:
+    """Controls lifecycle transitions for a single engine runtime instance.
+
+    The lifecycle follows the contract order:
+    ``init -> ready -> running -> stopping -> stopped``.
+    """
+
+    _state: str = field(default="init", init=False)
+
+    _STATE_ORDER: Final[tuple[str, ...]] = (
+        "init",
+        "ready",
+        "running",
+        "stopping",
+        "stopped",
+    )
+
+    @property
+    def state(self) -> str:
+        """Return the current lifecycle state.
+
+        Returns:
+            str: Current lifecycle state.
+        """
+
+        return self._state
+
+    def init(self) -> str:
+        """Transition the runtime to the ``ready`` state.
+
+        Returns:
+            str: The resulting lifecycle state.
+
+        Raises:
+            LifecycleTransitionError: If called when not in ``init`` state.
+        """
+
+        self._assert_state("init", action="init")
+        self._state = "ready"
+        return self._state
+
+    def start(self) -> str:
+        """Transition the runtime to the ``running`` state.
+
+        Returns:
+            str: The resulting lifecycle state.
+
+        Raises:
+            LifecycleTransitionError: If called when not in ``ready`` state.
+        """
+
+        self._assert_state("ready", action="start")
+        self._state = "running"
+        return self._state
+
+    def shutdown(self) -> str:
+        """Stop runtime execution safely and idempotently.
+
+        When in ``running`` state this method deterministically performs:
+        ``running -> stopping -> stopped``.
+
+        Returns:
+            str: The resulting lifecycle state.
+
+        Raises:
+            LifecycleTransitionError: If called before runtime reaches ``running``.
+        """
+
+        if self._state == "stopped":
+            return self._state
+
+        if self._state == "stopping":
+            self._state = "stopped"
+            return self._state
+
+        if self._state != "running":
+            raise LifecycleTransitionError(
+                f"Cannot shutdown() while in state '{self._state}'. Expected 'running', 'stopping', or 'stopped'."
+            )
+
+        self._state = "stopping"
+        self._state = "stopped"
+        return self._state
+
+    def _assert_state(self, expected: str, *, action: str) -> None:
+        """Validate current state for transition actions.
+
+        Args:
+            expected: Required current state.
+            action: Action being executed.
+
+        Raises:
+            LifecycleTransitionError: If current state does not match expected.
+        """
+
+        if self._state != expected:
+            raise LifecycleTransitionError(
+                f"Cannot {action}() while in state '{self._state}'. Expected '{expected}'."
+            )

--- a/src/cilly_trading/engine/tests/test_runtime_controller.py
+++ b/src/cilly_trading/engine/tests/test_runtime_controller.py
@@ -1,0 +1,58 @@
+"""Tests for engine runtime lifecycle controller."""
+
+import pytest
+
+from cilly_trading.engine.runtime_controller import (
+    EngineRuntimeController,
+    LifecycleTransitionError,
+)
+
+
+def test_valid_lifecycle_transitions_succeed() -> None:
+    controller = EngineRuntimeController()
+
+    assert controller.state == "init"
+    assert controller.init() == "ready"
+    assert controller.start() == "running"
+    assert controller.shutdown() == "stopped"
+    assert controller.state == "stopped"
+
+
+def test_invalid_transitions_are_rejected() -> None:
+    controller = EngineRuntimeController()
+
+    with pytest.raises(LifecycleTransitionError):
+        controller.start()
+
+    assert controller.init() == "ready"
+
+    with pytest.raises(LifecycleTransitionError):
+        controller.init()
+
+    assert controller.start() == "running"
+
+    with pytest.raises(LifecycleTransitionError):
+        controller.start()
+
+
+def test_shutdown_is_idempotent_and_deterministic() -> None:
+    controller = EngineRuntimeController()
+
+    controller.init()
+    controller.start()
+
+    assert controller.shutdown() == "stopped"
+    assert controller.shutdown() == "stopped"
+    assert controller.state == "stopped"
+
+
+def test_shutdown_before_running_is_rejected() -> None:
+    controller = EngineRuntimeController()
+
+    with pytest.raises(LifecycleTransitionError):
+        controller.shutdown()
+
+    controller.init()
+
+    with pytest.raises(LifecycleTransitionError):
+        controller.shutdown()


### PR DESCRIPTION
### Motivation
- Provide a single explicit runtime controller that enforces the engine lifecycle contract (`init -> ready -> running -> stopping -> stopped`).
- Ensure lifecycle transitions are deterministic, will reject invalid or repeated transitions, and make shutdown safe/idempotent.

### Description
- Add `src/cilly_trading/engine/runtime_controller.py` implementing `EngineRuntimeController` with lifecycle methods `init()`, `start()`, and `shutdown()`, and the `LifecycleTransitionError` exception.
- The controller enforces allowed transitions and prevents invalid/repeated transitions according to the lifecycle contract.
- Add tests in `src/cilly_trading/engine/tests/test_runtime_controller.py` that validate valid transitions, invalid transition rejection, idempotent/deterministic shutdown, and rejection of shutdown before `running`.
- Only files under `src/cilly_trading/engine/` were added: `runtime_controller.py` and the corresponding test file.

### Testing
- Ran the new unit tests with `PYTHONPATH=src pytest -q src/cilly_trading/engine/tests/test_runtime_controller.py` and all tests passed (`4 passed`).
- Tests verify: valid lifecycle progression succeeds, invalid transitions raise `LifecycleTransitionError`, `shutdown()` is deterministic and idempotent, and `shutdown()` before `running` is rejected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987937cb39c833396aa546d4f04997c)