### PR TITLE
test: add stable /ui dashboard smoke marker check

### DIFF
--- a/tests/health_endpoint.py
+++ b/tests/health_endpoint.py
@@ -144,4 +144,4 @@ def test_ui_endpoint_serves_html(monkeypatch) -> None:
 
     assert response.status_code == 200
     assert "text/html" in response.headers.get("content-type", "")
-    assert "Owner Dashboard" in response.text
+    assert "<title>Owner Dashboard</title>" in response.text


### PR DESCRIPTION
### Motivation
- Prevent regression of the dashboard route by asserting the mounted UI (`/ui`) is served and contains a stable HTML marker.

### Description
- Updated the existing test in `tests/health_endpoint.py` to assert `GET /ui` returns HTTP 200 and that the response body contains the stable marker `"<title>Owner Dashboard</title>"`.

### Testing
- Ran `pytest -q tests/health_endpoint.py` which completed successfully (`4 passed`) with only deprecation warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6e006a808333bae3eafe06b9b208)