### PR TITLE
P13-A2: Add deterministic read-only /health endpoint

### DIFF
--- a/docs/health.md
+++ b/docs/health.md
@@ -1,0 +1,49 @@
+# Engine Runtime Health (read-only)
+
+## Endpoint
+
+- `GET /health`
+- Read-only contract: no runtime initialization, no lifecycle transitions, no persistence writes.
+
+## Response payload
+
+```json
+{
+  "status": "healthy|degraded|unavailable",
+  "mode": "<runtime mode>",
+  "reason": "<deterministic rule id>",
+  "checked_at": "<ISO-8601 UTC timestamp>"
+}
+```
+
+The payload is intentionally lightweight and derived from runtime introspection plus deterministic evaluation.
+
+## Deterministic evaluation rules
+
+Inputs:
+- runtime snapshot (`mode`, `updated_at`)
+- injected `now` timestamp
+
+Thresholds:
+- `degraded_after = 30s`
+- `unavailable_after = 120s`
+
+Rules (in order):
+
+1. If `mode == running` and `now - updated_at <= 30s`:
+   - `status = healthy`
+   - `reason = runtime_running_fresh`
+2. If `mode == running` and `30s < now - updated_at <= 120s`:
+   - `status = degraded`
+   - `reason = runtime_running_stale`
+3. If `mode == running` and `now - updated_at > 120s`:
+   - `status = unavailable`
+   - `reason = runtime_running_timeout`
+4. If `mode == ready`:
+   - `status = degraded`
+   - `reason = runtime_not_started`
+5. Any other mode:
+   - `status = unavailable`
+   - `reason = runtime_not_available`
+
+These rules are implemented as a pure function so test cases can control both snapshot and time.

--- a/src/cilly_trading/engine/health/evaluator.py
+++ b/src/cilly_trading/engine/health/evaluator.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Literal, TypedDict
+
+HealthStatus = Literal["healthy", "degraded", "unavailable"]
+
+
+class RuntimeHealthSnapshot(TypedDict):
+    mode: str
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class RuntimeHealthResult:
+    status: HealthStatus
+    reason: str
+
+
+def evaluate_runtime_health(
+    snapshot: RuntimeHealthSnapshot,
+    *,
+    now: datetime,
+    degraded_after: timedelta = timedelta(seconds=30),
+    unavailable_after: timedelta = timedelta(seconds=120),
+) -> RuntimeHealthResult:
+    """Deterministically evaluate runtime health from an immutable snapshot.
+
+    The evaluation is pure: callers provide both runtime snapshot and the
+    reference timestamp (``now``), so tests can fully control outcomes.
+    """
+
+    normalized_now = _as_utc(now)
+    updated_at = _as_utc(snapshot["updated_at"])
+    lag = normalized_now - updated_at
+    mode = snapshot["mode"]
+
+    if mode == "running":
+        if lag <= degraded_after:
+            return RuntimeHealthResult(status="healthy", reason="runtime_running_fresh")
+        if lag <= unavailable_after:
+            return RuntimeHealthResult(status="degraded", reason="runtime_running_stale")
+        return RuntimeHealthResult(status="unavailable", reason="runtime_running_timeout")
+
+    if mode == "ready":
+        return RuntimeHealthResult(status="degraded", reason="runtime_not_started")
+
+    return RuntimeHealthResult(status="unavailable", reason="runtime_not_available")
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/tests/health_endpoint.py
+++ b/tests/health_endpoint.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+
+
+class _SideEffectProbe:
+    def __init__(self) -> None:
+        self.transition_calls = 0
+        self.write_calls = 0
+
+
+def test_health_endpoint_reports_runtime_health_from_simulated_snapshot(monkeypatch) -> None:
+    fixed_now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc)
+
+    def _start() -> str:
+        return "running"
+
+    def _health_now() -> datetime:
+        return fixed_now
+
+    def _introspection_payload() -> dict[str, object]:
+        return {
+            "schema_version": "v1",
+            "runtime_id": "engine-runtime-123",
+            "mode": "running",
+            "timestamps": {
+                "started_at": "2026-01-01T12:00:00+00:00",
+                "updated_at": "2026-01-01T12:00:10+00:00",
+            },
+            "ownership": {"owner_tag": "engine"},
+        }
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+    monkeypatch.setattr(api_main, "get_runtime_introspection_payload", _introspection_payload)
+    monkeypatch.setattr(api_main, "_health_now", _health_now)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "healthy",
+        "mode": "running",
+        "reason": "runtime_running_fresh",
+        "checked_at": fixed_now.isoformat(),
+    }
+
+
+def test_health_endpoint_is_read_only_without_runtime_transitions_or_writes(monkeypatch) -> None:
+    probe = _SideEffectProbe()
+
+    def _start() -> str:
+        return "running"
+
+    def _shutdown() -> str:
+        return "stopped"
+
+    def _health_now() -> datetime:
+        return datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _introspection_payload() -> dict[str, object]:
+        return {
+            "schema_version": "v1",
+            "runtime_id": "engine-runtime-123",
+            "mode": "ready",
+            "timestamps": {
+                "started_at": "2026-01-01T12:00:00+00:00",
+                "updated_at": "2026-01-01T12:00:00+00:00",
+            },
+            "ownership": {"owner_tag": "engine"},
+        }
+
+    def _unexpected_transition(*args, **kwargs):
+        probe.transition_calls += 1
+        raise AssertionError("runtime transitions must not be called by /health")
+
+    def _unexpected_write(*args, **kwargs):
+        probe.write_calls += 1
+        raise AssertionError("persistence writes must not be called by /health")
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", _shutdown)
+    monkeypatch.setattr(api_main, "get_runtime_introspection_payload", _introspection_payload)
+    monkeypatch.setattr(api_main, "_health_now", _health_now)
+    monkeypatch.setattr(api_main, "get_runtime_controller", _unexpected_transition)
+    monkeypatch.setattr(api_main.signal_repo, "save_signals", _unexpected_write)
+    monkeypatch.setattr(api_main.analysis_run_repo, "save_run", _unexpected_write)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "degraded"
+    assert response.json()["reason"] == "runtime_not_started"
+    assert probe.transition_calls == 0
+    assert probe.write_calls == 0
+
+
+def test_health_endpoint_reports_unavailable_boundary(monkeypatch) -> None:
+    fixed_now = datetime(2026, 1, 1, 12, 2, 1, tzinfo=timezone.utc)
+
+    def _start() -> str:
+        return "running"
+
+    def _health_now() -> datetime:
+        return fixed_now
+
+    def _introspection_payload() -> dict[str, object]:
+        return {
+            "schema_version": "v1",
+            "runtime_id": "engine-runtime-123",
+            "mode": "running",
+            "timestamps": {
+                "started_at": "2026-01-01T12:00:00+00:00",
+                "updated_at": "2026-01-01T12:00:00+00:00",
+            },
+            "ownership": {"owner_tag": "engine"},
+        }
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+    monkeypatch.setattr(api_main, "get_runtime_introspection_payload", _introspection_payload)
+    monkeypatch.setattr(api_main, "_health_now", _health_now)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "unavailable"
+    assert response.json()["reason"] == "runtime_running_timeout"

--- a/tests/health_evaluator.py
+++ b/tests/health_evaluator.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from cilly_trading.engine.health.evaluator import evaluate_runtime_health
+
+
+def test_health_evaluator_reports_healthy_at_degraded_boundary() -> None:
+    now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc)
+    snapshot = {
+        "mode": "running",
+        "updated_at": now - timedelta(seconds=30),
+    }
+
+    result = evaluate_runtime_health(snapshot, now=now)
+
+    assert result.status == "healthy"
+    assert result.reason == "runtime_running_fresh"
+
+
+def test_health_evaluator_reports_degraded_at_unavailable_boundary() -> None:
+    now = datetime(2026, 1, 1, 12, 2, 0, tzinfo=timezone.utc)
+    snapshot = {
+        "mode": "running",
+        "updated_at": now - timedelta(seconds=120),
+    }
+
+    result = evaluate_runtime_health(snapshot, now=now)
+
+    assert result.status == "degraded"
+    assert result.reason == "runtime_running_stale"
+
+
+def test_health_evaluator_reports_unavailable_after_timeout() -> None:
+    now = datetime(2026, 1, 1, 12, 2, 1, tzinfo=timezone.utc)
+    snapshot = {
+        "mode": "running",
+        "updated_at": now - timedelta(seconds=121),
+    }
+
+    result = evaluate_runtime_health(snapshot, now=now)
+
+    assert result.status == "unavailable"
+    assert result.reason == "runtime_running_timeout"
+
+
+def test_health_evaluator_reports_degraded_for_ready_mode() -> None:
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    snapshot = {
+        "mode": "ready",
+        "updated_at": now,
+    }
+
+    result = evaluate_runtime_health(snapshot, now=now)
+
+    assert result.status == "degraded"
+    assert result.reason == "runtime_not_started"
+
+
+def test_health_evaluator_reports_unavailable_for_non_running_modes() -> None:
+    now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    snapshot = {
+        "mode": "stopped",
+        "updated_at": now,
+    }
+
+    result = evaluate_runtime_health(snapshot, now=now)
+
+    assert result.status == "unavailable"
+    assert result.reason == "runtime_not_available"


### PR DESCRIPTION
### Motivation
- Provide a lightweight, read-only runtime health endpoint for the engine that deterministically reports `healthy` / `degraded` / `unavailable` without performing any lifecycle transitions or persistence writes.
- Make health evaluation testable and deterministic by implementing it as a pure function that accepts a runtime snapshot and an injected `now` timestamp.

### Description
- Add a pure evaluator `evaluate_runtime_health(snapshot, now=...)` in `src/cilly_trading/engine/health/evaluator.py` that returns `healthy|degraded|unavailable` and a deterministic `reason` based on `mode` and staleness thresholds (30s / 120s).
- Update `GET /health` in `src/api/main.py` to derive a read-only snapshot via `get_runtime_introspection_payload()`, call the evaluator, and return a small JSON payload with `status`, `mode`, `reason`, and `checked_at` without mutating runtime state.
- Add documentation of the health contract and deterministic rules in `docs/health.md` describing inputs, thresholds, and rule outcomes.
- Add unit and endpoint tests (`tests/health_evaluator.py`, `tests/health_endpoint.py`) that cover boundary conditions for the three health states and assert the endpoint performs no runtime transitions or persistence writes.

### Testing
- Ran the targeted tests with: `pytest -q tests/health_evaluator.py tests/health_endpoint.py tests/test_runtime_introspection.py`.
- Result: `10 passed, 0 failed` (existing FastAPI deprecation warnings observed but unrelated to the change).
- Tests exercise evaluator boundaries (30s and 120s), `ready`/non-running modes, and read-only guarantees of the `/health` endpoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fe6d94a88333b43fb7d61108ea32)