### PR TITLE
Deterministic backtest order execution model (Issue #382)

### DIFF
--- a/docs/backtesting/order_execution_model.md
+++ b/docs/backtesting/order_execution_model.md
@@ -1,0 +1,79 @@
+# Deterministic Order Execution Model
+
+## Scope
+
+This document defines the deterministic market order execution model for backtesting.
+The model is intentionally fixed and reproducible for identical inputs.
+
+## 1) Market order execution semantics
+
+Fill timing mode is **`next_snapshot`**.
+
+- An order created at snapshot `t` is **not** fillable at snapshot `t`.
+- The earliest fill opportunity is snapshot `t+1`.
+- This enforces no-lookahead behavior.
+- No partial fills are allowed. If an order is eligible for a snapshot and snapshot price data exists, the full order quantity is filled deterministically.
+
+## 2) Deterministic fill price rule
+
+For each fill snapshot:
+
+1. If `open` is present, base fill price is `snapshot.open`.
+2. Else, base fill price is `snapshot.price`.
+3. If neither field exists, execution raises a deterministic error.
+
+## 3) Deterministic slippage model
+
+`slippage_bps` is a fixed integer config value.
+
+- BUY: `fill_price = base_price * (1 + slippage_bps / 10_000)`
+- SELL: `fill_price = base_price * (1 - slippage_bps / 10_000)`
+
+## 4) Deterministic commission model
+
+Commission model is fixed **per order** (`commission_per_order`).
+
+- Every filled order uses the same fixed commission amount from config.
+- Formula: `commission = commission_per_order`
+
+## 5) Position lifecycle and transitions
+
+Position fields:
+
+- `quantity`
+- `avg_price`
+
+Transitions:
+
+- BUY increases quantity.
+- BUY average price updates by weighted average:
+  - `new_avg = ((old_avg * old_qty) + (fill_price * buy_qty)) / (old_qty + buy_qty)`
+- SELL reduces quantity.
+- SELL keeps `avg_price` unchanged while quantity remains positive.
+- When quantity reaches zero, `avg_price` is reset to `0`.
+- SELL quantity larger than current quantity raises a deterministic error.
+
+## 6) Rounding and numeric determinism
+
+All calculations use `Decimal` with explicit quantization (`ROUND_HALF_UP`):
+
+- Prices quantized to `price_scale` (default `0.00000001`).
+- Commission quantized to `money_scale` (default `0.01`).
+- Quantities quantized to `quantity_scale` (default `0.00000001`).
+
+Rounding is applied at deterministic steps:
+
+1. Base price extraction.
+2. Slippage-adjusted fill price.
+3. Commission amount.
+4. Position quantity and average price updates.
+
+## 7) Deterministic processing order
+
+Orders are processed in a total deterministic order using:
+
+1. `created_snapshot_key` (ascending)
+2. `sequence` (ascending)
+3. `id` (ascending)
+
+Snapshot lookup is field-address based (`open`, then `price`) and does not rely on dictionary iteration order.

--- a/src/cilly_trading/engine/order_execution_model.py
+++ b/src/cilly_trading/engine/order_execution_model.py
@@ -1,0 +1,220 @@
+"""Deterministic market order execution model for backtesting.
+
+This module defines deterministic market order filling, slippage, commission,
+and position transition behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Literal, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class Order:
+    """Represents an order submitted to the deterministic executor.
+
+    Args:
+        id: Stable order identifier.
+        side: Order side (``"BUY"`` or ``"SELL"``).
+        quantity: Requested quantity.
+        created_snapshot_key: Snapshot key where the order was created.
+        sequence: Monotonic sequence number for deterministic tie-breaking.
+    """
+
+    id: str
+    side: Literal["BUY", "SELL"]
+    quantity: Decimal
+    created_snapshot_key: str
+    sequence: int
+
+
+@dataclass(frozen=True)
+class Fill:
+    """Represents a deterministic full fill for an order.
+
+    Args:
+        order_id: Filled order identifier.
+        fill_price: Deterministic execution price including slippage.
+        quantity: Filled quantity.
+        commission: Deterministic commission amount.
+    """
+
+    order_id: str
+    fill_price: Decimal
+    quantity: Decimal
+    commission: Decimal
+
+
+@dataclass(frozen=True)
+class Position:
+    """Represents deterministic position state.
+
+    Args:
+        quantity: Current position quantity.
+        avg_price: Weighted average entry price for remaining quantity.
+    """
+
+    quantity: Decimal
+    avg_price: Decimal
+
+
+@dataclass(frozen=True)
+class DeterministicExecutionConfig:
+    """Configuration for deterministic order execution.
+
+    Args:
+        slippage_bps: Fixed slippage in basis points.
+        commission_per_order: Fixed deterministic commission per order.
+        price_scale: Decimal scale for prices.
+        money_scale: Decimal scale for commission amounts.
+        quantity_scale: Decimal scale for quantity tracking.
+        fill_timing: Fill timing mode. ``"next_snapshot"`` fills an order only
+            after its creation snapshot. ``"same_snapshot"`` allows filling on
+            creation snapshot.
+    """
+
+    slippage_bps: int
+    commission_per_order: Decimal
+    price_scale: Decimal = Decimal("0.00000001")
+    money_scale: Decimal = Decimal("0.01")
+    quantity_scale: Decimal = Decimal("0.00000001")
+    fill_timing: Literal["next_snapshot", "same_snapshot"] = "next_snapshot"
+
+
+class DeterministicExecutionModel:
+    """Executes market orders with deterministic semantics."""
+
+    def execute(
+        self,
+        *,
+        orders: Sequence[Order],
+        snapshot: Mapping[str, Any],
+        position: Position,
+        config: DeterministicExecutionConfig,
+    ) -> tuple[list[Fill], Position]:
+        """Executes ready orders for a snapshot in deterministic order.
+
+        Args:
+            orders: Orders that may be filled at this snapshot.
+            snapshot: Market snapshot providing ``open`` or ``price``.
+            position: Existing position state.
+            config: Deterministic execution settings.
+
+        Returns:
+            A tuple containing ordered fills and updated position.
+
+        Raises:
+            ValueError: If a required price is missing, a quantity is invalid,
+                or an order attempts to sell more than current position.
+        """
+
+        snapshot_key = self._snapshot_key(snapshot)
+        base_price = self._extract_fill_price(snapshot, config)
+        current = Position(
+            quantity=self._q(position.quantity, config.quantity_scale),
+            avg_price=self._q(position.avg_price, config.price_scale),
+        )
+        ordered_orders = sorted(
+            orders,
+            key=lambda order: (order.created_snapshot_key, order.sequence, order.id),
+        )
+
+        fills: list[Fill] = []
+        for order in ordered_orders:
+            quantity = self._q(order.quantity, config.quantity_scale)
+            if quantity <= Decimal("0"):
+                raise ValueError(f"Order quantity must be positive: {order.id}")
+            if not self._is_ready(order=order, snapshot_key=snapshot_key, config=config):
+                continue
+
+            fill_price = self._apply_slippage(price=base_price, side=order.side, config=config)
+            commission = self._q(config.commission_per_order, config.money_scale)
+            fills.append(
+                Fill(
+                    order_id=order.id,
+                    fill_price=fill_price,
+                    quantity=quantity,
+                    commission=commission,
+                )
+            )
+            current = self._apply_fill(position=current, side=order.side, quantity=quantity, fill_price=fill_price, config=config)
+
+        return fills, current
+
+    def _apply_fill(
+        self,
+        *,
+        position: Position,
+        side: Literal["BUY", "SELL"],
+        quantity: Decimal,
+        fill_price: Decimal,
+        config: DeterministicExecutionConfig,
+    ) -> Position:
+        if side == "BUY":
+            new_qty = self._q(position.quantity + quantity, config.quantity_scale)
+            if new_qty == Decimal("0"):
+                return Position(quantity=Decimal("0"), avg_price=Decimal("0"))
+            weighted = (position.avg_price * position.quantity) + (fill_price * quantity)
+            avg_price = self._q(weighted / new_qty, config.price_scale)
+            return Position(quantity=new_qty, avg_price=avg_price)
+
+        if quantity > position.quantity:
+            raise ValueError("SELL quantity exceeds current position quantity")
+
+        remaining = self._q(position.quantity - quantity, config.quantity_scale)
+        if remaining == Decimal("0"):
+            return Position(quantity=Decimal("0"), avg_price=Decimal("0"))
+        return Position(quantity=remaining, avg_price=self._q(position.avg_price, config.price_scale))
+
+    def _is_ready(
+        self,
+        *,
+        order: Order,
+        snapshot_key: str,
+        config: DeterministicExecutionConfig,
+    ) -> bool:
+        if config.fill_timing == "same_snapshot":
+            return order.created_snapshot_key <= snapshot_key
+        return order.created_snapshot_key < snapshot_key
+
+    def _extract_fill_price(self, snapshot: Mapping[str, Any], config: DeterministicExecutionConfig) -> Decimal:
+        if snapshot.get("open") is not None:
+            return self._q(Decimal(str(snapshot["open"])), config.price_scale)
+        if snapshot.get("price") is not None:
+            return self._q(Decimal(str(snapshot["price"])), config.price_scale)
+        raise ValueError("Snapshot must contain either 'open' or 'price'")
+
+    def _apply_slippage(
+        self,
+        *,
+        price: Decimal,
+        side: Literal["BUY", "SELL"],
+        config: DeterministicExecutionConfig,
+    ) -> Decimal:
+        slippage_fraction = Decimal(config.slippage_bps) / Decimal("10000")
+        if side == "BUY":
+            return self._q(price * (Decimal("1") + slippage_fraction), config.price_scale)
+        return self._q(price * (Decimal("1") - slippage_fraction), config.price_scale)
+
+    def _snapshot_key(self, snapshot: Mapping[str, Any]) -> str:
+        if snapshot.get("timestamp") is not None:
+            return str(snapshot["timestamp"])
+        if snapshot.get("snapshot_key") is not None:
+            return str(snapshot["snapshot_key"])
+        if snapshot.get("id") is not None:
+            return str(snapshot["id"])
+        raise ValueError("Snapshot must contain one of: timestamp, snapshot_key, id")
+
+    def _q(self, value: Decimal, scale: Decimal) -> Decimal:
+        return value.quantize(scale, rounding=ROUND_HALF_UP)
+
+
+__all__ = [
+    "DeterministicExecutionConfig",
+    "DeterministicExecutionModel",
+    "Fill",
+    "Order",
+    "Position",
+]

--- a/tests/cilly_trading/engine/test_order_execution_model.py
+++ b/tests/cilly_trading/engine/test_order_execution_model.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from cilly_trading.engine.order_execution_model import (
+    DeterministicExecutionConfig,
+    DeterministicExecutionModel,
+    Order,
+    Position,
+)
+
+
+def _config(fill_timing: str = "next_snapshot") -> DeterministicExecutionConfig:
+    return DeterministicExecutionConfig(
+        slippage_bps=10,
+        commission_per_order=Decimal("1.25"),
+        fill_timing=fill_timing,
+    )
+
+
+def test_order_fill_determinism_repeated_runs_identical() -> None:
+    model = DeterministicExecutionModel()
+    config = _config()
+    snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
+    position = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
+
+    orders = [
+        Order(id="ord-2", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=2),
+        Order(id="ord-1", side="BUY", quantity=Decimal("2"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1),
+    ]
+
+    fills_a, position_a = model.execute(orders=orders, snapshot=snapshot, position=position, config=config)
+    fills_b, position_b = model.execute(orders=orders, snapshot=snapshot, position=position, config=config)
+
+    assert fills_a == fills_b
+    assert position_a == position_b
+    assert [fill.order_id for fill in fills_a] == ["ord-1", "ord-2"]
+
+
+def test_commission_model_is_fixed_and_repeatable() -> None:
+    model = DeterministicExecutionModel()
+    config = _config()
+    snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "50"}
+    position = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
+    orders = [
+        Order(id="buy-a", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1),
+        Order(id="buy-b", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=2),
+    ]
+
+    fills_1, _ = model.execute(orders=orders, snapshot=snapshot, position=position, config=config)
+    fills_2, _ = model.execute(orders=orders, snapshot=snapshot, position=position, config=config)
+
+    assert [fill.commission for fill in fills_1] == [Decimal("1.25"), Decimal("1.25")]
+    assert fills_1 == fills_2
+
+
+def test_position_lifecycle_buy_increase_sell_reduce_close() -> None:
+    model = DeterministicExecutionModel()
+    config = _config()
+
+    buy_snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
+    first_buy = Order(
+        id="buy-1",
+        side="BUY",
+        quantity=Decimal("2"),
+        created_snapshot_key="2024-01-01T00:00:00Z",
+        sequence=1,
+    )
+    second_buy = Order(
+        id="buy-2",
+        side="BUY",
+        quantity=Decimal("2"),
+        created_snapshot_key="2024-01-01T00:00:00Z",
+        sequence=2,
+    )
+
+    fills_buy, position_after_buy = model.execute(
+        orders=[first_buy, second_buy],
+        snapshot=buy_snapshot,
+        position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
+        config=config,
+    )
+
+    assert len(fills_buy) == 2
+    assert position_after_buy.quantity == Decimal("4.00000000")
+    assert position_after_buy.avg_price == Decimal("100.10000000")
+
+    sell_snapshot = {"timestamp": "2024-01-03T00:00:00Z", "open": "110"}
+    reduce_and_close = [
+        Order(id="sell-1", side="SELL", quantity=Decimal("1"), created_snapshot_key="2024-01-02T00:00:00Z", sequence=3),
+        Order(id="sell-2", side="SELL", quantity=Decimal("3"), created_snapshot_key="2024-01-02T00:00:00Z", sequence=4),
+    ]
+
+    fills_sell, position_after_sell = model.execute(
+        orders=reduce_and_close,
+        snapshot=sell_snapshot,
+        position=position_after_buy,
+        config=config,
+    )
+
+    assert len(fills_sell) == 2
+    assert fills_sell[0].fill_price == Decimal("109.89000000")
+    assert position_after_sell.quantity == Decimal("0")
+    assert position_after_sell.avg_price == Decimal("0")
+
+
+def test_slippage_applies_by_side_direction() -> None:
+    model = DeterministicExecutionModel()
+    config = _config()
+    snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
+
+    buy_fills, _ = model.execute(
+        orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
+        snapshot=snapshot,
+        position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
+        config=config,
+    )
+
+    sell_fills, _ = model.execute(
+        orders=[Order(id="sell", side="SELL", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
+        snapshot=snapshot,
+        position=Position(quantity=Decimal("1"), avg_price=Decimal("99")),
+        config=config,
+    )
+
+    assert buy_fills[0].fill_price == Decimal("100.10000000")
+    assert sell_fills[0].fill_price == Decimal("99.90000000")
+
+
+def test_next_snapshot_fill_timing_enforced() -> None:
+    model = DeterministicExecutionModel()
+    config = _config(fill_timing="next_snapshot")
+
+    order = Order(
+        id="next-fill",
+        side="BUY",
+        quantity=Decimal("1"),
+        created_snapshot_key="2024-01-02T00:00:00Z",
+        sequence=1,
+    )
+    start = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
+
+    fills_t, position_t = model.execute(
+        orders=[order],
+        snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "10"},
+        position=start,
+        config=config,
+    )
+
+    fills_t1, position_t1 = model.execute(
+        orders=[order],
+        snapshot={"timestamp": "2024-01-03T00:00:00Z", "open": "11"},
+        position=start,
+        config=config,
+    )
+
+    assert fills_t == []
+    assert position_t == start
+    assert len(fills_t1) == 1
+    assert position_t1.quantity == Decimal("1.00000000")


### PR DESCRIPTION
### Motivation

- Define a deterministic, no-lookahead market order execution model for backtesting so identical inputs always produce identical outputs as required by Issue #382. 
- Make fill price, slippage, commission and position transitions explicit, deterministic, and well-documented to remove ambiguity in backtests.

### Description

- Added a new deterministic execution module `src/cilly_trading/engine/order_execution_model.py` that exposes dataclasses `Order`, `Fill`, `Position`, `DeterministicExecutionConfig` and the `DeterministicExecutionModel.execute(...)` method implementing deterministic fills, slippage, commission, and position transitions. 
- Enforced deterministic processing order for orders using the tuple `(created_snapshot_key, sequence, id)` and implemented `fill_timing` with default `next_snapshot` semantics (orders created at t fill earliest at t+1).
- Implemented deterministic price selection (`open` then `price`), fixed per-order commission (`commission_per_order`), side-aware fixed slippage (`slippage_bps`), and Decimal quantization/rounding (`ROUND_HALF_UP`) with configurable scales.
- Added documentation `docs/backtesting/order_execution_model.md` describing execution semantics, price/slippage/commission formulas, position lifecycle, and rounding rules.
- Added unit tests `tests/cilly_trading/engine/test_order_execution_model.py` covering determinism across repeated runs, commission stability, position lifecycle (BUY/SELL/close), slippage direction, and `next_snapshot` fill timing; no other modules were modified.

### Testing

- Ran `pytest -q tests/cilly_trading/engine/test_order_execution_model.py` which completed successfully with output: `5 passed in 0.07s`.
- Ran `pytest -q tests/cilly_trading/engine/test_backtest_runner.py` to ensure existing backtest runner invariants remain stable which completed successfully with output: `4 passed in 0.06s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924348cc4c8333be20bea6a2d8d73e)