### PR TITLE
docs: add operational release checklist for Phase 19 governance

### DIFF
--- a/docs/release/checklist.md
+++ b/docs/release/checklist.md
@@ -1,0 +1,52 @@
+# Release Checklist – Operational Governance
+
+## 1. Purpose
+This checklist governs manual release preparation and manual tagging under Phase 19 governance to ensure that each release is approved, versioned, and published using the defined repository controls.
+
+## 2. Pre-Release Preconditions
+- [ ] All Issues included in the release are **APPROVED**.
+- [ ] Required status check **"test"** is green.
+- [ ] No open blocker issues exist.
+- [ ] Release scope is frozen.
+
+## 3. Version Determination
+Reference documents:
+- [ ] `../versioning/change_enforcement.md`
+- [ ] `../versioning/model.md`
+
+Execution checklist:
+- [ ] Classify all included changes as **MAJOR**, **MINOR**, or **PATCH**.
+- [ ] Apply the highest precedence rule across all included changes.
+- [ ] Confirm the selected version increment aligns with enforcement rules.
+
+## 4. Compatibility Review Gate
+Reference document:
+- [ ] `../versioning/compatibility_gate.md`
+
+Gate checklist:
+- [ ] Compatibility gate checklist is completed.
+- [ ] All compatibility gate items are marked **YES**.
+- [ ] If the release is **MAJOR**, breaking changes are documented.
+
+## 5. Release Boundary Confirmation
+Reference document:
+- [ ] `../versioning/release_boundary.md`
+
+Boundary checklist:
+- [ ] Confirm there is a single release commit.
+- [ ] Confirm the version tag format is `vX.Y.Z`.
+- [ ] Confirm there are no post-tag modifications.
+
+## 6. Manual Approval Requirement
+- [ ] Codex A approval is required before tagging.
+- [ ] Approval is recorded in a PR review or in a release note.
+- [ ] No tag is created without documented approval.
+
+## 7. Tagging Step (Manual)
+- [ ] Create tag `vX.Y.Z` on the release commit.
+- [ ] Push tag `vX.Y.Z` to the repository.
+
+## 8. Post-Release Verification
+- [ ] Tag is visible in the repository.
+- [ ] Version command reflects the released version.
+- [ ] Smoke run passes.


### PR DESCRIPTION
### Motivation
- Introduce a formal manual release checklist to govern manual release preparation and tagging aligned with Phase 19 governance for Issue #362.

### Description
- Add `docs/release/checklist.md` containing the required sections (Purpose, Pre-Release Preconditions, Version Determination, Compatibility Review Gate, Release Boundary Confirmation, Manual Approval Requirement, Tagging Step (Manual), and Post-Release Verification) with explicit `- [ ]` checkboxes and references to `../versioning/*` documents, implemented as a documentation-only change with no automation or modifications outside `docs/**`.

### Testing
- Verified the change was created and committed by running `git show --stat --oneline HEAD` and inspected the file contents with `nl -ba docs/release/checklist.md`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990f35a6ec48333b14914b300cf7a22)