### PR TITLE
test(pytest): use importlib mode and disable cacheprovider to avoid c…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --import-mode=importlib -p no:cacheprovider
 pythonpath =
     .
     src


### PR DESCRIPTION
Closes #523

## What changed

Updated pytest configuration:

pytest.ini
addopts = --import-mode=importlib -p no:cacheprovider

## Why

Fixes pytest collection collisions caused by duplicate test module basenames.

Disables pytest cacheprovider to avoid cache permission issues in the Windows environment.

## Verification

Full test suite:

.\.venv\Scripts\python.exe -m pytest -q

Result:

373 passed, 4 warnings

Emergency guard tests:

.\.venv\Scripts\python.exe -m pytest -q engine/orchestrator/test_emergency_guard.py

Result:

2 passed

## Scope

No changes in engine/**.
Emergency execution guard behavior remains unchanged.