### PR TITLE
P30-ENGINE: Integrate Performance Reporting Artifacts Into Engine Flow (#543)

### DIFF
--- a/engine/performance_report.py
+++ b/engine/performance_report.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from decimal import Decimal, ROUND_HALF_EVEN
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+_QUANT = Decimal("0.000000000001")
+_ZERO = Decimal("0")
+
+
+def _to_decimal(value: object) -> Decimal | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        number = value
+    elif isinstance(value, (int, float, str)):
+        try:
+            number = Decimal(str(value))
+        except Exception:
+            return None
+    else:
+        return None
+
+    if not number.is_finite():
+        return None
+    return number
+
+
+def _round_12(value: Decimal) -> Decimal:
+    rounded = value.quantize(_QUANT, rounding=ROUND_HALF_EVEN)
+    if rounded == _ZERO:
+        return _ZERO
+    return rounded
+
+
+def _to_float(value: Decimal | None) -> float | None:
+    if value is None:
+        return None
+    return float(_round_12(value))
+
+
+def _trade_sort_key(item: tuple[int, Mapping[str, object]]) -> tuple[str, str, str, str, str, int]:
+    index, trade = item
+    return (
+        str(trade.get("exit_timestamp") or ""),
+        str(trade.get("entry_timestamp") or ""),
+        str(trade.get("symbol") or ""),
+        str(trade.get("strategy_id") or ""),
+        str(trade.get("trade_id") or ""),
+        index,
+    )
+
+
+def _ordered_trades(payload: Mapping[str, Any]) -> list[Mapping[str, object]]:
+    trades_raw = payload.get("trades")
+    if not isinstance(trades_raw, list):
+        return []
+
+    ordered = sorted(
+        [(index, trade) for index, trade in enumerate(trades_raw) if isinstance(trade, Mapping)],
+        key=_trade_sort_key,
+    )
+    return [trade for _, trade in ordered]
+
+
+def build_performance_report_from_trade_ledger(payload: Mapping[str, Any]) -> dict[str, object]:
+    """Build deterministic performance report from a post-trade ledger payload."""
+    ordered_trades = _ordered_trades(payload)
+
+    strategy_stats: dict[str, dict[str, Decimal | int]] = {}
+    total_pnl = _ZERO
+    total_holding_seconds = _ZERO
+    wins = 0
+    losses = 0
+    breakeven = 0
+
+    for trade in ordered_trades:
+        strategy_id = str(trade.get("strategy_id") or "")
+        pnl = _to_decimal(trade.get("pnl"))
+        if pnl is None:
+            continue
+
+        holding_time_raw = _to_decimal(trade.get("holding_time"))
+        holding_time = holding_time_raw if holding_time_raw is not None else _ZERO
+
+        strategy = strategy_stats.setdefault(
+            strategy_id,
+            {
+                "trade_count": 0,
+                "total_pnl": _ZERO,
+                "wins": 0,
+            },
+        )
+
+        strategy["trade_count"] = int(strategy["trade_count"]) + 1
+        strategy["total_pnl"] = (strategy["total_pnl"] if isinstance(strategy["total_pnl"], Decimal) else _ZERO) + pnl
+        if pnl > _ZERO:
+            strategy["wins"] = int(strategy["wins"]) + 1
+            wins += 1
+        elif pnl < _ZERO:
+            losses += 1
+        else:
+            breakeven += 1
+
+        total_pnl += pnl
+        total_holding_seconds += holding_time
+
+    total_trades = wins + losses + breakeven
+    strategy_count = len(strategy_stats)
+
+    strategy_comparison_raw: list[dict[str, object]] = []
+    for strategy_id, values in strategy_stats.items():
+        trade_count = int(values["trade_count"])
+        strategy_total_pnl = values["total_pnl"] if isinstance(values["total_pnl"], Decimal) else _ZERO
+        strategy_wins = int(values["wins"])
+
+        average_pnl = (strategy_total_pnl / Decimal(trade_count)) if trade_count > 0 else None
+        win_rate = (Decimal(strategy_wins) / Decimal(trade_count)) if trade_count > 0 else None
+
+        strategy_comparison_raw.append(
+            {
+                "strategy_id": strategy_id,
+                "trade_count": trade_count,
+                "total_pnl": _to_float(strategy_total_pnl),
+                "average_pnl": _to_float(average_pnl),
+                "win_rate": _to_float(win_rate),
+            }
+        )
+
+    strategy_comparison = sorted(
+        strategy_comparison_raw,
+        key=lambda item: (
+            -float(item["total_pnl"] if item["total_pnl"] is not None else 0.0),
+            str(item["strategy_id"]),
+        ),
+    )
+
+    average_pnl_per_trade = (total_pnl / Decimal(total_trades)) if total_trades > 0 else None
+    overall_win_rate = (Decimal(wins) / Decimal(total_trades)) if total_trades > 0 else None
+    average_holding_time = (total_holding_seconds / Decimal(total_trades)) if total_trades > 0 else None
+
+    best_strategy_id = strategy_comparison[0]["strategy_id"] if strategy_comparison else None
+    worst_strategy_id = strategy_comparison[-1]["strategy_id"] if strategy_comparison else None
+
+    risk_adjusted_metrics_raw = payload.get("risk_adjusted_metrics")
+    risk_adjusted_metrics = risk_adjusted_metrics_raw if isinstance(risk_adjusted_metrics_raw, Mapping) else None
+
+    return {
+        "artifact": "performance_report",
+        "artifact_version": "1",
+        "performance_summary": {
+            "total_trades": total_trades,
+            "strategies_analyzed": strategy_count,
+            "total_pnl": _to_float(total_pnl),
+            "winning_trades": wins,
+            "losing_trades": losses,
+            "breakeven_trades": breakeven,
+        },
+        "strategy_comparison": strategy_comparison,
+        "key_metrics_overview": {
+            "overall_win_rate": _to_float(overall_win_rate),
+            "average_pnl_per_trade": _to_float(average_pnl_per_trade),
+            "average_holding_time_seconds": _to_float(average_holding_time),
+            "best_strategy_id": best_strategy_id,
+            "worst_strategy_id": worst_strategy_id,
+            "risk_adjusted_metrics": risk_adjusted_metrics,
+        },
+    }
+
+
+def canonical_performance_report_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    rendered = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    return (rendered + "\n").encode("utf-8")
+
+
+def write_performance_report_artifact(output_dir: Path, payload: Mapping[str, Any]) -> tuple[Path, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = output_dir / "performance-report.json"
+
+    canonical_bytes = canonical_performance_report_json_bytes(payload)
+    artifact_path.write_bytes(canonical_bytes)
+
+    sha_value = hashlib.sha256(canonical_bytes).hexdigest()
+    (output_dir / "performance-report.sha256").write_text(f"{sha_value}\n", encoding="utf-8")
+    return artifact_path, sha_value
+
+
+def load_performance_report_artifact(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("performance report payload must be an object")
+
+    summary = payload.get("performance_summary")
+    if not isinstance(summary, dict):
+        raise ValueError("performance report missing performance_summary object")
+
+    strategy_comparison = payload.get("strategy_comparison")
+    if not isinstance(strategy_comparison, list):
+        raise ValueError("performance report missing strategy_comparison list")
+
+    for row in strategy_comparison:
+        if not isinstance(row, dict):
+            raise ValueError("strategy comparison entry must be an object")
+        required = {"strategy_id", "trade_count", "total_pnl", "average_pnl", "win_rate"}
+        missing = required.difference(row.keys())
+        if missing:
+            raise ValueError(f"strategy comparison entry missing fields: {sorted(missing)}")
+
+    key_metrics = payload.get("key_metrics_overview")
+    if not isinstance(key_metrics, dict):
+        raise ValueError("performance report missing key_metrics_overview object")
+
+    return payload
+
+
+__all__ = [
+    "build_performance_report_from_trade_ledger",
+    "canonical_performance_report_json_bytes",
+    "write_performance_report_artifact",
+    "load_performance_report_artifact",
+]

--- a/engine/trade_ledger.py
+++ b/engine/trade_ledger.py
@@ -7,6 +7,10 @@ from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from engine.performance_report import (
+    build_performance_report_from_trade_ledger,
+    write_performance_report_artifact,
+)
 from engine.risk_adjusted_metrics import compute_risk_adjusted_metrics_from_trade_ledger
 from engine.trade_attribution import build_trade_attribution
 
@@ -154,6 +158,7 @@ def build_trade_ledger_from_paper_trades(
         "trades": canonical_trades,
     }
     payload["risk_adjusted_metrics"] = compute_risk_adjusted_metrics_from_trade_ledger(payload)
+    payload["performance_report"] = build_performance_report_from_trade_ledger(payload)
     if signals is not None:
         attribution_payload = build_trade_attribution(trades=trades, signals=signals)
         payload["attributions"] = attribution_payload["attributions"]
@@ -173,6 +178,11 @@ def write_trade_ledger_artifact(output_dir: Path, payload: Mapping[str, Any]) ->
 
     sha_value = hashlib.sha256(canonical_bytes).hexdigest()
     (output_dir / "trade-ledger.sha256").write_text(f"{sha_value}\n", encoding="utf-8")
+
+    performance_report = payload.get("performance_report")
+    if isinstance(performance_report, Mapping):
+        write_performance_report_artifact(output_dir, performance_report)
+
     return artifact_path, sha_value
 
 
@@ -233,6 +243,14 @@ def load_trade_ledger_artifact(path: Path) -> dict[str, object]:
             metric_value = risk_adjusted_metrics.get(metric_name)
             if metric_value is not None and not isinstance(metric_value, (int, float)):
                 raise ValueError(f"trade ledger risk_adjusted_metrics field {metric_name} must be numeric or null")
+
+    performance_report = payload.get("performance_report")
+    if performance_report is not None:
+        if not isinstance(performance_report, dict):
+            raise ValueError("trade ledger performance_report must be an object when present")
+        for field in ("artifact", "artifact_version", "performance_summary", "strategy_comparison", "key_metrics_overview"):
+            if field not in performance_report:
+                raise ValueError(f"trade ledger performance_report missing field: {field}")
 
     return payload
 

--- a/tests/test_performance_report_artifact.py
+++ b/tests/test_performance_report_artifact.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import hashlib
+
+from pathlib import Path
+
+from engine.performance_report import (
+    build_performance_report_from_trade_ledger,
+    canonical_performance_report_json_bytes,
+    load_performance_report_artifact,
+    write_performance_report_artifact,
+)
+
+
+def _ledger_payload() -> dict[str, object]:
+    return {
+        "artifact": "trade_ledger",
+        "artifact_version": "1",
+        "trades": [
+            {
+                "trade_id": "trade-a",
+                "strategy_id": "ALPHA",
+                "symbol": "AAPL",
+                "entry_timestamp": "2024-01-01T00:00:00Z",
+                "exit_timestamp": "2024-01-01T01:00:00Z",
+                "entry_price": "100.0000",
+                "exit_price": "110.0000",
+                "quantity": "1.0000",
+                "pnl": "10.0000",
+                "holding_time": 3600,
+            },
+            {
+                "trade_id": "trade-b",
+                "strategy_id": "BETA",
+                "symbol": "MSFT",
+                "entry_timestamp": "2024-01-02T00:00:00Z",
+                "exit_timestamp": "2024-01-02T00:30:00Z",
+                "entry_price": "100.0000",
+                "exit_price": "98.0000",
+                "quantity": "1.0000",
+                "pnl": "-2.0000",
+                "holding_time": 1800,
+            },
+            {
+                "trade_id": "trade-c",
+                "strategy_id": "ALPHA",
+                "symbol": "NVDA",
+                "entry_timestamp": "2024-01-03T00:00:00Z",
+                "exit_timestamp": "2024-01-03T02:00:00Z",
+                "entry_price": "50.0000",
+                "exit_price": "54.0000",
+                "quantity": "1.0000",
+                "pnl": "4.0000",
+                "holding_time": 7200,
+            },
+        ],
+        "risk_adjusted_metrics": {
+            "sharpe_ratio": 1.23,
+            "sortino_ratio": 2.34,
+            "calmar_ratio": 0.9,
+            "profit_factor": 7.0,
+            "win_rate": 0.666666666667,
+        },
+    }
+
+
+def test_performance_report_generation_from_trade_ledger() -> None:
+    report = build_performance_report_from_trade_ledger(_ledger_payload())
+
+    assert report["artifact"] == "performance_report"
+    assert report["artifact_version"] == "1"
+    assert report["performance_summary"] == {
+        "total_trades": 3,
+        "strategies_analyzed": 2,
+        "total_pnl": 12.0,
+        "winning_trades": 2,
+        "losing_trades": 1,
+        "breakeven_trades": 0,
+    }
+    assert report["strategy_comparison"] == [
+        {
+            "strategy_id": "ALPHA",
+            "trade_count": 2,
+            "total_pnl": 14.0,
+            "average_pnl": 7.0,
+            "win_rate": 1.0,
+        },
+        {
+            "strategy_id": "BETA",
+            "trade_count": 1,
+            "total_pnl": -2.0,
+            "average_pnl": -2.0,
+            "win_rate": 0.0,
+        },
+    ]
+    assert report["key_metrics_overview"] == {
+        "overall_win_rate": 0.666666666667,
+        "average_pnl_per_trade": 4.0,
+        "average_holding_time_seconds": 4200.0,
+        "best_strategy_id": "ALPHA",
+        "worst_strategy_id": "BETA",
+        "risk_adjusted_metrics": {
+            "sharpe_ratio": 1.23,
+            "sortino_ratio": 2.34,
+            "calmar_ratio": 0.9,
+            "profit_factor": 7.0,
+            "win_rate": 0.666666666667,
+        },
+    }
+
+
+def test_performance_report_serialization_is_deterministic() -> None:
+    payload = _ledger_payload()
+    reversed_payload = {
+        **payload,
+        "trades": list(reversed(payload["trades"])),  # type: ignore[index]
+    }
+
+    report_a = build_performance_report_from_trade_ledger(payload)
+    report_b = build_performance_report_from_trade_ledger(reversed_payload)
+
+    bytes_a = canonical_performance_report_json_bytes(report_a)
+    bytes_b = canonical_performance_report_json_bytes(report_b)
+
+    assert report_a == report_b
+    assert bytes_a == bytes_b
+    assert bytes_a.endswith(b"\n")
+    assert b"\r\n" not in bytes_a
+
+
+
+def test_performance_report_artifact_write_and_load(tmp_path: Path) -> None:
+    report = build_performance_report_from_trade_ledger(_ledger_payload())
+
+    path_a, sha_a = write_performance_report_artifact(tmp_path / "run-a", report)
+    path_b, sha_b = write_performance_report_artifact(tmp_path / "run-b", report)
+
+    bytes_a = path_a.read_bytes()
+    bytes_b = path_b.read_bytes()
+
+    assert bytes_a == bytes_b
+    assert sha_a == sha_b
+    assert hashlib.sha256(bytes_a).hexdigest() == sha_a
+    assert (tmp_path / "run-a" / "performance-report.sha256").read_text(encoding="utf-8") == f"{sha_a}\n"
+
+    loaded = load_performance_report_artifact(path_a)
+    assert loaded == report

--- a/tests/test_trade_ledger_artifact.py
+++ b/tests/test_trade_ledger_artifact.py
@@ -99,6 +99,41 @@ def test_trade_ledger_generation_from_paper_trading_runtime() -> None:
         "profit_factor": None,
         "win_rate": 1.0,
     }
+    assert ledger["performance_report"] == {
+        "artifact": "performance_report",
+        "artifact_version": "1",
+        "performance_summary": {
+            "total_trades": 2,
+            "strategies_analyzed": 1,
+            "total_pnl": 4.0,
+            "winning_trades": 2,
+            "losing_trades": 0,
+            "breakeven_trades": 0,
+        },
+        "strategy_comparison": [
+            {
+                "strategy_id": "TEST",
+                "trade_count": 2,
+                "total_pnl": 4.0,
+                "average_pnl": 2.0,
+                "win_rate": 1.0,
+            }
+        ],
+        "key_metrics_overview": {
+            "overall_win_rate": 1.0,
+            "average_pnl_per_trade": 2.0,
+            "average_holding_time_seconds": 129600.0,
+            "best_strategy_id": "TEST",
+            "worst_strategy_id": "TEST",
+            "risk_adjusted_metrics": {
+                "sharpe_ratio": 2.12132034356,
+                "sortino_ratio": None,
+                "calmar_ratio": None,
+                "profit_factor": None,
+                "win_rate": 1.0,
+            },
+        },
+    }
 
     expected_first = {
         "strategy_id": "TEST",
@@ -148,6 +183,7 @@ def test_trade_ledger_serialization_is_deterministic() -> None:
     assert bytes_a.endswith(b"\n")
     assert b"\r\n" not in bytes_a
     assert b'"risk_adjusted_metrics"' in bytes_a
+    assert b'"performance_report"' in bytes_a
 
 
 def test_trade_ledger_artifact_can_be_loaded_by_analysis_modules(tmp_path: Path) -> None:
@@ -166,6 +202,8 @@ def test_trade_ledger_artifact_can_be_loaded_by_analysis_modules(tmp_path: Path)
         "win_rate": 1.0,
     }
     assert (tmp_path / "trade-ledger.sha256").read_text(encoding="utf-8") == f"{sha_value}\n"
+    assert (tmp_path / "performance-report.json").exists()
+    assert (tmp_path / "performance-report.sha256").exists()
 
 
 def test_trade_ledger_v1_legacy_payload_without_risk_metrics_loads(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #543

## What changed
- Added deterministic performance_report artifact module under engine/.
- Integrated performance report generation into existing post-trade artifact path (engine/trade_ledger.py):
  - uild_trade_ledger_from_paper_trades(...) now embeds performance_report.
  - write_trade_ledger_artifact(...) now emits:
    - 	rade-ledger.json
    - 	rade-ledger.sha256
    - performance-report.json
    - performance-report.sha256
- Extended trade ledger artifact validation to accept/validate embedded performance report shape.
- Added and updated tests under 	ests/:
  - direct performance report deterministic behavior
  - integrated trade-ledger flow assertions for embedded report and sidecar files

## Scope compliance
- Changed files only under engine/ and 	ests/.
- No changes to execution logic, API, runtime orchestration, or strategy lifecycle.
- No architecture boundary changes outside artifact-generation path.

## Validation
- Full suite run:
  - python -m pytest
  - 392 passed
@