### PR TITLE
Add risk framework contracts and architecture documentation

### DIFF
--- a/docs/architecture/risk_framework.md
+++ b/docs/architecture/risk_framework.md
@@ -1,0 +1,71 @@
+# Risk Framework Architecture
+
+## Purpose
+The risk framework defines a **mandatory, pre-execution gate** that every candidate execution request must pass before any order-side effect is allowed. This document establishes the architecture contract and governance rule for risk evaluation, independent of execution implementation details.
+
+## Architectural Position
+- Risk evaluation sits at the boundary between intent generation and execution authorization.
+- The risk layer owns policy evaluation and explicit decision output only.
+- The execution layer is a downstream consumer of a `RiskDecision` contract and is not permitted to bypass it.
+- This architecture is design-level only in Phase P27 and introduces no runtime wiring.
+
+## RiskGate Interface (Contract Only)
+The canonical risk contract is defined in `src/risk/contracts.py`:
+- `RiskGate.evaluate(request) -> RiskDecision`
+- `RiskEvaluationRequest` is a placeholder request shape for stable contract exchange.
+- `RiskGate` is a minimal protocol with no side effects and no runtime dependencies on execution, simulator, or lifecycle modules.
+
+Contract stability principles:
+1. Keep the interface minimal and deterministic.
+2. Return explicit decision objects, never boolean pass/fail values.
+3. Preserve compatibility by versioning policy via `rule_version` in `RiskDecision`.
+
+## RiskDecision Model
+`RiskDecision` is the mandatory schema for risk outcomes and includes:
+- `decision: "APPROVED" | "REJECTED"`
+- `score: float`
+- `max_allowed: float`
+- `reason: str`
+- `timestamp: datetime (UTC)`
+- `rule_version: str`
+
+Interpretation:
+- `APPROVED` means the request is eligible for execution authorization.
+- `REJECTED` means execution authorization must not occur.
+- `score` and `max_allowed` provide traceable policy context for audit and governance.
+
+## Exposure Scoring Concept
+Exposure scoring is a normalized risk measure computed per request.
+
+Conceptual components (documentation-level):
+- Position sizing pressure (e.g., requested notional relative to configured limits)
+- Concentration pressure (e.g., symbol or strategy concentration)
+- Market condition pressure (e.g., volatility/illiquidity multipliers)
+- Policy overlays (e.g., temporary tightening rules)
+
+The resulting `score` is compared to `max_allowed` under the active `rule_version`. The scoring algorithm is intentionally unspecified here and remains implementation-defined in later phases.
+
+## Enforcement Boundary
+**Boundary definition:**
+- Upstream systems may create candidate requests.
+- Only the risk framework may issue `RiskDecision`.
+- Downstream execution authorization requires a `RiskDecision` with `decision == "APPROVED"`.
+- Any missing decision, malformed decision, or `REJECTED` decision is treated as a hard stop.
+
+This boundary prohibits advisory-only risk behavior for execution eligibility.
+
+## Governance Enforcement Rule
+**Mandatory rule:** No execution authorization is permitted unless a valid `RiskDecision` exists and its `decision` field is exactly `"APPROVED"`.
+
+Governance implications:
+- `REJECTED` is terminal for the candidate request.
+- Absence of risk evaluation is equivalent to rejection.
+- Boolean-style checks (`True`/`False`) are non-compliant with the architecture contract.
+- Policy changes must be traceable through `rule_version`.
+
+## Non-Goals
+- No execution refactor or runtime integration in this phase.
+- No simulator changes.
+- No lifecycle or orchestration changes.
+- No portfolio model updates.
+- No definition of concrete scoring implementation details beyond conceptual architecture.

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -1,0 +1,15 @@
+"""Risk contract package for mandatory pre-execution risk evaluation."""
+
+from .contracts import (
+    DecisionType,
+    RiskDecision,
+    RiskEvaluationRequest,
+    RiskGate,
+)
+
+__all__ = [
+    "DecisionType",
+    "RiskDecision",
+    "RiskEvaluationRequest",
+    "RiskGate",
+]

--- a/src/risk/contracts.py
+++ b/src/risk/contracts.py
@@ -1,0 +1,73 @@
+"""Contracts for mandatory risk-gate evaluation.
+
+This module defines only interfaces and data models. It must not contain runtime
+wiring or side-effecting behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Protocol
+
+
+DecisionType = Literal["APPROVED", "REJECTED"]
+
+
+@dataclass(frozen=True)
+class RiskEvaluationRequest:
+    """Input contract for risk evaluation.
+
+    Attributes:
+        request_id: Stable identifier for the candidate execution request.
+        strategy_id: Strategy identifier associated with the request.
+        symbol: Instrument identifier associated with the request.
+        notional_usd: Requested notional exposure in USD.
+        metadata: Opaque structured metadata for risk policies.
+    """
+
+    request_id: str
+    strategy_id: str
+    symbol: str
+    notional_usd: float
+    metadata: dict[str, str]
+
+
+@dataclass(frozen=True)
+class RiskDecision:
+    """Explicit result contract returned by the mandatory risk gate.
+
+    Attributes:
+        decision: Mandatory explicit decision, either APPROVED or REJECTED.
+        score: Computed exposure score for the request.
+        max_allowed: Maximum score permitted by active policy.
+        reason: Human-readable explanation for the decision.
+        timestamp: timezone-aware UTC datetime of evaluation.
+        rule_version: Version identifier of the risk policy/ruleset used.
+    """
+
+    decision: DecisionType
+    score: float
+    max_allowed: float
+    reason: str
+    timestamp: datetime
+    rule_version: str
+
+
+class RiskGate(Protocol):
+    """Mandatory pre-execution risk gate contract.
+
+    Implementations must be pure evaluators for the supplied request and return a
+    `RiskDecision` without producing side effects.
+    """
+
+    def evaluate(self, request: RiskEvaluationRequest) -> RiskDecision:
+        """Evaluate a request against risk policy and return an explicit decision.
+
+        Args:
+            request: Candidate request to be scored by risk rules.
+
+        Returns:
+            RiskDecision: Explicit APPROVED or REJECTED contract result.
+        """
+        ...


### PR DESCRIPTION
### Motivation
- Establish a mandatory, pre-execution risk gate contract to separate intent generation from execution authorization.
- Define a minimal, deterministic, and versioned decision model to ensure governance and auditability of risk outcomes.
- Provide a design-level architecture and enforcement boundary without introducing runtime wiring in this phase.

### Description
- Add `docs/architecture/risk_framework.md` documenting the risk gate architecture, enforcement boundary, decision model, scoring concept, and governance rules. 
- Add `src/risk/contracts.py` defining `DecisionType`, `RiskEvaluationRequest`, `RiskDecision`, and the `RiskGate` `Protocol`, implemented as frozen dataclasses and a side-effect-free evaluator contract. 
- Add `src/risk/__init__.py` to expose `DecisionType`, `RiskDecision`, `RiskEvaluationRequest`, and `RiskGate` as the package public API. 
- Keep the module implementation-only to interface and model definitions with no runtime wiring or side effects per the architecture phase.

### Testing
- No automated tests were added or modified for this change. 
- Performed basic import sanity with `python -c "import src.risk"` and a static type check with `mypy src/risk`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f99112048333bfadfa7091ab720a)