### PR TITLE
docs: declare in-repo snapshot runtime execution and external scheduling boundary

### DIFF
--- a/docs/audit/roadmap_compliance_report.md
+++ b/docs/audit/roadmap_compliance_report.md
@@ -12,7 +12,7 @@ Paper-trading simulator code and tests are present, but documentation artifacts 
 
 No live trading endpoint, broker integration runtime, or AI decision engine implementation was verified.
 
-Snapshot ingestion creation/scheduling is documented as out-of-band and no in-repo scheduler runtime was verified.
+Snapshot runtime execution capability is implemented in-repo, while scheduling remains external and no in-repo scheduler runtime was verified.
 
 Documentation and implementation are therefore only partially aligned.
 
@@ -25,7 +25,7 @@ Documentation and implementation are therefore only partially aligned.
 | Phase | Status | Evidence | Notes |
 |-------|--------|----------|-------|
 | Phase 17b – Owner Dashboard | Partially Implemented | Backend UI mount in `src/api/main.py` (`app.mount("/ui", StaticFiles(..., html=True), name="ui")`); HTML marker in `src/ui/index.html` (`<title>Owner Dashboard</title>`); tests in `tests/health_endpoint.py`; manual trigger endpoint `POST /analysis/run` in `src/api/main.py`; test in `tests/test_api_manual_analysis_trigger.py`; documentation in `docs/ui/owner_dashboard.md`. | `/ui` is confirmed backend-served. `/owner` appears in documentation but no backend route definition was verified. |
-| Hourly Snapshot Runtime | Not Implemented | `docs/interfaces/batch_execution.md` states no scheduler implementation; `docs/api/usage_contract.md` and `docs/analyst-workflow.md` state ingestion is out-of-band; no scheduler/cron endpoint verified in `src/api/main.py`. | Snapshot consumption exists; hourly runtime scheduling not verified in-repo. |
+| Hourly Snapshot Runtime | Partially Implemented | `docs/runtime/snapshot_runtime.md` declares in-repo execution capability and external scheduling boundary; `docs/interfaces/batch_execution.md` states no scheduler implementation; no scheduler/cron endpoint verified in `src/api/main.py`. | Runtime execution capability exists in-repo; hourly scheduling is external and not provided by this repository. |
 | Phase 24 – Paper Trading Runtime | Partially Implemented | Simulator in `src/cilly_trading/engine/paper_trading.py`; tests in `tests/test_paper_trading_simulator.py`; documentation reference in `docs/RUNBOOK.md`. | Engine-level simulation exists; documentation still partially misaligned. |
 | Phase 23 – Research Dashboard | Not Implemented | Research Dashboard implementation artifact: Not confirmed (no verified code/docs/tests). | No repository-verified artifact found. |
 | Phase 27 – Risk Framework | Not Implemented | No standalone phase-scoped risk framework module verified; related artifacts include `src/cilly_trading/strategies/config_schema.py`, `tests/strategies/test_strategy_config_schema.py`, `docs/backtesting/metrics_contract.md`. | Risk-related fields exist but no framework-level artifact verified. |
@@ -98,7 +98,7 @@ Documentation and implementation are therefore only partially aligned.
    - **Phase classification:** Phase 24  
 
 4. **Proposed Issue:** `Hourly Snapshot Runtime status declaration`  
-   - Explicitly declare whether runtime scheduling remains out-of-band or is planned in-repo.  
+   - Formally declare the operational boundary: in-repo runtime execution capability with external scheduling ownership.  
    - **Phase classification:** Snapshot Runtime  
 
 5. **Proposed Issue:** `Phase 23 status artifact`  

--- a/docs/runtime/snapshot_runtime.md
+++ b/docs/runtime/snapshot_runtime.md
@@ -1,19 +1,28 @@
 # Snapshot Runtime – Scheduling & Ownership Status
 
 ## Status
-OUT-OF-BAND SCHEDULING
+IN-REPOSITORY EXECUTION CAPABILITY; EXTERNAL SCHEDULING RESPONSIBILITY
+
+## Operational Boundary — Snapshot Runtime vs Scheduling
+The snapshot runtime execution logic, including `execute_snapshot_runtime`, is implemented in this repository.
+
+The runtime layer is deterministic and internally callable within repository-owned execution paths.
+
+Scheduling mechanisms (for example cron jobs, infrastructure schedulers, or cloud trigger services) are external to this repository.
+
+The repository does not provide a scheduler implementation.
+
+Execution capability and scheduling responsibility are intentionally decoupled as a governance boundary.
+
+Hourly Snapshot Runtime refers to execution capability, not in-repo scheduling.
 
 ## Current Implementation State
-The repository does not contain an internal scheduler,
-cron job, background worker, or runtime loop
-responsible for hourly snapshot execution.
+The repository contains snapshot runtime execution logic and deterministic runtime contracts.
 
-Snapshot ingestion logic exists,
-but scheduling is not implemented in-repo.
+The repository does not contain an internal scheduler, cron job, background worker, or runtime loop responsible for automated hourly triggering.
 
 ## Scheduling Responsibility
-Snapshot scheduling is currently considered
-an external operational responsibility.
+Scheduling remains an external operational responsibility.
 
 This may include:
 - External cron jobs
@@ -25,7 +34,7 @@ No in-repository scheduler artifact exists.
 
 ## Ownership Boundary
 The Cilly Trading Engine repository provides:
-- Snapshot ingestion logic
+- Snapshot runtime execution logic
 - Deterministic execution contracts
 
 It does NOT provide:
@@ -34,19 +43,9 @@ It does NOT provide:
 - Deployment-level automation
 
 ## Phase Planning Status
-As of this document revision,
-there is no approved Phase defining
-an in-repo snapshot scheduler implementation.
+As of this document revision, there is no approved Phase defining an in-repo scheduler implementation.
 
 Any future scheduler implementation must be:
 - Defined in a dedicated Phase
 - Backed by repository-verifiable artifacts
 - Explicitly accepted via governance workflow
-
-## Explicit Declaration
-Hourly snapshot scheduling remains
-OUT-OF-BAND and is not implemented
-as an in-repo runtime component.
-
-This declaration removes ambiguity
-regarding runtime scope and ownership.


### PR DESCRIPTION
### Motivation
- Closes #452
- Formally declare the operational boundary so documentation reflects that snapshot runtime execution logic exists in-repo while scheduling remains an external responsibility.
- Remove ambiguity where docs previously described snapshot ingestion/scheduling as “out-of-band” and ensure governance-oriented wording that execution capability is present but scheduling is intentionally decoupled.

### Description
- Modified `docs/runtime/snapshot_runtime.md` to add a governance section titled `Operational Boundary — Snapshot Runtime vs Scheduling`, state that `execute_snapshot_runtime` is implemented in-repo, that the runtime layer is deterministic and internally callable, and that the repository does not provide a scheduler; added the explicit clarification that “Hourly Snapshot Runtime refers to execution capability, not in-repo scheduling.”
- Updated `docs/audit/roadmap_compliance_report.md` to align the audit language with the new boundary (noting in-repo execution capability while scheduling remains external) and to update the Phase matrix entry for Hourly Snapshot Runtime to `Partially Implemented` with the new evidence reference.
- No source code, tests, strategy/risk modules, or runtime behavior were modified; no scheduler was implemented and no engine contracts or code paths were changed.

### Testing
- Verified presence of the new governance statements using repository searches with `rg` and direct file inspection (`rg -n` and `sed -n`), confirming the phrases `Operational Boundary — Snapshot Runtime vs Scheduling`, `execute_snapshot_runtime`, and `Hourly Snapshot Runtime refers to execution capability, not in-repo scheduling` are present in `docs/runtime/snapshot_runtime.md`.
- Searched the documentation base to ensure prior phrasing implying snapshot runtime/scheduling was external was removed or updated using `rg -n` and confirmed no remaining occurrences of the targeted out-of-band runtime wording in the modified scope.
- Committed the documentation updates (`git commit`) after validation; all validation commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e128a96488333a7f0f019580cbd0c)