### PR TITLE
P25-ENGINE: implement strategy lifecycle promotion service

### DIFF
--- a/src/cilly_trading/engine/strategy_lifecycle/__init__.py
+++ b/src/cilly_trading/engine/strategy_lifecycle/__init__.py
@@ -1,6 +1,7 @@
 """Public API for strategy lifecycle modeling and transition validation."""
 
 from .model import StrategyLifecycleState, TERMINAL_STATES, is_terminal_state
+from .service import StrategyLifecycleStore, deprecate, promote_to_evaluation, promote_to_production
 from .transitions import (
     ALLOWED_TRANSITIONS,
     StrategyLifecycleTransitionError,
@@ -12,10 +13,14 @@ from .transitions import (
 __all__ = [
     "ALLOWED_TRANSITIONS",
     "StrategyLifecycleState",
+    "StrategyLifecycleStore",
     "StrategyLifecycleTransitionError",
     "TERMINAL_STATES",
+    "deprecate",
     "get_allowed_transitions",
     "is_terminal_state",
+    "promote_to_evaluation",
+    "promote_to_production",
     "transition_state",
     "validate_transition",
 ]

--- a/src/cilly_trading/engine/strategy_lifecycle/service.py
+++ b/src/cilly_trading/engine/strategy_lifecycle/service.py
@@ -1,0 +1,45 @@
+"""Promotion service API for deterministic strategy lifecycle transitions."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .model import StrategyLifecycleState
+from .transitions import transition_state
+
+
+class StrategyLifecycleStore(Protocol):
+    """Persistence hook interface for strategy lifecycle state access."""
+
+    def get_state(self, strategy_id: str) -> StrategyLifecycleState:
+        """Return the current lifecycle state for a strategy identifier."""
+
+    def set_state(self, strategy_id: str, new_state: StrategyLifecycleState) -> None:
+        """Persist a lifecycle state for a strategy identifier."""
+
+
+def promote_to_evaluation(current_state: StrategyLifecycleState) -> StrategyLifecycleState:
+    """Promote a strategy into EVALUATION when transition rules allow it."""
+
+    return transition_state(
+        current_state=current_state,
+        target_state=StrategyLifecycleState.EVALUATION,
+    )
+
+
+def promote_to_production(current_state: StrategyLifecycleState) -> StrategyLifecycleState:
+    """Promote a strategy into PRODUCTION when transition rules allow it."""
+
+    return transition_state(
+        current_state=current_state,
+        target_state=StrategyLifecycleState.PRODUCTION,
+    )
+
+
+def deprecate(current_state: StrategyLifecycleState) -> StrategyLifecycleState:
+    """Transition a strategy into DEPRECATED when transition rules allow it."""
+
+    return transition_state(
+        current_state=current_state,
+        target_state=StrategyLifecycleState.DEPRECATED,
+    )

--- a/tests/strategy_lifecycle/test_service.py
+++ b/tests/strategy_lifecycle/test_service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from cilly_trading.engine.strategy_lifecycle import (
+    StrategyLifecycleState,
+    StrategyLifecycleTransitionError,
+    deprecate,
+    promote_to_evaluation,
+    promote_to_production,
+)
+
+
+@pytest.mark.parametrize(
+    ("operation", "current", "expected"),
+    [
+        (promote_to_evaluation, StrategyLifecycleState.DRAFT, StrategyLifecycleState.EVALUATION),
+        (promote_to_production, StrategyLifecycleState.EVALUATION, StrategyLifecycleState.PRODUCTION),
+        (deprecate, StrategyLifecycleState.DRAFT, StrategyLifecycleState.DEPRECATED),
+        (deprecate, StrategyLifecycleState.EVALUATION, StrategyLifecycleState.DEPRECATED),
+        (deprecate, StrategyLifecycleState.PRODUCTION, StrategyLifecycleState.DEPRECATED),
+    ],
+)
+def test_promotion_service_valid_transitions(operation, current: StrategyLifecycleState, expected: StrategyLifecycleState) -> None:
+    assert operation(current) == expected
+
+
+@pytest.mark.parametrize(
+    ("operation", "current", "expected_error"),
+    [
+        (
+            promote_to_evaluation,
+            StrategyLifecycleState.EVALUATION,
+            "Illegal lifecycle transition: EVALUATION -> EVALUATION",
+        ),
+        (
+            promote_to_production,
+            StrategyLifecycleState.PRODUCTION,
+            "Illegal lifecycle transition: PRODUCTION -> PRODUCTION",
+        ),
+        (
+            promote_to_evaluation,
+            StrategyLifecycleState.DEPRECATED,
+            "Illegal lifecycle transition: DEPRECATED is terminal",
+        ),
+        (
+            promote_to_production,
+            StrategyLifecycleState.DRAFT,
+            "Illegal lifecycle transition: DRAFT -> PRODUCTION",
+        ),
+    ],
+)
+def test_promotion_service_invalid_transitions_raise_deterministic_errors(
+    operation,
+    current: StrategyLifecycleState,
+    expected_error: str,
+) -> None:
+    with pytest.raises(StrategyLifecycleTransitionError) as error:
+        operation(current)
+
+    assert str(error.value) == expected_error
+
+
+@pytest.mark.parametrize(
+    ("operation", "current"),
+    [
+        (promote_to_evaluation, StrategyLifecycleState.DRAFT),
+        (promote_to_production, StrategyLifecycleState.EVALUATION),
+        (deprecate, StrategyLifecycleState.PRODUCTION),
+    ],
+)
+def test_promotion_service_deterministic_success(operation, current: StrategyLifecycleState) -> None:
+    assert operation(current) == operation(current)
+
+
+@pytest.mark.parametrize(
+    ("operation", "current", "expected_error"),
+    [
+        (
+            promote_to_evaluation,
+            StrategyLifecycleState.DEPRECATED,
+            "Illegal lifecycle transition: DEPRECATED is terminal",
+        ),
+        (
+            promote_to_production,
+            StrategyLifecycleState.DRAFT,
+            "Illegal lifecycle transition: DRAFT -> PRODUCTION",
+        ),
+    ],
+)
+def test_promotion_service_deterministic_errors(operation, current: StrategyLifecycleState, expected_error: str) -> None:
+    errors: list[str] = []
+
+    for _ in range(2):
+        with pytest.raises(StrategyLifecycleTransitionError) as error:
+            operation(current)
+        errors.append(str(error.value))
+
+    assert errors == [expected_error, expected_error]


### PR DESCRIPTION
### Motivation
- Provide a small, deterministic service layer that exposes intentful promotion APIs on top of the existing lifecycle transition rules to centralize promotion logic and preserve deterministic error semantics.
- Keep transition semantics unchanged and avoid side effects or DB/schema integration while allowing an optional persistence hook interface for future use.

### Description
- Add `src/cilly_trading/engine/strategy_lifecycle/service.py` implementing `promote_to_evaluation`, `promote_to_production`, and `deprecate`, each delegating to `transition_state` for deterministic validation and return of the next state.
- Introduce the `StrategyLifecycleStore` `Protocol` in `service.py` with `get_state(strategy_id: str)` and `set_state(strategy_id: str, new_state)` as a lightweight persistence hook interface (no DB integration performed).
- Update `src/cilly_trading/engine/strategy_lifecycle/__init__.py` to export the new service API and `StrategyLifecycleStore` while keeping the existing model and transitions API unchanged.
- Add `tests/strategy_lifecycle/test_service.py` to cover valid promotions, invalid deterministic failures (same-state, terminal-state, illegal), and repeated-call determinism for both successes and errors.

### Testing
- Ran the full test suite with `pytest` and the new service tests; command used: `pytest`.
- Full test summary: `304 passed, 4 warnings in 22.14s` and the new `tests/strategy_lifecycle/test_service.py` tests passed as part of the suite.
- Tests exercise positive promotion paths and negative deterministic error paths and verify repeated-call determinism for both success and error outcomes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42df25dfc83339dfaf8190430a576)