### PR TITLE
P30-ENGINE: Implement Trade Attribution Engine (#541)

### DIFF
--- a/engine/trade_attribution.py
+++ b/engine/trade_attribution.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import Any, Deque, Mapping, Sequence
+
+
+def _signal_action(signal: Mapping[str, object]) -> str:
+    action = signal.get("action")
+    if isinstance(action, str) and action:
+        return action.lower()
+    return "entry"
+
+
+def _signal_sort_key(item: tuple[int, Mapping[str, object]]) -> tuple[str, str, str, int]:
+    index, signal = item
+    timestamp = str(signal.get("timestamp") or "")
+    symbol = str(signal.get("symbol") or "")
+    action = _signal_action(signal)
+    return (timestamp, symbol, action, index)
+
+
+def _signal_reason(signal: Mapping[str, object]) -> str:
+    reasons = signal.get("reasons")
+    if isinstance(reasons, list) and reasons:
+        first_reason = reasons[0]
+        if isinstance(first_reason, Mapping):
+            reason_id = first_reason.get("reason_id")
+            if isinstance(reason_id, str) and reason_id:
+                return reason_id
+
+    confirmation_rule = signal.get("confirmation_rule")
+    if isinstance(confirmation_rule, str) and confirmation_rule:
+        return confirmation_rule
+
+    return "unknown"
+
+
+def _signal_key(signal: Mapping[str, object]) -> tuple[str, str, str, str, str, str, str]:
+    return (
+        str(signal.get("strategy") or ""),
+        str(signal.get("symbol") or ""),
+        str(signal.get("timestamp") or ""),
+        _signal_reason(signal),
+        str(signal.get("timeframe") or ""),
+        str(signal.get("market_type") or "stock"),
+        str(signal.get("data_source") or "yahoo"),
+    )
+
+
+def _trade_key(trade: Mapping[str, object]) -> tuple[str, str, str, str, str, str, str]:
+    return (
+        str(trade.get("strategy") or ""),
+        str(trade.get("symbol") or ""),
+        str(trade.get("entry_date") or ""),
+        str(trade.get("reason_entry") or ""),
+        str(trade.get("timeframe") or ""),
+        str(trade.get("market_type") or "stock"),
+        str(trade.get("data_source") or "yahoo"),
+    )
+
+
+def _trade_sort_key(item: tuple[int, Mapping[str, object]]) -> tuple[str, str, str, str, int]:
+    index, trade = item
+    return (
+        str(trade.get("exit_date") or ""),
+        str(trade.get("entry_date") or ""),
+        str(trade.get("symbol") or ""),
+        str(trade.get("strategy") or ""),
+        index,
+    )
+
+
+def build_trade_attribution(
+    *,
+    trades: Sequence[Mapping[str, object]],
+    signals: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    """Build deterministic attribution linking each trade to its originating signal."""
+    signal_queues: dict[tuple[str, str, str, str, str, str, str], Deque[Mapping[str, object]]] = defaultdict(deque)
+
+    ordered_signals = [signal for _, signal in sorted(enumerate(signals), key=_signal_sort_key)]
+    for signal in ordered_signals:
+        if _signal_action(signal) != "entry":
+            continue
+        signal_queues[_signal_key(signal)].append(signal)
+
+    ordered_trades = [trade for _, trade in sorted(enumerate(trades), key=_trade_sort_key)]
+    attributions: list[dict[str, object]] = []
+
+    for trade in ordered_trades:
+        symbol = str(trade.get("symbol") or "")
+        if symbol == "__SUMMARY__":
+            continue
+        entry_timestamp = trade.get("entry_date")
+        exit_timestamp = trade.get("exit_date")
+        entry_price = trade.get("entry_price")
+        exit_price = trade.get("exit_price")
+        if not isinstance(entry_timestamp, str) or not isinstance(exit_timestamp, str):
+            continue
+        if entry_price is None or exit_price is None:
+            continue
+
+        key = _trade_key(trade)
+        matched_signal = signal_queues[key].popleft() if signal_queues[key] else None
+        if matched_signal is None:
+            raise ValueError(f"no originating signal found for trade key: {key!r}")
+
+        attribution: dict[str, object] = {
+            "trade_ref": {
+                "symbol": symbol,
+                "strategy_id": str(trade.get("strategy") or ""),
+                "entry_timestamp": entry_timestamp,
+                "exit_timestamp": exit_timestamp,
+            },
+            "strategy_id": str(matched_signal.get("strategy") or ""),
+            "originating_signal": {
+                "signal_id": str(matched_signal.get("signal_id") or ""),
+                "timestamp": str(matched_signal.get("timestamp") or ""),
+                "reason": _signal_reason(matched_signal),
+            },
+            "market_context": {
+                "timeframe": str(matched_signal.get("timeframe") or ""),
+                "market_type": str(matched_signal.get("market_type") or "stock"),
+                "data_source": str(matched_signal.get("data_source") or "yahoo"),
+            },
+        }
+        attributions.append(attribution)
+
+    return {
+        "artifact": "trade_attribution",
+        "artifact_version": "1",
+        "attributions": attributions,
+    }
+
+
+__all__ = ["build_trade_attribution"]

--- a/engine/trade_ledger.py
+++ b/engine/trade_ledger.py
@@ -7,6 +7,8 @@ from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from engine.trade_attribution import build_trade_attribution
+
 _PRICE_QUANTIZER = Decimal("0.0001")
 
 
@@ -56,6 +58,8 @@ def _build_trade_id(
 
 def build_trade_ledger_from_paper_trades(
     trades: Sequence[Mapping[str, object]],
+    *,
+    signals: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object]:
     """Build canonical deterministic ledger from paper-trading trades."""
     ledger_trades: list[dict[str, object]] = []
@@ -143,11 +147,15 @@ def build_trade_ledger_from_paper_trades(
             }
         )
 
-    return {
+    payload: dict[str, object] = {
         "artifact": "trade_ledger",
         "artifact_version": "1",
         "trades": canonical_trades,
     }
+    if signals is not None:
+        attribution_payload = build_trade_attribution(trades=trades, signals=signals)
+        payload["attributions"] = attribution_payload["attributions"]
+    return payload
 
 
 def canonical_trade_ledger_json_bytes(payload: Mapping[str, Any]) -> bytes:
@@ -193,6 +201,17 @@ def load_trade_ledger_artifact(path: Path) -> dict[str, object]:
         missing = required_fields.difference(trade.keys())
         if missing:
             raise ValueError(f"trade ledger entry missing fields: {sorted(missing)}")
+
+    attributions = payload.get("attributions")
+    if attributions is not None:
+        if not isinstance(attributions, list):
+            raise ValueError("trade ledger attributions must be a list")
+        for attribution in attributions:
+            if not isinstance(attribution, dict):
+                raise ValueError("trade ledger attribution entry must be an object")
+            for field in ("trade_ref", "strategy_id", "originating_signal", "market_context"):
+                if field not in attribution:
+                    raise ValueError(f"trade ledger attribution missing field: {field}")
 
     return payload
 

--- a/tests/test_trade_attribution.py
+++ b/tests/test_trade_attribution.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from engine.trade_attribution import build_trade_attribution
+
+
+def _signals() -> list[dict[str, object]]:
+    return [
+        {
+            "signal_id": "sig-rsi2-1",
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "action": "entry",
+            "timestamp": "2024-01-01T09:30:00Z",
+            "confirmation_rule": "rsi2-oversold",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+        {
+            "signal_id": "sig-rsi2-exit",
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "action": "exit",
+            "timestamp": "2024-01-02T09:30:00Z",
+            "confirmation_rule": "rsi2-exit",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+        {
+            "signal_id": "sig-turtle-1",
+            "symbol": "BTC-USD",
+            "strategy": "TURTLE",
+            "action": "entry",
+            "timestamp": "2024-01-03T00:00:00Z",
+            "confirmation_rule": "turtle-breakout",
+            "timeframe": "H4",
+            "market_type": "crypto",
+            "data_source": "binance",
+            "reasons": [
+                {
+                    "reason_id": "sr_123",
+                    "reason_type": "PATTERN_MATCH",
+                    "signal_id": "sig-turtle-1",
+                    "ordering_key": 0,
+                    "rule_ref": {"rule_id": "TURTLE_BREAKOUT_CONFIRMED", "rule_version": "1.0.0"},
+                    "data_refs": [],
+                }
+            ],
+        },
+    ]
+
+
+def _trades() -> list[dict[str, object]]:
+    return [
+        {
+            "symbol": "BTC-USD",
+            "strategy": "TURTLE",
+            "entry_date": "2024-01-03T00:00:00Z",
+            "exit_date": "2024-01-03T04:00:00Z",
+            "entry_price": 100.0,
+            "exit_price": 104.0,
+            "reason_entry": "sr_123",
+            "timeframe": "H4",
+            "market_type": "crypto",
+            "data_source": "binance",
+        },
+        {
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "entry_date": "2024-01-01T09:30:00Z",
+            "exit_date": "2024-01-02T09:30:00Z",
+            "entry_price": 100.0,
+            "exit_price": 102.0,
+            "reason_entry": "rsi2-oversold",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+    ]
+
+
+def test_trade_attribution_is_deterministic_and_order_independent() -> None:
+    first = build_trade_attribution(trades=_trades(), signals=_signals())
+    second = build_trade_attribution(trades=list(reversed(_trades())), signals=list(reversed(_signals())))
+
+    assert first == second
+    assert first["artifact"] == "trade_attribution"
+    assert first["artifact_version"] == "1"
+
+
+def test_trade_attribution_links_each_trade_to_originating_signal() -> None:
+    payload = build_trade_attribution(trades=_trades(), signals=_signals())
+    attributions = payload["attributions"]
+
+    assert isinstance(attributions, list)
+    assert len(attributions) == 2
+
+    assert attributions[0]["strategy_id"] == "RSI2"
+    assert attributions[0]["originating_signal"]["signal_id"] == "sig-rsi2-1"
+    assert attributions[0]["originating_signal"]["reason"] == "rsi2-oversold"
+    assert attributions[0]["market_context"] == {
+        "timeframe": "D1",
+        "market_type": "stock",
+        "data_source": "yahoo",
+    }
+
+    assert attributions[1]["strategy_id"] == "TURTLE"
+    assert attributions[1]["originating_signal"]["signal_id"] == "sig-turtle-1"
+    assert attributions[1]["originating_signal"]["reason"] == "sr_123"
+    assert attributions[1]["market_context"] == {
+        "timeframe": "H4",
+        "market_type": "crypto",
+        "data_source": "binance",
+    }
+
+
+def test_trade_attribution_raises_when_trade_cannot_be_linked() -> None:
+    mismatched_trade = _trades()[0] | {"reason_entry": "missing-signal-reason"}
+
+    try:
+        build_trade_attribution(trades=[mismatched_trade], signals=_signals())
+    except ValueError as exc:
+        assert "no originating signal found" in str(exc)
+    else:
+        raise AssertionError("Expected unmatched trade attribution to raise ValueError")

--- a/tests/test_trade_ledger_artifact.py
+++ b/tests/test_trade_ledger_artifact.py
@@ -85,7 +85,7 @@ def _signals() -> list[dict[str, object]]:
 def test_trade_ledger_generation_from_paper_trading_runtime() -> None:
     result = PaperTradingSimulator().run(_signals())
 
-    ledger = build_trade_ledger_from_paper_trades(result.trades)
+    ledger = build_trade_ledger_from_paper_trades(result.trades, signals=_signals())
     trades = ledger["trades"]
 
     assert ledger["artifact"] == "trade_ledger"
@@ -128,8 +128,11 @@ def test_trade_ledger_generation_from_paper_trading_runtime() -> None:
 def test_trade_ledger_serialization_is_deterministic() -> None:
     result = PaperTradingSimulator().run(_signals())
 
-    ledger_a = build_trade_ledger_from_paper_trades(result.trades)
-    ledger_b = build_trade_ledger_from_paper_trades(list(reversed(result.trades)))
+    ledger_a = build_trade_ledger_from_paper_trades(result.trades, signals=_signals())
+    ledger_b = build_trade_ledger_from_paper_trades(
+        list(reversed(result.trades)),
+        signals=list(reversed(_signals())),
+    )
 
     bytes_a = canonical_trade_ledger_json_bytes(ledger_a)
     bytes_b = canonical_trade_ledger_json_bytes(ledger_b)
@@ -141,10 +144,38 @@ def test_trade_ledger_serialization_is_deterministic() -> None:
 
 def test_trade_ledger_artifact_can_be_loaded_by_analysis_modules(tmp_path: Path) -> None:
     result = PaperTradingSimulator().run(_signals())
-    ledger = build_trade_ledger_from_paper_trades(result.trades)
+    ledger = build_trade_ledger_from_paper_trades(result.trades, signals=_signals())
 
     artifact_path, sha_value = write_trade_ledger_artifact(tmp_path, ledger)
     loaded = load_trade_ledger_artifact(artifact_path)
 
     assert loaded == ledger
     assert (tmp_path / "trade-ledger.sha256").read_text(encoding="utf-8") == f"{sha_value}\n"
+
+
+def test_trade_ledger_includes_attribution_via_existing_artifact_path() -> None:
+    result = PaperTradingSimulator().run(_signals())
+    ledger = build_trade_ledger_from_paper_trades(result.trades, signals=_signals())
+
+    attributions = ledger.get("attributions")
+    assert isinstance(attributions, list)
+    assert len(attributions) == 2
+
+    first = attributions[0]
+    second = attributions[1]
+
+    assert first["strategy_id"] == "TEST"
+    assert first["originating_signal"]["reason"] == "rule-d"
+    assert first["market_context"] == {
+        "timeframe": "D1",
+        "market_type": "stock",
+        "data_source": "yahoo",
+    }
+
+    assert second["strategy_id"] == "TEST"
+    assert second["originating_signal"]["reason"] == "rule-a"
+    assert second["market_context"] == {
+        "timeframe": "D1",
+        "market_type": "stock",
+        "data_source": "yahoo",
+    }


### PR DESCRIPTION
Closes #541

## Summary
- Added deterministic trade attribution engine (engine/trade_attribution.py)
- Wired attribution into normal ledger artifact path in engine/trade_ledger.py
- Ledger output now includes attributions when signals are supplied
- Preserved deterministic ordering and strict one-to-one signal linkage

## Validation
Full repository test run:

.\.venv\Scripts\python -m pytest

Result:
385 passed, 4 warnings