### PR TITLE
Enforce orchestrator-only execution entrypoint and add pipeline orchestrator

### DIFF
--- a/src/cilly_trading/engine/pipeline/__init__.py
+++ b/src/cilly_trading/engine/pipeline/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline orchestration entrypoints."""
+
+from .orchestrator import PipelineResult, run_pipeline
+
+__all__ = ["PipelineResult", "run_pipeline"]

--- a/src/cilly_trading/engine/pipeline/orchestrator.py
+++ b/src/cilly_trading/engine/pipeline/orchestrator.py
@@ -1,0 +1,81 @@
+"""Central pipeline orchestrator enforcing risk-before-execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Mapping, Sequence
+
+from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
+
+from cilly_trading.engine.order_execution_model import (
+    DeterministicExecutionConfig,
+    Fill,
+    Order,
+    Position,
+    _execute_order,
+)
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Result payload for orchestrated pipeline execution."""
+
+    status: Literal["executed", "rejected"]
+    fills: list[Fill]
+    position: Position
+    risk_decision: RiskDecision
+
+
+def run_pipeline(
+    signal: Mapping[str, object],
+    *,
+    risk_gate: RiskGate,
+    risk_request: RiskEvaluationRequest,
+    position: Position,
+    execution_config: DeterministicExecutionConfig,
+) -> PipelineResult:
+    """Run the central execution pipeline for a signal.
+
+    The risk gate is always evaluated before any execution attempt.
+    """
+
+    risk_decision = risk_gate.evaluate(risk_request)
+    if risk_decision.decision != "APPROVED":
+        return PipelineResult(
+            status="rejected",
+            fills=[],
+            position=position,
+            risk_decision=risk_decision,
+        )
+
+    fills, updated_position = _execute_order(
+        orders=_extract_orders(signal),
+        snapshot=_extract_snapshot(signal),
+        position=position,
+        config=execution_config,
+        risk_decision=risk_decision,
+    )
+
+    return PipelineResult(
+        status="executed",
+        fills=fills,
+        position=updated_position,
+        risk_decision=risk_decision,
+    )
+
+
+def _extract_orders(signal: Mapping[str, object]) -> Sequence[Order]:
+    orders = signal.get("orders")
+    if not isinstance(orders, Sequence):
+        raise ValueError("Signal must define 'orders' as a sequence")
+    return orders  # type: ignore[return-value]
+
+
+def _extract_snapshot(signal: Mapping[str, object]) -> Mapping[str, object]:
+    snapshot = signal.get("snapshot")
+    if not isinstance(snapshot, Mapping):
+        raise ValueError("Signal must define 'snapshot' as a mapping")
+    return snapshot
+
+
+__all__ = ["PipelineResult", "run_pipeline"]

--- a/tests/cilly_trading/engine/test_execution_import_boundary.py
+++ b/tests/cilly_trading/engine/test_execution_import_boundary.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FORBIDDEN_DIRECT_IMPORT = (
+    "from cilly_trading.engine.order_execution_model import " + "_execute_order"
+)
+
+
+def test_private_execution_entrypoint_only_imported_by_orchestrator() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    allowed = {repo_root / "src/cilly_trading/engine/pipeline/orchestrator.py"}
+    violations: list[str] = []
+
+    search_roots = [repo_root / "src", repo_root / "tests"]
+    for root in search_roots:
+        for path in root.rglob("*.py"):
+            if path in allowed:
+                continue
+            text = path.read_text(encoding="utf-8")
+            if FORBIDDEN_DIRECT_IMPORT in text:
+                violations.append(str(path.relative_to(repo_root)))
+
+    assert not violations, (
+        "Forbidden direct _execute_order imports outside orchestrator: "
+        + ", ".join(sorted(violations))
+    )

--- a/tests/cilly_trading/engine/test_order_execution_model.py
+++ b/tests/cilly_trading/engine/test_order_execution_model.py
@@ -7,12 +7,19 @@ import pytest
 
 from cilly_trading.engine.order_execution_model import (
     DeterministicExecutionConfig,
-    DeterministicExecutionModel,
     Order,
     Position,
 )
-from cilly_trading.engine.risk import RiskApprovalMissingError, RiskRejectedError
-from risk.contracts import RiskDecision
+from cilly_trading.engine.pipeline.orchestrator import run_pipeline
+from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
+
+
+class _StaticDecisionRiskGate(RiskGate):
+    def __init__(self, decision: RiskDecision) -> None:
+        self._decision = decision
+
+    def evaluate(self, request: RiskEvaluationRequest) -> RiskDecision:
+        return self._decision
 
 
 def _config(fill_timing: str = "next_snapshot") -> DeterministicExecutionConfig:
@@ -34,8 +41,34 @@ def _risk_decision(decision: str = "APPROVED") -> RiskDecision:
     )
 
 
+def _risk_request() -> RiskEvaluationRequest:
+    return RiskEvaluationRequest(
+        request_id="req-1",
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        notional_usd=100.0,
+        metadata={"source": "test"},
+    )
+
+
+def _run(
+    *,
+    orders: list[Order],
+    snapshot: dict[str, str],
+    position: Position,
+    config: DeterministicExecutionConfig,
+    decision: str = "APPROVED",
+):
+    return run_pipeline(
+        {"orders": orders, "snapshot": snapshot},
+        risk_gate=_StaticDecisionRiskGate(_risk_decision(decision=decision)),
+        risk_request=_risk_request(),
+        position=position,
+        execution_config=config,
+    )
+
+
 def test_order_fill_determinism_repeated_runs_identical() -> None:
-    model = DeterministicExecutionModel()
     config = _config()
     snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
     position = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
@@ -45,28 +78,15 @@ def test_order_fill_determinism_repeated_runs_identical() -> None:
         Order(id="ord-1", side="BUY", quantity=Decimal("2"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1),
     ]
 
-    fills_a, position_a = model.execute(
-        orders=orders,
-        snapshot=snapshot,
-        position=position,
-        config=config,
-        risk_decision=_risk_decision(),
-    )
-    fills_b, position_b = model.execute(
-        orders=orders,
-        snapshot=snapshot,
-        position=position,
-        config=config,
-        risk_decision=_risk_decision(),
-    )
+    result_a = _run(orders=orders, snapshot=snapshot, position=position, config=config)
+    result_b = _run(orders=orders, snapshot=snapshot, position=position, config=config)
 
-    assert fills_a == fills_b
-    assert position_a == position_b
-    assert [fill.order_id for fill in fills_a] == ["ord-1", "ord-2"]
+    assert result_a.fills == result_b.fills
+    assert result_a.position == result_b.position
+    assert [fill.order_id for fill in result_a.fills] == ["ord-1", "ord-2"]
 
 
 def test_commission_model_is_fixed_and_repeatable() -> None:
-    model = DeterministicExecutionModel()
     config = _config()
     snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "50"}
     position = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
@@ -75,27 +95,14 @@ def test_commission_model_is_fixed_and_repeatable() -> None:
         Order(id="buy-b", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=2),
     ]
 
-    fills_1, _ = model.execute(
-        orders=orders,
-        snapshot=snapshot,
-        position=position,
-        config=config,
-        risk_decision=_risk_decision(),
-    )
-    fills_2, _ = model.execute(
-        orders=orders,
-        snapshot=snapshot,
-        position=position,
-        config=config,
-        risk_decision=_risk_decision(),
-    )
+    result_1 = _run(orders=orders, snapshot=snapshot, position=position, config=config)
+    result_2 = _run(orders=orders, snapshot=snapshot, position=position, config=config)
 
-    assert [fill.commission for fill in fills_1] == [Decimal("1.25"), Decimal("1.25")]
-    assert fills_1 == fills_2
+    assert [fill.commission for fill in result_1.fills] == [Decimal("1.25"), Decimal("1.25")]
+    assert result_1.fills == result_2.fills
 
 
 def test_position_lifecycle_buy_increase_sell_reduce_close() -> None:
-    model = DeterministicExecutionModel()
     config = _config()
 
     buy_snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
@@ -114,17 +121,16 @@ def test_position_lifecycle_buy_increase_sell_reduce_close() -> None:
         sequence=2,
     )
 
-    fills_buy, position_after_buy = model.execute(
+    buy_result = _run(
         orders=[first_buy, second_buy],
         snapshot=buy_snapshot,
         position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
         config=config,
-        risk_decision=_risk_decision(),
     )
 
-    assert len(fills_buy) == 2
-    assert position_after_buy.quantity == Decimal("4.00000000")
-    assert position_after_buy.avg_price == Decimal("100.10000000")
+    assert len(buy_result.fills) == 2
+    assert buy_result.position.quantity == Decimal("4.00000000")
+    assert buy_result.position.avg_price == Decimal("100.10000000")
 
     sell_snapshot = {"timestamp": "2024-01-03T00:00:00Z", "open": "110"}
     reduce_and_close = [
@@ -132,47 +138,42 @@ def test_position_lifecycle_buy_increase_sell_reduce_close() -> None:
         Order(id="sell-2", side="SELL", quantity=Decimal("3"), created_snapshot_key="2024-01-02T00:00:00Z", sequence=4),
     ]
 
-    fills_sell, position_after_sell = model.execute(
+    sell_result = _run(
         orders=reduce_and_close,
         snapshot=sell_snapshot,
-        position=position_after_buy,
+        position=buy_result.position,
         config=config,
-        risk_decision=_risk_decision(),
     )
 
-    assert len(fills_sell) == 2
-    assert fills_sell[0].fill_price == Decimal("109.89000000")
-    assert position_after_sell.quantity == Decimal("0")
-    assert position_after_sell.avg_price == Decimal("0")
+    assert len(sell_result.fills) == 2
+    assert sell_result.fills[0].fill_price == Decimal("109.89000000")
+    assert sell_result.position.quantity == Decimal("0")
+    assert sell_result.position.avg_price == Decimal("0")
 
 
 def test_slippage_applies_by_side_direction() -> None:
-    model = DeterministicExecutionModel()
     config = _config()
     snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
 
-    buy_fills, _ = model.execute(
+    buy_result = _run(
         orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
         snapshot=snapshot,
         position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
         config=config,
-        risk_decision=_risk_decision(),
     )
 
-    sell_fills, _ = model.execute(
+    sell_result = _run(
         orders=[Order(id="sell", side="SELL", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
         snapshot=snapshot,
         position=Position(quantity=Decimal("1"), avg_price=Decimal("99")),
         config=config,
-        risk_decision=_risk_decision(),
     )
 
-    assert buy_fills[0].fill_price == Decimal("100.10000000")
-    assert sell_fills[0].fill_price == Decimal("99.90000000")
+    assert buy_result.fills[0].fill_price == Decimal("100.10000000")
+    assert sell_result.fills[0].fill_price == Decimal("99.90000000")
 
 
 def test_next_snapshot_fill_timing_enforced() -> None:
-    model = DeterministicExecutionModel()
     config = _config(fill_timing="next_snapshot")
 
     order = Order(
@@ -184,62 +185,47 @@ def test_next_snapshot_fill_timing_enforced() -> None:
     )
     start = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
 
-    fills_t, position_t = model.execute(
+    result_t = _run(
         orders=[order],
         snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "10"},
         position=start,
         config=config,
-        risk_decision=_risk_decision(),
     )
 
-    fills_t1, position_t1 = model.execute(
+    result_t1 = _run(
         orders=[order],
         snapshot={"timestamp": "2024-01-03T00:00:00Z", "open": "11"},
         position=start,
         config=config,
-        risk_decision=_risk_decision(),
     )
 
-    assert fills_t == []
-    assert position_t == start
-    assert len(fills_t1) == 1
-    assert position_t1.quantity == Decimal("1.00000000")
+    assert result_t.fills == []
+    assert result_t.position == start
+    assert len(result_t1.fills) == 1
+    assert result_t1.position.quantity == Decimal("1.00000000")
 
 
-def test_execution_without_risk_approval_fails() -> None:
-    model = DeterministicExecutionModel()
+def test_execution_rejected_risk_decision_fails_closed() -> None:
+    result = _run(
+        orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
+        snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "100"},
+        position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
+        config=_config(),
+        decision="REJECTED",
+    )
 
-    with pytest.raises(RiskApprovalMissingError, match="risk approval"):
-        model.execute(
-            orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
-            snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "100"},
-            position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
-            config=_config(),
-            risk_decision=None,
-        )
-
-
-def test_execution_rejected_risk_decision_fails() -> None:
-    model = DeterministicExecutionModel()
-
-    with pytest.raises(RiskRejectedError, match="REJECTED"):
-        model.execute(
-            orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
-            snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "100"},
-            position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
-            config=_config(),
-            risk_decision=_risk_decision(decision="REJECTED"),
-        )
+    assert result.status == "rejected"
+    assert result.fills == []
 
 
-def test_execution_with_malformed_risk_decision_fails() -> None:
-    model = DeterministicExecutionModel()
+def test_execution_with_malformed_risk_decision_is_rejected() -> None:
+    result = _run(
+        orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
+        snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "100"},
+        position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
+        config=_config(),
+        decision="MALFORMED",
+    )
 
-    with pytest.raises(ValueError, match="must be APPROVED or REJECTED"):
-        model.execute(
-            orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
-            snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "100"},
-            position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
-            config=_config(),
-            risk_decision=_risk_decision(decision="MALFORMED"),
-        )
+    assert result.status == "rejected"
+    assert result.fills == []


### PR DESCRIPTION
### Motivation
- Ensure risk evaluation always precedes order execution by centralizing execution behind a pipeline orchestrator.
- Prevent accidental direct invocation of the execution internals to avoid bypassing the risk gate.
- Clarify public API surface by making the deterministic executor implementation private and exposing a single orchestrator entrypoint.

### Description
- Added `cilly_trading.engine.pipeline.orchestrator` with `run_pipeline` and `PipelineResult` that evaluate a `RiskGate` before invoking execution. 
- Moved the public `DeterministicExecutionModel.execute` to a private `_DeterministicExecutionModel._execute` and introduced a private wrapper `_execute_order` that enforces the caller is `cilly_trading.engine.pipeline.orchestrator` via stack inspection.
- Created `cilly_trading.engine.pipeline.__init__` to export `run_pipeline` and `PipelineResult`.
- Updated tests to use the orchestrator entrypoint and added `test_execution_import_boundary.py` to detect forbidden direct imports of `_execute_order`.
- Adjusted existing tests in `test_order_execution_model.py` and `test_risk_enforcement_bypass.py` to assert orchestrator behavior and that direct execution attempts raise a `RuntimeError`.

### Testing
- Ran `tests/cilly_trading/engine/test_order_execution_model.py` which verifies deterministic fills, commission behavior, position lifecycle, slippage, and fill timing and it passed.
- Ran `tests/cilly_trading/engine/test_risk_enforcement_bypass.py` which checks that execution is performed only via the orchestrator and that risk evaluation precedes execution and it passed.
- Ran `tests/cilly_trading/engine/test_execution_import_boundary.py` which ensures `_execute_order` is only imported by the orchestrator and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40cce2f6483338ef9d9508dd95262)