### PR TITLE
Run pytest with --import-mode=importlib in CI smoke-run job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
           python -m pip install pytest
 
       - name: Run smoke-run contract tests
-        run: python -m pytest tests/test_smoke_run.py
+        run: python -m pytest --import-mode=importlib


### PR DESCRIPTION
### Motivation
- Make test discovery and imports more robust in the CI smoke-run contract job to avoid import-related failures under newer Python environments.

### Description
- Updated the GitHub Actions CI step to run `python -m pytest --import-mode=importlib` instead of invoking a single test file directly to rely on pytest's importlib import mode and full test discovery.

### Testing
- The smoke-run contract tests are executed by the CI workflow using `python -m pytest --import-mode=importlib` and completed successfully in the validation run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7329e6f5c8333b4a61c7a85733a00)