### PR TITLE
docs(risk): declare portfolio framework architectural boundary

### DIFF
--- a/docs/risk/portfolio_framework.md
+++ b/docs/risk/portfolio_framework.md
@@ -1,0 +1,87 @@
+# Portfolio Framework – Architectural Boundary Declaration
+
+## 1. Purpose
+
+The portfolio framework is the deterministic aggregation and capital allocation boundary for portfolio-level controls.
+
+Its purpose is to:
+- Aggregate exposures across strategies in a deterministic manner.
+- Enforce portfolio-level capital allocation constraints.
+- Provide predictable, repeatable outcomes for identical inputs.
+
+## 2. Scope
+
+The portfolio framework scope is explicitly limited to:
+
+- **Exposure aggregation**
+  - Deterministic aggregation of exposure inputs across participating strategies and positions.
+- **Capital allocation enforcement**
+  - Deterministic enforcement of cross-strategy capital limits, caps, and allocation constraints.
+- **Deterministic behavior**
+  - All outputs are fully determined by provided inputs and configuration.
+- **Pure-function constraint**
+  - Computation is implemented as pure transformations with no side effects.
+
+## 3. Non-Goals (Out of Scope)
+
+The following areas are explicitly out of scope for the portfolio framework:
+
+- Trading logic
+- Broker integration
+- Optimization theory
+- Execution integration
+- Live rebalancing
+- RiskEvaluator override
+
+## 4. Architectural Boundary
+
+The portfolio framework boundary is defined as follows:
+
+- The portfolio framework is a standalone module.
+- It operates above request-level risk enforcement.
+- It does not call execution or broker layers.
+- It must remain import-safe and side-effect free.
+
+## 5. Import Direction Rules
+
+Import direction is constrained by the following rules:
+
+- `engine.portfolio_framework` **MAY** import:
+  - Python standard library (`stdlib`)
+  - `engine.portfolio_framework.*`
+
+- `engine.portfolio_framework` **MUST NOT** import:
+  - `engine.execution`
+  - `engine.orchestrator`
+  - `engine.broker`
+  - `src.*`
+
+- Higher layers **MAY** depend on `engine.portfolio_framework`.
+
+## 6. Relationship to Risk Framework
+
+The relationship between frameworks is defined as:
+
+- The risk framework enforces per-request constraints.
+- The portfolio framework enforces cross-strategy capital caps.
+- No bidirectional dependency is permitted.
+
+## 7. Determinism Guarantees
+
+The portfolio framework must satisfy all determinism guarantees below:
+
+- No global state.
+- No IO.
+- No time-dependence.
+- No randomness.
+- Stable ordering guarantees.
+- Equal input → equal output.
+
+## 8. Guardrails
+
+The following guardrails are mandatory:
+
+- Pure functions only.
+- Immutable contracts.
+- Coverage expectations are defined and maintained for framework behavior.
+- Enforcement must be test-verified.


### PR DESCRIPTION
### Motivation

- Closes #499 by adding a governance artifact that declares the portfolio framework as the deterministic aggregation and capital-allocation boundary.
- The change documents explicit scope, non-goals, architectural boundaries, import rules, relationship to the risk framework, determinism guarantees, and guardrails required for the module.

### Description

- Add `docs/risk/portfolio_framework.md` containing the full "Portfolio Framework – Architectural Boundary Declaration" with sections: Purpose, Scope, Non-Goals, Architectural Boundary, Import Direction Rules, Relationship to Risk Framework, Determinism Guarantees, and Guardrails.
- The file enforces import and dependency rules (what `engine.portfolio_framework` may and must not import) and restates pure-function and immutability constraints for the module.
- No code changes outside `docs/risk/portfolio_framework.md` were made and the file was committed to the repository.

### Testing

- Ran `sed -n '1,260p' docs/risk/portfolio_framework.md` to verify file contents, which completed successfully.
- Ran `git status --short` to confirm working tree state, which completed successfully.
- Ran `git add docs/risk/portfolio_framework.md && git commit -m "docs(risk): add portfolio framework boundary declaration"` to record the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f47fb54083338d9ac6f0ac203b34)