### PR TITLE
docs: add Phase 23 status artifact (Closes #440)

### DIFF
--- a/docs/phases/phase-23-status.md
+++ b/docs/phases/phase-23-status.md
@@ -1,0 +1,24 @@
+# Phase 23 – Research Dashboard
+
+## Status
+NOT IMPLEMENTED
+
+## Verification Source
+Audit #433 did not verify any implementation artifacts.
+
+## Planned Scope
+- Research data aggregation
+- Internal dashboard views
+- Metrics visualization for analysis workflows
+- No trading execution capability
+
+## Dependencies
+- Data availability layer
+- Metrics computation modules
+- Internal reporting interfaces
+
+## Explicit Declaration
+As of this document revision, Phase 23 is NOT implemented.
+No UI artifacts, backend services, or integration components exist.
+
+This declaration removes any ambiguity from the execution roadmap.

--- a/docs/roadmap/execution_roadmap.md
+++ b/docs/roadmap/execution_roadmap.md
@@ -41,6 +41,10 @@ Define and track the Owner Dashboard phase based on repository-verified artifact
 ### Goal
 Define Phase 23 status using only repository-verified evidence.
 
+> Governance Note  
+> The implementation status of Phase 23 is explicitly documented in:  
+> docs/phases/phase-23-status.md
+
 ### Explicit Deliverables
 - Explicit status declaration: Research Dashboard implementation artifact not confirmed in repository.
 - Phase 23 tracking issue/PR references this canonical roadmap entry when changing status.


### PR DESCRIPTION
### Motivation
- Remove ambiguity about the Research Dashboard implementation state by adding an explicit, repository-tracked status declaration for Phase 23.  
- Ensure the execution roadmap references a single authoritative source of truth for Phase 23 status.

### Description
- Added `docs/phases/phase-23-status.md` containing an explicit Phase 23 declaration with `NOT IMPLEMENTED`, verification source, planned scope, dependencies, and an explicit governance statement.  
- Updated `docs/roadmap/execution_roadmap.md` to include a governance note under the Phase 23 section that points to `docs/phases/phase-23-status.md`.  
- Only the two documentation files `docs/phases/phase-23-status.md` and `docs/roadmap/execution_roadmap.md` were changed and no code or tests under `src/` or `tests/` were modified.

### Testing
- Per issue requirements, a manual review of diffs and full file contents was performed to confirm the new file content matches the exact requested text and the roadmap note was inserted correctly.  
- No automated tests were added or modified for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb1a9ba7483338a13f1d57c14f80c)