### PR TITLE
Introduce deterministic strategy lifecycle model, transitions, and tests

### DIFF
--- a/docs/strategy_lifecycle_model.md
+++ b/docs/strategy_lifecycle_model.md
@@ -1,0 +1,52 @@
+# Strategy Lifecycle Model
+
+## States
+
+- **DRAFT**: Initial design and development state. The strategy is not yet approved for production use.
+- **EVALUATION**: Controlled validation state for deterministic review and promotion checks.
+- **PRODUCTION**: Approved operational state for strategies that passed evaluation.
+- **DEPRECATED**: Terminal retirement state. A deprecated strategy cannot be reactivated.
+
+## Transition Graph
+
+Only the following directed transitions are allowed:
+
+- `DRAFT -> EVALUATION`
+- `DRAFT -> DEPRECATED`
+- `EVALUATION -> PRODUCTION`
+- `EVALUATION -> DEPRECATED`
+- `PRODUCTION -> DEPRECATED`
+
+All other transitions are illegal.
+
+```text
+DRAFT ------> EVALUATION ------> PRODUCTION ------> DEPRECATED
+  \              \                                   ^
+   \              +---------------> DEPRECATED       |
+    +-----------------------------> DEPRECATED -------+
+```
+
+## Promotion Invariants
+
+- Only `EVALUATION` can promote to `PRODUCTION`.
+- `PRODUCTION` cannot revert to any prior state.
+- `DEPRECATED` is terminal and has no outbound transitions.
+- Every transition must be explicit in the transition matrix and validated before state change.
+
+## Deterministic Validation
+
+Validation is deterministic and implemented with an explicit transition matrix.
+
+- Valid transitions are accepted.
+- Illegal transitions raise a deterministic error message.
+- Self-transitions are illegal.
+- Transitions from `DEPRECATED` are always rejected as terminal-state violations.
+
+## Execution Eligibility (Design Only)
+
+Execution eligibility is defined by lifecycle state semantics only:
+
+- `PRODUCTION` is the lifecycle state intended for execution eligibility.
+- `DRAFT`, `EVALUATION`, and `DEPRECATED` are not execution-eligible by definition.
+
+This document defines eligibility semantics only and does not enforce execution gating.

--- a/src/cilly_trading/engine/strategy_lifecycle/__init__.py
+++ b/src/cilly_trading/engine/strategy_lifecycle/__init__.py
@@ -1,0 +1,21 @@
+"""Public API for strategy lifecycle modeling and transition validation."""
+
+from .model import StrategyLifecycleState, TERMINAL_STATES, is_terminal_state
+from .transitions import (
+    ALLOWED_TRANSITIONS,
+    StrategyLifecycleTransitionError,
+    get_allowed_transitions,
+    transition_state,
+    validate_transition,
+)
+
+__all__ = [
+    "ALLOWED_TRANSITIONS",
+    "StrategyLifecycleState",
+    "StrategyLifecycleTransitionError",
+    "TERMINAL_STATES",
+    "get_allowed_transitions",
+    "is_terminal_state",
+    "transition_state",
+    "validate_transition",
+]

--- a/src/cilly_trading/engine/strategy_lifecycle/model.py
+++ b/src/cilly_trading/engine/strategy_lifecycle/model.py
@@ -1,0 +1,25 @@
+"""Strategy lifecycle state model definitions."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class StrategyLifecycleState(str, Enum):
+    """Canonical lifecycle states for a strategy."""
+
+    DRAFT = "DRAFT"
+    EVALUATION = "EVALUATION"
+    PRODUCTION = "PRODUCTION"
+    DEPRECATED = "DEPRECATED"
+
+
+TERMINAL_STATES: frozenset[StrategyLifecycleState] = frozenset(
+    {StrategyLifecycleState.DEPRECATED}
+)
+
+
+def is_terminal_state(state: StrategyLifecycleState) -> bool:
+    """Return True when the state is terminal and cannot transition further."""
+
+    return state in TERMINAL_STATES

--- a/src/cilly_trading/engine/strategy_lifecycle/transitions.py
+++ b/src/cilly_trading/engine/strategy_lifecycle/transitions.py
@@ -1,0 +1,76 @@
+"""Deterministic transition rules for the strategy lifecycle model."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+from .model import StrategyLifecycleState, is_terminal_state
+
+
+class StrategyLifecycleTransitionError(ValueError):
+    """Raised when a lifecycle transition is not explicitly allowed."""
+
+
+_ALLOWED_TRANSITIONS_MUTABLE: dict[StrategyLifecycleState, frozenset[StrategyLifecycleState]] = {
+    StrategyLifecycleState.DRAFT: frozenset(
+        {
+            StrategyLifecycleState.EVALUATION,
+            StrategyLifecycleState.DEPRECATED,
+        }
+    ),
+    StrategyLifecycleState.EVALUATION: frozenset(
+        {
+            StrategyLifecycleState.PRODUCTION,
+            StrategyLifecycleState.DEPRECATED,
+        }
+    ),
+    StrategyLifecycleState.PRODUCTION: frozenset({StrategyLifecycleState.DEPRECATED}),
+    StrategyLifecycleState.DEPRECATED: frozenset(),
+}
+
+ALLOWED_TRANSITIONS = MappingProxyType(_ALLOWED_TRANSITIONS_MUTABLE)
+
+
+def get_allowed_transitions(state: StrategyLifecycleState) -> frozenset[StrategyLifecycleState]:
+    """Return the explicit set of allowed outbound transitions for a state."""
+
+    return ALLOWED_TRANSITIONS[state]
+
+
+def validate_transition(
+    current_state: StrategyLifecycleState,
+    target_state: StrategyLifecycleState,
+) -> None:
+    """Validate one lifecycle transition.
+
+    Raises:
+        StrategyLifecycleTransitionError: If the transition is not explicitly allowed.
+    """
+
+    if current_state == target_state:
+        raise StrategyLifecycleTransitionError(
+            f"Illegal lifecycle transition: {current_state.value} -> {target_state.value}"
+        )
+
+    allowed_targets = get_allowed_transitions(current_state)
+    if target_state in allowed_targets:
+        return
+
+    if is_terminal_state(current_state):
+        raise StrategyLifecycleTransitionError(
+            f"Illegal lifecycle transition: {current_state.value} is terminal"
+        )
+
+    raise StrategyLifecycleTransitionError(
+        f"Illegal lifecycle transition: {current_state.value} -> {target_state.value}"
+    )
+
+
+def transition_state(
+    current_state: StrategyLifecycleState,
+    target_state: StrategyLifecycleState,
+) -> StrategyLifecycleState:
+    """Validate and return the deterministic next state."""
+
+    validate_transition(current_state=current_state, target_state=target_state)
+    return target_state

--- a/tests/strategy_lifecycle/test_state_model.py
+++ b/tests/strategy_lifecycle/test_state_model.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from cilly_trading.engine.strategy_lifecycle import StrategyLifecycleState, TERMINAL_STATES, is_terminal_state
+
+
+def test_strategy_lifecycle_state_values_are_canonical() -> None:
+    assert StrategyLifecycleState.DRAFT.value == "DRAFT"
+    assert StrategyLifecycleState.EVALUATION.value == "EVALUATION"
+    assert StrategyLifecycleState.PRODUCTION.value == "PRODUCTION"
+    assert StrategyLifecycleState.DEPRECATED.value == "DEPRECATED"
+
+
+def test_terminal_state_definition_is_deterministic() -> None:
+    assert TERMINAL_STATES == frozenset({StrategyLifecycleState.DEPRECATED})
+    assert is_terminal_state(StrategyLifecycleState.DEPRECATED)
+    assert not is_terminal_state(StrategyLifecycleState.DRAFT)
+    assert not is_terminal_state(StrategyLifecycleState.EVALUATION)
+    assert not is_terminal_state(StrategyLifecycleState.PRODUCTION)
+
+
+def test_state_representation_is_immutable() -> None:
+    with pytest.raises(AttributeError):
+        StrategyLifecycleState.DRAFT.value = "OTHER"  # type: ignore[misc]

--- a/tests/strategy_lifecycle/test_transitions.py
+++ b/tests/strategy_lifecycle/test_transitions.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from cilly_trading.engine.strategy_lifecycle import (
+    ALLOWED_TRANSITIONS,
+    StrategyLifecycleState,
+    StrategyLifecycleTransitionError,
+    get_allowed_transitions,
+    transition_state,
+    validate_transition,
+)
+
+
+VALID_TRANSITIONS = {
+    (StrategyLifecycleState.DRAFT, StrategyLifecycleState.EVALUATION),
+    (StrategyLifecycleState.EVALUATION, StrategyLifecycleState.PRODUCTION),
+    (StrategyLifecycleState.PRODUCTION, StrategyLifecycleState.DEPRECATED),
+    (StrategyLifecycleState.EVALUATION, StrategyLifecycleState.DEPRECATED),
+    (StrategyLifecycleState.DRAFT, StrategyLifecycleState.DEPRECATED),
+}
+
+
+@pytest.mark.parametrize(("current", "target"), sorted(VALID_TRANSITIONS, key=lambda t: (t[0].value, t[1].value)))
+def test_valid_transitions_succeed(current: StrategyLifecycleState, target: StrategyLifecycleState) -> None:
+    validate_transition(current_state=current, target_state=target)
+    assert transition_state(current_state=current, target_state=target) == target
+
+
+def test_all_invalid_transitions_fail_deterministically() -> None:
+    all_pairs = set(itertools.product(StrategyLifecycleState, repeat=2))
+    invalid_pairs = sorted(all_pairs - VALID_TRANSITIONS, key=lambda t: (t[0].value, t[1].value))
+
+    for current, target in invalid_pairs:
+        with pytest.raises(StrategyLifecycleTransitionError) as error:
+            validate_transition(current_state=current, target_state=target)
+
+        if current == target:
+            assert str(error.value) == f"Illegal lifecycle transition: {current.value} -> {target.value}"
+        elif current == StrategyLifecycleState.DEPRECATED:
+            assert str(error.value) == f"Illegal lifecycle transition: {current.value} is terminal"
+        else:
+            assert str(error.value) == f"Illegal lifecycle transition: {current.value} -> {target.value}"
+
+
+def test_explicit_transition_matrix_matches_specification() -> None:
+    assert get_allowed_transitions(StrategyLifecycleState.DRAFT) == frozenset(
+        {StrategyLifecycleState.EVALUATION, StrategyLifecycleState.DEPRECATED}
+    )
+    assert get_allowed_transitions(StrategyLifecycleState.EVALUATION) == frozenset(
+        {StrategyLifecycleState.PRODUCTION, StrategyLifecycleState.DEPRECATED}
+    )
+    assert get_allowed_transitions(StrategyLifecycleState.PRODUCTION) == frozenset(
+        {StrategyLifecycleState.DEPRECATED}
+    )
+    assert get_allowed_transitions(StrategyLifecycleState.DEPRECATED) == frozenset()
+
+
+def test_transition_matrix_is_immutable() -> None:
+    with pytest.raises(TypeError):
+        ALLOWED_TRANSITIONS[StrategyLifecycleState.DRAFT] = frozenset()  # type: ignore[index]
+
+    with pytest.raises(AttributeError):
+        get_allowed_transitions(StrategyLifecycleState.DRAFT).add(StrategyLifecycleState.PRODUCTION)  # type: ignore[attr-defined]


### PR DESCRIPTION
### Motivation

- Provide a deterministic, explicit lifecycle model for strategies with canonical states and terminal semantics.
- Ensure promotions and retirement are validated against an immutable transition matrix to avoid accidental or illegal state changes.
- Document lifecycle semantics and execution-eligibility to guide usage and future enforcement.

### Description

- Add `StrategyLifecycleState` enum, `TERMINAL_STATES`, and `is_terminal_state` in `src/cilly_trading/engine/strategy_lifecycle/model.py` to define canonical states and terminal behavior.
- Implement an explicit immutable transition matrix `ALLOWED_TRANSITIONS`, `validate_transition`, and `transition_state` in `src/cilly_trading/engine/strategy_lifecycle/transitions.py` and expose the public API in `src/cilly_trading/engine/strategy_lifecycle/__init__.py`.
- Ensure deterministic failure modes by raising `StrategyLifecycleTransitionError` for self-transitions, illegal transitions, and attempts to transition from terminal states, and make the matrix immutable via `MappingProxyType`.
- Add `docs/strategy_lifecycle_model.md` with the states, allowed transitions, invariants, and execution-eligibility semantics.

### Testing

- Add unit tests `tests/strategy_lifecycle/test_state_model.py` and `tests/strategy_lifecycle/test_transitions.py` which verify enum values, terminal-state detection, immutability, allowed transitions, and deterministic error messages.
- Ran `pytest tests/strategy_lifecycle` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4279ca2cc8333957557db793521ed)