### PR TITLE
Add deterministic metrics-result.json artifact writer and schema

### DIFF
--- a/schemas/metrics-result.schema.json
+++ b/schemas/metrics-result.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://trading-engine.local/schemas/metrics-result.schema.json",
+  "title": "Metrics Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "total_return",
+    "cagr",
+    "max_drawdown",
+    "sharpe_ratio",
+    "win_rate",
+    "profit_factor"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "1.0.0"
+      ]
+    },
+    "total_return": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "cagr": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "max_drawdown": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "sharpe_ratio": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "win_rate": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "profit_factor": {
+      "type": [
+        "number",
+        "null"
+      ]
+    }
+  }
+}

--- a/src/cilly_trading/metrics/__init__.py
+++ b/src/cilly_trading/metrics/__init__.py
@@ -1,3 +1,10 @@
+from .artifact import (
+    METRICS_ARTIFACT_FILENAME,
+    METRICS_SCHEMA_VERSION,
+    build_metrics_artifact,
+    canonical_json_bytes,
+    write_metrics_artifact,
+)
 from .backtest_metrics import (
     _timestamp_to_epoch_seconds,
     calculate_metrics,
@@ -10,4 +17,9 @@ __all__ = [
     "compute_backtest_metrics",
     "compute_metrics",
     "calculate_metrics",
+    "METRICS_ARTIFACT_FILENAME",
+    "METRICS_SCHEMA_VERSION",
+    "build_metrics_artifact",
+    "canonical_json_bytes",
+    "write_metrics_artifact",
 ]

--- a/src/cilly_trading/metrics/artifact.py
+++ b/src/cilly_trading/metrics/artifact.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_EVEN
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+METRICS_ARTIFACT_FILENAME = "metrics-result.json"
+METRICS_SCHEMA_VERSION = "1.0.0"
+METRIC_KEYS = (
+    "total_return",
+    "cagr",
+    "max_drawdown",
+    "sharpe_ratio",
+    "win_rate",
+    "profit_factor",
+)
+_QUANT = Decimal("0.000000000001")
+
+
+def _normalize_float(value: float) -> float:
+    rounded = float(Decimal(str(value)).quantize(_QUANT, rounding=ROUND_HALF_EVEN))
+    if rounded == 0.0:
+        return 0.0
+    return rounded
+
+
+def _normalize_for_json(value: Any) -> Any:
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return _normalize_float(value)
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_for_json(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_normalize_for_json(item) for item in value]
+    if isinstance(value, tuple):
+        return [_normalize_for_json(item) for item in value]
+    return value
+
+
+def canonical_json_bytes(obj: Any) -> bytes:
+    normalized = _normalize_for_json(obj)
+    serialized = json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return (serialized + "\n").encode("utf-8")
+
+
+def build_metrics_artifact(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": METRICS_SCHEMA_VERSION,
+        **{key: metrics.get(key) for key in METRIC_KEYS},
+    }
+
+
+def write_metrics_artifact(metrics: Mapping[str, Any], output_dir: str | Path) -> Path:
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    artifact = build_metrics_artifact(metrics)
+    artifact_path = output_path / METRICS_ARTIFACT_FILENAME
+    artifact_path.write_bytes(canonical_json_bytes(artifact))
+    return artifact_path

--- a/tests/test_metrics_artifact.py
+++ b/tests/test_metrics_artifact.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cilly_trading.metrics import (
+    METRICS_ARTIFACT_FILENAME,
+    build_metrics_artifact,
+    canonical_json_bytes,
+    compute_backtest_metrics,
+    write_metrics_artifact,
+)
+from cilly_trading.metrics.artifact import _normalize_for_json
+
+
+DETERMINISTIC_FIXTURE_INPUT = {
+    "summary": {"start_equity": 100.0, "end_equity": 120.0},
+    "equity_curve": [
+        {"timestamp": 0, "equity": 100.0},
+        {"timestamp": 31_557_600, "equity": 120.0},
+    ],
+    "trades": [
+        {"trade_id": "a", "exit_ts": 1, "pnl": 5.0},
+        {"trade_id": "b", "exit_ts": 2, "pnl": 10.0},
+        {"trade_id": "c", "exit_ts": 3, "pnl": -3.0},
+    ],
+}
+
+
+def test_metrics_artifact_three_runs_identical_bytes(tmp_path: Path) -> None:
+    metrics = compute_backtest_metrics(**DETERMINISTIC_FIXTURE_INPUT)
+
+    artifact_paths = [
+        write_metrics_artifact(metrics, tmp_path / f"run-{idx}")
+        for idx in range(3)
+    ]
+
+    artifact_bytes = [path.read_bytes() for path in artifact_paths]
+
+    assert all(path.name == METRICS_ARTIFACT_FILENAME for path in artifact_paths)
+    assert artifact_bytes[0] == artifact_bytes[1] == artifact_bytes[2]
+
+
+def test_metrics_artifact_matches_canonical_json_bytes(tmp_path: Path) -> None:
+    metrics = compute_backtest_metrics(**DETERMINISTIC_FIXTURE_INPUT)
+    artifact = build_metrics_artifact(metrics)
+
+    artifact_path = write_metrics_artifact(metrics, tmp_path)
+
+    expected = canonical_json_bytes(artifact)
+    observed = artifact_path.read_bytes()
+
+    assert observed == expected
+
+
+def test_metrics_artifact_uses_deterministic_key_ordering_and_rounding(tmp_path: Path) -> None:
+    metrics = {
+        "win_rate": 2.0 / 3.0,
+        "cagr": -0.0,
+        "profit_factor": 5,
+        "total_return": 0.2,
+        "max_drawdown": 0.0,
+        "sharpe_ratio": None,
+    }
+
+    artifact_path = write_metrics_artifact(metrics, tmp_path)
+
+    expected_obj = _normalize_for_json(build_metrics_artifact(metrics))
+    expected_json = json.dumps(
+        expected_obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ) + "\n"
+
+    assert artifact_path.read_text(encoding="utf-8") == expected_json


### PR DESCRIPTION
### Motivation
- Ensure backtest metrics are exported as a deterministic, reproducible JSON artifact named `metrics-result.json` suitable for byte-level comparisons and storage. 
- Provide stable float formatting and key ordering so repeated runs produce identical bytes and artifact hashes. 
- Define an explicit JSON Schema for the artifact so consumers can validate the artifact structure and types.

### Description
- Added `src/cilly_trading/metrics/artifact.py` implementing `canonical_json_bytes(obj)`, `build_metrics_artifact(metrics)`, and `write_metrics_artifact(metrics, output_dir)` with UTF-8 output, sorted keys, separators `(",", ":")`, trailing newline, and `allow_nan=False`.
- Implemented explicit float normalization using round-half-to-even to 12 fractional digits and normalization of `-0.0` to `0.0` via `_normalize_for_json` before serialization. 
- Exported artifact helpers from `src/cilly_trading/metrics/__init__.py` so they are available alongside existing metric functions. 
- Added JSON Schema at `schemas/metrics-result.schema.json` declaring `schema_version` ("1.0.0"), the six metric keys, allowing `number` or `null`, and enforcing `additionalProperties: false`.

### Testing
- Added `tests/test_metrics_artifact.py` which runs a 3x-run identical-byte smoke test, verifies byte equality against `canonical_json_bytes`, and asserts deterministic ordering/rounding behavior. 
- Ran `pytest -q tests/test_metrics_artifact.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699624b60a94833381106b552ec8fd09)