### PR TITLE
Implement Issue #415: show runtime status on Owner Dashboard

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -174,10 +174,12 @@
 
             setValues({
               status: healthData.status,
-              mode: runtimeData.mode,
+              mode: runtimeData.mode || healthData.mode,
               runtime_id: runtimeData.runtime_id,
-              started_at: runtimeData.started_at,
-              updated_at: runtimeData.updated_at,
+              started_at:
+                runtimeData.timestamps && runtimeData.timestamps.started_at,
+              updated_at:
+                runtimeData.timestamps && runtimeData.timestamps.updated_at,
             });
 
             if (!results[0] && !results[1]) {


### PR DESCRIPTION
### Motivation
- Extend the static Owner Dashboard UI to show live runtime status using only existing frontend endpoints and without backend changes. 
- Surface `status`, `mode`, `runtime_id`, `started_at`, and `updated_at` to owners and handle offline/unavailable endpoints gracefully to avoid UI errors.

### Description
- Modified `src/ui/index.html` to add a new "Runtime Status" panel and related CSS for layout and accessibility. 
- Added vanilla JavaScript that fetches `GET /health` and `GET /runtime/introspection`, safely parses responses, maps required fields, and renders them to the panel. 
- Implemented fallback defaults and user-facing status messages for partial or total endpoint failures and guarded promise paths to avoid uncaught console errors. 
- No backend, API, or engine changes were made and no polling or new endpoints were introduced.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues and succeeded. 
- Served the repo locally with `python3 -m http.server 4173 --directory /workspace/Trading-engine` and verified the static page loads. 
- Executed an automated Playwright script to open `http://127.0.0.1:4173/src/ui/index.html` and capture a screenshot which completed successfully and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699773f15c6083339992b19b63a4a5ab)