### PR TITLE
Implement Issue #414: serve static Owner Dashboard at /ui

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 import logging
 import os
 import uuid
+from pathlib import Path
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .config import SIGNALS_READ_MAX_LIMIT
@@ -344,6 +346,9 @@ app = FastAPI(
     version="0.1.0",
     description="MVP-API für die Cilly Trading Engine (RSI2 & Turtle, D1, SQLite).",
 )
+
+UI_DIRECTORY = Path(__file__).resolve().parent.parent / "ui"
+app.mount("/ui", StaticFiles(directory=UI_DIRECTORY, html=True), name="ui")
 
 logger.info("Cilly Trading Engine API starting up")
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Owner Dashboard</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+
+      main {
+        width: min(640px, calc(100% - 2rem));
+        border: 1px solid #334155;
+        border-radius: 12px;
+        padding: 1.5rem;
+        background: #111827;
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      p {
+        margin-bottom: 0;
+        color: #cbd5e1;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Owner Dashboard</h1>
+      <p>Trading Engine owner dashboard UI is available at <code>/ui</code>.</p>
+    </main>
+  </body>
+</html>

--- a/tests/health_endpoint.py
+++ b/tests/health_endpoint.py
@@ -131,3 +131,17 @@ def test_health_endpoint_reports_unavailable_boundary(monkeypatch) -> None:
     assert response.status_code == 200
     assert response.json()["status"] == "unavailable"
     assert response.json()["reason"] == "runtime_running_timeout"
+
+
+def test_ui_endpoint_serves_html(monkeypatch) -> None:
+    def _start() -> str:
+        return "running"
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/ui")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert "Owner Dashboard" in response.text


### PR DESCRIPTION
### Motivation
- Provide a minimal, static Owner Dashboard UI served from the API so operators can access a landing page at `/ui` without adding frontend frameworks or changing engine code. 
- Keep changes minimal and robust by resolving the UI path relative to the API module rather than relying on CWD.

### Description
- Mounted a `StaticFiles` instance at `/ui` in `src/api/main.py` using `html=True` and a `UI_DIRECTORY` resolved with `pathlib.Path(__file__).resolve().parent.parent / "ui"` so the route serves `index.html` reliably. 
- Added a minimal static HTML page at `src/ui/index.html` (no JS frameworks or build pipeline). 
- Added a test in `tests/health_endpoint.py` named `test_ui_endpoint_serves_html` that requests `GET /ui` and asserts a `200` response, an HTML content-type, and the presence of the marker text `Owner Dashboard`. 
- Only modified allowed files and did not change any code under `src/cilly_trading/engine/**`.

### Testing
- Ran the API test file with `pytest -q tests/health_endpoint.py` and all tests in that file passed (`4 passed`).
- To reproduce: run `pytest -q tests/health_endpoint.py` to run the added test, or start the app with `uvicorn api.main:app --host 0.0.0.0 --port 8000` (from `src/`) and open `http://localhost:8000/ui` to verify the page loads and shows "Owner Dashboard".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69976db9dc388333beb371d007986851)