### PR TITLE
Add governance enforcement workflow for PR issue linkage

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,17 @@
+name: Governance Enforcement
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  governance-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body issue reference
+        shell: bash
+        run: |
+          if ! echo "${{ github.event.pull_request.body }}" | grep -E "Closes #[0-9]+"; then
+            echo "Missing Closes #<IssueID> reference"
+            exit 1
+          fi


### PR DESCRIPTION
### Motivation
- Ensure PRs link to an issue so repository governance is enforced by failing CI when a PR body does not include `Closes #<number>`.

### Description
- Add GitHub Actions workflow `.github/workflows/governance.yml` that triggers on `pull_request` events (`opened`, `edited`, `synchronize`) and runs job `governance-check` which runs a shell step that fails if the PR body does not match `Closes #[0-9]+`.

### Testing
- Validated the created workflow file with `sed -n '1,200p' .github/workflows/governance.yml` and `nl -ba .github/workflows/governance.yml`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6fcd25c483339a9950a41443995a)