### PR TITLE
Implement Issue #485: Global Risk Kill Switch

### DIFF
--- a/engine/risk_framework/kill_switch.py
+++ b/engine/risk_framework/kill_switch.py
@@ -1,6 +1,12 @@
-"""Kill switch module skeleton for Issue #483.
+"""Kill switch utilities for global risk controls."""
 
-This module intentionally contains no business logic.
-"""
+from __future__ import annotations
 
-pass
+
+def is_kill_switch_enabled(*, config: dict[str, object] | None) -> bool:
+    """Return whether the global risk kill switch is enabled."""
+    if config is None:
+        return False
+
+    enabled = config.get("risk.kill_switch.enabled")
+    return enabled is True

--- a/tests/risk/test_kill_switch.py
+++ b/tests/risk/test_kill_switch.py
@@ -1,0 +1,84 @@
+"""Tests for global risk kill switch behavior (Issue #485)."""
+
+from __future__ import annotations
+
+from engine.risk_framework.allocation_rules import RiskLimits
+from engine.risk_framework.contract import RiskEvaluationRequest
+from engine.risk_framework.kill_switch import is_kill_switch_enabled
+from engine.risk_framework.risk_evaluator import evaluate_risk
+
+
+def _request() -> RiskEvaluationRequest:
+    return RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=20_000.0,
+    )
+
+
+def _limits() -> RiskLimits:
+    return RiskLimits(
+        max_account_exposure_pct=0.50,
+        max_position_size=10_000.0,
+        max_strategy_exposure_pct=0.30,
+        max_symbol_exposure_pct=0.20,
+    )
+
+
+def test_enabled_kill_switch_always_rejects() -> None:
+    response = evaluate_risk(
+        _request(),
+        limits=_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+        config={"risk.kill_switch.enabled": True},
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: kill_switch_enabled"
+    assert response.adjusted_position_size == 0.0
+    assert response.risk_score == float("inf")
+
+
+def test_disabled_kill_switch_allows_normal_approval_path() -> None:
+    response = evaluate_risk(
+        _request(),
+        limits=_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+        config={"risk.kill_switch.enabled": False},
+    )
+
+    assert response.approved is True
+    assert response.reason == "approved: within_risk_limits"
+
+
+def test_kill_switch_determinism() -> None:
+    request = _request()
+    limits = _limits()
+    config = {"risk.kill_switch.enabled": True}
+
+    first = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+        config=config,
+    )
+    second = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+        config=config,
+    )
+
+    assert first == second
+
+
+def test_is_kill_switch_enabled_invalid_values_are_false() -> None:
+    assert is_kill_switch_enabled(config=None) is False
+    assert is_kill_switch_enabled(config={}) is False
+    assert is_kill_switch_enabled(config={"risk.kill_switch.enabled": "true"}) is False


### PR DESCRIPTION
### Motivation
- Add a global, deterministic kill switch to short-circuit all risk approvals for emergency shutdowns. 
- Ensure the kill-switch logic is a pure, side-effect-free predicate driven only by a provided config map.

### Description
- Implemented `is_kill_switch_enabled(*, config: dict[str, object] | None) -> bool` in `engine/risk_framework/kill_switch.py` that returns `True` only when `config["risk.kill_switch.enabled"] is True` and returns `False` for `None`, missing, or invalid values. 
- Extended `evaluate_risk` in `engine/risk_framework/risk_evaluator.py` with an optional `config: dict[str, object] | None = None` parameter and added an early-return when the kill switch is enabled that returns `RiskEvaluationResponse(approved=False, reason="rejected: kill_switch_enabled", adjusted_position_size=0.0, risk_score=float("inf"))`. 
- Added `tests/risk/test_kill_switch.py` covering enabled/disabled behavior, determinism, and invalid/missing config handling. 
- Changes are minimal and constrained to the allowed files with no IO, environment access, or globals introduced.

### Testing
- Ran `pytest tests/risk/test_kill_switch.py` and observed `4 passed in 0.04s`. 
- Ran the full suite with `pytest -q` and observed `328 passed, 4 warnings` (warnings are FastAPI deprecation notices unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a2280e988333877f96d1a3f53a4a)