### PR TITLE
Add risk_framework package skeleton and import boundary tests

### DIFF
--- a/engine/risk_framework/__init__.py
+++ b/engine/risk_framework/__init__.py
@@ -1,0 +1,7 @@
+"""Risk framework package skeleton for Issue #483.
+
+Import direction:
+- Orchestrator -> Risk framework is allowed.
+- Risk framework must not import ``engine.execution`` or ``engine.orchestrator``.
+- No runtime wiring is defined here.
+"""

--- a/engine/risk_framework/allocation_rules.py
+++ b/engine/risk_framework/allocation_rules.py
@@ -1,0 +1,6 @@
+"""Allocation rules module skeleton for Issue #483.
+
+This module intentionally contains no business logic.
+"""
+
+pass

--- a/engine/risk_framework/exposure_model.py
+++ b/engine/risk_framework/exposure_model.py
@@ -1,0 +1,6 @@
+"""Exposure model module skeleton for Issue #483.
+
+This module intentionally contains no business logic.
+"""
+
+pass

--- a/engine/risk_framework/kill_switch.py
+++ b/engine/risk_framework/kill_switch.py
@@ -1,0 +1,6 @@
+"""Kill switch module skeleton for Issue #483.
+
+This module intentionally contains no business logic.
+"""
+
+pass

--- a/engine/risk_framework/risk_evaluator.py
+++ b/engine/risk_framework/risk_evaluator.py
@@ -1,0 +1,6 @@
+"""Risk evaluator module skeleton for Issue #483.
+
+This module intentionally contains no business logic.
+"""
+
+pass

--- a/tests/risk/test_imports.py
+++ b/tests/risk/test_imports.py
@@ -1,0 +1,51 @@
+"""Import and architecture boundary tests for risk framework skeleton modules."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+MODULES = [
+    "engine.risk_framework",
+    "engine.risk_framework.contract",
+    "engine.risk_framework.risk_evaluator",
+    "engine.risk_framework.exposure_model",
+    "engine.risk_framework.allocation_rules",
+    "engine.risk_framework.kill_switch",
+]
+
+FORBIDDEN_PREFIXES = (
+    "engine.execution",
+    "engine.orchestrator",
+)
+
+
+def test_import_risk_framework_modules() -> None:
+    """Each risk framework module should import without raising exceptions."""
+    for module_name in MODULES:
+        __import__(module_name)
+
+
+def _imported_module_names(node: ast.AST) -> list[str]:
+    """Return normalized imported module names for import nodes."""
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        return [node.module] if node.module else []
+    return []
+
+
+def test_risk_framework_import_boundary() -> None:
+    """Risk framework package must not import execution or orchestrator packages."""
+    root = Path(__file__).resolve().parents[2]
+    package_dir = root / "engine" / "risk_framework"
+
+    for path in package_dir.glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            for module_name in _imported_module_names(node):
+                assert not module_name.startswith(FORBIDDEN_PREFIXES), (
+                    f"Forbidden import '{module_name}' found in {path}"
+                )


### PR DESCRIPTION
### Motivation
- Introduce a skeleton for a new `engine.risk_framework` package as the basis for Issue #483. 
- Enforce an architectural import boundary so the risk framework does not depend on `engine.execution` or `engine.orchestrator`.

### Description
- Add `engine/risk_framework/__init__.py` with documentation describing allowed import direction and that no runtime wiring is defined. 
- Add skeleton modules `allocation_rules.py`, `exposure_model.py`, `kill_switch.py`, and `risk_evaluator.py` containing only module docstrings and `pass`. 
- Add `tests/risk/test_imports.py` which imports the new modules and statically checks with `ast` that no module in `engine.risk_framework` imports forbidden prefixes `engine.execution` or `engine.orchestrator`.

### Testing
- Ran the import and boundary test with `pytest tests/risk/test_imports.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43c8fc980833385ce219a819903e2)