### PR TITLE
Add centralized version declaration and CLI/API exposure (Issue #350)

### DIFF
--- a/docs/versioning/declaration.md
+++ b/docs/versioning/declaration.md
@@ -1,0 +1,35 @@
+# Version declaration
+
+## Source of truth
+
+The authoritative project version is defined in `src/cilly_trading/version.py` as:
+
+- `__version__: str`
+- `get_version() -> str`
+
+All other version exposure mechanisms must read from this module.
+
+## CLI exposure
+
+The package module entrypoint exposes version output:
+
+```bash
+PYTHONPATH=src python -m cilly_trading --version
+```
+
+This prints the exact `__version__` value and exits with code `0`.
+
+Running without flags prints help text and exits with code `0`:
+
+```bash
+PYTHONPATH=src python -m cilly_trading
+```
+
+## Python API exposure
+
+Version is exposed through the public Python API via:
+
+- `cilly_trading.__version__`
+- `cilly_trading.version.get_version()`
+
+These two values are contractually required to match.

--- a/src/cilly_trading/__init__.py
+++ b/src/cilly_trading/__init__.py
@@ -1,1 +1,5 @@
-# Package initialisation for cilly_trading
+"""Public package interface for cilly_trading."""
+
+from .version import __version__
+
+__all__ = ["__version__"]

--- a/src/cilly_trading/__main__.py
+++ b/src/cilly_trading/__main__.py
@@ -1,0 +1,33 @@
+"""Module entrypoint for cilly_trading CLI."""
+
+from __future__ import annotations
+
+import argparse
+
+from .version import get_version
+
+
+def main() -> int:
+    """Run the package CLI.
+
+    Returns:
+        int: Process exit code.
+    """
+    parser = argparse.ArgumentParser(prog="cilly_trading")
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the cilly_trading package version and exit.",
+    )
+    args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return 0
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cilly_trading/version.py
+++ b/src/cilly_trading/version.py
@@ -1,0 +1,12 @@
+"""Version declaration module for the cilly_trading package."""
+
+__version__: str = "0.1.0"
+
+
+def get_version() -> str:
+    """Return the authoritative package version string.
+
+    Returns:
+        str: The package version.
+    """
+    return __version__

--- a/tests/test_version_declaration.py
+++ b/tests/test_version_declaration.py
@@ -1,0 +1,33 @@
+"""Tests for package version declaration and exposure."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import cilly_trading
+from cilly_trading.version import get_version
+
+
+def test_package_version_is_non_empty_string() -> None:
+    """Assert package-level __version__ is present and non-empty."""
+    assert isinstance(cilly_trading.__version__, str)
+    assert cilly_trading.__version__.strip() != ""
+
+
+def test_get_version_matches_package_version() -> None:
+    """Assert helper API returns same authoritative package version."""
+    assert get_version() == cilly_trading.__version__
+
+
+def test_module_cli_version_prints_and_exits_zero() -> None:
+    """Assert module CLI exposes version and exits successfully."""
+    result = subprocess.run(
+        [sys.executable, "-m", "cilly_trading", "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == cilly_trading.__version__


### PR DESCRIPTION
### Motivation
- Provide a single, code-contained source of truth for the project version so all consumers read the same value.
- Surface the version via the public Python API and a minimal CLI so tooling and users can easily query it.
- Add minimal docs and tests to validate the contract without introducing release automation or auto-bumping.

### Description
- Introduced `src/cilly_trading/version.py` defining `__version__: str` and `get_version() -> str` as the authoritative version source.
- Exported the package-level `__version__` from `src/cilly_trading/__init__.py` so `import cilly_trading` exposes the version on the public API.
- Added a minimal module CLI `src/cilly_trading/__main__.py` that implements `python -m cilly_trading --version` to print the version and exit `0`, and prints help when run without flags.
- Added unit tests `tests/test_version_declaration.py` and documentation `docs/versioning/declaration.md` describing the source-of-truth and how to query the version.

### Testing
- Ran the version unit tests with `PYTHONPATH=src pytest -q tests/test_version_declaration.py` which succeeded with `3 passed` and exit code `0`.
- Executed the deterministic smoke run command `PYTHONPATH=src python -c 'from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())'` which produced the exact stdout:
  `SMOKE_RUN:START\nSMOKE_RUN:FIXTURES_OK\nSMOKE_RUN:CHECKS_OK\nSMOKE_RUN:END` and exited `0`.
- All automated checks included in this change passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f961f644c83339fb4ad7e9bd63380)