### PR TITLE
docs: declare snapshot runtime scheduling boundary (Closes #439)

### DIFF
--- a/docs/interfaces/batch_execution.md
+++ b/docs/interfaces/batch_execution.md
@@ -1,5 +1,10 @@
 # Batch Execution Workflow – Cilly Trading Engine
 
+> Governance Note  
+> Snapshot scheduling status and ownership boundary  
+> are explicitly documented in:  
+> docs/runtime/snapshot_runtime.md
+
 ## 1. Purpose
 - This document defines a deterministic, bounded batch execution workflow contract for automation usage in this repository.
 - Scope is limited to invocation pattern, input/output contract boundaries, and logging expectations for batch usage.

--- a/docs/runtime/snapshot_runtime.md
+++ b/docs/runtime/snapshot_runtime.md
@@ -1,0 +1,52 @@
+# Snapshot Runtime – Scheduling & Ownership Status
+
+## Status
+OUT-OF-BAND SCHEDULING
+
+## Current Implementation State
+The repository does not contain an internal scheduler,
+cron job, background worker, or runtime loop
+responsible for hourly snapshot execution.
+
+Snapshot ingestion logic exists,
+but scheduling is not implemented in-repo.
+
+## Scheduling Responsibility
+Snapshot scheduling is currently considered
+an external operational responsibility.
+
+This may include:
+- External cron jobs
+- Hosting platform schedulers
+- CI-based scheduled triggers
+- Infrastructure-level automation
+
+No in-repository scheduler artifact exists.
+
+## Ownership Boundary
+The Cilly Trading Engine repository provides:
+- Snapshot ingestion logic
+- Deterministic execution contracts
+
+It does NOT provide:
+- Scheduling orchestration
+- Runtime background services
+- Deployment-level automation
+
+## Phase Planning Status
+As of this document revision,
+there is no approved Phase defining
+an in-repo snapshot scheduler implementation.
+
+Any future scheduler implementation must be:
+- Defined in a dedicated Phase
+- Backed by repository-verifiable artifacts
+- Explicitly accepted via governance workflow
+
+## Explicit Declaration
+Hourly snapshot scheduling remains
+OUT-OF-BAND and is not implemented
+as an in-repo runtime component.
+
+This declaration removes ambiguity
+regarding runtime scope and ownership.


### PR DESCRIPTION
### Motivation
- Make explicit whether hourly snapshot scheduling is implemented in-repo or handled externally and to define the ownership boundary for operational clarity.

### Description
- Add `docs/runtime/snapshot_runtime.md` declaring that hourly snapshot scheduling is OUT-OF-BAND and describing scheduling responsibility, ownership boundary, and phase planning status, and add a short governance reference block to `docs/interfaces/batch_execution.md` pointing to the new document.

### Testing
- No automated tests were run because this is a documentation-only change that does not touch `src/` or `tests/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cbcf8a1f8833393cf6a001b234980)