### PR TITLE
Implement deterministic global kill switch guard

### DIFF
--- a/engine/compliance/kill_switch.py
+++ b/engine/compliance/kill_switch.py
@@ -1,0 +1,22 @@
+"""Deterministic global kill switch state utilities."""
+
+from __future__ import annotations
+
+
+_KILL_SWITCH_KEY = "execution.kill_switch.active"
+
+
+def is_kill_switch_active(*, config: dict[str, object] | None = None) -> bool:
+    """Return deterministic global kill switch state.
+
+    Args:
+        config: Optional in-process configuration dictionary.
+
+    Returns:
+        bool: True only when the explicit kill-switch key is set to ``True``.
+    """
+
+    if config is None:
+        return False
+
+    return config.get(_KILL_SWITCH_KEY) is True

--- a/engine/orchestrator/__init__.py
+++ b/engine/orchestrator/__init__.py
@@ -1,0 +1,13 @@
+"""Orchestrator package for deterministic execution gating."""
+
+from engine.orchestrator.runtime import (
+    ExecutionBlockedError,
+    ExecutionRequest,
+    execute_request,
+)
+
+__all__ = [
+    "ExecutionBlockedError",
+    "ExecutionRequest",
+    "execute_request",
+]

--- a/engine/orchestrator/runtime.py
+++ b/engine/orchestrator/runtime.py
@@ -1,0 +1,42 @@
+"""Deterministic orchestrator entrypoint with compliance gating."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from engine.compliance.kill_switch import is_kill_switch_active
+
+
+class ExecutionBlockedError(RuntimeError):
+    """Raised when execution is blocked by a deterministic compliance gate."""
+
+
+@dataclass(frozen=True)
+class ExecutionRequest:
+    """Input contract for orchestrator execution attempts."""
+
+    strategy_id: str
+    symbol: str
+    quantity: float
+
+
+ExecutionAdapter = Callable[[ExecutionRequest], Any]
+
+
+def execute_request(
+    request: ExecutionRequest,
+    *,
+    execute_adapter: ExecutionAdapter,
+    config: dict[str, object] | None = None,
+) -> Any:
+    """Execute a request unless blocked by the global kill switch.
+
+    The compliance gate is evaluated before the adapter is called.
+    """
+
+    if is_kill_switch_active(config=config):
+        raise ExecutionBlockedError("blocked: global_kill_switch_active")
+
+    return execute_adapter(request)

--- a/tests/compliance/test_kill_switch.py
+++ b/tests/compliance/test_kill_switch.py
@@ -1,0 +1,56 @@
+"""Tests for deterministic global kill switch orchestration guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.orchestrator.runtime import (
+    ExecutionBlockedError,
+    ExecutionRequest,
+    execute_request,
+)
+
+
+def _request() -> ExecutionRequest:
+    return ExecutionRequest(strategy_id="strategy-a", symbol="AAPL", quantity=1.0)
+
+
+def test_execution_blocked_when_kill_switch_active() -> None:
+    adapter_called = False
+
+    def _adapter(_: ExecutionRequest) -> dict[str, object]:
+        nonlocal adapter_called
+        adapter_called = True
+        return {"status": "executed"}
+
+    with pytest.raises(ExecutionBlockedError, match="global_kill_switch_active"):
+        execute_request(
+            _request(),
+            execute_adapter=_adapter,
+            config={"execution.kill_switch.active": True},
+        )
+
+    assert adapter_called is False
+
+
+def test_execution_proceeds_when_kill_switch_inactive() -> None:
+    adapter_called = False
+
+    def _adapter(request: ExecutionRequest) -> dict[str, object]:
+        nonlocal adapter_called
+        adapter_called = True
+        return {
+            "status": "executed",
+            "strategy_id": request.strategy_id,
+            "symbol": request.symbol,
+            "quantity": request.quantity,
+        }
+
+    result = execute_request(
+        _request(),
+        execute_adapter=_adapter,
+        config={"execution.kill_switch.active": False},
+    )
+
+    assert adapter_called is True
+    assert result["status"] == "executed"


### PR DESCRIPTION
### Motivation
- Provide a deterministic, in-process global kill switch to safely disable execution without external systems or time dependencies.
- Ensure the orchestrator enforces the kill switch before any execution adapter is invoked so execution cannot bypass compliance gates.
- Keep behavior simple and deterministic (explicit config key, default safe state) to satisfy safety and determinism constraints for the engine.

### Description
- Add a deterministic state lookup `is_kill_switch_active` that reads the explicit config key `"execution.kill_switch.active"` and defaults to `False` when unset in `engine/compliance/kill_switch.py`.
- Implement an orchestrator entrypoint `execute_request` that evaluates the kill switch before calling the adapter and raises a domain error `ExecutionBlockedError` with message `"blocked: global_kill_switch_active"` when active in `engine/orchestrator/runtime.py`.
- Introduce `ExecutionRequest` contract and `ExecutionAdapter` type for the orchestrator API surface and export them in `engine/orchestrator/__init__.py`.
- Add deterministic unit tests in `tests/compliance/test_kill_switch.py` that assert execution is blocked when the kill switch is active and that execution proceeds (adapter called) when inactive.

### Testing
- Ran `pytest -q tests/compliance/test_kill_switch.py` and the two tests passed.
- Ran `pytest -q tests/risk/test_imports.py` and `pytest -q tests/portfolio/test_imports.py` to validate import boundaries and both passed.
- All invoked automated tests completed successfully (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85cff25508333a4b779fc0db7ab77)