### PR TITLE
Add deterministic risk evaluation contract, docs, and unit tests

### DIFF
--- a/docs/risk/contract.md
+++ b/docs/risk/contract.md
@@ -1,0 +1,40 @@
+# P27-DESIGN Risk Evaluation Contract
+
+## Purpose
+This document defines the deterministic and immutable contract surface for risk
+assessment in Issue #482.
+
+## Module
+- `engine/risk_framework/contract.py`
+
+## Design Constraints
+- Use frozen dataclasses.
+- No business logic.
+- No imports from `engine.execution` or `engine.orchestrator`.
+- Deterministic contract behavior through explicit, value-based fields.
+
+## Types
+
+### `RiskEvaluationRequest`
+Frozen dataclass fields:
+- `strategy_id: str`
+- `symbol: str`
+- `proposed_position_size: float`
+- `account_equity: float`
+- `current_exposure: float`
+
+### `RiskEvaluationResponse`
+Frozen dataclass fields:
+- `approved: bool`
+- `reason: str`
+- `adjusted_position_size: Optional[float]`
+- `risk_score: float`
+
+### `RiskEvaluator` (optional protocol)
+Method signature:
+- `evaluate(request: RiskEvaluationRequest) -> RiskEvaluationResponse`
+
+## Out of Scope
+- Policy/risk business logic
+- Runtime orchestration
+- Execution integration

--- a/engine/risk_framework/contract.py
+++ b/engine/risk_framework/contract.py
@@ -1,0 +1,54 @@
+"""Risk evaluation contract definitions for Issue #482.
+
+This module contains immutable data contracts and an optional protocol surface
+for risk evaluation. It contains no business logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+
+@dataclass(frozen=True)
+class RiskEvaluationRequest:
+    """Input contract for risk evaluation.
+
+    Attributes:
+        strategy_id: Identifier of the strategy under evaluation.
+        symbol: Instrument symbol for the proposed position.
+        proposed_position_size: Requested position size before risk adjustment.
+        account_equity: Current account equity used by downstream evaluators.
+        current_exposure: Current account exposure before this proposal.
+    """
+
+    strategy_id: str
+    symbol: str
+    proposed_position_size: float
+    account_equity: float
+    current_exposure: float
+
+
+@dataclass(frozen=True)
+class RiskEvaluationResponse:
+    """Output contract for risk evaluation.
+
+    Attributes:
+        approved: Whether the proposed risk request is approved.
+        reason: Human-readable explanation of the evaluation outcome.
+        adjusted_position_size: Optional adjusted position size.
+        risk_score: Numeric risk score produced by an implementation.
+    """
+
+    approved: bool
+    reason: str
+    adjusted_position_size: Optional[float]
+    risk_score: float
+
+
+class RiskEvaluator(Protocol):
+    """Protocol for deterministic risk evaluators."""
+
+    def evaluate(self, request: RiskEvaluationRequest) -> RiskEvaluationResponse:
+        """Evaluate a request and return an immutable response contract."""
+        ...

--- a/tests/risk/test_contract.py
+++ b/tests/risk/test_contract.py
@@ -1,0 +1,120 @@
+"""Unit tests for Issue #482 risk contract definitions."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import FrozenInstanceError, is_dataclass
+from pathlib import Path
+from typing import get_type_hints
+
+import pytest
+
+from engine.risk_framework.contract import (
+    RiskEvaluationRequest,
+    RiskEvaluationResponse,
+    RiskEvaluator,
+)
+
+
+def test_request_and_response_construction() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=10.0,
+        account_equity=100000.0,
+        current_exposure=25000.0,
+    )
+    response = RiskEvaluationResponse(
+        approved=True,
+        reason="within limits",
+        adjusted_position_size=None,
+        risk_score=0.12,
+    )
+
+    assert request.strategy_id == "strategy-a"
+    assert request.symbol == "AAPL"
+    assert request.proposed_position_size == 10.0
+    assert request.account_equity == 100000.0
+    assert request.current_exposure == 25000.0
+
+    assert response.approved is True
+    assert response.reason == "within limits"
+    assert response.adjusted_position_size is None
+    assert response.risk_score == 0.12
+
+
+def test_request_and_response_are_frozen_dataclasses() -> None:
+    assert is_dataclass(RiskEvaluationRequest)
+    assert RiskEvaluationRequest.__dataclass_params__.frozen is True
+
+    assert is_dataclass(RiskEvaluationResponse)
+    assert RiskEvaluationResponse.__dataclass_params__.frozen is True
+
+
+def test_request_rejects_mutation() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=10.0,
+        account_equity=100000.0,
+        current_exposure=25000.0,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        request.symbol = "MSFT"  # type: ignore[misc]
+
+
+def test_response_rejects_mutation() -> None:
+    response = RiskEvaluationResponse(
+        approved=False,
+        reason="limit exceeded",
+        adjusted_position_size=3.0,
+        risk_score=0.91,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        response.approved = True  # type: ignore[misc]
+
+
+def test_request_deterministic_equality() -> None:
+    payload = dict(
+        strategy_id="strategy-a",
+        symbol="BTC-USD",
+        proposed_position_size=1.5,
+        account_equity=50000.0,
+        current_exposure=10000.0,
+    )
+
+    left = RiskEvaluationRequest(**payload)
+    right = RiskEvaluationRequest(**payload)
+
+    assert left == right
+    assert hash(left) == hash(right)
+    assert repr(left) == repr(right)
+
+
+def test_contract_uses_no_forbidden_execution_or_orchestrator_imports() -> None:
+    source = Path("engine/risk_framework/contract.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.add(node.module)
+
+    forbidden_prefixes = ("engine.execution", "engine.orchestrator")
+
+    assert not any(
+        module.startswith(prefix)
+        for module in imported_modules
+        for prefix in forbidden_prefixes
+    )
+
+
+def test_protocol_evaluate_signature() -> None:
+    annotations = get_type_hints(RiskEvaluator.evaluate)
+
+    assert annotations["request"] is RiskEvaluationRequest
+    assert annotations["return"] is RiskEvaluationResponse


### PR DESCRIPTION
### Motivation

- Define a deterministic, immutable contract surface for risk assessment for Issue #482. 
- Keep contract types free of business logic and runtime orchestration dependencies. 
- Provide a clear, documented interface so downstream evaluators can rely on explicit value-based fields.

### Description

- Add `engine/risk_framework/contract.py` with frozen dataclasses `RiskEvaluationRequest` and `RiskEvaluationResponse` and an optional `RiskEvaluator` `Protocol`. 
- Create `docs/risk/contract.md` documenting the contract, types, design constraints, and out-of-scope items. 
- Add unit tests in `tests/risk/test_contract.py` that verify construction, immutability, deterministic equality, forbidden import checks, and the `RiskEvaluator.evaluate` signature. 
- Ensure the contract module contains no business logic and does not import from `engine.execution` or `engine.orchestrator`.

### Testing

- Ran `pytest tests/risk/test_contract.py` which executed the tests for construction, immutability, equality, forbidden-import checks, and protocol signature, and they all passed. 
- The dataclass freezing behavior is asserted via `FrozenInstanceError` checks and was validated successfully. 
- AST-based import inspection confirmed no forbidden `engine.execution` or `engine.orchestrator` imports in the contract module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a439eb8d048333ae5beef05021e668)