### PR TITLE
docs: align paper trading documentation with implemented simulator (Closes #438)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -133,4 +133,4 @@ python -m pytest
 - A red check blocks merge until tests pass.
 
 ### Run Paper Trading (Simulation)
-No dedicated CLI endpoint is documented for paper-trading simulation in this runbook. The repository contains a simulator module (`src/cilly_trading/engine/paper_trading.py`), but no owner-facing run command is defined here. No live trading, broker keys, or real orders are used.
+No production operator CLI/runtime entrypoint is documented for paper-trading simulation in this runbook. The repository contains an engine-level deterministic simulator module (`src/cilly_trading/engine/paper_trading.py`) that is test-verified, but no owner-facing run command is defined here. It does not provide live trading or broker integration, and no real orders are used.

--- a/docs/phase-9-exit.md
+++ b/docs/phase-9-exit.md
@@ -9,13 +9,14 @@ Phase 9 is formally closed.
 ## MVP Capabilities
 - View market price data in the application.
 - Review historical price data in the application.
-- Run paper trading simulations in the application.
+- Use the engine-level deterministic paper-trading simulator artifact (test-verified) for non-live simulation workflows.
 - View stored signals and alerts in the application.
 - Manage strategies and related settings in the application.
 
 ## Explicit Non-Goals / Exclusions
 - No live trading.
 - No broker integrations.
+- No production operator CLI/runtime entrypoint for paper-trading execution.
 - No backtesting.
 - No AI decision-making.
 - No automated execution of real orders.

--- a/docs/repo-snapshot.md
+++ b/docs/repo-snapshot.md
@@ -6,7 +6,7 @@ This repository describes a trading analysis engine intended to support a websit
 
 ## High-Level Project State
 
-Current materials include detailed scope, architecture, workflow, and deterministic contracts captured in markdown files. The documentation defines what the MVP should cover and what it excludes, while the deterministic smoke-run is defined and implemented. Documentation states that paper trading/simulation is not available. Trading and simulation execution are explicitly not implemented.
+Current materials include detailed scope, architecture, workflow, and deterministic contracts captured in markdown files. The documentation defines what the MVP should cover and what it excludes, while the deterministic smoke-run is defined and implemented. An engine-level deterministic paper-trading simulator artifact is implemented and test-verified. This simulator does not provide live trading, broker integration, or a production operator runtime entrypoint.
 
 ## Repository Structure Overview
 
@@ -30,7 +30,7 @@ Work is structured around a single active Issue with an explicit execution workf
 
 ## Key Documents
 
-- `docs/RUNBOOK.md`: Working SOP that defines the end-to-end workflow, review gate, Definition of Done, and the local deterministic smoke-run execution steps. It also states that paper trading/simulation is not available.
+- `docs/RUNBOOK.md`: Working SOP that defines the end-to-end workflow, review gate, Definition of Done, and the local deterministic smoke-run execution steps. It also documents that an engine-level deterministic paper-trading simulator artifact exists without introducing live trading, broker integrations, or a production operator runtime entrypoint.
 - `docs/smoke-run.md`: Deterministic smoke-run specification with exact fixtures, output, and exit codes.
 - `docs/MVP_SPEC.md`: Product scope and exclusions for MVP v1, including explicit exclusions such as live trading, broker integrations, backtesting, and AI-based signal generation.
 - `docs/mvp_v1.md`: Detailed MVP v1 system overview and component breakdown (engine, persistence, API, and trading desk) with scope and non-goals.
@@ -47,13 +47,13 @@ A new developer can start with:
 4. `docs/local_run.md` for how the API is invoked in local development.
 5. `docs/smoke-run.md` to understand the deterministic smoke-run contract and its implementation details.
 
-They should not expect to run a paper-trading or simulation entrypoint, or a live trading workflow, because these are explicitly not implemented. There is no CLI entrypoint documented; API usage via `uvicorn` is the described path, and the smoke-run is executed via the documented local command. The documentation provides the scope and operational workflow; implementation specifics are in `src/` and `api/` and are outside the scope of this snapshot.
+They should not expect a production operator CLI/entrypoint for paper-trading simulation, and they should not expect a live trading workflow. The deterministic paper-trading simulator exists as an engine-level, test-verified artifact only, with no broker connectivity or real-capital execution path. There is no CLI entrypoint documented; API usage via `uvicorn` is the described path, and the smoke-run is executed via the documented local command. The documentation provides the scope and operational workflow; implementation specifics are in `src/` and `api/` and are outside the scope of this snapshot.
 
 ## Known Gaps / Non-Implemented Areas
 
 The following components are explicitly absent or described as not implemented in the current repository state:
 
-- Paper trading or simulation execution.
+- A production operator CLI/runtime entrypoint for paper-trading simulation (the engine-level deterministic simulator artifact exists and is test-verified).
 - Live trading, broker integrations, or order execution.
 - Backtesting frameworks.
 - AI-based signal generation or automated decision-making.


### PR DESCRIPTION
### Motivation
- Reconcile documentation that previously claimed paper trading/simulation was unavailable with the implemented deterministic simulator artifacts present in the engine layer.
- Clarify scope boundaries so documentation accurately states the simulator exists while preserving explicit MVP guardrails that exclude live trading and broker integration.

### Description
- Updated wording in `docs/phase-9-exit.md`, `docs/repo-snapshot.md`, and `docs/RUNBOOK.md` to state that an engine-level deterministic paper-trading simulator artifact exists and is test-verified.
- Added explicit notes that the simulator does not enable live trading, has no broker integrations, and that there is no production operator CLI/runtime entrypoint for paper-trading execution.
- Changes are documentation-only and limited to the three files listed above; `src/cilly_trading/engine/paper_trading.py` and simulator tests were not modified.

### Testing
- No automated test changes were required for this documentation-only update, and no test suite run was necessary.
- Confirmed that simulator code and `tests/test_paper_trading_simulator.py` were not changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cbad7e7448333bead47a7be2708ca)