### PR TITLE
Add deterministic `evaluate` CLI command and tests

### DIFF
--- a/docs/backtesting/evaluate_cli.md
+++ b/docs/backtesting/evaluate_cli.md
@@ -1,0 +1,37 @@
+# Evaluate CLI
+
+## Command
+
+```bash
+python -m cilly_trading evaluate --artifact <PATH> --out <DIR>
+```
+
+- `--artifact`: Path to a deterministic backtest artifact JSON file (for example `backtest-result.json`).
+- `--out`: Output directory for metrics artifacts. The directory is created if it does not exist.
+
+## Behavior
+
+- Artifact input is read as UTF-8 JSON.
+- JSON constants like `NaN`, `Infinity`, and `-Infinity` are rejected.
+- Metrics are computed deterministically from artifact content.
+- The command writes `metrics-result.json` to `--out` with canonical JSON bytes.
+- On success, stdout prints exactly one deterministic line:
+
+```text
+WROTE <path>
+```
+
+## Exit codes
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Success |
+| `2` | CLI usage or invalid arguments (argparse default) |
+| `10` | Determinism violation |
+| `20` | Artifact input invalid (missing file, invalid JSON, or schema/type mismatch) |
+| `1` | Unexpected error fallback |
+
+## Determinism guard
+
+The `evaluate` command installs the determinism guard at startup and uninstalls it in a `finally` block.
+If forbidden non-deterministic APIs are used during execution, the command exits with code `10`.

--- a/src/cilly_trading/__main__.py
+++ b/src/cilly_trading/__main__.py
@@ -21,6 +21,10 @@ def _build_parser() -> argparse.ArgumentParser:
     backtest_parser.add_argument("--run-id", default="deterministic")
     backtest_parser.add_argument("--strategy-module", action="append", default=None)
 
+    evaluate_parser = subparsers.add_parser("evaluate")
+    evaluate_parser.add_argument("--artifact", required=True)
+    evaluate_parser.add_argument("--out", required=True)
+
     return parser
 
 
@@ -39,6 +43,14 @@ def main(argv: list[str] | None = None) -> int:
             out_dir=Path(args.out),
             run_id=args.run_id,
             strategy_modules=args.strategy_module,
+        )
+
+    if args.command == "evaluate":
+        from .cli.evaluate_cli import run_evaluate
+
+        return run_evaluate(
+            artifact_path=Path(args.artifact),
+            out_dir=Path(args.out),
         )
 
     parser.print_usage()

--- a/src/cilly_trading/cli/evaluate_cli.py
+++ b/src/cilly_trading/cli/evaluate_cli.py
@@ -1,0 +1,72 @@
+"""Evaluate CLI execution helpers."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+from cilly_trading.engine.determinism_guard import (
+    DeterminismViolationError,
+    install_guard,
+    uninstall_guard,
+)
+from cilly_trading.metrics import compute_metrics, write_metrics_artifact
+
+
+class EvaluateInputError(ValueError):
+    """Raised when evaluate input cannot be loaded or validated."""
+
+
+def _parse_constant(_value: str) -> Any:
+    raise ValueError("invalid constant")
+
+
+def _load_artifact(path: Path) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=_parse_constant,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise EvaluateInputError("Invalid artifact input") from exc
+
+    if not isinstance(payload, Mapping):
+        raise EvaluateInputError("Invalid artifact input")
+
+    summary = payload.get("summary")
+    equity_curve = payload.get("equity_curve")
+    trades = payload.get("trades")
+
+    if summary is not None and not isinstance(summary, Mapping):
+        raise EvaluateInputError("Invalid artifact input")
+    if equity_curve is not None and not isinstance(equity_curve, list):
+        raise EvaluateInputError("Invalid artifact input")
+    if trades is not None and not isinstance(trades, list):
+        raise EvaluateInputError("Invalid artifact input")
+
+    return payload
+
+
+def run_evaluate(*, artifact_path: Path, out_dir: Path) -> int:
+    """Run deterministic metrics evaluation command and return deterministic exit code."""
+
+    install_guard()
+    try:
+        payload = _load_artifact(artifact_path)
+        metrics = compute_metrics(payload)
+        output_path = write_metrics_artifact(metrics, out_dir)
+        print(f"WROTE {output_path}")
+        return 0
+    except DeterminismViolationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 10
+    except EvaluateInputError as exc:
+        print(str(exc), file=sys.stderr)
+        return 20
+    except Exception as exc:  # pragma: no cover - fallback protection
+        print(f"Unexpected error: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        uninstall_guard()

--- a/tests/test_cli_evaluate_metrics.py
+++ b/tests/test_cli_evaluate_metrics.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_cli(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    run_env = dict(os.environ)
+    if env is not None:
+        run_env.update(env)
+
+    project_paths = [str(Path.cwd()), str(Path.cwd() / "src")]
+    existing_pythonpath = run_env.get("PYTHONPATH")
+    if existing_pythonpath:
+        run_env["PYTHONPATH"] = os.pathsep.join(project_paths + [existing_pythonpath])
+    else:
+        run_env["PYTHONPATH"] = os.pathsep.join(project_paths)
+
+    return subprocess.run(
+        [sys.executable, "-m", "cilly_trading", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=run_env,
+    )
+
+
+def _build_artifact() -> dict[str, object]:
+    return {
+        "summary": {"start_equity": 10000, "end_equity": 10500},
+        "equity_curve": [
+            {"timestamp": "2024-01-01T00:00:00Z", "equity": 10000},
+            {"timestamp": "2024-01-02T00:00:00Z", "equity": 10250},
+            {"timestamp": "2024-01-03T00:00:00Z", "equity": 10500},
+        ],
+        "trades": [
+            {"trade_id": "t1", "exit_ts": "2024-01-02T00:00:00Z", "pnl": 100},
+            {"trade_id": "t2", "exit_ts": "2024-01-03T00:00:00Z", "pnl": -50},
+        ],
+    }
+
+
+def test_cli_evaluate_is_deterministic_across_three_runs(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "backtest-result.json"
+    artifact_path.write_text(json.dumps(_build_artifact()), encoding="utf-8")
+
+    output_bytes: list[bytes] = []
+    output_hashes: list[str] = []
+
+    for idx in range(3):
+        out_dir = tmp_path / f"out-{idx}"
+        result = _run_cli(
+            [
+                "evaluate",
+                "--artifact",
+                str(artifact_path),
+                "--out",
+                str(out_dir),
+            ]
+        )
+
+        assert result.returncode == 0
+        artifact_output = out_dir / "metrics-result.json"
+        assert artifact_output.exists()
+
+        content = artifact_output.read_bytes()
+        output_bytes.append(content)
+        output_hashes.append(hashlib.sha256(content).hexdigest())
+
+    assert output_bytes[0] == output_bytes[1] == output_bytes[2]
+    assert output_hashes[0] == output_hashes[1] == output_hashes[2]
+
+
+def test_cli_evaluate_missing_artifact_exit_20(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing-artifact.json"
+
+    result = _run_cli(
+        [
+            "evaluate",
+            "--artifact",
+            str(missing_path),
+            "--out",
+            str(tmp_path / "out"),
+        ]
+    )
+
+    assert result.returncode == 20


### PR DESCRIPTION
### Motivation

- Provide a deterministic CLI entrypoint to compute metrics from an existing Phase‑22 backtest artifact and produce a canonical `metrics-result.json` output. 
- Reuse the existing determinism guard and Phase‑22 exit‑code semantics so metric evaluation behaves consistently with the backtest CLI.

### Description

- Added an `evaluate` subcommand to the package entrypoint with required `--artifact` and `--out` arguments and wired it to a new handler in `src/cilly_trading/cli/evaluate_cli.py`. 
- Implemented `run_evaluate` which installs/uninstalls the determinism guard, reads UTF‑8 JSON with `parse_constant` rejecting `NaN`/`Infinity`, validates artifact structure, computes metrics via the existing metrics API, writes canonical bytes using the existing artifact writer, prints `WROTE <path>`, and returns Phase‑22 aligned exit codes. 
- Added deterministic tests in `tests/test_cli_evaluate_metrics.py` that run the CLI three times to assert identical `metrics-result.json` bytes and SHA‑256 hashes and assert missing artifact input returns the invalid input exit code. 
- Added documentation `docs/backtesting/evaluate_cli.md` describing usage, behavior, determinism guard, and explicit exit code mapping; changed files are `src/cilly_trading/__main__.py`, `src/cilly_trading/cli/evaluate_cli.py`, `tests/test_cli_evaluate_metrics.py`, and `docs/backtesting/evaluate_cli.md`.

### Testing

- Ran `pytest -q tests/test_cli_evaluate_metrics.py` and the new evaluate tests passed (`2 passed`).
- Ran `pytest -q tests/test_backtest_cli.py` to ensure CLI conventions and determinism guard behavior remained intact and those tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69962dd631388333a099f76315b3a9ac)