### PR TITLE
Make smoke_run executable; add determinism test and audit note

### DIFF
--- a/docs/determinism_audit.md
+++ b/docs/determinism_audit.md
@@ -1,0 +1,6 @@
+# Determinism Audit Note
+
+- Date: 2026-02-11
+- Issue: #309
+- Finding: `src/cilly_trading/smoke_run.py` did not provide a `__main__` entry point, so `python -m cilly_trading.smoke_run` imported the module and exited without executing the smoke-run contract. Determinism verification was therefore not provable through module execution.
+- Fix: Added a module `main()` entry point with `if __name__ == "__main__": raise SystemExit(main())`, and added a deterministic test that runs the module twice, verifies the four smoke-run stdout markers, and compares `artifacts/smoke-run/result.json` bytes across runs.

--- a/src/cilly_trading/smoke_run.py
+++ b/src/cilly_trading/smoke_run.py
@@ -293,6 +293,13 @@ def _emit_stdout() -> None:
         print(line)
 
 
+def main(argv: list[str] | None = None) -> int:
+    """Run the smoke-run module entry point."""
+
+    _ = argv
+    return run_smoke_run()
+
+
 @contextmanager
 def _determinism_guard():
     blocked_error = SmokeRunError(12, "constraints_failed")
@@ -318,3 +325,7 @@ def _determinism_guard():
         time.monotonic = original_monotonic
         random.random = original_random
         random.randint = original_randint
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_smoke_run_determinism.py
+++ b/tests/test_smoke_run_determinism.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+def _run_smoke(repo_root: Path) -> tuple[subprocess.CompletedProcess[str], bytes]:
+    src_dir = repo_root / "src"
+    fixtures_src_dir = repo_root / "fixtures" / "smoke-run"
+
+    with TemporaryDirectory() as temp_path:
+        temp_dir = Path(temp_path)
+        shutil.copytree(
+            fixtures_src_dir,
+            temp_dir / "fixtures" / "smoke-run",
+            dirs_exist_ok=True,
+        )
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(src_dir)
+
+        completed = subprocess.run(
+            [sys.executable, "-m", "cilly_trading.smoke_run"],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=temp_dir,
+            check=False,
+        )
+
+        result_path = temp_dir / "artifacts" / "smoke-run" / "result.json"
+        assert result_path.is_file()
+        artifact_bytes = result_path.read_bytes()
+
+        return completed, artifact_bytes
+
+
+def test_smoke_run_module_is_deterministic() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    first, first_bytes = _run_smoke(repo_root)
+    second, second_bytes = _run_smoke(repo_root)
+
+    expected_lines = [
+        "SMOKE_RUN:START",
+        "SMOKE_RUN:FIXTURES_OK",
+        "SMOKE_RUN:CHECKS_OK",
+        "SMOKE_RUN:END",
+    ]
+
+    for completed in (first, second):
+        assert completed.returncode == 0
+        stdout_lines = completed.stdout.splitlines()
+        assert stdout_lines == expected_lines
+        assert completed.stderr == ""
+
+    assert first_bytes == second_bytes


### PR DESCRIPTION
### Motivation
- The `smoke_run` module lacked a `__main__` entry point so `python -m cilly_trading.smoke_run` imported the module and did not execute the smoke-run contract, preventing reproducible determinism verification. 
- Provide a minimal, testable entrypoint and an automated determinism proof so the smoke-run can be executed and audited in CI.

### Description
- Added `def main(argv: list[str] | None = None) -> int:` to `src/cilly_trading/smoke_run.py` that calls `run_smoke_run()` exactly once and preserved the existing determinism guard behavior. 
- Added module guard `if __name__ == "__main__": raise SystemExit(main())` so `python -m cilly_trading.smoke_run` runs the smoke-run and emits the 4 stdout markers and writes `artifacts/smoke-run/result.json`. 
- Added deterministic verification test `tests/test_smoke_run_determinism.py` which runs `[sys.executable, "-m", "cilly_trading.smoke_run"]` twice in isolated temporary directories with `PYTHONPATH` set to `src`, validates the exact 4 stdout markers, ensures `artifacts/smoke-run/result.json` exists, and asserts the result bytes are identical across runs. 
- Added audit note `docs/determinism_audit.md` documenting issue `#309`, the finding, and the remediation and test added.

### Testing
- Ran `pytest tests/test_smoke_run_determinism.py` which passed (`1 passed`).
- Ran full `pytest` which failed during collection due to unrelated pre-existing errors in other parts of the repo (package import/indentation and test collection errors), so only the targeted smoke-run determinism test was validated in isolation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce6fa04c8833383378a78c43ea021)