### PR TITLE
docs: add external integration assumptions and non-guarantees

### DIFF
--- a/docs/external/integration_assumptions.md
+++ b/docs/external/integration_assumptions.md
@@ -1,0 +1,54 @@
+# Integration Assumptions and Non-Guarantees
+
+This document defines the external integration assumptions for the Trading Engine project.
+It is documentation-only guidance and does not change runtime behavior, API contracts, or implementation.
+
+## 1) Explicit Non-Guarantees
+
+The project does **not** provide any of the following guarantees for external integrations:
+
+- **No SLA commitment**: no service-level agreement is offered.
+- **No uptime guarantee**: no availability target or continuity guarantee is promised.
+- **No performance guarantee**: no latency, throughput, response-time, or capacity guarantees are provided.
+
+Integrators must treat all interactions as best-effort and design their systems accordingly.
+
+## 2) Environmental Assumptions
+
+External integrations are expected to operate under the following assumptions:
+
+- Integrator-managed infrastructure is responsible for network access, DNS resolution, and secure transport setup.
+- Integrators are responsible for configuration management (credentials, secrets, endpoint configuration, and rotation policies).
+- Client applications should tolerate transient failures (timeouts, connection interruptions, and upstream dependency failures).
+- Integrators should validate compatibility in their own environments, including operating system, runtime, and dependency constraints.
+- Data quality, ordering, and timeliness of third-party inputs are not guaranteed by this project and must be validated by the integrator.
+
+## 3) Support Boundaries
+
+Support for external integrations is limited to:
+
+- Clarification of published project documentation.
+- Clarification of intended usage of documented interfaces.
+
+Support does **not** include:
+
+- Environment-specific debugging for third-party or customer infrastructure.
+- Operational commitments (incident response windows, recovery timelines, escalation guarantees).
+- Custom integration implementation, deployment, or managed operations.
+
+## 4) Unsupported Integration Patterns
+
+The following integration patterns are explicitly unsupported:
+
+- Tight coupling that assumes continuous availability or fixed response times.
+- Architectures that require guaranteed ordering, guaranteed delivery, or exactly-once semantics unless explicitly documented elsewhere.
+- Integrations that depend on undocumented internal behavior, private implementation details, or non-public endpoints.
+- Reliance on this project for monitoring ownership, alerting ownership, or production operations management.
+
+## 5) Documentation-Only Scope
+
+This document defines assumptions and boundaries only.
+
+- It introduces **no** runtime changes.
+- It introduces **no** API or contract changes.
+- It introduces **no** monitoring, alerting, SLA, uptime, or performance commitments.


### PR DESCRIPTION
### Motivation

- Make explicit that external integrations carry no SLA, uptime, or performance guarantees and set clear expectations for integrators.
- Provide a single, documentation-only reference for environmental assumptions and support boundaries to reduce ambiguity.
- Prevent unsupported integration patterns by documenting what the project will not support or be relied upon for.

### Description

- Added new file `docs/external/integration_assumptions.md` containing explicit non-guarantees (no SLA, no uptime guarantee, no performance guarantee), environmental assumptions, support boundaries, unsupported integration patterns, and a documentation-only scope statement.
- The document explicitly states it introduces no runtime, API, monitoring, operational, or contractual changes.
- Change is documentation-only and confined to `docs/external/integration_assumptions.md` with no modifications to `src/`, `.github/`, or other code/configuration.

### Testing

- Verified file content with `nl -ba docs/external/integration_assumptions.md`, which displayed the created document (succeeded).
- Committed the new file via `git commit` which reported a successful commit (succeeded).
- Confirmed working tree status with `git status --short` after the commit (clean working tree, succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f893e23048333bafecde8150bb773)