### PR TITLE
Deterministic risk evaluation, exposure model, and limits with unit tests

### DIFF
--- a/engine/risk_framework/allocation_rules.py
+++ b/engine/risk_framework/allocation_rules.py
@@ -1,6 +1,26 @@
-"""Allocation rules module skeleton for Issue #483.
+"""Deterministic allocation limits for risk evaluation."""
 
-This module intentionally contains no business logic.
-"""
+from __future__ import annotations
 
-pass
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RiskLimits:
+    """Immutable risk constraints for deterministic evaluation.
+
+    Attributes:
+        max_account_exposure_pct: Maximum account exposure percentage after a
+            proposed position is applied.
+        max_position_size: Maximum absolute position size allowed for one
+            proposal.
+        max_strategy_exposure_pct: Maximum strategy-level exposure percentage
+            after applying the proposed position.
+        max_symbol_exposure_pct: Maximum symbol-level exposure percentage after
+            applying the proposed position.
+    """
+
+    max_account_exposure_pct: float
+    max_position_size: float
+    max_strategy_exposure_pct: float
+    max_symbol_exposure_pct: float

--- a/engine/risk_framework/exposure_model.py
+++ b/engine/risk_framework/exposure_model.py
@@ -1,6 +1,59 @@
-"""Exposure model module skeleton for Issue #483.
+"""Pure and deterministic exposure calculations.
 
-This module intentionally contains no business logic.
+This module contains only deterministic arithmetic for exposure metrics.
 """
 
-pass
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExposureMetrics:
+    """Computed exposure metrics for a risk request.
+
+    Attributes:
+        account_exposure: Absolute account exposure after proposal.
+        account_exposure_pct: Account exposure as percentage of account equity.
+        proposed_allocation_pct: Proposed position as percentage of account equity.
+    """
+
+    account_exposure: float
+    account_exposure_pct: float
+    proposed_allocation_pct: float
+
+
+def compute_exposure_metrics(
+    *,
+    account_equity: float,
+    current_exposure: float,
+    proposed_position_size: float,
+) -> ExposureMetrics:
+    """Compute deterministic exposure metrics.
+
+    Args:
+        account_equity: Current account equity.
+        current_exposure: Current account exposure before proposal.
+        proposed_position_size: Requested position size.
+
+    Returns:
+        ExposureMetrics: Derived deterministic metrics.
+    """
+
+    absolute_equity = abs(account_equity)
+    absolute_current_exposure = abs(current_exposure)
+    absolute_proposed_size = abs(proposed_position_size)
+
+    account_exposure = absolute_current_exposure + absolute_proposed_size
+    if absolute_equity == 0.0:
+        account_exposure_pct = float("inf")
+        proposed_allocation_pct = float("inf")
+    else:
+        account_exposure_pct = account_exposure / absolute_equity
+        proposed_allocation_pct = absolute_proposed_size / absolute_equity
+
+    return ExposureMetrics(
+        account_exposure=account_exposure,
+        account_exposure_pct=account_exposure_pct,
+        proposed_allocation_pct=proposed_allocation_pct,
+    )

--- a/engine/risk_framework/risk_evaluator.py
+++ b/engine/risk_framework/risk_evaluator.py
@@ -1,6 +1,99 @@
-"""Risk evaluator module skeleton for Issue #483.
+"""Deterministic and pure risk evaluation implementation."""
 
-This module intentionally contains no business logic.
-"""
+from __future__ import annotations
 
-pass
+from engine.risk_framework.allocation_rules import RiskLimits
+from engine.risk_framework.contract import RiskEvaluationRequest, RiskEvaluationResponse
+from engine.risk_framework.exposure_model import compute_exposure_metrics
+
+
+def _safe_pct(numerator: float, denominator: float) -> float:
+    """Return a deterministic percentage value."""
+    if denominator == 0.0:
+        return float("inf")
+    return numerator / denominator
+
+
+def evaluate_risk(
+    request: RiskEvaluationRequest,
+    *,
+    limits: RiskLimits,
+    strategy_exposure: float,
+    symbol_exposure: float,
+) -> RiskEvaluationResponse:
+    """Evaluate a risk request deterministically.
+
+    Args:
+        request: Risk evaluation request contract.
+        limits: Immutable risk limits used for this evaluation.
+        strategy_exposure: Current absolute exposure for the request strategy.
+        symbol_exposure: Current absolute exposure for the request symbol.
+
+    Returns:
+        RiskEvaluationResponse: Deterministic evaluation result.
+    """
+
+    absolute_equity = abs(request.account_equity)
+    absolute_proposed_size = abs(request.proposed_position_size)
+    absolute_strategy_exposure = abs(strategy_exposure)
+    absolute_symbol_exposure = abs(symbol_exposure)
+
+    metrics = compute_exposure_metrics(
+        account_equity=request.account_equity,
+        current_exposure=request.current_exposure,
+        proposed_position_size=request.proposed_position_size,
+    )
+    risk_score = metrics.account_exposure_pct
+
+    if absolute_proposed_size > limits.max_position_size:
+        return RiskEvaluationResponse(
+            approved=False,
+            reason="rejected: max_position_size_exceeded",
+            adjusted_position_size=limits.max_position_size,
+            risk_score=risk_score,
+        )
+
+    if metrics.account_exposure_pct > limits.max_account_exposure_pct:
+        max_allowed_account = absolute_equity * limits.max_account_exposure_pct
+        adjusted_position_size = max(0.0, max_allowed_account - abs(request.current_exposure))
+        return RiskEvaluationResponse(
+            approved=False,
+            reason="rejected: max_account_exposure_pct_exceeded",
+            adjusted_position_size=adjusted_position_size,
+            risk_score=risk_score,
+        )
+
+    strategy_exposure_pct = _safe_pct(
+        absolute_strategy_exposure + absolute_proposed_size,
+        absolute_equity,
+    )
+    if strategy_exposure_pct > limits.max_strategy_exposure_pct:
+        max_allowed_strategy = absolute_equity * limits.max_strategy_exposure_pct
+        adjusted_position_size = max(0.0, max_allowed_strategy - absolute_strategy_exposure)
+        return RiskEvaluationResponse(
+            approved=False,
+            reason="rejected: max_strategy_exposure_pct_exceeded",
+            adjusted_position_size=adjusted_position_size,
+            risk_score=risk_score,
+        )
+
+    symbol_exposure_pct = _safe_pct(
+        absolute_symbol_exposure + absolute_proposed_size,
+        absolute_equity,
+    )
+    if symbol_exposure_pct > limits.max_symbol_exposure_pct:
+        max_allowed_symbol = absolute_equity * limits.max_symbol_exposure_pct
+        adjusted_position_size = max(0.0, max_allowed_symbol - absolute_symbol_exposure)
+        return RiskEvaluationResponse(
+            approved=False,
+            reason="rejected: max_symbol_exposure_pct_exceeded",
+            adjusted_position_size=adjusted_position_size,
+            risk_score=risk_score,
+        )
+
+    return RiskEvaluationResponse(
+        approved=True,
+        reason="approved: within_risk_limits",
+        adjusted_position_size=absolute_proposed_size,
+        risk_score=risk_score,
+    )

--- a/tests/risk/test_risk_evaluator.py
+++ b/tests/risk/test_risk_evaluator.py
@@ -1,0 +1,160 @@
+"""Tests for deterministic risk evaluation rules (Issue #484)."""
+
+from __future__ import annotations
+
+from engine.risk_framework.allocation_rules import RiskLimits
+from engine.risk_framework.contract import RiskEvaluationRequest
+from engine.risk_framework.risk_evaluator import evaluate_risk
+
+
+def _request() -> RiskEvaluationRequest:
+    return RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=20_000.0,
+    )
+
+
+def _limits() -> RiskLimits:
+    return RiskLimits(
+        max_account_exposure_pct=0.50,
+        max_position_size=10_000.0,
+        max_strategy_exposure_pct=0.30,
+        max_symbol_exposure_pct=0.20,
+    )
+
+
+def test_approval_case() -> None:
+    response = evaluate_risk(
+        _request(),
+        limits=_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+    )
+
+    assert response.approved is True
+    assert response.reason == "approved: within_risk_limits"
+    assert response.adjusted_position_size == 5_000.0
+    assert response.risk_score == 0.25
+
+
+def test_rejection_max_position_size_rule() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=12_000.0,
+        account_equity=100_000.0,
+        current_exposure=20_000.0,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_limits(),
+        strategy_exposure=5_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: max_position_size_exceeded"
+    assert response.adjusted_position_size == 10_000.0
+    assert response.risk_score == 0.32
+
+
+def test_rejection_max_account_exposure_pct_rule() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=6_000.0,
+        account_equity=100_000.0,
+        current_exposure=48_000.0,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: max_account_exposure_pct_exceeded"
+    assert response.adjusted_position_size == 2_000.0
+    assert response.risk_score == 0.54
+
+
+def test_rejection_max_strategy_exposure_pct_rule() -> None:
+    response = evaluate_risk(
+        _request(),
+        limits=_limits(),
+        strategy_exposure=26_000.0,
+        symbol_exposure=8_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: max_strategy_exposure_pct_exceeded"
+    assert response.adjusted_position_size == 4_000.0
+    assert response.risk_score == 0.25
+
+
+def test_rejection_max_symbol_exposure_pct_rule() -> None:
+    response = evaluate_risk(
+        _request(),
+        limits=_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=18_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: max_symbol_exposure_pct_exceeded"
+    assert response.adjusted_position_size == 2_000.0
+    assert response.risk_score == 0.25
+
+
+def test_boundary_equals_limit_is_approved() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=10_000.0,
+        account_equity=100_000.0,
+        current_exposure=40_000.0,
+    )
+    limits = RiskLimits(
+        max_account_exposure_pct=0.50,
+        max_position_size=10_000.0,
+        max_strategy_exposure_pct=0.30,
+        max_symbol_exposure_pct=0.20,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=20_000.0,
+        symbol_exposure=10_000.0,
+    )
+
+    assert response.approved is True
+    assert response.reason == "approved: within_risk_limits"
+    assert response.adjusted_position_size == 10_000.0
+    assert response.risk_score == 0.50
+
+
+def test_determinism() -> None:
+    request = _request()
+    limits = _limits()
+
+    first = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+    )
+    second = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+    )
+
+    assert first == second


### PR DESCRIPTION
### Motivation

- Provide a pure, deterministic implementation of exposure and risk evaluation to replace the previous skeletons. 
- Encapsulate allocation constraints and deterministic arithmetic so risk decisions can be reasoned about and unit-tested.

### Description

- Add `RiskLimits` dataclass in `allocation_rules.py` to represent immutable allocation constraints. 
- Add `ExposureMetrics` and `compute_exposure_metrics` in `exposure_model.py` to calculate deterministic exposure percentages and handle zero-equity cases. 
- Implement `evaluate_risk` and helper `_safe_pct` in `risk_evaluator.py` to apply deterministic rules for `max_position_size`, `max_account_exposure_pct`, `max_strategy_exposure_pct`, and `max_symbol_exposure_pct`, returning a `RiskEvaluationResponse`. 
- Add comprehensive unit tests in `tests/risk/test_risk_evaluator.py` covering approvals, each rejection rule, boundary conditions, and determinism.

### Testing

- Ran the new test module with `pytest tests/risk/test_risk_evaluator.py`. 
- All tests in `tests/risk/test_risk_evaluator.py` passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4964e5bd8833390ceb7b3c0607835)