### PR TITLE
test(portfolio): add full portfolio enforcement suite

### DIFF
--- a/tests/portfolio/test_full_portfolio_enforcement.py
+++ b/tests/portfolio/test_full_portfolio_enforcement.py
@@ -1,0 +1,216 @@
+"""Full portfolio enforcement suite for deterministic allocation behavior."""
+
+from __future__ import annotations
+
+from engine.portfolio_framework.capital_allocation_policy import (
+    CapitalAllocationRules,
+    StrategyAllocationRule,
+    assess_capital_allocation,
+)
+from engine.portfolio_framework.contract import PortfolioPosition, PortfolioState
+from engine.portfolio_framework.exposure_aggregator import aggregate_portfolio_exposure
+
+
+def test_enforcement_approval_case() -> None:
+    state = PortfolioState(
+        account_equity=1_000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                quantity=1.0,
+                mark_price=100.0,
+            ),
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="ETHUSDT",
+                quantity=2.0,
+                mark_price=50.0,
+            ),
+        ),
+    )
+    rules = CapitalAllocationRules(
+        global_capital_cap_pct=0.25,
+        strategy_rules=(
+            StrategyAllocationRule(
+                strategy_id="alpha",
+                capital_cap_pct=0.15,
+                allocation_score=1.0,
+            ),
+            StrategyAllocationRule(
+                strategy_id="beta",
+                capital_cap_pct=0.15,
+                allocation_score=1.0,
+            ),
+        ),
+    )
+
+    assessment = assess_capital_allocation(state, rules)
+
+    assert assessment.approved
+    assert assessment.reasons == ()
+
+
+def test_enforcement_global_cap_rejection() -> None:
+    state = PortfolioState(
+        account_equity=1_000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                quantity=3.0,
+                mark_price=100.0,
+            ),
+        ),
+    )
+    rules = CapitalAllocationRules(
+        global_capital_cap_pct=0.2,
+        strategy_rules=(
+            StrategyAllocationRule(
+                strategy_id="alpha",
+                capital_cap_pct=0.5,
+                allocation_score=1.0,
+            ),
+        ),
+    )
+
+    assessment = assess_capital_allocation(state, rules)
+
+    assert not assessment.approved
+    assert assessment.reasons[0].startswith("global_cap_exceeded")
+
+
+def test_enforcement_strategy_cap_rejection() -> None:
+    state = PortfolioState(
+        account_equity=1_000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                quantity=2.0,
+                mark_price=100.0,
+            ),
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="SOLUSDT",
+                quantity=1.0,
+                mark_price=100.0,
+            ),
+        ),
+    )
+    rules = CapitalAllocationRules(
+        global_capital_cap_pct=0.5,
+        strategy_rules=(
+            StrategyAllocationRule(
+                strategy_id="alpha",
+                capital_cap_pct=0.2,
+                allocation_score=1.0,
+            ),
+            StrategyAllocationRule(
+                strategy_id="beta",
+                capital_cap_pct=0.5,
+                allocation_score=4.0,
+            ),
+        ),
+    )
+
+    assessment = assess_capital_allocation(state, rules)
+
+    assert not assessment.approved
+    assert assessment.reasons == ("strategy_cap_exceeded: strategy_id=alpha",)
+
+
+def test_cross_symbol_aggregation_and_enforcement_outcome() -> None:
+    state = PortfolioState(
+        account_equity=1_000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="ADAUSDT",
+                quantity=100.0,
+                mark_price=1.0,
+            ),
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="ADAUSDT",
+                quantity=-40.0,
+                mark_price=1.0,
+            ),
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="SOLUSDT",
+                quantity=5.0,
+                mark_price=20.0,
+            ),
+        ),
+    )
+    rules = CapitalAllocationRules(
+        global_capital_cap_pct=0.25,
+        strategy_rules=(
+            StrategyAllocationRule(
+                strategy_id="alpha",
+                capital_cap_pct=0.25,
+                allocation_score=1.0,
+            ),
+            StrategyAllocationRule(
+                strategy_id="beta",
+                capital_cap_pct=0.25,
+                allocation_score=1.0,
+            ),
+        ),
+    )
+
+    summary = aggregate_portfolio_exposure(state)
+    assessment = assess_capital_allocation(state, rules)
+
+    assert [row.symbol for row in summary.symbol_exposures] == ["ADAUSDT", "SOLUSDT"]
+    assert summary.symbol_exposures[0].total_absolute_notional == 140.0
+    assert summary.symbol_exposures[0].net_notional == 60.0
+    assert summary.symbol_exposures[1].total_absolute_notional == 100.0
+    assert summary.symbol_exposures[1].net_notional == 100.0
+
+    assert not assessment.approved
+    assert assessment.reasons == ("strategy_cap_exceeded: strategy_id=beta",)
+
+
+def test_full_portfolio_enforcement_determinism() -> None:
+    state = PortfolioState(
+        account_equity=2_000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="ETHUSDT",
+                quantity=-1.0,
+                mark_price=200.0,
+            ),
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                quantity=0.5,
+                mark_price=400.0,
+            ),
+        ),
+    )
+    rules = CapitalAllocationRules(
+        global_capital_cap_pct=0.3,
+        strategy_rules=(
+            StrategyAllocationRule(
+                strategy_id="alpha",
+                capital_cap_pct=0.2,
+                allocation_score=2.0,
+            ),
+            StrategyAllocationRule(
+                strategy_id="beta",
+                capital_cap_pct=0.2,
+                allocation_score=1.0,
+            ),
+        ),
+    )
+
+    summary_a = aggregate_portfolio_exposure(state)
+    summary_b = aggregate_portfolio_exposure(state)
+    assessment_a = assess_capital_allocation(state, rules)
+    assessment_b = assess_capital_allocation(state, rules)
+
+    assert summary_a == summary_b
+    assert assessment_a == assessment_b

--- a/tests/portfolio/test_imports.py
+++ b/tests/portfolio/test_imports.py
@@ -20,6 +20,12 @@ FORBIDDEN_PREFIXES = (
 )
 
 
+DYNAMIC_IMPORT_FUNCTIONS = {
+    "importlib.import_module",
+    "__import__",
+}
+
+
 def test_import_portfolio_framework_modules() -> None:
     """Each portfolio framework module should import without side effects."""
     for module_name in MODULES:
@@ -35,6 +41,29 @@ def _imported_module_names(node: ast.AST) -> list[str]:
     return []
 
 
+def _dynamic_import_target(node: ast.AST) -> str | None:
+    """Return dynamic import target when found, else None."""
+    if not isinstance(node, ast.Call):
+        return None
+
+    if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+        callable_name = f"{node.func.value.id}.{node.func.attr}"
+    elif isinstance(node.func, ast.Name):
+        callable_name = node.func.id
+    else:
+        return None
+
+    if callable_name not in DYNAMIC_IMPORT_FUNCTIONS:
+        return None
+
+    if not node.args or not isinstance(node.args[0], ast.Constant):
+        return None
+    if not isinstance(node.args[0].value, str):
+        return None
+
+    return node.args[0].value
+
+
 def test_portfolio_framework_import_boundary() -> None:
     """Portfolio framework package must not import forbidden runtime packages."""
     root = Path(__file__).resolve().parents[2]
@@ -47,4 +76,10 @@ def test_portfolio_framework_import_boundary() -> None:
             for module_name in _imported_module_names(node):
                 assert not module_name.startswith(FORBIDDEN_PREFIXES), (
                     f"Forbidden import '{module_name}' found in {path}"
+                )
+
+            dynamic_target = _dynamic_import_target(node)
+            if dynamic_target is not None:
+                assert not dynamic_target.startswith(FORBIDDEN_PREFIXES), (
+                    f"Forbidden dynamic import '{dynamic_target}' found in {path}"
                 )


### PR DESCRIPTION
### Motivation
- Provide a deterministic, non-invasive test suite that validates full portfolio capital-allocation enforcement (approval, global cap, strategy cap, cross-symbol aggregation and enforcement outcome, and determinism). 
- Harden import-boundary checks to prevent import-based execution bypasses by detecting common dynamic import call sites.

### Description
- Add `tests/portfolio/test_full_portfolio_enforcement.py` with tests covering approval case, global-cap rejection, strategy-cap rejection, cross-symbol aggregation plus enforcement outcome, and determinism guarantees.
- Extend `tests/portfolio/test_imports.py` to statically analyze and assert against dynamic import calls (`importlib.import_module` and `__import__`) that reference forbidden runtime prefixes.
- Changes are tests-only and follow deterministic, no-IO assertions and the existing import/boundary testing pattern.

### Testing
- Installed coverage tooling via `python -m pip install pytest-cov`.
- Ran `pytest tests/portfolio -q --cov=engine/portfolio_framework --cov-report=term-missing --cov-fail-under=95` and achieved successful results with all portfolio tests passing.
- Final automated run reported `16 passed` and coverage `98.69%`, exceeding the `95%` threshold.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f141d178833399ee06c78d9594e5)