### PR TITLE
feat(ui): add minimal Owner Dashboard frontend scaffold

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Owner Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "owner-dashboard-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10",
+    "vitest": "^2.1.4"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import OwnerDashboard from './pages/OwnerDashboard';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/owner" element={<OwnerDashboard />} />
+      <Route path="*" element={<Navigate to="/owner" replace />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/OwnerDashboard.test.tsx
+++ b/frontend/src/pages/OwnerDashboard.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import OwnerDashboard from './OwnerDashboard';
+
+describe('OwnerDashboard', () => {
+  it('renders dashboard headline and placeholder copy', () => {
+    render(
+      <MemoryRouter>
+        <OwnerDashboard />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Owner Dashboard' })).toBeInTheDocument();
+    expect(screen.getByText('Manual analysis controls will appear here.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/OwnerDashboard.tsx
+++ b/frontend/src/pages/OwnerDashboard.tsx
@@ -1,0 +1,12 @@
+function OwnerDashboard() {
+  return (
+    <main className="dashboard-layout">
+      <h1>Owner Dashboard</h1>
+      <section className="dashboard-placeholder" aria-label="manual-analysis-controls-placeholder">
+        Manual analysis controls will appear here.
+      </section>
+    </main>
+  );
+}
+
+export default OwnerDashboard;

--- a/frontend/src/services/dashboardApi.ts
+++ b/frontend/src/services/dashboardApi.ts
@@ -1,0 +1,7 @@
+export type DashboardStatus = {
+  status: 'not-implemented';
+};
+
+export async function fetchDashboardStatus(): Promise<DashboardStatus> {
+  return Promise.resolve({ status: 'not-implemented' });
+}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,20 @@
+:root {
+  font-family: Arial, sans-serif;
+  color: #111;
+  background-color: #fff;
+}
+
+body {
+  margin: 0;
+}
+
+.dashboard-layout {
+  margin: 2rem;
+}
+
+.dashboard-placeholder {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  max-width: 36rem;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts'
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide a stable, minimal UI target for future Owner Dashboard work so front-end work (e.g. #419) can land against a concrete page. 
- Keep the change minimal and non-invasive by introducing an isolated frontend root rather than touching existing backend code. 
- Ship a testable, buildable scaffold that satisfies acceptance criteria for headline, placeholder and a lightweight API stub.

### Description
- Add a new `frontend/` Vite + React + TypeScript scaffold with `dev`, `build` and `test` scripts in `package.json` and minimal config files (`tsconfig.json`, `vite.config.ts`).
- Add app bootstrap and routing (`src/main.tsx`, `src/App.tsx`) that exposes the dashboard at the `/owner` route and redirects unknown paths to it.
- Add `OwnerDashboard` component (`src/pages/OwnerDashboard.tsx`) rendering the required headline `Owner Dashboard` and the placeholder text `Manual analysis controls will appear here.`.
- Add a minimal API service stub (`src/services/dashboardApi.ts`) to host future dashboard calls, and add test setup + one render test (`src/pages/OwnerDashboard.test.tsx`) that asserts headline and placeholder exist.

### Testing
- Ran unit tests with `vitest` (`cd frontend && npm test`), the single render test passed (1 test, 1 passed).
- Built the production bundle with Vite (`cd frontend && npm run build`), the build completed successfully.
- Started the dev server locally to verify the page is reachable (`npm run dev -- --host 0.0.0.0 --port 4173`) and captured a screenshot during validation.

Closes #428

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b564a89408333a94716ee6d115ab8)