### PR TITLE
P22-DETERMINISM-GUARD – Enforce backtest determinism validation

### DIFF
--- a/src/cilly_trading/engine/determinism_guard.py
+++ b/src/cilly_trading/engine/determinism_guard.py
@@ -1,0 +1,98 @@
+"""Determinism guard for backtest validation."""
+
+from __future__ import annotations
+
+import datetime
+import random
+import secrets
+import socket
+import time
+from typing import Any, Callable
+
+
+__all__ = [
+    "DeterminismViolationError",
+    "install_guard",
+    "uninstall_guard",
+]
+
+
+class DeterminismViolationError(RuntimeError):
+    """Raised when a forbidden non-deterministic API is accessed."""
+
+
+_ORIGINALS: dict[tuple[Any, str], Any] = {}
+_INSTALLED = False
+
+
+def _raise_violation(message: str) -> None:
+    raise DeterminismViolationError(message)
+
+
+def _blocked_callable(message: str) -> Callable[..., Any]:
+    def _blocked(*_args: Any, **_kwargs: Any) -> Any:
+        _raise_violation(message)
+
+    return _blocked
+
+
+def _patch(target: Any, attr: str, replacement: Any) -> None:
+    key = (target, attr)
+    if key in _ORIGINALS:
+        return
+    _ORIGINALS[key] = getattr(target, attr)
+    setattr(target, attr, replacement)
+
+
+def install_guard() -> None:
+    """Install deterministic validation guard by monkeypatching forbidden APIs."""
+
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    # System time access.
+    _patch(time, "time", _blocked_callable("Determinism violation: system time access (time.time)"))
+    _patch(time, "time_ns", _blocked_callable("Determinism violation: system time access (time.time_ns)"))
+
+    class _DeterministicDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+            _raise_violation("Determinism violation: system time access (datetime.datetime.now)")
+
+        @classmethod
+        def utcnow(cls) -> datetime.datetime:
+            _raise_violation("Determinism violation: system time access (datetime.datetime.utcnow)")
+
+    _patch(datetime, "datetime", _DeterministicDatetime)
+
+    # Randomness access.
+    _patch(random, "random", _blocked_callable("Determinism violation: randomness access (random.random)"))
+    _patch(random, "randint", _blocked_callable("Determinism violation: randomness access (random.randint)"))
+    _patch(random, "choice", _blocked_callable("Determinism violation: randomness access (random.choice)"))
+    _patch(random, "randrange", _blocked_callable("Determinism violation: randomness access (random.randrange)"))
+    _patch(secrets, "token_bytes", _blocked_callable("Determinism violation: randomness access (secrets.token_bytes)"))
+    _patch(secrets, "token_hex", _blocked_callable("Determinism violation: randomness access (secrets.token_hex)"))
+    _patch(secrets, "choice", _blocked_callable("Determinism violation: randomness access (secrets.choice)"))
+
+    # Network access.
+    _patch(socket.socket, "connect", _blocked_callable("Determinism violation: network access (socket.socket.connect)"))
+    _patch(socket, "create_connection", _blocked_callable("Determinism violation: network access (socket.create_connection)"))
+    _patch(socket, "getaddrinfo", _blocked_callable("Determinism violation: network access (socket.getaddrinfo)"))
+
+    _INSTALLED = True
+
+
+def uninstall_guard() -> None:
+    """Restore all patched callables and remove the deterministic guard."""
+
+    global _INSTALLED
+    if not _INSTALLED and not _ORIGINALS:
+        return
+
+    for (target, attr), original in reversed(list(_ORIGINALS.items())):
+        setattr(target, attr, original)
+
+    _ORIGINALS.clear()
+    _INSTALLED = False
+

--- a/tests/cilly_trading/engine/test_determinism_guard.py
+++ b/tests/cilly_trading/engine/test_determinism_guard.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import datetime
+import random
+import secrets
+import socket
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+import pytest
+
+from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerConfig
+from cilly_trading.engine.determinism_guard import (
+    DeterminismViolationError,
+    install_guard,
+    uninstall_guard,
+)
+
+
+class SpyStrategy:
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    def on_run_start(self, config: Mapping[str, Any]) -> None:
+        self.calls.append("on_run_start")
+
+    def on_snapshot(self, snapshot: Mapping[str, Any], config: Mapping[str, Any]) -> None:
+        self.calls.append(f"on_snapshot:{snapshot['id']}")
+
+    def on_run_end(self, config: Mapping[str, Any]) -> None:
+        self.calls.append("on_run_end")
+
+
+def test_guard_blocks_system_time() -> None:
+    install_guard()
+    try:
+        with pytest.raises(
+            DeterminismViolationError,
+            match=r"Determinism violation: system time access \(time.time\)",
+        ):
+            time.time()
+        with pytest.raises(
+            DeterminismViolationError,
+            match=r"Determinism violation: system time access \(time.time_ns\)",
+        ):
+            time.time_ns()
+        with pytest.raises(
+            DeterminismViolationError,
+            match=r"Determinism violation: system time access \(datetime.datetime.now\)",
+        ):
+            datetime.datetime.now()
+        with pytest.raises(
+            DeterminismViolationError,
+            match=r"Determinism violation: system time access \(datetime.datetime.utcnow\)",
+        ):
+            datetime.datetime.utcnow()
+    finally:
+        uninstall_guard()
+
+
+def test_guard_blocks_randomness() -> None:
+    install_guard()
+    try:
+        with pytest.raises(DeterminismViolationError, match="random.random"):
+            random.random()
+        with pytest.raises(DeterminismViolationError, match="random.randint"):
+            random.randint(0, 1)
+        with pytest.raises(DeterminismViolationError, match="random.choice"):
+            random.choice([1, 2])
+        with pytest.raises(DeterminismViolationError, match="random.randrange"):
+            random.randrange(10)
+        with pytest.raises(DeterminismViolationError, match="secrets.token_hex"):
+            secrets.token_hex(16)
+        with pytest.raises(DeterminismViolationError, match="secrets.token_bytes"):
+            secrets.token_bytes(16)
+        with pytest.raises(DeterminismViolationError, match="secrets.choice"):
+            secrets.choice([1, 2])
+    finally:
+        uninstall_guard()
+
+
+def test_guard_blocks_network() -> None:
+    install_guard()
+    try:
+        with pytest.raises(
+            DeterminismViolationError,
+            match=r"Determinism violation: network access \(socket.getaddrinfo\)",
+        ):
+            socket.getaddrinfo("example.com", 80)
+        with pytest.raises(
+            DeterminismViolationError,
+            match=r"Determinism violation: network access \(socket.create_connection\)",
+        ):
+            socket.create_connection(("example.com", 80))
+    finally:
+        uninstall_guard()
+
+
+def test_guard_allows_backtest_smoke_run(tmp_path: Path) -> None:
+    install_guard()
+    try:
+        runner = BacktestRunner()
+
+        def strategy_factory() -> SpyStrategy:
+            return SpyStrategy()
+
+        snapshots: List[Dict[str, Any]] = [
+            {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "price": 11.0},
+            {"id": "s1", "timestamp": "2024-01-01T00:00:00Z", "price": 10.0},
+        ]
+
+        result = runner.run(
+            snapshots=snapshots,
+            strategy_factory=strategy_factory,
+            config=BacktestRunnerConfig(output_dir=tmp_path / "guard-smoke"),
+        )
+
+        assert result.artifact_path.exists()
+    finally:
+        uninstall_guard()


### PR DESCRIPTION
### Motivation
- Add a fail-fast guard to detect non-deterministic operations during backtests by blocking system time, randomness, and network access. 
- Ensure deterministic smoke runs (the existing `BacktestRunner`) continue to work while forbidding the listed APIs. 

### Description
- Added `src/cilly_trading/engine/determinism_guard.py` providing `DeterminismViolationError`, `install_guard()`, and `uninstall_guard()` and exported via `__all__`. 
- `install_guard()` monkeypatches `time.time`, `time.time_ns`, `datetime.datetime.now`, `datetime.datetime.utcnow`, select `random` functions, select `secrets` functions, and socket network entry points to raise `DeterminismViolationError` with precise messages, and is idempotent. 
- `uninstall_guard()` restores original callables and is safe to call multiple times. 
- Added tests at `tests/cilly_trading/engine/test_determinism_guard.py` that cover blocked system time, randomness, network calls, and a guarded backtest smoke run.

### Testing
- Ran `pytest -q tests/cilly_trading/engine/test_determinism_guard.py` which passed: `4 passed`. 
- Ran the full test suite with `pytest -q` which produced one unrelated failure in `tests/test_version_declaration.py::test_module_cli_version_prints_and_exits_zero` while the rest of the suite passed (`242 passed, 1 failed, 4 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994bf909938833383c2cad7f20c0f17)