### PR TITLE
Align CI and repo to Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Summary
- Updated GitHub Actions CI to use Python 3.12 explicitly via `actions/setup-python`.
- Kept repository Python requirement as-is in `pyproject.toml` (already `>=3.12`).
- No additional CI steps or unrelated changes were introduced.

Testing
- Ran `pytest -q tests/test_smoke_run.py` locally and it passed.
- CI will run the existing smoke-run contract test job on Python 3.12.

Closes #511

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72d608c048333a885880fdf709989)