### PR TITLE
docs: add Phase 27 status artifact (Closes #441)

### DIFF
--- a/docs/phases/phase-27-status.md
+++ b/docs/phases/phase-27-status.md
@@ -1,0 +1,32 @@
+# Phase 27 – Risk Framework
+
+## Status
+FRAMEWORK NOT IMPLEMENTED
+
+## Verified Existing Artifacts
+The repository contains risk-related configuration fields and metrics.
+These include:
+- Risk-related config schema elements
+- Risk-related metric fields
+- Tests referencing risk-related values
+
+These artifacts DO NOT constitute a standalone Risk Framework.
+
+## Not Verified
+No standalone, phase-scoped Risk Framework module,
+engine component, or enforcement layer was verified.
+
+## Acceptance Boundary
+Phase 27 can only be marked as implemented if:
+- A standalone framework-level artifact exists
+- Repository-verifiable module(s) define risk policy logic
+- Documentation and tests explicitly map to Phase 27 framework scope
+
+## Explicit Declaration
+As of this document revision, Phase 27 Risk Framework
+is NOT implemented as a standalone framework artifact.
+
+Existing risk-related metrics/config fields must not be
+interpreted as framework-level completion.
+
+This declaration removes ambiguity between metrics and framework.

--- a/docs/roadmap/execution_roadmap.md
+++ b/docs/roadmap/execution_roadmap.md
@@ -83,19 +83,27 @@ Define and track Paper Trading Runtime status from repository-verified implement
 ## Phase 27
 
 ### Goal
-Define Phase 27 status using repository evidence that distinguishes framework-level implementation from related but non-framework artifacts.
+Explicitly distinguish risk-related artifacts from a standalone Risk Framework implementation.
 
-### Explicit Deliverables
-- Explicit status declaration: standalone phase-scoped risk framework module not verified.
-- Catalog of related risk artifacts (config schema, tests, metrics contract) recognized as adjacent evidence.
+> Governance Note  
+> The implementation status of Phase 27 is explicitly documented in:  
+> docs/phases/phase-27-status.md
+
+### Verified Existing Artifacts
+- Risk-related configuration fields exist.
+- Risk-related metrics and tests exist.
+
+### Framework Status
+No standalone Phase 27 Risk Framework module was verified.
 
 ### Explicitly Out of Scope
-- Treating existing risk-related fields/artifacts as proof of a completed standalone risk framework.
-- Declaring implementation completion without phase-scoped framework artifact evidence.
+- Treating config fields or metrics as proof of a completed framework.
+- Declaring framework completion without standalone artifact evidence.
 
 ### Acceptance Evidence Requirements
-- Any completion claim includes repository-verifiable standalone framework artifact(s).
-- PR/issue references clearly separate adjacent risk artifacts from framework-level deliverables.
+- Standalone repository-verifiable framework module(s).
+- Explicit policy logic definition.
+- Documentation and tests mapped directly to Phase 27 framework scope.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Remove ambiguity about whether Phase 27 is a standalone Risk Framework versus only risk-related fields/metrics present in the repo.

### Description
- Add new file `docs/phases/phase-27-status.md` declaring that a standalone Phase 27 Risk Framework is NOT implemented and listing verified vs not-verified artifacts.
- Update the primary Phase 27 section in `docs/roadmap/execution_roadmap.md` to point to the new status doc and explicitly distinguish existing risk-related config/metrics from a standalone framework.
- Changes are documentation-only and limited to `docs/phases/phase-27-status.md` and `docs/roadmap/execution_roadmap.md` as requested.

### Testing
- No automated test suite was run as part of this documentation-only change.
- Validations performed: confirmed a single commit with message `docs: add Phase 27 status artifact (Closes #441)` and verified only the two allowed files (`docs/phases/phase-27-status.md`, `docs/roadmap/execution_roadmap.md`) were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb36cf9848333bb4af9a009c9d623)