### PR TITLE
P30-ENGINE: Deterministic risk-adjusted metrics with backward-compatible ledger v1 loading (#542)

### DIFF
--- a/engine/risk_adjusted_metrics.py
+++ b/engine/risk_adjusted_metrics.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_EVEN, localcontext
+from typing import Any, Mapping, Sequence
+
+_QUANT = Decimal("0.000000000001")
+_ZERO = Decimal("0")
+_ONE = Decimal("1")
+
+
+def _to_decimal(value: object) -> Decimal | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        number = value
+    elif isinstance(value, (int, float, str)):
+        try:
+            number = Decimal(str(value))
+        except Exception:
+            return None
+    else:
+        return None
+    if not number.is_finite():
+        return None
+    return number
+
+
+def _round_12(value: Decimal) -> Decimal:
+    rounded = value.quantize(_QUANT, rounding=ROUND_HALF_EVEN)
+    if rounded == _ZERO:
+        return _ZERO
+    return rounded
+
+
+def _to_float(value: Decimal | None) -> float | None:
+    if value is None:
+        return None
+    return float(_round_12(value))
+
+
+def _trade_sort_key(item: tuple[int, Mapping[str, object]]) -> tuple[str, str, str, str, str, int]:
+    index, trade = item
+    return (
+        str(trade.get("exit_timestamp") or ""),
+        str(trade.get("entry_timestamp") or ""),
+        str(trade.get("symbol") or ""),
+        str(trade.get("strategy_id") or ""),
+        str(trade.get("trade_id") or ""),
+        index,
+    )
+
+
+def _extract_trade_pnls_and_returns(
+    trades: Sequence[Mapping[str, object]],
+) -> tuple[list[Decimal], list[Decimal]]:
+    ordered = sorted(
+        [(idx, trade) for idx, trade in enumerate(trades) if isinstance(trade, Mapping)],
+        key=_trade_sort_key,
+    )
+
+    pnls: list[Decimal] = []
+    returns: list[Decimal] = []
+    for _, trade in ordered:
+        pnl = _to_decimal(trade.get("pnl"))
+        if pnl is None:
+            continue
+
+        pnls.append(pnl)
+
+        entry_price = _to_decimal(trade.get("entry_price"))
+        quantity = _to_decimal(trade.get("quantity"))
+        if entry_price is None or quantity is None:
+            continue
+
+        notional = abs(entry_price * quantity)
+        if notional <= _ZERO:
+            continue
+
+        returns.append(pnl / notional)
+
+    return pnls, returns
+
+
+def _compute_win_rate(pnls: list[Decimal]) -> Decimal | None:
+    if not pnls:
+        return None
+    wins = sum(1 for pnl in pnls if pnl > _ZERO)
+    return Decimal(wins) / Decimal(len(pnls))
+
+
+def _compute_profit_factor(pnls: list[Decimal]) -> Decimal | None:
+    if not pnls:
+        return None
+    gross_profit = sum((pnl for pnl in pnls if pnl > _ZERO), _ZERO)
+    gross_loss = sum((-pnl for pnl in pnls if pnl < _ZERO), _ZERO)
+    if gross_loss == _ZERO:
+        return None
+    return gross_profit / gross_loss
+
+
+def _compute_sharpe_ratio(returns: list[Decimal]) -> Decimal | None:
+    count = len(returns)
+    if count < 2:
+        return None
+
+    mean_return = sum(returns, _ZERO) / Decimal(count)
+    variance_sum = sum(((value - mean_return) ** 2 for value in returns), _ZERO)
+    variance = variance_sum / Decimal(count - 1)
+    if variance <= _ZERO:
+        return None
+
+    with localcontext() as context:
+        context.prec = 50
+        volatility = variance.sqrt()
+    if volatility == _ZERO:
+        return None
+    return mean_return / volatility
+
+
+def _compute_sortino_ratio(returns: list[Decimal]) -> Decimal | None:
+    count = len(returns)
+    if count == 0:
+        return None
+
+    mean_return = sum(returns, _ZERO) / Decimal(count)
+    downside_sum = sum((((value if value < _ZERO else _ZERO) ** 2) for value in returns), _ZERO)
+    if downside_sum == _ZERO:
+        return None
+
+    downside_variance = downside_sum / Decimal(count)
+    with localcontext() as context:
+        context.prec = 50
+        downside_deviation = downside_variance.sqrt()
+    if downside_deviation == _ZERO:
+        return None
+    return mean_return / downside_deviation
+
+
+def _compute_calmar_ratio(returns: list[Decimal]) -> Decimal | None:
+    if not returns:
+        return None
+
+    equity = _ONE
+    peak = _ONE
+    max_drawdown = _ZERO
+
+    for trade_return in returns:
+        equity *= (_ONE + trade_return)
+        if equity > peak:
+            peak = equity
+        if peak > _ZERO:
+            drawdown = (peak - equity) / peak
+            if drawdown > max_drawdown:
+                max_drawdown = drawdown
+
+    if max_drawdown == _ZERO:
+        return None
+
+    total_return = equity - _ONE
+    return total_return / max_drawdown
+
+
+def compute_risk_adjusted_metrics_from_trade_ledger(payload: Mapping[str, Any]) -> dict[str, float | None]:
+    trades_raw = payload.get("trades")
+    if not isinstance(trades_raw, list):
+        trades: list[Mapping[str, object]] = []
+    else:
+        trades = [item for item in trades_raw if isinstance(item, Mapping)]
+
+    pnls, returns = _extract_trade_pnls_and_returns(trades)
+
+    metrics = {
+        "sharpe_ratio": _to_float(_compute_sharpe_ratio(returns)),
+        "sortino_ratio": _to_float(_compute_sortino_ratio(returns)),
+        "calmar_ratio": _to_float(_compute_calmar_ratio(returns)),
+        "profit_factor": _to_float(_compute_profit_factor(pnls)),
+        "win_rate": _to_float(_compute_win_rate(pnls)),
+    }
+    return metrics
+
+
+__all__ = ["compute_risk_adjusted_metrics_from_trade_ledger"]

--- a/engine/trade_ledger.py
+++ b/engine/trade_ledger.py
@@ -7,6 +7,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from engine.risk_adjusted_metrics import compute_risk_adjusted_metrics_from_trade_ledger
 from engine.trade_attribution import build_trade_attribution
 
 _PRICE_QUANTIZER = Decimal("0.0001")
@@ -152,6 +153,7 @@ def build_trade_ledger_from_paper_trades(
         "artifact_version": "1",
         "trades": canonical_trades,
     }
+    payload["risk_adjusted_metrics"] = compute_risk_adjusted_metrics_from_trade_ledger(payload)
     if signals is not None:
         attribution_payload = build_trade_attribution(trades=trades, signals=signals)
         payload["attributions"] = attribution_payload["attributions"]
@@ -212,6 +214,25 @@ def load_trade_ledger_artifact(path: Path) -> dict[str, object]:
             for field in ("trade_ref", "strategy_id", "originating_signal", "market_context"):
                 if field not in attribution:
                     raise ValueError(f"trade ledger attribution missing field: {field}")
+
+    risk_adjusted_metrics = payload.get("risk_adjusted_metrics")
+    if risk_adjusted_metrics is not None:
+        if not isinstance(risk_adjusted_metrics, dict):
+            raise ValueError("trade ledger risk_adjusted_metrics must be an object when present")
+        required_metric_fields = {
+            "sharpe_ratio",
+            "sortino_ratio",
+            "calmar_ratio",
+            "profit_factor",
+            "win_rate",
+        }
+        missing_metric_fields = required_metric_fields.difference(risk_adjusted_metrics.keys())
+        if missing_metric_fields:
+            raise ValueError(f"trade ledger risk_adjusted_metrics missing fields: {sorted(missing_metric_fields)}")
+        for metric_name in required_metric_fields:
+            metric_value = risk_adjusted_metrics.get(metric_name)
+            if metric_value is not None and not isinstance(metric_value, (int, float)):
+                raise ValueError(f"trade ledger risk_adjusted_metrics field {metric_name} must be numeric or null")
 
     return payload
 

--- a/tests/test_risk_adjusted_metrics.py
+++ b/tests/test_risk_adjusted_metrics.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+from cilly_trading.engine.paper_trading import PaperTradingSimulator
+
+from engine.risk_adjusted_metrics import compute_risk_adjusted_metrics_from_trade_ledger
+from engine.trade_ledger import build_trade_ledger_from_paper_trades
+
+
+def _deterministic_ledger() -> dict[str, object]:
+    return {
+        "artifact": "trade_ledger",
+        "artifact_version": "1",
+        "trades": [
+            {
+                "trade_id": "trade-a",
+                "strategy_id": "S",
+                "symbol": "AAPL",
+                "entry_timestamp": "2024-01-01T00:00:00Z",
+                "exit_timestamp": "2024-01-01T01:00:00Z",
+                "entry_price": "100.0000",
+                "exit_price": "110.0000",
+                "quantity": "1.0000",
+                "pnl": "10.0000",
+                "holding_time": 3600,
+            },
+            {
+                "trade_id": "trade-b",
+                "strategy_id": "S",
+                "symbol": "AAPL",
+                "entry_timestamp": "2024-01-02T00:00:00Z",
+                "exit_timestamp": "2024-01-02T01:00:00Z",
+                "entry_price": "100.0000",
+                "exit_price": "95.0000",
+                "quantity": "1.0000",
+                "pnl": "-5.0000",
+                "holding_time": 3600,
+            },
+            {
+                "trade_id": "trade-c",
+                "strategy_id": "S",
+                "symbol": "MSFT",
+                "entry_timestamp": "2024-01-03T00:00:00Z",
+                "exit_timestamp": "2024-01-03T01:00:00Z",
+                "entry_price": "200.0000",
+                "exit_price": "210.0000",
+                "quantity": "2.0000",
+                "pnl": "20.0000",
+                "holding_time": 3600,
+            },
+            {
+                "trade_id": "trade-d",
+                "strategy_id": "S",
+                "symbol": "MSFT",
+                "entry_timestamp": "2024-01-04T00:00:00Z",
+                "exit_timestamp": "2024-01-04T01:00:00Z",
+                "entry_price": "50.0000",
+                "exit_price": "50.0000",
+                "quantity": "1.0000",
+                "pnl": "0.0000",
+                "holding_time": 3600,
+            },
+        ],
+    }
+
+
+def _signals() -> list[dict[str, object]]:
+    return [
+        {
+            "symbol": "AAPL",
+            "strategy": "TEST",
+            "direction": "long",
+            "action": "entry",
+            "timestamp": "2024-01-01T09:30:00Z",
+            "stage": "entry_confirmed",
+            "entry_zone": {"from_": 99.5, "to": 100.5},
+            "confirmation_rule": "rule-a",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+        {
+            "symbol": "AAPL",
+            "strategy": "TEST",
+            "direction": "long",
+            "action": "entry",
+            "timestamp": "2024-01-02T09:30:00Z",
+            "stage": "entry_confirmed",
+            "entry_zone": {"from_": 100.5, "to": 101.5},
+            "confirmation_rule": "rule-b",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+        {
+            "symbol": "AAPL",
+            "strategy": "TEST",
+            "direction": "long",
+            "action": "exit",
+            "timestamp": "2024-01-03T09:30:00Z",
+            "stage": "setup",
+            "entry_zone": {"from_": 101.0, "to": 103.0},
+            "confirmation_rule": "rule-c",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+        {
+            "symbol": "MSFT",
+            "strategy": "TEST",
+            "direction": "long",
+            "action": "entry",
+            "timestamp": "2024-01-01T09:35:00Z",
+            "stage": "entry_confirmed",
+            "entry_zone": {"from_": 198.0, "to": 202.0},
+            "confirmation_rule": "rule-d",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+        {
+            "symbol": "MSFT",
+            "strategy": "TEST",
+            "direction": "long",
+            "action": "exit",
+            "timestamp": "2024-01-02T09:35:00Z",
+            "stage": "setup",
+            "entry_zone": {"from_": 201.0, "to": 203.0},
+            "confirmation_rule": "rule-e",
+            "timeframe": "D1",
+            "market_type": "stock",
+            "data_source": "yahoo",
+        },
+    ]
+
+
+def test_risk_adjusted_metrics_values_are_deterministic() -> None:
+    metrics = compute_risk_adjusted_metrics_from_trade_ledger(_deterministic_ledger())
+
+    assert metrics == {
+        "sharpe_ratio": 0.387298334621,
+        "sortino_ratio": 1.0,
+        "calmar_ratio": 1.945,
+        "profit_factor": 6.0,
+        "win_rate": 0.5,
+    }
+
+
+def test_risk_adjusted_metrics_are_order_independent_and_reproducible() -> None:
+    ledger = _deterministic_ledger()
+    reversed_ledger = {
+        **ledger,
+        "trades": list(reversed(ledger["trades"])),  # type: ignore[index]
+    }
+
+    first = compute_risk_adjusted_metrics_from_trade_ledger(ledger)
+    second = compute_risk_adjusted_metrics_from_trade_ledger(reversed_ledger)
+    third = compute_risk_adjusted_metrics_from_trade_ledger(ledger)
+
+    first_json = json.dumps(first, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    second_json = json.dumps(second, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    third_json = json.dumps(third, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+    assert first == second == third
+    assert hashlib.sha256(first_json.encode("utf-8")).hexdigest() == hashlib.sha256(
+        second_json.encode("utf-8")
+    ).hexdigest()
+    assert hashlib.sha256(first_json.encode("utf-8")).hexdigest() == hashlib.sha256(
+        third_json.encode("utf-8")
+    ).hexdigest()
+
+
+def test_risk_adjusted_metrics_accept_trade_ledger_artifact_payload() -> None:
+    result = PaperTradingSimulator().run(_signals())
+    ledger = build_trade_ledger_from_paper_trades(result.trades, signals=_signals())
+
+    metrics = compute_risk_adjusted_metrics_from_trade_ledger(ledger)
+
+    assert set(metrics.keys()) == {
+        "sharpe_ratio",
+        "sortino_ratio",
+        "calmar_ratio",
+        "profit_factor",
+        "win_rate",
+    }
+    assert metrics["profit_factor"] is None
+    assert metrics["win_rate"] == 1.0
+    assert metrics["sharpe_ratio"] == 2.12132034356
+    assert metrics["sortino_ratio"] is None
+    assert metrics["calmar_ratio"] is None

--- a/tests/test_trade_ledger_artifact.py
+++ b/tests/test_trade_ledger_artifact.py
@@ -92,6 +92,13 @@ def test_trade_ledger_generation_from_paper_trading_runtime() -> None:
     assert ledger["artifact_version"] == "1"
     assert isinstance(trades, list)
     assert len(trades) == 2
+    assert ledger["risk_adjusted_metrics"] == {
+        "sharpe_ratio": 2.12132034356,
+        "sortino_ratio": None,
+        "calmar_ratio": None,
+        "profit_factor": None,
+        "win_rate": 1.0,
+    }
 
     expected_first = {
         "strategy_id": "TEST",
@@ -140,6 +147,7 @@ def test_trade_ledger_serialization_is_deterministic() -> None:
     assert bytes_a == bytes_b
     assert bytes_a.endswith(b"\n")
     assert b"\r\n" not in bytes_a
+    assert b'"risk_adjusted_metrics"' in bytes_a
 
 
 def test_trade_ledger_artifact_can_be_loaded_by_analysis_modules(tmp_path: Path) -> None:
@@ -150,7 +158,42 @@ def test_trade_ledger_artifact_can_be_loaded_by_analysis_modules(tmp_path: Path)
     loaded = load_trade_ledger_artifact(artifact_path)
 
     assert loaded == ledger
+    assert loaded["risk_adjusted_metrics"] == {
+        "sharpe_ratio": 2.12132034356,
+        "sortino_ratio": None,
+        "calmar_ratio": None,
+        "profit_factor": None,
+        "win_rate": 1.0,
+    }
     assert (tmp_path / "trade-ledger.sha256").read_text(encoding="utf-8") == f"{sha_value}\n"
+
+
+def test_trade_ledger_v1_legacy_payload_without_risk_metrics_loads(tmp_path: Path) -> None:
+    legacy_payload = {
+        "artifact": "trade_ledger",
+        "artifact_version": "1",
+        "trades": [
+            {
+                "trade_id": "trade-legacy-1",
+                "strategy_id": "LEGACY",
+                "symbol": "AAPL",
+                "entry_timestamp": "2024-01-01T09:30:00Z",
+                "exit_timestamp": "2024-01-02T09:30:00Z",
+                "entry_price": "100.0000",
+                "exit_price": "101.0000",
+                "quantity": "1.0000",
+                "pnl": "1.0000",
+                "holding_time": 86400,
+            }
+        ],
+    }
+
+    artifact_text = canonical_trade_ledger_json_bytes(legacy_payload).decode("utf-8")
+    artifact_path = tmp_path / "trade-ledger-legacy-v1.json"
+    artifact_path.write_text(artifact_text, encoding="utf-8")
+    loaded = load_trade_ledger_artifact(artifact_path)
+
+    assert loaded == legacy_payload
 
 
 def test_trade_ledger_includes_attribution_via_existing_artifact_path() -> None:


### PR DESCRIPTION
Closes #542

## Summary
- Added deterministic risk-adjusted metrics engine for:
  - Sharpe ratio
  - Sortino ratio
  - Calmar ratio
  - Profit factor
  - Win rate
- Wired metrics into the existing engine trade-ledger output flow (uild_trade_ledger_from_paper_trades) via isk_adjusted_metrics.
- Preserved backward compatibility for 	rade_ledger artifact version 1:
  - load_trade_ledger_artifact accepts legacy payloads without isk_adjusted_metrics.
  - If isk_adjusted_metrics is present, it is validated for required keys and numeric/null values.
- Added/updated tests to prove:
  - legacy v1 payloads without metrics still load
  - new generated ledgers include deterministic risk-adjusted metrics
  - serialization remains deterministic

## Scope compliance
- Changed only engine/ and 	ests/.
- No changes to src/, API layer, portfolio/risk orchestration, or trading decision behavior.