### PR TITLE
Bind engine runtime lifecycle to API startup and shutdown

### DIFF
--- a/api/test_runtime_lifecycle.py
+++ b/api/test_runtime_lifecycle.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+
+
+def test_runtime_is_started_on_api_startup(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def _start() -> str:
+        calls.append("start")
+        return "running"
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+
+    with TestClient(api_main.app):
+        assert calls == ["start"]
+
+
+def test_runtime_is_shutdown_on_api_shutdown(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def _start() -> str:
+        return "running"
+
+    def _shutdown() -> str:
+        calls.append("shutdown")
+        return "stopped"
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", _shutdown)
+
+    with TestClient(api_main.app):
+        pass
+
+    assert calls == ["shutdown"]

--- a/src/cilly_trading/engine/tests/test_runtime_controller.py
+++ b/src/cilly_trading/engine/tests/test_runtime_controller.py
@@ -5,7 +5,16 @@ import pytest
 from cilly_trading.engine.runtime_controller import (
     EngineRuntimeController,
     LifecycleTransitionError,
+    _reset_runtime_controller_for_tests,
+    get_runtime_controller,
+    shutdown_engine_runtime,
+    start_engine_runtime,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_singleton() -> None:
+    _reset_runtime_controller_for_tests()
 
 
 def test_valid_lifecycle_transitions_succeed() -> None:
@@ -56,3 +65,27 @@ def test_shutdown_before_running_is_rejected() -> None:
 
     with pytest.raises(LifecycleTransitionError):
         controller.shutdown()
+
+
+def test_process_runtime_is_singleton_and_started_once() -> None:
+    runtime_a = get_runtime_controller()
+    runtime_b = get_runtime_controller()
+
+    assert runtime_a is runtime_b
+    assert runtime_a.state == "init"
+
+    assert start_engine_runtime() == "running"
+    assert start_engine_runtime() == "running"
+    assert runtime_a.state == "running"
+
+
+def test_process_runtime_shutdown_is_best_effort() -> None:
+    runtime = get_runtime_controller()
+
+    assert shutdown_engine_runtime() == "init"
+    assert runtime.state == "init"
+
+    start_engine_runtime()
+    assert shutdown_engine_runtime() == "stopped"
+    assert shutdown_engine_runtime() == "stopped"
+    assert runtime.state == "stopped"


### PR DESCRIPTION
### Motivation

- Ensure the engine runtime is initialized and explicitly started during API startup and cleanly shut down during API shutdown while keeping single-runtime ownership with the engine layer.
- Follow the existing lifecycle contract so the API only triggers start/shutdown without taking ownership or modifying API endpoints or engine logic.

### Description

- Added process-wide, thread-safe runtime helpers in `src/cilly_trading/engine/runtime_controller.py`: `get_runtime_controller`, `_get_or_create_runtime_controller`, `start_engine_runtime`, `shutdown_engine_runtime`, and `_reset_runtime_controller_for_tests` to enforce a single runtime per process and provide start/shutdown operations. 
- Wired API lifecycle hooks in `api/main.py` using FastAPI startup/shutdown handlers to call `start_engine_runtime` and `shutdown_engine_runtime`, and added error handling for `LifecycleTransitionError` using existing logging patterns. 
- Extended `src/cilly_trading/engine/tests/test_runtime_controller.py` to cover singleton semantics and the start/shutdown helper behavior and added `api/test_runtime_lifecycle.py` to verify runtime start on API startup and shutdown on API shutdown via `TestClient`.
- Changes were restricted to the allowed paths and are minimal-invasive to satisfy the lifecycle binding scope.

### Testing

- Ran `pytest -q src/cilly_trading/engine/tests/test_runtime_controller.py api/test_runtime_lifecycle.py tests/test_api_smoke_engine_db_api.py` which completed successfully with all tests passing.
- Test summary: `10 passed, 4 warnings` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987a5a4f1a083338271abdb19f13255)