### PR TITLE
docs: add deterministic backtesting README for issue #386

### DIFF
--- a/docs/backtesting/README.md
+++ b/docs/backtesting/README.md
@@ -1,0 +1,42 @@
+# Backtesting
+
+## Purpose
+Backtesting runs a strategy against historical snapshots and writes deterministic results for review.
+
+## Usage
+```bash
+python -m cilly_trading backtest --snapshots <PATH> --strategy <NAME> --out <DIR> [--run-id <STR>] [--strategy-module <PYMOD>]...
+```
+
+- `--snapshots`: Path to a JSON file containing snapshot data.
+- `--strategy`: Strategy name to resolve and execute.
+- `--out`: Output directory for backtest artifacts.
+- `--run-id` (default deterministic): Optional run identifier; when omitted, a deterministic identifier is used.
+- `--strategy-module` (optional, repeatable, imports module(s) before strategy resolution): Optional module path to import before strategy lookup; may be provided multiple times.
+
+## Determinism Rules
+- Determinism guard is installed during backtest execution and uninstalled in a finally block.
+- Non-deterministic APIs are forbidden; violations exit with code 10.
+- Snapshot input must be a JSON list.
+- Each snapshot item must include:
+  - `id` (non-empty string)
+  - `timestamp` (non-empty string)
+
+## Exit Codes
+| Code | Meaning |
+| --- | --- |
+| 0 | success |
+| 10 | determinism violation |
+| 20 | snapshot input invalid |
+| 30 | strategy selection invalid |
+| 1 | unexpected error |
+
+## Limitations
+- No live trading
+- No broker integrations
+- No AI-based trading decisions
+
+## Artifact Contract
+- Output directory contains deterministic artifact(s)
+- Artifact file: `backtest-result.json`
+- Artifact content is deterministic for identical inputs


### PR DESCRIPTION
### Motivation
- Align backtesting documentation with determinism and governance rules and remove any marketing language.
- Provide an operational, concise reference for CLI usage, determinism requirements, exit codes, limitations, and artifact contract.

### Description
- Added `docs/backtesting/README.md` containing the exact sections and order required: Purpose, Usage, Determinism Rules, Exit Codes, Limitations, and Artifact Contract.
- Included the exact CLI command syntax line: `python -m cilly_trading backtest --snapshots <PATH> --strategy <NAME> --out <DIR> [--run-id <STR>] [--strategy-module <PYMOD>]...` and factual flag descriptions.
- Explicitly documented determinism rules, required snapshot schema, and the required exit codes including code `10` for determinism violations.
- Stated operational limitations and a deterministic artifact contract naming `backtest-result.json` as the output artifact.

### Testing
- Ran `git status --short` which showed the new file `docs/backtesting/README.md` and succeeded.
- Ran `nl -ba docs/backtesting/README.md` to verify file contents and succeeded.
- Performed `git add` and `git commit` which succeeded and created the new file in the local branch.
- `git diff --name-status origin/main...HEAD` failed in this environment because `origin/main` is not present, so remote diff could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994dcd90ac48333b0c7bdfd2ec561cc)