### PR TITLE
P29-QUALITY: Add full deterministic decision trace test suite

### DIFF
--- a/tests/journal/test_decision_trace.py
+++ b/tests/journal/test_decision_trace.py
@@ -6,6 +6,7 @@ import ast
 import pathlib
 
 from engine.journal_framework import generate_decision_trace
+from engine.journal_framework.decision_trace import _canonicalize, _deep_freeze
 from engine.portfolio_framework.capital_allocation_policy import (
     CapitalAllocationRules,
     StrategyAllocationRule,
@@ -16,19 +17,23 @@ from engine.portfolio_framework.exposure_aggregator import aggregate_portfolio_e
 
 
 
-def _build_exposure_and_allocation(*, tweak: bool = False):
+def _build_exposure_and_allocation(*, tweak: bool = False, reorder_positions: bool = False):
+    positions = [
+        PortfolioPosition(strategy_id="s1", symbol="BTC-USD", quantity=1.0, mark_price=100.0),
+        PortfolioPosition(strategy_id="s2", symbol="ETH-USD", quantity=-2.0, mark_price=50.0),
+        PortfolioPosition(
+            strategy_id="s1" if not tweak else "s3",
+            symbol="SOL-USD",
+            quantity=3.0,
+            mark_price=10.0,
+        ),
+    ]
+    if reorder_positions:
+        positions = [positions[2], positions[0], positions[1]]
+
     state = PortfolioState(
         account_equity=1000.0,
-        positions=(
-            PortfolioPosition(strategy_id="s1", symbol="BTC-USD", quantity=1.0, mark_price=100.0),
-            PortfolioPosition(strategy_id="s2", symbol="ETH-USD", quantity=-2.0, mark_price=50.0),
-            PortfolioPosition(
-                strategy_id="s1" if not tweak else "s3",
-                symbol="SOL-USD",
-                quantity=3.0,
-                mark_price=10.0,
-            ),
-        ),
+        positions=tuple(positions),
     )
     rules = CapitalAllocationRules(
         global_capital_cap_pct=0.5,
@@ -68,13 +73,37 @@ def test_generate_decision_trace_is_deterministic() -> None:
 
 
 
-def test_snapshot_equality_is_stable() -> None:
+def test_identical_inputs_produce_identical_exposure_allocation_and_trace() -> None:
     exposure_a, allocation_a = _build_exposure_and_allocation()
     exposure_b, allocation_b = _build_exposure_and_allocation()
+    context_a = {"market_regime": "range", "params": [1, 2, 3], "nested": {"b": 2, "a": 1}}
+    context_b = {"nested": {"a": 1, "b": 2}, "params": [1, 2, 3], "market_regime": "range"}
+
+    trace_a = generate_decision_trace(
+        exposure=exposure_a,
+        allocation=allocation_a,
+        decision_context=context_a,
+    )
+    trace_b = generate_decision_trace(
+        exposure=exposure_b,
+        allocation=allocation_b,
+        decision_context=context_b,
+    )
+
+    assert exposure_a == exposure_b
+    assert allocation_a == allocation_b
+    assert trace_a == trace_b
+
+
+
+def test_snapshot_reproducible_with_different_position_ordering() -> None:
+    exposure_a, allocation_a = _build_exposure_and_allocation(reorder_positions=False)
+    exposure_b, allocation_b = _build_exposure_and_allocation(reorder_positions=True)
 
     trace_a = generate_decision_trace(exposure=exposure_a, allocation=allocation_a)
     trace_b = generate_decision_trace(exposure=exposure_b, allocation=allocation_b)
 
+    assert trace_a.trace_id == trace_b.trace_id
     assert trace_a == trace_b
 
 
@@ -90,18 +119,44 @@ def test_cross_strategy_generates_distinct_trace_ids() -> None:
 
 
 
-def test_generate_decision_trace_has_no_side_effects(monkeypatch) -> None:
+def test_generate_decision_trace_has_no_runtime_side_effects(monkeypatch) -> None:
     def _forbidden(*_args, **_kwargs):
         raise AssertionError("non-deterministic function should not be called")
 
     monkeypatch.setattr("time.time", _forbidden)
     monkeypatch.setattr("random.random", _forbidden)
+    monkeypatch.setattr("builtins.open", _forbidden)
 
     exposure, allocation = _build_exposure_and_allocation()
 
     trace = generate_decision_trace(exposure=exposure, allocation=allocation)
 
     assert len(trace.trace_id) == 64
+
+
+
+def test_context_is_frozen_and_default_context_is_empty_mapping() -> None:
+    exposure, allocation = _build_exposure_and_allocation()
+
+    trace = generate_decision_trace(exposure=exposure, allocation=allocation, decision_context=None)
+
+    assert dict(trace.decision_context) == {}
+
+
+
+def test_deep_freeze_and_canonicalize_cover_container_variants() -> None:
+    input_value = {
+        "z": [3, {"k2": 2, "k1": 1}],
+        "a": (1, 2),
+    }
+
+    frozen = _deep_freeze(input_value)
+    canonical = _canonicalize(frozen)
+
+    assert list(frozen.keys()) == ["a", "z"]
+    assert frozen["a"] == (1, 2)
+    assert frozen["z"][1]["k1"] == 1
+    assert canonical == {"a": [1, 2], "z": [3, {"k1": 1, "k2": 2}]}
 
 
 


### PR DESCRIPTION
### Motivation
- Ensure the journal decision trace generation is fully deterministic and free of runtime side-effects, and that snapshots are reproducible across input-ordering variations.

### Description
- Add and extend tests in `tests/journal/test_decision_trace.py` to verify identical inputs produce identical exposure/allocation/trace outputs, and that different input ordering yields the same snapshot.
- Harden side-effect checks by monkeypatching `time.time`, `random.random`, and `builtins.open` to raise if called during trace generation.
- Add direct unit coverage for `_deep_freeze` and `_canonicalize` behaviors and retain the AST import-boundary guard for `engine/journal_framework` modules.
- Modified file: `tests/journal/test_decision_trace.py`.

### Testing
- Installed coverage plugin via `pip install pytest-cov` to enable coverage collection for the run.
- Ran `pytest tests/journal -q --cov=engine/journal_framework --cov-report=term-missing --cov-fail-under=95` and observed all tests pass with required coverage (8 passed, total coverage 97.78%, `engine/journal_framework/decision_trace.py` 98%).

Closes #505

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a60071f0ec8333bf0ebd743eff1597)