### PR TITLE
Add daily loss guard enforcement

### DIFF
--- a/engine/compliance/daily_loss_guard.py
+++ b/engine/compliance/daily_loss_guard.py
@@ -1,0 +1,49 @@
+"""Deterministic daily loss shutdown guard utilities."""
+
+from __future__ import annotations
+
+from engine.portfolio import PortfolioState
+
+
+_DAILY_LOSS_LIMIT_KEY = "execution.daily_loss.max_abs"
+
+
+def configured_daily_loss_limit(*, config: dict[str, object] | None) -> float | None:
+    """Return configured max daily loss in absolute portfolio currency."""
+    if config is None:
+        return None
+
+    value = config.get(_DAILY_LOSS_LIMIT_KEY)
+    if not isinstance(value, int | float):
+        return None
+
+    limit = float(value)
+    if limit < 0.0:
+        return None
+
+    return limit
+
+
+def is_daily_loss_limit_breached(
+    *,
+    portfolio_state: PortfolioState,
+    max_daily_loss: float,
+) -> bool:
+    """Return True when daily loss strictly exceeds max allowed loss."""
+    return portfolio_state.daily_loss() > max_daily_loss
+
+
+def should_block_execution_for_daily_loss(
+    *,
+    portfolio_state: PortfolioState,
+    config: dict[str, object] | None = None,
+) -> bool:
+    """Return deterministic execution block state for daily loss guard."""
+    daily_loss_limit = configured_daily_loss_limit(config=config)
+    if daily_loss_limit is None:
+        return False
+
+    return is_daily_loss_limit_breached(
+        portfolio_state=portfolio_state,
+        max_daily_loss=daily_loss_limit,
+    )

--- a/engine/portfolio/__init__.py
+++ b/engine/portfolio/__init__.py
@@ -1,5 +1,5 @@
-"""Portfolio state utilities for deterministic drawdown-aware controls."""
+"""Portfolio state utilities for deterministic risk controls."""
 
-from engine.portfolio.state import PortfolioState, calculate_drawdown
+from engine.portfolio.state import PortfolioState, calculate_daily_pnl, calculate_drawdown
 
-__all__ = ["PortfolioState", "calculate_drawdown"]
+__all__ = ["PortfolioState", "calculate_drawdown", "calculate_daily_pnl"]

--- a/engine/portfolio/state.py
+++ b/engine/portfolio/state.py
@@ -1,4 +1,4 @@
-"""Portfolio state and drawdown calculation utilities."""
+"""Portfolio state, drawdown and daily PnL calculation utilities."""
 
 from __future__ import annotations
 
@@ -12,10 +12,12 @@ class PortfolioState:
     Attributes:
         peak_equity: Highest observed portfolio equity in the active window.
         current_equity: Current portfolio equity.
+        start_of_day_equity: Equity snapshot at start of trading day.
     """
 
     peak_equity: float
     current_equity: float
+    start_of_day_equity: float | None = None
 
     def drawdown(self) -> float:
         """Return current drawdown as a ratio in [0.0, 1.0]."""
@@ -23,6 +25,24 @@ class PortfolioState:
             peak_equity=self.peak_equity,
             current_equity=self.current_equity,
         )
+
+    def daily_pnl(self) -> float:
+        """Return daily PnL based on start-of-day and current equity."""
+        if self.start_of_day_equity is None:
+            return 0.0
+
+        return calculate_daily_pnl(
+            start_of_day_equity=self.start_of_day_equity,
+            current_equity=self.current_equity,
+        )
+
+    def daily_loss(self) -> float:
+        """Return non-negative realized daily loss amount."""
+        pnl = self.daily_pnl()
+        if pnl >= 0.0:
+            return 0.0
+
+        return -pnl
 
 
 def calculate_drawdown(*, peak_equity: float, current_equity: float) -> float:
@@ -41,3 +61,8 @@ def calculate_drawdown(*, peak_equity: float, current_equity: float) -> float:
         return 0.0
 
     return raw_drawdown
+
+
+def calculate_daily_pnl(*, start_of_day_equity: float, current_equity: float) -> float:
+    """Calculate daily PnL from start-of-day and current equity."""
+    return current_equity - start_of_day_equity

--- a/engine/portfolio/test_daily_loss_guard.py
+++ b/engine/portfolio/test_daily_loss_guard.py
@@ -1,0 +1,69 @@
+"""Deterministic tests for daily loss shutdown guard (Issue #522)."""
+
+from __future__ import annotations
+
+from engine.compliance.daily_loss_guard import (
+    configured_daily_loss_limit,
+    should_block_execution_for_daily_loss,
+)
+from engine.portfolio.state import PortfolioState, calculate_daily_pnl
+
+
+def test_calculate_daily_pnl_deterministic_scenario() -> None:
+    assert calculate_daily_pnl(start_of_day_equity=100_000.0, current_equity=98_500.0) == -1_500.0
+    assert calculate_daily_pnl(start_of_day_equity=100_000.0, current_equity=101_250.0) == 1_250.0
+
+
+def test_guard_blocks_execution_when_daily_loss_limit_exceeded() -> None:
+    state = PortfolioState(
+        peak_equity=110_000.0,
+        start_of_day_equity=100_000.0,
+        current_equity=98_900.0,
+    )
+
+    blocked = should_block_execution_for_daily_loss(
+        portfolio_state=state,
+        config={"execution.daily_loss.max_abs": 1_000.0},
+    )
+
+    assert blocked is True
+
+
+def test_guard_does_not_block_when_daily_loss_limit_not_exceeded() -> None:
+    state = PortfolioState(
+        peak_equity=110_000.0,
+        start_of_day_equity=100_000.0,
+        current_equity=99_000.0,
+    )
+
+    blocked = should_block_execution_for_daily_loss(
+        portfolio_state=state,
+        config={"execution.daily_loss.max_abs": 1_000.0},
+    )
+
+    assert blocked is False
+
+
+def test_invalid_or_missing_daily_loss_limit_does_not_activate_guard() -> None:
+    state = PortfolioState(
+        peak_equity=110_000.0,
+        start_of_day_equity=100_000.0,
+        current_equity=98_000.0,
+    )
+
+    assert configured_daily_loss_limit(config=None) is None
+    assert configured_daily_loss_limit(config={}) is None
+    assert configured_daily_loss_limit(config={"execution.daily_loss.max_abs": "1000"}) is None
+    assert configured_daily_loss_limit(config={"execution.daily_loss.max_abs": -1.0}) is None
+    assert should_block_execution_for_daily_loss(portfolio_state=state, config=None) is False
+
+
+def test_missing_start_of_day_equity_does_not_trigger_block() -> None:
+    state = PortfolioState(peak_equity=110_000.0, current_equity=95_000.0)
+
+    blocked = should_block_execution_for_daily_loss(
+        portfolio_state=state,
+        config={"execution.daily_loss.max_abs": 500.0},
+    )
+
+    assert blocked is False


### PR DESCRIPTION
Summary
- add deterministic daily loss tracking helpers and guard to block execution when the configured limit is breached
- expose daily PnL utilities on the portfolio state and add tests covering loss limit enforcement and configuration validation
Testing
- Not run (not requested)