### PR TITLE
docs: Phase 13 runtime observability scope (status / health / introspection)

### DIFF
--- a/docs/phase-13/runtime-observability-scope.md
+++ b/docs/phase-13/runtime-observability-scope.md
@@ -1,0 +1,124 @@
+# Phase 13 – Runtime Status, Health & Introspection Scope
+
+## Purpose
+Phase 13 introduces runtime observability interfaces only. This phase exposes current runtime information for operators and diagnostics and does not change runtime behavior, decision logic, or lifecycle behavior.
+
+## Non-Goals (Out of Scope)
+- New runtime states or lifecycle transitions.
+- Control operations (start, stop, pause, resume, restart, or equivalent).
+- Any write operation against runtime state, configuration, queues, or storage.
+- Live trading workflows or broker integrations.
+- Backtesting workflows.
+- AI-driven or strategy decision logic.
+
+## Read-Only Contract (No Side Effects)
+- All Phase 13 status, health, and introspection endpoints **MUST** be read-only.
+- These endpoints **MUST NOT** trigger runtime state transitions.
+- These endpoints **MUST NOT** mutate memory, configuration, queues, persistence, or external systems.
+- These endpoints **MUST NOT** execute expensive side-effecting operations (for example: forced refreshes, cache rebuilds, or external reconfiguration).
+- The API contract **WILL NOT** expose operator command surfaces.
+- Exposed fields are intentionally minimal and stable.
+
+## Runtime Status
+Runtime status reports current engine identity, lifecycle snapshot, and timing metadata without defining or changing lifecycle transitions.
+
+### Status Fields
+- `engine_id` (string): Stable identifier of the running engine instance.
+- `runtime_state` (string): Current lifecycle state snapshot (generic values only, e.g. `starting`, `running`, `stopping`, `stopped`, `error`).
+- `since` (RFC3339 timestamp): Time when the current `runtime_state` began.
+- `uptime_seconds` (number): Elapsed runtime duration in seconds.
+- `version` (object): Runtime version metadata.
+  - `build` (string)
+  - `commit` (string)
+  - `api` (string)
+- `clock` (object): Server time metadata.
+  - `now` (RFC3339 timestamp)
+- `last_event` (object, optional): Minimal recent event context.
+  - `at` (RFC3339 timestamp)
+  - `kind` (string)
+  - `message` (string)
+
+### Example Status Payload
+```json
+{
+  "engine_id": "engine-main",
+  "runtime_state": "running",
+  "since": "2026-02-08T10:00:00Z",
+  "uptime_seconds": 8640,
+  "version": {
+    "build": "2026.02.08.1",
+    "commit": "abc123def",
+    "api": "v1"
+  },
+  "clock": {
+    "now": "2026-02-08T12:24:00Z"
+  },
+  "last_event": {
+    "at": "2026-02-08T12:23:58Z",
+    "kind": "heartbeat",
+    "message": "Runtime loop active"
+  }
+}
+```
+
+### Field Stability
+Status fields in this scope are stable. Any future additive changes must be versioned and documented.
+
+## Health Semantics
+Health expresses operational readiness at a high level and remains implementation-agnostic.
+
+### Health Levels
+- `healthy`: Core runtime services are available, checks are passing, and no known condition currently blocks normal operation.
+- `degraded`: Runtime is available but one or more non-fatal checks indicate reduced reliability or elevated risk.
+- `unavailable`: Runtime is not operationally available for normal use, or critical checks are failing.
+
+### Health Payload Shape
+- `level` (string): `healthy` | `degraded` | `unavailable`
+- `summary` (string): Human-readable one-line health summary.
+- `checks` (array): Small set of operational checks.
+  - `name` (string)
+  - `status` (string)
+  - `detail` (string, optional)
+  - `last_ok_at` (RFC3339 timestamp, optional)
+
+### Example Health Payload
+```json
+{
+  "level": "degraded",
+  "summary": "Runtime available with one degraded dependency check",
+  "checks": [
+    {
+      "name": "runtime_loop",
+      "status": "ok",
+      "last_ok_at": "2026-02-08T12:23:59Z"
+    },
+    {
+      "name": "outbound_queue",
+      "status": "warn",
+      "detail": "Queue depth near configured threshold",
+      "last_ok_at": "2026-02-08T12:23:10Z"
+    }
+  ]
+}
+```
+
+## Introspection (Operator/Debug)
+Introspection exposes safe runtime metadata to support operator diagnostics without exposing sensitive data.
+
+### Included Metadata
+- `configuration_snapshot`: Redacted and safe effective configuration view (no secrets).
+- `feature_flags`: Read-only feature flag states, if present.
+- `runtime_limits`: Safe runtime limits (for example: queue capacity thresholds) when non-sensitive.
+- `dependencies`: Optional dependency status summary suitable for diagnostics.
+
+### Explicit Exclusions
+- Secrets, credentials, private keys, tokens, or raw secret material.
+- Personal data.
+- Large data dumps by default.
+- Raw logs by default.
+
+## Derived Follow-Up Issues (P13-A1, P13-A2, P13-A3, P13-D1)
+- **P13-A1**: Implement runtime status endpoint(s) that conform to the status contract and field stability requirements in this document.
+- **P13-A2**: Implement health endpoint(s) that return the defined health levels and checks payload shape.
+- **P13-A3**: Implement introspection endpoint(s) exposing only the included safe metadata and enforcing explicit exclusions.
+- **P13-D1**: Publish API reference documentation and example payloads for status, health, and introspection, aligned with this scope contract.


### PR DESCRIPTION
### Motivation
- Provide a minimal, stable, and normative observability contract for Phase 13 covering runtime status, health, and operator-safe introspection. 
- Ensure the contract is explicitly read-only and prohibits any side effects or operator control surfaces.

### Description
- Added one documentation file at `docs/phase-13/runtime-observability-scope.md` that declares the Phase 13 scope and read-only contract.  
- Specifies the required `status` fields (`engine_id`, `runtime_state`, `since`, `uptime_seconds`, `version`, `clock`, optional `last_event`) with an example JSON payload and a field stability note.  
- Defines `health` semantics and payload shape with three levels (`healthy` / `degraded` / `unavailable`), checks structure, and an example JSON payload.  
- Defines `introspection` inclusions (redacted `configuration_snapshot`, `feature_flags`, `runtime_limits`, optional `dependencies`) and explicit exclusions (secrets, personal data, large dumps, raw logs).  
- Maps derived follow-up work to P13-A1 (status endpoints), P13-A2 (health endpoints), P13-A3 (introspection endpoints), and P13-D1 (publish API reference and examples).

### Testing
- Verified the new file `docs/phase-13/runtime-observability-scope.md` exists and its contents match the declared scope; repository checks confirm only documentation was added.  
- Performed content inspection of the file to ensure examples and normative language are present and stable.  
- No unit or integration tests were applicable because this is a documentation-only change; no runtime/code paths were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988dfc393c8833383893ea2c7625084)