### PR TITLE
Add deterministic multi-run backtest CLI smoke test

### DIFF
--- a/tests/test_backtest_determinism_smoke.py
+++ b/tests/test_backtest_determinism_smoke.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_backtest(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    run_env = dict(os.environ)
+    if env is not None:
+        run_env.update(env)
+
+    project_paths = [str(Path.cwd()), str(Path.cwd() / "src")]
+    existing_pythonpath = run_env.get("PYTHONPATH")
+    if existing_pythonpath:
+        run_env["PYTHONPATH"] = os.pathsep.join(project_paths + [existing_pythonpath])
+    else:
+        run_env["PYTHONPATH"] = os.pathsep.join(project_paths)
+
+    return subprocess.run(
+        [sys.executable, "-m", "cilly_trading", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=run_env,
+    )
+
+
+def test_backtest_cli_produces_identical_artifacts_across_three_runs(tmp_path: Path) -> None:
+    snapshots_path = tmp_path / "snapshots.json"
+    snapshots_path.write_text(
+        json.dumps(
+            [
+                {"id": "s1", "timestamp": "2024-01-01T00:00:00Z", "price": 10},
+                {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "price": 11},
+                {"id": "s3", "timestamp": "2024-01-03T00:00:00Z", "price": 12},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    artifacts: list[bytes] = []
+    hashes: list[str] = []
+
+    for run_index in range(3):
+        out_dir = tmp_path / f"out-{run_index}"
+        result = _run_backtest(
+            [
+                "backtest",
+                "--snapshots",
+                str(snapshots_path),
+                "--strategy",
+                "REFERENCE",
+                "--out",
+                str(out_dir),
+            ]
+        )
+
+        assert result.returncode == 0
+
+        artifact_bytes = (out_dir / "backtest-result.json").read_bytes()
+        artifacts.append(artifact_bytes)
+        hashes.append(hashlib.sha256(artifact_bytes).hexdigest())
+
+    assert artifacts[0] == artifacts[1] == artifacts[2]
+    assert hashes[0] == hashes[1] == hashes[2]


### PR DESCRIPTION
### Motivation
- Add a lightweight smoke test to verify the backtest CLI produces byte-identical artifacts across multiple runs to catch non-deterministic behavior.

### Description
- Add `tests/test_backtest_determinism_smoke.py` which writes a temporary snapshots JSON, runs `python -m cilly_trading backtest` three times with the same `--snapshots`, `--strategy REFERENCE`, and distinct `--out` dirs while injecting `PYTHONPATH` (`cwd` + `cwd/src`), asserts each run's `returncode == 0`, reads `backtest-result.json` as bytes, and verifies strict byte equality and identical `sha256` hashes across all three artifacts.

### Testing
- Ran `pytest -q`; the test suite completed successfully with all tests passing (`249 passed, 4 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994de93ad148333b54f50dea6d9d61c)