### PR TITLE
Add deterministic portfolio exposure aggregation package

### DIFF
--- a/engine/portfolio_framework/__init__.py
+++ b/engine/portfolio_framework/__init__.py
@@ -1,0 +1,20 @@
+"""Portfolio framework package for deterministic portfolio-state aggregation."""
+
+from engine.portfolio_framework.contract import PortfolioPosition, PortfolioState
+from engine.portfolio_framework.exposure_aggregator import (
+    PortfolioExposureSummary,
+    PositionExposure,
+    StrategyExposure,
+    SymbolExposure,
+    aggregate_portfolio_exposure,
+)
+
+__all__ = [
+    "PortfolioExposureSummary",
+    "PortfolioPosition",
+    "PortfolioState",
+    "PositionExposure",
+    "StrategyExposure",
+    "SymbolExposure",
+    "aggregate_portfolio_exposure",
+]

--- a/engine/portfolio_framework/contract.py
+++ b/engine/portfolio_framework/contract.py
@@ -1,0 +1,35 @@
+"""Portfolio framework contracts for Issue #496."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PortfolioPosition:
+    """Represents a single portfolio position.
+
+    Attributes:
+        strategy_id: Strategy identifier that owns the position.
+        symbol: Instrument symbol.
+        quantity: Signed quantity for the position.
+        mark_price: Current mark price used for notional calculations.
+    """
+
+    strategy_id: str
+    symbol: str
+    quantity: float
+    mark_price: float
+
+
+@dataclass(frozen=True)
+class PortfolioState:
+    """Immutable portfolio state input for aggregation functions.
+
+    Attributes:
+        account_equity: Current account equity.
+        positions: Tuple of current portfolio positions.
+    """
+
+    account_equity: float
+    positions: tuple[PortfolioPosition, ...]

--- a/engine/portfolio_framework/exposure_aggregator.py
+++ b/engine/portfolio_framework/exposure_aggregator.py
@@ -1,0 +1,266 @@
+"""Pure and deterministic portfolio exposure aggregation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from engine.portfolio_framework.contract import PortfolioState
+
+
+@dataclass(frozen=True)
+class StrategyExposure:
+    """Aggregated exposure information for one strategy.
+
+    Attributes:
+        strategy_id: Strategy identifier.
+        total_absolute_notional: Sum of absolute notional exposure for strategy positions.
+        net_notional: Sum of signed notional exposure for strategy positions.
+        gross_exposure_pct: Strategy gross exposure as fraction of absolute account equity.
+        net_exposure_pct: Strategy net exposure as fraction of absolute account equity.
+    """
+
+    strategy_id: str
+    total_absolute_notional: float
+    net_notional: float
+    gross_exposure_pct: float
+    net_exposure_pct: float
+
+
+@dataclass(frozen=True)
+class SymbolExposure:
+    """Aggregated exposure information for one symbol.
+
+    Attributes:
+        symbol: Instrument symbol.
+        total_absolute_notional: Sum of absolute notional exposure for symbol positions.
+        net_notional: Sum of signed notional exposure for symbol positions.
+        gross_exposure_pct: Symbol gross exposure as fraction of absolute account equity.
+        net_exposure_pct: Symbol net exposure as fraction of absolute account equity.
+    """
+
+    symbol: str
+    total_absolute_notional: float
+    net_notional: float
+    gross_exposure_pct: float
+    net_exposure_pct: float
+
+
+@dataclass(frozen=True)
+class PositionExposure:
+    """Normalized exposure information for one position.
+
+    Attributes:
+        strategy_id: Strategy identifier that owns the position.
+        symbol: Instrument symbol.
+        quantity: Signed quantity.
+        mark_price: Mark price used for notional.
+        notional: Signed notional exposure.
+        absolute_notional: Absolute notional exposure.
+        exposure_pct: Absolute notional as a fraction of absolute account equity.
+    """
+
+    strategy_id: str
+    symbol: str
+    quantity: float
+    mark_price: float
+    notional: float
+    absolute_notional: float
+    exposure_pct: float
+
+
+@dataclass(frozen=True)
+class PortfolioExposureSummary:
+    """Aggregate portfolio exposure metrics.
+
+    Attributes:
+        strategy_exposures: Deterministically ordered strategy exposure rows.
+        symbol_exposures: Deterministically ordered symbol exposure rows.
+        position_exposures: Deterministically ordered position exposure rows.
+        total_absolute_notional: Sum of absolute notional exposure across positions.
+        net_notional: Sum of signed notional exposure across positions.
+        gross_exposure_pct: Gross exposure as fraction of absolute account equity.
+        net_exposure_pct: Net exposure as fraction of absolute account equity.
+    """
+
+    strategy_exposures: tuple[StrategyExposure, ...]
+    symbol_exposures: tuple[SymbolExposure, ...]
+    position_exposures: tuple[PositionExposure, ...]
+    total_absolute_notional: float
+    net_notional: float
+    gross_exposure_pct: float
+    net_exposure_pct: float
+
+
+def aggregate_portfolio_exposure(state: PortfolioState) -> PortfolioExposureSummary:
+    """Aggregate deterministic portfolio exposure metrics from immutable state.
+
+    Args:
+        state: Immutable portfolio state.
+
+    Returns:
+        PortfolioExposureSummary: Deterministic exposure summary.
+    """
+
+    absolute_equity = abs(state.account_equity)
+
+    sorted_positions = tuple(
+        sorted(
+            state.positions,
+            key=lambda position: (
+                position.strategy_id,
+                position.symbol,
+                position.quantity,
+                position.mark_price,
+            ),
+        )
+    )
+
+    position_exposures = tuple(
+        _position_exposure(
+            strategy_id=position.strategy_id,
+            symbol=position.symbol,
+            quantity=position.quantity,
+            mark_price=position.mark_price,
+            absolute_equity=absolute_equity,
+        )
+        for position in sorted_positions
+    )
+
+    total_absolute_notional = sum(item.absolute_notional for item in position_exposures)
+    net_notional = sum(item.notional for item in position_exposures)
+
+    strategy_exposures = _aggregate_by_strategy(position_exposures, absolute_equity)
+    symbol_exposures = _aggregate_by_symbol(position_exposures, absolute_equity)
+
+    gross_exposure_pct = _ratio_or_inf(total_absolute_notional, absolute_equity)
+    net_exposure_pct = _signed_ratio_or_inf(net_notional, absolute_equity)
+
+    return PortfolioExposureSummary(
+        strategy_exposures=strategy_exposures,
+        symbol_exposures=symbol_exposures,
+        position_exposures=position_exposures,
+        total_absolute_notional=total_absolute_notional,
+        net_notional=net_notional,
+        gross_exposure_pct=gross_exposure_pct,
+        net_exposure_pct=net_exposure_pct,
+    )
+
+
+def _position_exposure(
+    *,
+    strategy_id: str,
+    symbol: str,
+    quantity: float,
+    mark_price: float,
+    absolute_equity: float,
+) -> PositionExposure:
+    """Build normalized per-position exposure rows."""
+
+    notional = quantity * mark_price
+    absolute_notional = abs(notional)
+
+    return PositionExposure(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        quantity=quantity,
+        mark_price=mark_price,
+        notional=notional,
+        absolute_notional=absolute_notional,
+        exposure_pct=_ratio_or_inf(absolute_notional, absolute_equity),
+    )
+
+
+def _aggregate_by_strategy(
+    position_exposures: tuple[PositionExposure, ...],
+    absolute_equity: float,
+) -> tuple[StrategyExposure, ...]:
+    """Aggregate exposures grouped by strategy_id in deterministic order."""
+
+    strategy_ids = tuple(sorted({item.strategy_id for item in position_exposures}))
+
+    return tuple(
+        _build_strategy_exposure(
+            strategy_id=strategy_id,
+            position_exposures=position_exposures,
+            absolute_equity=absolute_equity,
+        )
+        for strategy_id in strategy_ids
+    )
+
+
+def _build_strategy_exposure(
+    *,
+    strategy_id: str,
+    position_exposures: tuple[PositionExposure, ...],
+    absolute_equity: float,
+) -> StrategyExposure:
+    """Build one strategy exposure row."""
+
+    rows = tuple(item for item in position_exposures if item.strategy_id == strategy_id)
+    total_absolute_notional = sum(item.absolute_notional for item in rows)
+    net_notional = sum(item.notional for item in rows)
+
+    return StrategyExposure(
+        strategy_id=strategy_id,
+        total_absolute_notional=total_absolute_notional,
+        net_notional=net_notional,
+        gross_exposure_pct=_ratio_or_inf(total_absolute_notional, absolute_equity),
+        net_exposure_pct=_signed_ratio_or_inf(net_notional, absolute_equity),
+    )
+
+
+def _aggregate_by_symbol(
+    position_exposures: tuple[PositionExposure, ...],
+    absolute_equity: float,
+) -> tuple[SymbolExposure, ...]:
+    """Aggregate exposures grouped by symbol in deterministic order."""
+
+    symbols = tuple(sorted({item.symbol for item in position_exposures}))
+
+    return tuple(
+        _build_symbol_exposure(
+            symbol=symbol,
+            position_exposures=position_exposures,
+            absolute_equity=absolute_equity,
+        )
+        for symbol in symbols
+    )
+
+
+def _build_symbol_exposure(
+    *,
+    symbol: str,
+    position_exposures: tuple[PositionExposure, ...],
+    absolute_equity: float,
+) -> SymbolExposure:
+    """Build one symbol exposure row."""
+
+    rows = tuple(item for item in position_exposures if item.symbol == symbol)
+    total_absolute_notional = sum(item.absolute_notional for item in rows)
+    net_notional = sum(item.notional for item in rows)
+
+    return SymbolExposure(
+        symbol=symbol,
+        total_absolute_notional=total_absolute_notional,
+        net_notional=net_notional,
+        gross_exposure_pct=_ratio_or_inf(total_absolute_notional, absolute_equity),
+        net_exposure_pct=_signed_ratio_or_inf(net_notional, absolute_equity),
+    )
+
+
+def _ratio_or_inf(value: float, denominator: float) -> float:
+    """Return deterministic non-negative ratio with explicit zero-denominator behavior."""
+
+    if denominator == 0.0:
+        return float("inf") if value > 0.0 else 0.0
+    return value / denominator
+
+
+def _signed_ratio_or_inf(value: float, denominator: float) -> float:
+    """Return deterministic signed ratio with explicit zero-denominator behavior."""
+
+    if denominator == 0.0:
+        if value == 0.0:
+            return 0.0
+        return float("inf") if value > 0.0 else float("-inf")
+    return value / denominator

--- a/tests/portfolio/test_contract.py
+++ b/tests/portfolio/test_contract.py
@@ -1,0 +1,27 @@
+"""Contract tests for portfolio framework."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from engine.portfolio_framework.contract import PortfolioPosition, PortfolioState
+
+
+def test_portfolio_state_is_immutable() -> None:
+    """PortfolioState must be an immutable dataclass."""
+    state = PortfolioState(
+        account_equity=1000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="strategy-a",
+                symbol="BTCUSDT",
+                quantity=1.0,
+                mark_price=25000.0,
+            ),
+        ),
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        state.account_equity = 1200.0  # type: ignore[misc]

--- a/tests/portfolio/test_exposure_aggregator.py
+++ b/tests/portfolio/test_exposure_aggregator.py
@@ -1,0 +1,168 @@
+"""Acceptance tests for deterministic portfolio exposure aggregation."""
+
+from __future__ import annotations
+
+from engine.portfolio_framework.contract import PortfolioPosition, PortfolioState
+from engine.portfolio_framework.exposure_aggregator import aggregate_portfolio_exposure
+
+
+def test_multi_strategy_aggregation_with_shared_symbol() -> None:
+    """Verify strategy-level aggregates and shared-symbol aggregation."""
+    state = PortfolioState(
+        account_equity=1000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="strategy-b",
+                symbol="BTCUSDT",
+                quantity=1.0,
+                mark_price=100.0,
+            ),
+            PortfolioPosition(
+                strategy_id="strategy-a",
+                symbol="BTCUSDT",
+                quantity=-2.0,
+                mark_price=100.0,
+            ),
+            PortfolioPosition(
+                strategy_id="strategy-a",
+                symbol="ETHUSDT",
+                quantity=3.0,
+                mark_price=50.0,
+            ),
+        ),
+    )
+
+    summary = aggregate_portfolio_exposure(state)
+
+    assert [item.strategy_id for item in summary.strategy_exposures] == [
+        "strategy-a",
+        "strategy-b",
+    ]
+    assert summary.strategy_exposures[0].total_absolute_notional == 350.0
+    assert summary.strategy_exposures[0].net_notional == -50.0
+    assert summary.strategy_exposures[0].gross_exposure_pct == 0.35
+    assert summary.strategy_exposures[0].net_exposure_pct == -0.05
+
+    assert summary.strategy_exposures[1].total_absolute_notional == 100.0
+    assert summary.strategy_exposures[1].net_notional == 100.0
+    assert summary.strategy_exposures[1].gross_exposure_pct == 0.1
+    assert summary.strategy_exposures[1].net_exposure_pct == 0.1
+
+    assert [item.symbol for item in summary.symbol_exposures] == ["BTCUSDT", "ETHUSDT"]
+    assert summary.symbol_exposures[0].total_absolute_notional == 300.0
+    assert summary.symbol_exposures[0].net_notional == -100.0
+    assert summary.symbol_exposures[1].total_absolute_notional == 150.0
+    assert summary.symbol_exposures[1].net_notional == 150.0
+
+
+def test_multi_symbol_aggregation_verifies_global_account_metrics() -> None:
+    """Verify symbol-level and global account aggregation."""
+    state = PortfolioState(
+        account_equity=2000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="SOLUSDT",
+                quantity=10.0,
+                mark_price=20.0,
+            ),
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="ADAUSDT",
+                quantity=100.0,
+                mark_price=1.0,
+            ),
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="ADAUSDT",
+                quantity=-40.0,
+                mark_price=1.0,
+            ),
+        ),
+    )
+
+    summary = aggregate_portfolio_exposure(state)
+
+    assert summary.total_absolute_notional == 340.0
+    assert summary.net_notional == 260.0
+    assert summary.gross_exposure_pct == 0.17
+    assert summary.net_exposure_pct == 0.13
+
+    assert [item.symbol for item in summary.symbol_exposures] == ["ADAUSDT", "SOLUSDT"]
+    assert summary.symbol_exposures[0].total_absolute_notional == 140.0
+    assert summary.symbol_exposures[0].net_notional == 60.0
+    assert summary.symbol_exposures[1].total_absolute_notional == 200.0
+    assert summary.symbol_exposures[1].net_notional == 200.0
+
+
+def test_aggregate_portfolio_exposure_output_is_deterministic() -> None:
+    """Deterministic ordering and values across identical calls."""
+    state = PortfolioState(
+        account_equity=5000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="strategy-c",
+                symbol="SOLUSDT",
+                quantity=3.0,
+                mark_price=20.0,
+            ),
+            PortfolioPosition(
+                strategy_id="strategy-a",
+                symbol="ADAUSDT",
+                quantity=10.0,
+                mark_price=1.0,
+            ),
+            PortfolioPosition(
+                strategy_id="strategy-b",
+                symbol="BTCUSDT",
+                quantity=-0.1,
+                mark_price=30000.0,
+            ),
+        ),
+    )
+
+    summary_a = aggregate_portfolio_exposure(state)
+    summary_b = aggregate_portfolio_exposure(state)
+
+    assert summary_a == summary_b
+    assert [
+        (item.strategy_id, item.symbol, item.quantity, item.mark_price)
+        for item in summary_a.position_exposures
+    ] == [
+        ("strategy-a", "ADAUSDT", 10.0, 1.0),
+        ("strategy-b", "BTCUSDT", -0.1, 30000.0),
+        ("strategy-c", "SOLUSDT", 3.0, 20.0),
+    ]
+
+
+def test_aggregate_portfolio_exposure_handles_zero_equity_deterministically() -> None:
+    """Zero-equity output is deterministic and explicit."""
+    state = PortfolioState(
+        account_equity=0.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="strategy-a",
+                symbol="XRPUSDT",
+                quantity=50.0,
+                mark_price=0.5,
+            ),
+            PortfolioPosition(
+                strategy_id="strategy-b",
+                symbol="BTCUSDT",
+                quantity=-1.0,
+                mark_price=10.0,
+            ),
+        ),
+    )
+
+    summary = aggregate_portfolio_exposure(state)
+
+    assert summary.total_absolute_notional == 35.0
+    assert summary.net_notional == 15.0
+    assert summary.gross_exposure_pct == float("inf")
+    assert summary.net_exposure_pct == float("inf")
+
+    assert summary.strategy_exposures[0].net_exposure_pct == float("inf")
+    assert summary.strategy_exposures[1].net_exposure_pct == float("-inf")
+    assert summary.symbol_exposures[0].gross_exposure_pct == float("inf")
+    assert summary.position_exposures[0].exposure_pct == float("inf")

--- a/tests/portfolio/test_imports.py
+++ b/tests/portfolio/test_imports.py
@@ -1,0 +1,49 @@
+"""Import and boundary tests for portfolio framework modules."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+MODULES = [
+    "engine.portfolio_framework",
+    "engine.portfolio_framework.contract",
+    "engine.portfolio_framework.exposure_aggregator",
+]
+
+FORBIDDEN_PREFIXES = (
+    "engine.execution",
+    "engine.orchestrator",
+    "engine.broker",
+)
+
+
+def test_import_portfolio_framework_modules() -> None:
+    """Each portfolio framework module should import without side effects."""
+    for module_name in MODULES:
+        __import__(module_name)
+
+
+def _imported_module_names(node: ast.AST) -> list[str]:
+    """Return normalized imported module names for import nodes."""
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        return [node.module] if node.module else []
+    return []
+
+
+def test_portfolio_framework_import_boundary() -> None:
+    """Portfolio framework package must not import forbidden runtime packages."""
+    root = Path(__file__).resolve().parents[2]
+    package_dir = root / "engine" / "portfolio_framework"
+
+    for path in package_dir.glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            for module_name in _imported_module_names(node):
+                assert not module_name.startswith(FORBIDDEN_PREFIXES), (
+                    f"Forbidden import '{module_name}' found in {path}"
+                )


### PR DESCRIPTION
### Motivation

- Introduce a small, pure and deterministic portfolio framework to compute exposure summaries from an immutable portfolio state for Issue #496.

### Description

- Add `engine.portfolio_framework.contract` with immutable dataclasses `PortfolioPosition` and `PortfolioState` to model portfolio input state.
- Implement `engine.portfolio_framework.exposure_aggregator` which computes `PositionExposure`, `StrategyExposure`, `SymbolExposure`, and `PortfolioExposureSummary` along with `aggregate_portfolio_exposure` and deterministic helper functions, including explicit zero-equity behavior.
- Export the public API via `engine.portfolio_framework.__init__` to expose the main types and `aggregate_portfolio_exposure`.
- Add import-boundary tests to ensure the package has no forbidden runtime imports and acceptance tests that validate deterministic ordering, aggregation math, and zero-equity handling.

### Testing

- Run `tests/portfolio/test_contract.py` to verify immutability of `PortfolioState`, and it passed.
- Run `tests/portfolio/test_exposure_aggregator.py` to validate multi-strategy/symbol aggregation, deterministic outputs, and zero-equity handling, and it passed.
- Run `tests/portfolio/test_imports.py` to confirm modules import cleanly and enforce import boundaries, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e9411f3c833384feae6f9cac7d2f)