### PR TITLE
Implement deterministic BacktestRunner core (issue #381)

### DIFF
--- a/src/cilly_trading/engine/backtest_runner.py
+++ b/src/cilly_trading/engine/backtest_runner.py
@@ -1,0 +1,136 @@
+"""Deterministic snapshot-bound backtest runner."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Protocol, Sequence, Tuple
+
+
+class BacktestStrategy(Protocol):
+    """Strategy protocol used by ``BacktestRunner``."""
+
+    def on_run_start(self, config: Mapping[str, Any]) -> None:
+        """Hook called once before snapshot processing starts."""
+
+    def on_snapshot(self, snapshot: Mapping[str, Any], config: Mapping[str, Any]) -> None:
+        """Hook called for each snapshot in deterministic order."""
+
+    def on_run_end(self, config: Mapping[str, Any]) -> None:
+        """Hook called once after all snapshots have been processed."""
+
+
+@dataclass(frozen=True)
+class BacktestResult:
+    """Result payload for a deterministic backtest run."""
+
+    processed_snapshots: List[Dict[str, Any]]
+    invocation_log: List[str]
+    artifact_path: Path
+    artifact_sha256: str
+
+
+@dataclass(frozen=True)
+class BacktestRunnerConfig:
+    """Configuration for deterministic backtest execution."""
+
+    output_dir: Path
+    artifact_name: str = "backtest-result.json"
+    hash_name: str = "backtest-result.sha256"
+
+
+class BacktestRunner:
+    """Deterministic snapshot-bound backtest runner."""
+
+    def run(
+        self,
+        *,
+        snapshots: Sequence[Mapping[str, Any]],
+        strategy_factory: Callable[[], BacktestStrategy],
+        config: BacktestRunnerConfig,
+    ) -> BacktestResult:
+        strategy = strategy_factory()
+        ordered_snapshots = self._sort_snapshots(snapshots)
+
+        invocation_log: List[str] = ["on_run_start"]
+        strategy.on_run_start(config={
+            "output_dir": str(config.output_dir),
+            "artifact_name": config.artifact_name,
+            "hash_name": config.hash_name,
+        })
+
+        processed_snapshots: List[Dict[str, Any]] = []
+        for snapshot in ordered_snapshots:
+            snapshot_id = str(snapshot.get("id", ""))
+            invocation_log.append(f"on_snapshot:{snapshot_id}")
+            strategy.on_snapshot(snapshot=snapshot, config={
+                "output_dir": str(config.output_dir),
+                "artifact_name": config.artifact_name,
+                "hash_name": config.hash_name,
+            })
+            processed_snapshots.append(dict(snapshot))
+
+        invocation_log.append("on_run_end")
+        strategy.on_run_end(config={
+            "output_dir": str(config.output_dir),
+            "artifact_name": config.artifact_name,
+            "hash_name": config.hash_name,
+        })
+
+        artifact_path, artifact_sha256 = self._write_artifacts(
+            processed_snapshots=processed_snapshots,
+            invocation_log=invocation_log,
+            config=config,
+        )
+
+        return BacktestResult(
+            processed_snapshots=processed_snapshots,
+            invocation_log=invocation_log,
+            artifact_path=artifact_path,
+            artifact_sha256=artifact_sha256,
+        )
+
+    def _sort_snapshots(self, snapshots: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+        sortable: List[Tuple[Tuple[str, str], Dict[str, Any]]] = []
+        for snapshot in snapshots:
+            normalized = dict(snapshot)
+            primary = str(
+                normalized.get("timestamp", normalized.get("snapshot_key", ""))
+            )
+            secondary = str(normalized.get("id", ""))
+            sortable.append(((primary, secondary), normalized))
+
+        sortable.sort(key=lambda item: item[0])
+        return [item[1] for item in sortable]
+
+    def _write_artifacts(
+        self,
+        *,
+        processed_snapshots: List[Dict[str, Any]],
+        invocation_log: List[str],
+        config: BacktestRunnerConfig,
+    ) -> tuple[Path, str]:
+        payload = {
+            "invocation_log": invocation_log,
+            "processed_snapshots": processed_snapshots,
+        }
+        artifact_text = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ) + "\n"
+
+        config.output_dir.mkdir(parents=True, exist_ok=True)
+
+        artifact_path = config.output_dir / config.artifact_name
+        artifact_path.write_text(artifact_text, encoding="utf-8", newline="\n")
+
+        artifact_sha256 = hashlib.sha256(artifact_text.encode("utf-8")).hexdigest()
+        hash_path = config.output_dir / config.hash_name
+        hash_path.write_text(f"{artifact_sha256}\n", encoding="utf-8", newline="\n")
+
+        return artifact_path, artifact_sha256

--- a/tests/cilly_trading/engine/test_backtest_runner.py
+++ b/tests/cilly_trading/engine/test_backtest_runner.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerConfig
+
+
+class SpyStrategy:
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def on_run_start(self, config: Mapping[str, Any]) -> None:
+        self.calls.append("on_run_start")
+
+    def on_snapshot(self, snapshot: Mapping[str, Any], config: Mapping[str, Any]) -> None:
+        self.calls.append(f"on_snapshot:{snapshot['id']}")
+
+    def on_run_end(self, config: Mapping[str, Any]) -> None:
+        self.calls.append("on_run_end")
+
+
+def _sample_snapshots() -> List[Dict[str, Any]]:
+    return [
+        {"id": "s3", "timestamp": "2024-01-02T00:00:00Z", "price": 12},
+        {"id": "s1", "timestamp": "2024-01-01T00:00:00Z", "price": 10},
+        {"id": "s2", "timestamp": "2024-01-01T00:00:00Z", "price": 11},
+    ]
+
+
+def _run_with_spy(output_dir: Path):
+    container: Dict[str, SpyStrategy] = {}
+
+    def strategy_factory() -> SpyStrategy:
+        strategy = SpyStrategy()
+        container["strategy"] = strategy
+        return strategy
+
+    runner = BacktestRunner()
+    result = runner.run(
+        snapshots=_sample_snapshots(),
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=output_dir),
+    )
+    return result, container["strategy"]
+
+
+def test_backtest_runner_deterministic_repeat(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    run1_dir = tmp_path / "run-1"
+    run2_dir = tmp_path / "run-2"
+
+    result1 = runner.run(
+        snapshots=_sample_snapshots(),
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=run1_dir),
+    )
+    result2 = runner.run(
+        snapshots=_sample_snapshots(),
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=run2_dir),
+    )
+
+    bytes1 = result1.artifact_path.read_bytes()
+    bytes2 = result2.artifact_path.read_bytes()
+
+    assert bytes1 == bytes2
+    assert result1.artifact_sha256 == result2.artifact_sha256
+
+
+def test_backtest_runner_snapshot_consistency_order(tmp_path: Path) -> None:
+    result, _ = _run_with_spy(tmp_path / "ordered")
+
+    processed_ids = [snapshot["id"] for snapshot in result.processed_snapshots]
+    assert processed_ids == ["s1", "s2", "s3"]
+
+
+def test_backtest_runner_strategy_invocation_stability(tmp_path: Path) -> None:
+    result1, spy1 = _run_with_spy(tmp_path / "run-a")
+    result2, spy2 = _run_with_spy(tmp_path / "run-b")
+
+    assert result1.invocation_log == result2.invocation_log
+    assert spy1.calls == spy2.calls
+    assert result1.invocation_log == spy1.calls
+
+
+def test_backtest_runner_smoke_artifact_created(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    result = runner.run(
+        snapshots=[
+            {"id": "a", "timestamp": "2024-01-01T00:00:00Z", "price": 1},
+            {"id": "b", "timestamp": "2024-01-01T00:00:00Z", "price": 2},
+        ],
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=tmp_path / "smoke"),
+    )
+
+    assert result.artifact_path.exists()
+    assert result.artifact_path.read_text(encoding="utf-8").endswith("\n")


### PR DESCRIPTION
### Motivation
- Provide a deterministic, snapshot-bound backtest core that produces bit-for-bit reproducible artifacts for offline validation and golden-master testing.
- Ensure strategy execution has no shared/singleton state by requiring explicit per-run instantiation and a fixed hook invocation order.
- Guarantee stable ordering for all collections that influence outputs (snapshots, JSON keys, arrays) so repeat runs produce identical bytes.

### Description
- Added a new `BacktestRunner` module with public API `run({ snapshots, strategy_factory, config }) => BacktestResult` that enforces explicit per-run `strategy_factory()` instantiation.
- Implemented deterministic snapshot sorting using a primary key (`timestamp` or `snapshot_key`) and a secondary tie-breaker (`id`) to ensure a total order across runs.
- Enforced a fixed strategy hook invocation order (`on_run_start` → `on_snapshot:*` → `on_run_end`) and recorded a deterministic `invocation_log` returned in the result.
- Wrote deterministic artifacts to `config.output_dir` using canonical JSON (`sort_keys=True`, fixed separators, `ensure_ascii=False`) with newline normalized to `\n` and produced a reproducible SHA-256 sidecar file.

### Testing
- Added tests under `tests/cilly_trading/engine` covering deterministic repeat (byte-for-byte artifact equality), snapshot ordering, strategy invocation stability (spy strategy), and a smoke test that checks artifact creation.
- Commands executed: `pytest -q tests/cilly_trading/engine/test_backtest_runner.py`.
- Result: `4 passed in 0.06s` (all added tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923ec1e5388333963e61b21b6ee596)