### PR TITLE
Add AST-based import guard and adapt execution tests to use orchestrator entrypoint

### DIFF
--- a/tests/cilly_trading/engine/test_execution_import_boundary.py
+++ b/tests/cilly_trading/engine/test_execution_import_boundary.py
@@ -2,27 +2,55 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
-FORBIDDEN_DIRECT_IMPORT = (
-    "from cilly_trading.engine.order_execution_model import " + "_execute_order"
+from tests.utils.architecture_import_guard import (
+    collect_forbidden_execution_import_violations,
 )
 
 
-def test_private_execution_entrypoint_only_imported_by_orchestrator() -> None:
+def test_execution_imports_are_restricted_to_orchestrator() -> None:
     repo_root = Path(__file__).resolve().parents[3]
-    allowed = {repo_root / "src/cilly_trading/engine/pipeline/orchestrator.py"}
-    violations: list[str] = []
 
-    search_roots = [repo_root / "src", repo_root / "tests"]
-    for root in search_roots:
-        for path in root.rglob("*.py"):
-            if path in allowed:
-                continue
-            text = path.read_text(encoding="utf-8")
-            if FORBIDDEN_DIRECT_IMPORT in text:
-                violations.append(str(path.relative_to(repo_root)))
+    violations = collect_forbidden_execution_import_violations(repo_root)
 
     assert not violations, (
-        "Forbidden direct _execute_order imports outside orchestrator: "
-        + ", ".join(sorted(violations))
+        "Forbidden execution imports outside orchestrator:\n"
+        + "\n".join(f"- {violation}" for violation in violations)
     )
+
+
+def test_execution_import_guard_detects_static_and_dynamic_violations(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src"
+
+    static_violation_file = src_dir / "static_violation.py"
+    static_violation_file.parent.mkdir(parents=True, exist_ok=True)
+    static_violation_file.write_text(
+        "import cilly_trading.engine.order_execution_model\n",
+        encoding="utf-8",
+    )
+
+    dynamic_violation_file = src_dir / "dynamic_violation.py"
+    dynamic_violation_file.write_text(
+        "import importlib\n"
+        "mod = importlib.import_module('cilly_trading.engine.order_execution_model')\n",
+        encoding="utf-8",
+    )
+
+    orchestrator_file = src_dir / "cilly_trading/engine/pipeline/orchestrator.py"
+    orchestrator_file.parent.mkdir(parents=True, exist_ok=True)
+    orchestrator_file.write_text(
+        "import cilly_trading.engine.order_execution_model\n",
+        encoding="utf-8",
+    )
+
+    violations = collect_forbidden_execution_import_violations(tmp_path)
+
+    assert violations
+    assert any(
+        "src/static_violation.py: static import cilly_trading.engine.order_execution_model" in violation
+        for violation in violations
+    )
+    assert any(
+        "src/dynamic_violation.py: dynamic import cilly_trading.engine.order_execution_model" in violation
+        for violation in violations
+    )
+    assert not any("orchestrator.py" in violation for violation in violations)

--- a/tests/utils/architecture_import_guard.py
+++ b/tests/utils/architecture_import_guard.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+FORBIDDEN_IMPORT_ROOTS = (
+    "cilly_trading.engine.order_execution_model",
+)
+OPTIONAL_FORBIDDEN_IMPORT_ROOTS = (
+    "cilly_trading.engine.execution",
+)
+ALLOWED_IMPORTER_RELATIVE_PATH = Path("src/cilly_trading/engine/pipeline/orchestrator.py")
+
+
+def collect_forbidden_execution_import_violations(repo_root: Path) -> list[str]:
+    """Collect forbidden execution import violations outside the orchestrator module."""
+    repo_root = repo_root.resolve()
+    forbidden_roots = _resolve_forbidden_import_roots(repo_root)
+    allowed_importer = (repo_root / ALLOWED_IMPORTER_RELATIVE_PATH).resolve()
+    violations: list[str] = []
+
+    for path in _iter_python_files(repo_root):
+        if path.resolve() == allowed_importer:
+            continue
+
+        source = path.read_text(encoding="utf-8-sig")
+        tree = ast.parse(source, filename=str(path))
+
+        for import_name in _iter_static_imports(tree):
+            if _matches_forbidden_root(import_name, forbidden_roots):
+                relative_path = path.resolve().relative_to(repo_root)
+                violations.append(f"{relative_path}: static import {import_name}")
+
+        for module_name in _iter_dynamic_import_calls(tree):
+            if _matches_forbidden_root(module_name, forbidden_roots):
+                relative_path = path.resolve().relative_to(repo_root)
+                violations.append(f"{relative_path}: dynamic import {module_name}")
+
+    return sorted(set(violations))
+
+
+def _resolve_forbidden_import_roots(repo_root: Path) -> tuple[str, ...]:
+    forbidden_roots = list(FORBIDDEN_IMPORT_ROOTS)
+
+    for module_path in OPTIONAL_FORBIDDEN_IMPORT_ROOTS:
+        if _module_exists(repo_root, module_path):
+            forbidden_roots.append(module_path)
+
+    return tuple(forbidden_roots)
+
+
+def _iter_python_files(repo_root: Path) -> list[Path]:
+    python_files: list[Path] = []
+    for scope in ("src", "tests"):
+        scope_root = repo_root / scope
+        if not scope_root.exists():
+            continue
+        python_files.extend(scope_root.rglob("*.py"))
+    return python_files
+
+
+def _iter_static_imports(tree: ast.AST) -> list[str]:
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is not None:
+                imports.append(node.module)
+    return imports
+
+
+def _iter_dynamic_import_calls(tree: ast.AST) -> list[str]:
+    dynamic_imports: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        if _is_importlib_import_module_call(node) and node.args:
+            module_name = _extract_str_literal(node.args[0])
+            if module_name is not None:
+                dynamic_imports.append(module_name)
+
+        if _is_builtin_import_call(node) and node.args:
+            module_name = _extract_str_literal(node.args[0])
+            if module_name is not None:
+                dynamic_imports.append(module_name)
+
+    return dynamic_imports
+
+
+def _is_importlib_import_module_call(node: ast.Call) -> bool:
+    if isinstance(node.func, ast.Attribute):
+        return (
+            isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "importlib"
+            and node.func.attr == "import_module"
+        )
+    if isinstance(node.func, ast.Name):
+        return node.func.id == "import_module"
+    return False
+
+
+def _is_builtin_import_call(node: ast.Call) -> bool:
+    return isinstance(node.func, ast.Name) and node.func.id == "__import__"
+
+
+def _extract_str_literal(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _matches_forbidden_root(import_name: str, forbidden_roots: tuple[str, ...]) -> bool:
+    return any(
+        import_name == root or import_name.startswith(f"{root}.")
+        for root in forbidden_roots
+    )
+
+
+def _module_exists(repo_root: Path, module_path: str) -> bool:
+    module_file = repo_root / "src" / Path(*module_path.split("."))
+    return module_file.with_suffix(".py").exists() or module_file.is_dir()


### PR DESCRIPTION
### Motivation
- Prevent direct imports of internal execution modules outside the orchestrator by detecting static and dynamic import occurrences.
- Avoid relying on internal module types in tests so tests exercise the public orchestrator entrypoint and import restrictions.

### Description
- Add `tests/utils/architecture_import_guard.py` which implements an AST-based scanner `collect_forbidden_execution_import_violations(repo_root)` to detect forbidden static and dynamic imports and optional forbidden roots.
- Replace direct references to `cilly_trading.engine.order_execution_model` in engine tests with local `@dataclass` definitions for `Order`, `Position`, and `DeterministicExecutionConfig` and update assertions to inspect fields instead of equality with module types.
- Update tests to use the orchestrator entrypoint (`orchestrator._execute_order`) and to monkeypatch the orchestrator implementation instead of patching the private execution model, and rename tests for clarity.
- Add `test_execution_import_guard_detects_static_and_dynamic_violations` to validate detection of both static (`import ...`) and dynamic (`importlib.import_module` / `__import__`) violations, and ensure orchestrator imports are allowed.

### Testing
- Ran the engine test suite with `pytest tests/cilly_trading/engine -q`, and the modified tests completed successfully.
- Executed the import guard unit checks via the new test `test_execution_import_guard_detects_static_and_dynamic_violations`, which passed and validated both static and dynamic detection paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4123bcf6483338aafe8053e96d7bf)