### PR TITLE
P27-ENGINE: enforce mandatory Risk Gate approval before execution

### DIFF
--- a/src/cilly_trading/engine/order_execution_model.py
+++ b/src/cilly_trading/engine/order_execution_model.py
@@ -10,6 +10,10 @@ from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Literal, Mapping, Sequence
 
+from risk.contracts import RiskDecision
+
+from cilly_trading.engine.risk import enforce_approved_risk_decision
+
 
 @dataclass(frozen=True)
 class Order:
@@ -93,6 +97,7 @@ class DeterministicExecutionModel:
         snapshot: Mapping[str, Any],
         position: Position,
         config: DeterministicExecutionConfig,
+        risk_decision: RiskDecision | None,
     ) -> tuple[list[Fill], Position]:
         """Executes ready orders for a snapshot in deterministic order.
 
@@ -101,6 +106,7 @@ class DeterministicExecutionModel:
             snapshot: Market snapshot providing ``open`` or ``price``.
             position: Existing position state.
             config: Deterministic execution settings.
+            risk_decision: Mandatory explicit pre-execution risk decision.
 
         Returns:
             A tuple containing ordered fills and updated position.
@@ -109,6 +115,8 @@ class DeterministicExecutionModel:
             ValueError: If a required price is missing, a quantity is invalid,
                 or an order attempts to sell more than current position.
         """
+
+        enforce_approved_risk_decision(risk_decision)
 
         snapshot_key = self._snapshot_key(snapshot)
         base_price = self._extract_fill_price(snapshot, config)

--- a/src/cilly_trading/engine/risk/__init__.py
+++ b/src/cilly_trading/engine/risk/__init__.py
@@ -1,0 +1,15 @@
+"""Risk gate utilities for execution boundary enforcement."""
+
+from .gate import (
+    RiskApprovalMissingError,
+    RiskRejectedError,
+    ThresholdRiskGate,
+    enforce_approved_risk_decision,
+)
+
+__all__ = [
+    "RiskApprovalMissingError",
+    "RiskRejectedError",
+    "ThresholdRiskGate",
+    "enforce_approved_risk_decision",
+]

--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -1,0 +1,70 @@
+"""Risk gate implementations and execution guardrails."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
+
+
+class RiskApprovalMissingError(ValueError):
+    """Raised when execution is attempted without an explicit risk approval."""
+
+
+class RiskRejectedError(ValueError):
+    """Raised when execution is attempted with a non-approved risk decision."""
+
+
+@dataclass(frozen=True)
+class ThresholdRiskGate(RiskGate):
+    """Trivial concrete risk gate using a fixed notional threshold policy."""
+
+    max_notional_usd: float
+    rule_version: str = "threshold-v1"
+
+    def evaluate(self, request: RiskEvaluationRequest) -> RiskDecision:
+        score = float(request.notional_usd)
+        decision = "APPROVED" if score <= self.max_notional_usd else "REJECTED"
+        reason = (
+            "notional within threshold"
+            if decision == "APPROVED"
+            else "notional exceeds threshold"
+        )
+        return RiskDecision(
+            decision=decision,
+            score=score,
+            max_allowed=float(self.max_notional_usd),
+            reason=reason,
+            timestamp=datetime.now(tz=timezone.utc),
+            rule_version=self.rule_version,
+        )
+
+
+def enforce_approved_risk_decision(risk_decision: RiskDecision | None) -> RiskDecision:
+    """Require an explicit APPROVED risk decision before execution continues."""
+
+    if risk_decision is None:
+        raise RiskApprovalMissingError(
+            "Execution requires explicit risk approval: risk_decision is missing"
+        )
+
+    if risk_decision.decision == "APPROVED":
+        return risk_decision
+
+    if risk_decision.decision == "REJECTED":
+        raise RiskRejectedError(
+            "Execution blocked by risk gate: risk_decision.decision=REJECTED"
+        )
+
+    raise ValueError(
+        "Execution blocked by risk gate: risk_decision.decision must be APPROVED or REJECTED"
+    )
+
+
+__all__ = [
+    "RiskApprovalMissingError",
+    "RiskRejectedError",
+    "ThresholdRiskGate",
+    "enforce_approved_risk_decision",
+]

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from risk.contracts import RiskEvaluationRequest
+
+from cilly_trading.engine.risk import ThresholdRiskGate
+
+
+def test_threshold_risk_gate_returns_approved_for_within_threshold() -> None:
+    gate = ThresholdRiskGate(max_notional_usd=1000.0)
+
+    decision = gate.evaluate(
+        RiskEvaluationRequest(
+            request_id="req-1",
+            strategy_id="strat-a",
+            symbol="AAPL",
+            notional_usd=750.0,
+            metadata={},
+        )
+    )
+
+    assert decision.decision == "APPROVED"
+
+
+def test_threshold_risk_gate_returns_rejected_for_above_threshold() -> None:
+    gate = ThresholdRiskGate(max_notional_usd=1000.0)
+
+    decision = gate.evaluate(
+        RiskEvaluationRequest(
+            request_id="req-2",
+            strategy_id="strat-a",
+            symbol="AAPL",
+            notional_usd=1500.0,
+            metadata={},
+        )
+    )
+
+    assert decision.decision == "REJECTED"


### PR DESCRIPTION
### Motivation
- Prevent any execution from proceeding unless an explicit pre-execution risk approval is present to satisfy the P27 requirement.
- Provide a minimal concrete risk-gate implementation and enforce it at the execution entrypoint without touching UI/lifecycle or other out-of-scope modules.

### Description
- Added `src/cilly_trading/engine/risk/gate.py` implementing `ThresholdRiskGate`, `enforce_approved_risk_decision`, and exceptions `RiskApprovalMissingError` and `RiskRejectedError`, reusing `risk.contracts` types (`RiskDecision`, `RiskEvaluationRequest`, `RiskGate`).
- Added package exports in `src/cilly_trading/engine/risk/__init__.py` to expose the new gate utilities.
- Integrated enforcement in exactly one execution entrypoint by changing `DeterministicExecutionModel.execute` (in `src/cilly_trading/engine/order_execution_model.py`) to require a `risk_decision: RiskDecision | None` parameter and call `enforce_approved_risk_decision` before any execution logic.
- Updated/added unit tests in `tests/cilly_trading/engine/test_order_execution_model.py` and `tests/cilly_trading/engine/test_risk_gate.py` to cover approved, missing, rejected, and malformed decision paths.

### Testing
- Ran `pytest tests/cilly_trading/engine/test_order_execution_model.py tests/cilly_trading/engine/test_risk_gate.py` and observed all tests passing (10 passed).
- The tests verify that execution succeeds when `RiskDecision.decision == "APPROVED"` and fails with `RiskApprovalMissingError`, `RiskRejectedError`, or `ValueError` for missing, rejected, or malformed decisions respectively.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3fd0f7cb8833391588521b5876e67)