### PR TITLE
docs(engine): add runtime ownership and lifetime model

### DIFF
--- a/docs/engine/runtime-ownership.md
+++ b/docs/engine/runtime-ownership.md
@@ -1,0 +1,49 @@
+# Engine Runtime Ownership & Lifetime Model
+
+## Zweck
+Dieses Dokument definiert eindeutig, wo die Engine-Runtime lebt,
+wem sie gehört und wie ihr Lebenszyklus gesteuert wird.
+Es beschreibt bewusst keine Implementierungsdetails.
+
+## Runtime-Instanzmodell
+- Es existiert genau EINE Engine-Runtime-Instanz pro Prozess.
+- Die Runtime ist ein langlebiges, zustandsbehaftetes Objekt.
+- Es gibt keine kurzlebigen oder mehrfachen Runtime-Instanzen.
+
+## Ownership
+- Die Runtime gehört der Engine-Schicht.
+- Die Engine ist allein verantwortlich für:
+  - Erzeugung der Runtime
+  - Halten der Runtime
+  - Geordnetes Beenden der Runtime
+- Externe Komponenten (z. B. API-Schicht) besitzen die Runtime NICHT.
+
+## Kontrolle vs. Sichtbarkeit
+- Die API-Schicht darf die Runtime:
+  - nutzen
+  - ansprechen
+  - Status abfragen
+- Die API-Schicht darf die Runtime NICHT:
+  - erzeugen
+  - ersetzen
+  - neu starten
+  - direkt beenden
+
+## Lifetime-Regeln
+- Die Runtime wird beim Start der Engine initialisiert.
+- Die Runtime existiert für die gesamte Lebensdauer der Engine.
+- Die Runtime wird exakt einmal sauber heruntergefahren:
+  - ausgelöst durch die Engine
+  - als Teil des Engine-Shutdowns
+
+## Verbotene Annahmen
+- Keine Lazy-Initialisierung durch API-Zugriffe
+- Kein implizites Neustarten der Runtime
+- Keine Ownership-Übergabe an andere Schichten
+
+## Scope-Hinweis
+Dieses Dokument trifft keine Aussagen zu:
+- technischer Umsetzung
+- Threading oder Concurrency
+- Dependency Injection
+- konkreten Klassen oder Funktionen


### PR DESCRIPTION
### Motivation
- Provide a formal, implementation-agnostic specification that defines the Engine runtime instance model, ownership boundaries, control vs. visibility, lifetime rules, and explicit exclusions for implementation details.

### Description
- Add one new documentation file `docs/engine/runtime-ownership.md` containing the mandated Engine Runtime Ownership & Lifetime Model text exactly as specified.

### Testing
- Verified the file was created and its contents match the specification using `cat docs/engine/runtime-ownership.md`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a20f102083338ac5588d88702bda)