### PR TITLE
docs: add Phase 25 strategy lifecycle governance artifact

### DIFF
--- a/docs/phases/phase_25_strategy_lifecycle.md
+++ b/docs/phases/phase_25_strategy_lifecycle.md
@@ -1,0 +1,60 @@
+# Phase 25 — Strategy Lifecycle Management
+
+**Status:** READY FOR COMPLETION (pending PR merge + CI)
+
+## Objective
+Phase 25 introduced the official lifecycle governance framework for strategies, including:
+- Lifecycle state model
+- Deterministic transition matrix
+- Promotion service API
+- Orchestrator production-only enforcement
+
+## Lifecycle States
+The Phase 25 lifecycle model defines four states:
+- **DRAFT**
+- **EVALUATION**
+- **PRODUCTION**
+- **DEPRECATED**
+
+**Terminal state definition:**
+- **DEPRECATED** is the terminal state. No transitions are permitted out of DEPRECATED.
+
+## Promotion Rules
+Allowed transitions are strictly limited to:
+- DRAFT -> EVALUATION
+- DRAFT -> DEPRECATED
+- EVALUATION -> PRODUCTION
+- EVALUATION -> DEPRECATED
+- PRODUCTION -> DEPRECATED
+
+All other transitions are illegal and must be rejected by lifecycle governance.
+
+## Execution Enforcement Rule
+Execution is governed by a strict production-only policy:
+- Only **PRODUCTION** strategies may execute.
+- This rule is enforced in the orchestrator.
+- Non-production strategies are rejected before execution.
+- CI must fail if this guard is removed.
+
+## Linked Pull Requests
+- PR #474 (Closes #474) — Lifecycle Model Design
+- PR #475 (Closes #475) — Lifecycle State Machine Implementation
+- PR #476 (Closes #476) — Production-Only Execution Enforcement
+- PR #477 (Closes #477) — Governance Artifact
+
+## Validation Proof
+- `pytest`
+- Full test suite passing (308 passed, 4 warnings)
+- Enforcement tests present
+- Transition tests present
+
+## Governance Review
+- Review Authority: Codex A
+- Review Decision: APPROVED (pending final merge verification)
+
+## Completion Declaration
+Phase 25 is declared **COMPLETE** only after all of the following are satisfied:
+- All PRs merged
+- CI passing
+- Governance review recorded
+- Artifact committed to main branch


### PR DESCRIPTION
### Motivation
- Create the official Phase 25 governance artifact to record the strategy lifecycle model, deterministic transition rules, promotion API, and orchestrator production-only execution enforcement.

### Description
- Add `docs/phases/phase_25_strategy_lifecycle.md` containing the required sections: Status, Objective, Lifecycle States (DRAFT, EVALUATION, PRODUCTION, DEPRECATED with DEPRECATED as terminal), Promotion Rules (allowed transitions and illegal other transitions), Execution Enforcement Rule (production-only execution enforced by the orchestrator and CI guard), Linked PRs, Validation Proof, Governance Review, and Completion Declaration.

### Testing
- Executed `pytest` (result: `308 passed, 4 warnings`) and validation commands including `test -f docs/phases/phase_25_strategy_lifecycle.md` and `git status --short`, and committed the new file with no other files changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43243d64c8333bfe6fac9affbcb74)