### PR TITLE
Add canonical REFERENCE strategy pack and deterministic registry wiring

### DIFF
--- a/docs/strategy_packs/reference_pack/README.md
+++ b/docs/strategy_packs/reference_pack/README.md
@@ -1,0 +1,24 @@
+## Overview
+This reference pack defines a single canonical strategy implementation used as a deterministic baseline.
+
+## Strategy Objective
+Provide a harmless strategy entry that exercises registry and pack wiring without emitting actionable signals.
+
+## Strategy Logic Summary
+The strategy is registered with the stable name `REFERENCE` and always returns an empty signal list from `generate_signals`.
+
+## Parameter Definitions
+This strategy accepts a config object to match the engine strategy contract but does not read or mutate any parameters.
+
+## Deterministic Behavior
+This strategy produces identical outputs for identical inputs across environments.
+
+## Risk Disclosure
+This strategy does not provide trading recommendations and emits no signals.
+
+## Version & Compatibility
+Pack version: `1.0.0`.
+Engine compatibility: `>=1.0.0`.
+
+## Change Log Reference
+See repository history for changes affecting `docs/strategy_packs/reference_pack/` and strategy registration.

--- a/docs/strategy_packs/reference_pack/metadata.yaml
+++ b/docs/strategy_packs/reference_pack/metadata.yaml
@@ -1,0 +1,8 @@
+pack_id: reference-pack
+version: 1.0.0
+description: Canonical deterministic reference strategy pack with a no-op strategy.
+author: Trading Engine Team
+created_at: 2026-01-01T00:00:00Z
+deterministic_hash: reference-pack-v1-hash
+engine_compatibility: ">=1.0.0"
+dependencies: []

--- a/src/cilly_trading/strategies/reference.py
+++ b/src/cilly_trading/strategies/reference.py
@@ -1,0 +1,25 @@
+"""Minimal deterministic reference strategy."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from cilly_trading.engine.core import BaseStrategy
+from cilly_trading.models import Signal
+
+
+class ReferenceStrategy(BaseStrategy):
+    """Reference strategy that intentionally emits no signals."""
+
+    name: str = "REFERENCE"
+
+    def generate_signals(
+        self,
+        df: pd.DataFrame,
+        config: Dict[str, Any],
+    ) -> List[Signal]:
+        _ = df
+        _ = config
+        return []

--- a/src/cilly_trading/strategies/registry.py
+++ b/src/cilly_trading/strategies/registry.py
@@ -125,9 +125,20 @@ def initialize_default_registry() -> None:
     if _REGISTRY:
         return
 
+    from cilly_trading.strategies.reference import ReferenceStrategy
     from cilly_trading.strategies.rsi2 import Rsi2Strategy
     from cilly_trading.strategies.turtle import TurtleStrategy
 
+    register_strategy(
+        "REFERENCE",
+        lambda: ReferenceStrategy(),
+        metadata={
+            "pack_id": "reference-pack",
+            "version": "1.0.0",
+            "deterministic_hash": "reference-pack-v1-hash",
+            "dependencies": [],
+        },
+    )
     register_strategy(
         "RSI2",
         lambda: Rsi2Strategy(),

--- a/tests/strategies/test_reference_pack.py
+++ b/tests/strategies/test_reference_pack.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cilly_trading.strategies.registry import run_registry_smoke
+
+
+REFERENCE_PACK_DIR = Path("docs/strategy_packs/reference_pack")
+
+
+def test_reference_pack_directory_and_metadata_exist() -> None:
+    assert REFERENCE_PACK_DIR.exists()
+    metadata_path = REFERENCE_PACK_DIR / "metadata.yaml"
+    assert metadata_path.exists()
+
+    metadata_text = metadata_path.read_text(encoding="utf-8")
+    for required_key in (
+        "pack_id:",
+        "version:",
+        "deterministic_hash:",
+        "dependencies:",
+    ):
+        assert required_key in metadata_text
+
+
+def test_reference_pack_readme_contains_required_sections_in_order() -> None:
+    readme_path = REFERENCE_PACK_DIR / "README.md"
+    assert readme_path.exists()
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+    required_sections = [
+        "## Overview",
+        "## Strategy Objective",
+        "## Strategy Logic Summary",
+        "## Parameter Definitions",
+        "## Deterministic Behavior",
+        "## Risk Disclosure",
+        "## Version & Compatibility",
+        "## Change Log Reference",
+    ]
+
+    section_positions = [readme_text.index(section) for section in required_sections]
+    assert section_positions == sorted(section_positions)
+
+
+def test_reference_strategy_is_in_deterministic_smoke_output() -> None:
+    first = run_registry_smoke()
+    second = run_registry_smoke()
+
+    assert first == ["REFERENCE", "RSI2", "TURTLE"]
+    assert second == ["REFERENCE", "RSI2", "TURTLE"]

--- a/tests/strategies/test_strategy_registry.py
+++ b/tests/strategies/test_strategy_registry.py
@@ -72,15 +72,15 @@ def test_smoke_run_is_deterministic_and_uses_registry_only() -> None:
     first = run_registry_smoke()
     second = run_registry_smoke()
 
-    assert first == ["RSI2", "TURTLE"]
-    assert second == ["RSI2", "TURTLE"]
+    assert first == ["REFERENCE", "RSI2", "TURTLE"]
+    assert second == ["REFERENCE", "RSI2", "TURTLE"]
 
     strategy_names = [strategy.name for strategy in create_registered_strategies()]
-    assert strategy_names == ["RSI2", "TURTLE"]
+    assert strategy_names == ["REFERENCE", "RSI2", "TURTLE"]
 
 
 def test_initialize_default_registry_idempotent() -> None:
     initialize_default_registry()
     initialize_default_registry()
 
-    assert [entry.key for entry in get_registered_strategies()] == ["RSI2", "TURTLE"]
+    assert [entry.key for entry in get_registered_strategies()] == ["REFERENCE", "RSI2", "TURTLE"]

--- a/tests/strategies/test_strategy_validation.py
+++ b/tests/strategies/test_strategy_validation.py
@@ -90,4 +90,4 @@ def test_validation_preserves_registry_ordering_and_smoke_stability() -> None:
     assert [entry.key for entry in get_registered_strategies()] == ["BETA", "ZETA"]
 
     reset_registry()
-    assert run_registry_smoke() == ["RSI2", "TURTLE"]
+    assert run_registry_smoke() == ["REFERENCE", "RSI2", "TURTLE"]


### PR DESCRIPTION
### Motivation
- Provide a single canonical, deterministic reference strategy pack as the Phase-21 reference required by the issue, so the engine has a harmless, documented baseline strategy that emits no signals.

### Description
- Add pack documentation at `docs/strategy_packs/reference_pack/` including `metadata.yaml` with Phase-21 pack-model fields and a `README.md` following the mandatory section order and containing the required deterministic statement.
- Implement a minimal deterministic strategy `ReferenceStrategy` in `src/cilly_trading/strategies/reference.py` with stable name `"REFERENCE"` and `generate_signals(self, df, config)` returning `[]` and no side effects.
- Register `REFERENCE` inside `initialize_default_registry()` in `src/cilly_trading/strategies/registry.py` using a zero-arg factory and valid metadata (`pack_id`, SemVer `version`, `deterministic_hash`, `dependencies`) while preserving deterministic ordering behavior.
- Update registry-related tests to include `REFERENCE` deterministically and add `tests/strategies/test_reference_pack.py` which checks the pack directory, `metadata.yaml` keys, README section order, and that `run_registry_smoke()` includes `"REFERENCE"`.

### Testing
- Ran the full automated test suite with `PYTHONPATH=src pytest -q`, result: `225 passed, 4 warnings`.
- Verified deterministic smoke output via `run_registry_smoke()` now returns `["REFERENCE", "RSI2", "TURTLE"]` in tests which passed under the test run.
- New pack/documentation tests in `tests/strategies/test_reference_pack.py` executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699230ee356c8333bff5132024a5c70f)