### PR TITLE
docs: add runtime extension model documentation

### DIFF
--- a/docs/runtime_extension_model.md
+++ b/docs/runtime_extension_model.md
@@ -1,0 +1,82 @@
+# Runtime Extension Model
+
+## Definition
+
+Runtime extensions are optional, read-only additions that can attach extra information to runtime reporting. They are designed to enrich what operators and reviewers can see when they read runtime status, runtime health, and runtime introspection.
+
+In plain terms, an extension is an extra voice in the report: it can add context, but it does not change what the engine does.
+
+Runtime extensions are **not**:
+- a control surface for operating the engine,
+- a way to change runtime decisions,
+- a replacement for the engine’s core status and health contract,
+- an API feature for turning runtime behavior on or off in real time.
+
+## Contribution Points
+
+Runtime extensions are organized by contribution point. A contribution point describes where extension data belongs in runtime reporting.
+
+### 1) Status
+
+Status extensions contribute additional status-oriented details. This sits alongside the core status view and helps explain current runtime state in richer language.
+
+### 2) Health
+
+Health extensions contribute additional health-oriented details. This supports the core health picture with more signals about whether the runtime appears operationally sound.
+
+### 3) Introspection
+
+Introspection extensions contribute additional metadata-oriented details. This helps reviewers understand the runtime environment and context without introducing control actions.
+
+## Metadata
+
+Each registered runtime extension is represented with stable metadata so reviewers can understand what is available and how it is classified.
+
+### name
+A human-readable identifier for the extension entry.
+
+### point
+The contribution point where the extension belongs: `status`, `health`, or `introspection`.
+
+### enabled
+Whether the extension is currently active (`true`) or listed but inactive (`false`). Disabled entries remain visible in metadata so the reporting surface is transparent.
+
+### source
+Where the extension entry comes from:
+- `core`: built-in runtime extension metadata supplied by the engine itself,
+- `extension`: non-core extension metadata supplied as an extension.
+
+## Safety Guarantees
+
+The runtime extension model is intentionally constrained for predictable, low-risk observability.
+
+### Isolation
+Extensions run against a read-only runtime context intended for reporting. The extension surface exposes metadata snapshots rather than mutable runtime controls.
+
+### Timeout guards
+Extension execution is time-bounded. If an extension does not respond within the budget, that extension is treated as timed out for the current reporting cycle.
+
+### Deterministic behavior
+For the same runtime state and extension set, extension handling is designed to be stable and repeatable at the reporting-contract level.
+
+### No side effects
+Runtime extension reporting is read-only in intent: it does not perform runtime transitions, does not allocate new runtime identities, and does not write operational records as part of introspection reporting.
+
+## Limitations
+
+The runtime extension model is intentionally limited to keep observability safe and predictable.
+
+- **No API toggles:** the public reporting APIs describe extension metadata; they do not provide runtime on/off switching for extensions.
+- **No retries or cancellation:** a timed-out or failed extension result is surfaced as-is for that cycle rather than retried or cancelled mid-flight.
+- **No changes to engine behavior:** extension outputs enrich reporting only; they do not alter engine state transitions, trading logic, or lifecycle decisions.
+
+## Plain-Language Examples
+
+- A **status** extension can add a short operational note that helps explain why the runtime currently appears steady.
+- A **health** extension can add one extra check summary that helps reviewers understand risk posture.
+- An **introspection** extension can add context metadata that clarifies what environment or ownership context the runtime reports under.
+- A disabled extension still appears in extension metadata with `enabled: false`, so reviewers can see that it exists but is not active.
+
+## Summary
+
+Runtime extensions are a controlled way to enrich runtime reporting with additional read-only context at three contribution points—status, health, and introspection—while preserving core safety boundaries: isolated execution context, timeout-bounded evaluation, deterministic reporting behavior, and no operational side effects. They improve visibility for operators and reviewers, but they do not provide runtime control, do not retry or cancel extension execution, and do not change engine behavior.


### PR DESCRIPTION
### Motivation
- Provide a concise, human-readable explanation of the runtime extension model for operators and reviewers that matches the engine's current behavior (extension metadata exposure, read-only introspection, timeout/failure shaping). 

### Description
- Add `docs/runtime_extension_model.md` which describes what runtime extensions are and are not, the three contribution points (`status`, `health`, `introspection`), extension metadata (`name`, `point`, `enabled`, `source`), safety guarantees (isolation, timeout guards, deterministic behavior, no side effects), documented limitations, plain-language examples, and a one-paragraph summary, with no code changes. 

### Testing
- Ran the focused test set `pytest -q tests/test_runtime_introspection.py tests/test_runtime_introspection_snapshot.py src/cilly_trading/engine/tests/test_observability_extensions.py` and all tests passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b94f9211c83339d4d59ddab178a20)