### PR TITLE
docs(cli): add CLI usage and version exposure documentation

### DIFF
--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -4,13 +4,13 @@
 
 Invoke the CLI by executing the package module.
 
-### Bash
+Bash:
 
 ```bash
 PYTHONPATH=src python -m cilly_trading
 ```
 
-### PowerShell
+PowerShell:
 
 ```powershell
 $env:PYTHONPATH="src"
@@ -23,13 +23,13 @@ When run without flags, the CLI prints argparse help output and exits with code 
 
 The CLI exposes a version flag.
 
-### Bash
+Bash:
 
 ```bash
 PYTHONPATH=src python -m cilly_trading --version
 ```
 
-### PowerShell
+PowerShell:
 
 ```powershell
 $env:PYTHONPATH="src"


### PR DESCRIPTION
### Motivation
- Provide authoritative documentation for invoking the package CLI, its `--version` exposure, and help behavior that matches the current implementation without changing runtime code.

### Description
- Add `docs/cli/usage.md` which documents module invocation for Bash and PowerShell, the `--version` flag behavior (output equals `cilly_trading.version`), help behavior and exit codes, and links to `../versioning/declaration.md` and `../versioning/model.md`, with no modifications to `src/` or other project files.

### Testing
- Executed `PYTHONPATH=src python -m cilly_trading` and `PYTHONPATH=src python -m cilly_trading --version` to confirm the help is printed and the authoritative package version is emitted, both commands exited with code `0` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f02deb008333a36d26b0b8f62778)