### PR TITLE
docs: add Owner Dashboard documentation

### DIFF
--- a/docs/ui/owner_dashboard.md
+++ b/docs/ui/owner_dashboard.md
@@ -1,0 +1,75 @@
+# Owner Dashboard
+
+## Overview
+The Owner Dashboard is an operator interface for manually triggering and reviewing single-symbol analysis runs from the UI.
+
+## Current Features
+- Manual single-symbol analysis trigger from the Owner Dashboard UI.
+- Display of returned signals for the requested symbol.
+- Display of the analysis generation timestamp (`generated_at`).
+- Tabular display of signal data fields returned by the analysis response.
+
+## UI Behavior
+- **Symbol input default:** `BTCUSDT`
+- **Loading state:** the trigger button is disabled and shows `Loading...` while the request is in progress.
+- **Error state:** an alert is shown when the request fails; fallback message is `Analysis request failed.`
+- **Empty state:** `No signals returned.` is shown when no signals are returned.
+
+## Scope & Limitations
+This Owner Dashboard documentation only covers the current manual, single-symbol operator flow.
+
+The following are explicitly **not included** in this scope:
+- Batch analysis flows
+- Scheduling workflows
+- Optimization workflows
+- Deployment workflows
+
+## Local Development Setup
+### Prerequisites
+- Node.js and npm installed for frontend development.
+- Python with a virtual environment available if backend services are run locally.
+
+### Frontend
+From the repository root, run:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Then open the Owner Dashboard at:
+
+- `/owner`
+
+### Backend requirement for analysis endpoint
+The Owner Dashboard triggers `POST /analysis/run`, so the backend must be running for successful analysis responses.
+
+Use the following uvicorn command pattern (replace `MODULE_PATH` with your app module path):
+
+```bash
+uvicorn MODULE_PATH:app --reload --port 8000
+```
+
+How to find the module path:
+- Search the backend codebase for `app = FastAPI()`.
+- Use the containing Python module path as `MODULE_PATH`.
+
+### Same-origin and backend port note
+If the frontend and backend are not configured for the same origin (or a development proxy is not configured), requests to `/analysis/run` may fail due to origin/port mismatch.
+
+## Manual Test Checklist
+1. Start frontend (`npm run dev`) and open `/owner`.
+2. Confirm the symbol input defaults to `BTCUSDT`.
+3. With backend **down**, trigger analysis and verify:
+   - The button enters loading state (`Loading...`) and is disabled during the request.
+   - An alert appears with an error, including fallback text `Analysis request failed.` when no detailed message is available.
+4. Start backend so `POST /analysis/run` is reachable.
+5. Trigger analysis again and verify with backend **up**:
+   - Request completes without error alert.
+   - `generated_at` is displayed.
+   - Signal rows appear in the table when signals are returned.
+6. Verify empty-result handling by using a case that returns no signals, and confirm `No signals returned.` is shown.
+
+## Related Issues
+- #419 – feature implementation described by this document.


### PR DESCRIPTION
### Motivation
- Provide an operator-facing reference describing the Owner Dashboard UI, its current manual single-symbol analysis workflow, observable UI states, scope limits, and local run instructions so operators and developers can use and test the feature reliably.

### Description
- Added one new documentation file `docs/ui/owner_dashboard.md` containing the required sections: Overview, Current Features, UI Behavior, Scope & Limitations, Local Development Setup (with frontend commands and uvicorn pattern using `MODULE_PATH`), Manual Test Checklist, and Related Issues; no other files were changed.
- Modified files: none outside `docs/ui/`.
- New files: `docs/ui/owner_dashboard.md`.

Full contents of `docs/ui/owner_dashboard.md`:

# Owner Dashboard

## Overview
The Owner Dashboard is an operator interface for manually triggering and reviewing single-symbol analysis runs from the UI.

## Current Features
- Manual single-symbol analysis trigger from the Owner Dashboard UI.
- Display of returned signals for the requested symbol.
- Display of the analysis generation timestamp (`generated_at`).
- Tabular display of signal data fields returned by the analysis response.

## UI Behavior
- **Symbol input default:** `BTCUSDT`
- **Loading state:** the trigger button is disabled and shows `Loading...` while the request is in progress.
- **Error state:** an alert is shown when the request fails; fallback message is `Analysis request failed.`
- **Empty state:** `No signals returned.` is shown when no signals are returned.

## Scope & Limitations
This Owner Dashboard documentation only covers the current manual, single-symbol operator flow.

The following are explicitly **not included** in this scope:
- Batch analysis flows
- Scheduling workflows
- Optimization workflows
- Deployment workflows

## Local Development Setup
### Prerequisites
- Node.js and npm installed for frontend development.
- Python with a virtual environment available if backend services are run locally.

### Frontend
From the repository root, run:

```bash
cd frontend
npm install
npm run dev
```

Then open the Owner Dashboard at:

- `/owner`

### Backend requirement for analysis endpoint
The Owner Dashboard triggers `POST /analysis/run`, so the backend must be running for successful analysis responses.

Use the following uvicorn command pattern (replace `MODULE_PATH` with your app module path):

```bash
uvicorn MODULE_PATH:app --reload --port 8000
```

How to find the module path:
- Search the backend codebase for `app = FastAPI()`.
- Use the containing Python module path as `MODULE_PATH`.

### Same-origin and backend port note
If the frontend and backend are not configured for the same origin (or a development proxy is not configured), requests to `/analysis/run` may fail due to origin/port mismatch.

## Manual Test Checklist
1. Start frontend (`npm run dev`) and open `/owner`.
2. Confirm the symbol input defaults to `BTCUSDT`.
3. With backend **down**, trigger analysis and verify:
   - The button enters loading state (`Loading...`) and is disabled during the request.
   - An alert appears with an error, including fallback text `Analysis request failed.` when no detailed message is available.
4. Start backend so `POST /analysis/run` is reachable.
5. Trigger analysis again and verify with backend **up**:
   - Request completes without error alert.
   - `generated_at` is displayed.
   - Signal rows appear in the table when signals are returned.
6. Verify empty-result handling by using a case that returns no signals, and confirm `No signals returned.` is shown.

## Related Issues
- #419 – feature implementation described by this document.

Mapping to issue scope: the file provides the required headings and content for Overview, Current Features, UI Behavior (default symbol, loading/error/empty states), Scope & Limitations (explicit exclusions), Local Development Setup (prereqs, frontend commands, `uvicorn MODULE_PATH:app --reload --port 8000` pattern, module-path tip, same-origin note), Manual Test Checklist (backend down vs up cases), and Related Issues referencing `#419`.

Confirmed no files outside `docs/ui/` were changed.

### Testing
- Automated repository checks executed: `git status --short`, `nl -ba docs/ui/owner_dashboard.md`, and `wc -l docs/ui/owner_dashboard.md` completed successfully.
- Git operations performed: branch creation `docs/420-owner-dashboard`, commit of the new file, and PR creation with body exactly `Closes #420` all succeeded.
- No unit or integration test suites were modified or executed as part of this docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6aa85aa08333a067ed0bd4455edc)