### PR TITLE
P30-ENGINE: implement equity curve and drawdown analysis (#544)

### DIFF
--- a/engine/equity_curve.py
+++ b/engine/equity_curve.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from decimal import Decimal, ROUND_HALF_EVEN
+from pathlib import Path
+from typing import Any, Mapping
+
+_QUANT = Decimal("0.000000000001")
+_ZERO = Decimal("0")
+
+
+def _to_decimal(value: object) -> Decimal | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, Decimal):
+        number = value
+    elif isinstance(value, (int, float, str)):
+        try:
+            number = Decimal(str(value))
+        except Exception:
+            return None
+    else:
+        return None
+
+    if not number.is_finite():
+        return None
+    return number
+
+
+def _round_12(value: Decimal) -> Decimal:
+    rounded = value.quantize(_QUANT, rounding=ROUND_HALF_EVEN)
+    if rounded == _ZERO:
+        return _ZERO
+    return rounded
+
+
+def _to_float(value: Decimal | None) -> float | None:
+    if value is None:
+        return None
+    return float(_round_12(value))
+
+
+def _trade_sort_key(item: tuple[int, Mapping[str, object]]) -> tuple[str, str, str, str, str, int]:
+    index, trade = item
+    return (
+        str(trade.get("exit_timestamp") or ""),
+        str(trade.get("entry_timestamp") or ""),
+        str(trade.get("symbol") or ""),
+        str(trade.get("strategy_id") or ""),
+        str(trade.get("trade_id") or ""),
+        index,
+    )
+
+
+def _ordered_trades(payload: Mapping[str, Any]) -> list[Mapping[str, object]]:
+    trades_raw = payload.get("trades")
+    if not isinstance(trades_raw, list):
+        return []
+    ordered = sorted(
+        [(index, trade) for index, trade in enumerate(trades_raw) if isinstance(trade, Mapping)],
+        key=_trade_sort_key,
+    )
+    return [trade for _, trade in ordered]
+
+
+def build_equity_curve_from_trade_ledger(payload: Mapping[str, Any]) -> dict[str, object]:
+    ordered_trades = _ordered_trades(payload)
+
+    curve_points: list[dict[str, object]] = []
+    equity = _ZERO
+
+    for trade in ordered_trades:
+        pnl = _to_decimal(trade.get("pnl"))
+        if pnl is None:
+            continue
+
+        equity += pnl
+        curve_points.append(
+            {
+                "timestamp": str(trade.get("exit_timestamp") or ""),
+                "equity": _to_float(equity),
+            }
+        )
+
+    if not curve_points:
+        return {
+            "artifact": "equity_curve",
+            "artifact_version": "1",
+            "equity_curve": [],
+            "drawdown_stats": {
+                "max_drawdown": None,
+                "recovery_time_steps": None,
+                "drawdown_distribution": [],
+            },
+        }
+
+    peak_equity = _to_decimal(curve_points[0]["equity"]) or _ZERO
+    peak_timestamp = str(curve_points[0]["timestamp"])
+    trough_equity = peak_equity
+    trough_timestamp = peak_timestamp
+    trough_index = 0
+    in_drawdown = False
+
+    max_drawdown = _ZERO
+    best_recovery_steps: int | None = None
+    drawdown_distribution: list[dict[str, object]] = []
+
+    for index, point in enumerate(curve_points):
+        equity_value = _to_decimal(point["equity"])
+        if equity_value is None:
+            continue
+        timestamp = str(point["timestamp"])
+
+        if equity_value > peak_equity:
+            if in_drawdown:
+                recovery_steps = index - trough_index
+                drawdown_distribution.append(
+                    {
+                        "peak_timestamp": peak_timestamp,
+                        "trough_timestamp": trough_timestamp,
+                        "recovery_timestamp": timestamp,
+                        "drawdown": _to_float(
+                            ((peak_equity - trough_equity) / abs(peak_equity)) if peak_equity != _ZERO else _ZERO
+                        ),
+                        "recovery_time_steps": recovery_steps,
+                    }
+                )
+                if best_recovery_steps is None or recovery_steps < best_recovery_steps:
+                    best_recovery_steps = recovery_steps
+                in_drawdown = False
+
+            peak_equity = equity_value
+            peak_timestamp = timestamp
+            trough_equity = equity_value
+            trough_timestamp = timestamp
+            trough_index = index
+            continue
+
+        drawdown = ((peak_equity - equity_value) / abs(peak_equity)) if peak_equity != _ZERO else _ZERO
+        if drawdown > max_drawdown:
+            max_drawdown = drawdown
+
+        if equity_value < peak_equity:
+            if not in_drawdown:
+                in_drawdown = True
+                trough_equity = equity_value
+                trough_timestamp = timestamp
+                trough_index = index
+            elif equity_value < trough_equity:
+                trough_equity = equity_value
+                trough_timestamp = timestamp
+                trough_index = index
+
+    if in_drawdown:
+        drawdown_distribution.append(
+            {
+                "peak_timestamp": peak_timestamp,
+                "trough_timestamp": trough_timestamp,
+                "recovery_timestamp": None,
+                "drawdown": _to_float(((peak_equity - trough_equity) / abs(peak_equity)) if peak_equity != _ZERO else _ZERO),
+                "recovery_time_steps": None,
+            }
+        )
+
+    return {
+        "artifact": "equity_curve",
+        "artifact_version": "1",
+        "equity_curve": curve_points,
+        "drawdown_stats": {
+            "max_drawdown": _to_float(max_drawdown),
+            "recovery_time_steps": best_recovery_steps,
+            "drawdown_distribution": drawdown_distribution,
+        },
+    }
+
+
+def canonical_equity_curve_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    rendered = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    return (rendered + "\n").encode("utf-8")
+
+
+def write_equity_curve_artifact(output_dir: Path, payload: Mapping[str, Any]) -> tuple[Path, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = output_dir / "equity-curve.json"
+
+    canonical_bytes = canonical_equity_curve_json_bytes(payload)
+    artifact_path.write_bytes(canonical_bytes)
+
+    sha_value = hashlib.sha256(canonical_bytes).hexdigest()
+    (output_dir / "equity-curve.sha256").write_text(f"{sha_value}\n", encoding="utf-8")
+    return artifact_path, sha_value
+
+
+def load_equity_curve_artifact(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("equity curve payload must be an object")
+
+    equity_curve = payload.get("equity_curve")
+    if not isinstance(equity_curve, list):
+        raise ValueError("equity curve missing equity_curve list")
+
+    drawdown_stats = payload.get("drawdown_stats")
+    if not isinstance(drawdown_stats, dict):
+        raise ValueError("equity curve missing drawdown_stats object")
+
+    if "max_drawdown" not in drawdown_stats:
+        raise ValueError("equity curve drawdown_stats missing max_drawdown")
+    if "recovery_time_steps" not in drawdown_stats:
+        raise ValueError("equity curve drawdown_stats missing recovery_time_steps")
+    distribution = drawdown_stats.get("drawdown_distribution")
+    if not isinstance(distribution, list):
+        raise ValueError("equity curve drawdown_stats missing drawdown_distribution list")
+
+    return payload
+
+
+__all__ = [
+    "build_equity_curve_from_trade_ledger",
+    "canonical_equity_curve_json_bytes",
+    "write_equity_curve_artifact",
+    "load_equity_curve_artifact",
+]

--- a/engine/trade_ledger.py
+++ b/engine/trade_ledger.py
@@ -11,6 +11,7 @@ from engine.performance_report import (
     build_performance_report_from_trade_ledger,
     write_performance_report_artifact,
 )
+from engine.equity_curve import build_equity_curve_from_trade_ledger, write_equity_curve_artifact
 from engine.risk_adjusted_metrics import compute_risk_adjusted_metrics_from_trade_ledger
 from engine.trade_attribution import build_trade_attribution
 
@@ -159,6 +160,7 @@ def build_trade_ledger_from_paper_trades(
     }
     payload["risk_adjusted_metrics"] = compute_risk_adjusted_metrics_from_trade_ledger(payload)
     payload["performance_report"] = build_performance_report_from_trade_ledger(payload)
+    payload["equity_curve_analysis"] = build_equity_curve_from_trade_ledger(payload)
     if signals is not None:
         attribution_payload = build_trade_attribution(trades=trades, signals=signals)
         payload["attributions"] = attribution_payload["attributions"]
@@ -182,6 +184,10 @@ def write_trade_ledger_artifact(output_dir: Path, payload: Mapping[str, Any]) ->
     performance_report = payload.get("performance_report")
     if isinstance(performance_report, Mapping):
         write_performance_report_artifact(output_dir, performance_report)
+
+    equity_curve_analysis = payload.get("equity_curve_analysis")
+    if isinstance(equity_curve_analysis, Mapping):
+        write_equity_curve_artifact(output_dir, equity_curve_analysis)
 
     return artifact_path, sha_value
 
@@ -251,6 +257,14 @@ def load_trade_ledger_artifact(path: Path) -> dict[str, object]:
         for field in ("artifact", "artifact_version", "performance_summary", "strategy_comparison", "key_metrics_overview"):
             if field not in performance_report:
                 raise ValueError(f"trade ledger performance_report missing field: {field}")
+
+    equity_curve_analysis = payload.get("equity_curve_analysis")
+    if equity_curve_analysis is not None:
+        if not isinstance(equity_curve_analysis, dict):
+            raise ValueError("trade ledger equity_curve_analysis must be an object when present")
+        for field in ("artifact", "artifact_version", "equity_curve", "drawdown_stats"):
+            if field not in equity_curve_analysis:
+                raise ValueError(f"trade ledger equity_curve_analysis missing field: {field}")
 
     return payload
 

--- a/tests/test_equity_curve_artifact.py
+++ b/tests/test_equity_curve_artifact.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+
+from pathlib import Path
+
+from engine.equity_curve import (
+    build_equity_curve_from_trade_ledger,
+    canonical_equity_curve_json_bytes,
+    load_equity_curve_artifact,
+    write_equity_curve_artifact,
+)
+
+
+def _ledger_payload() -> dict[str, object]:
+    return {
+        "artifact": "trade_ledger",
+        "artifact_version": "1",
+        "trades": [
+            {
+                "trade_id": "trade-a",
+                "strategy_id": "S",
+                "symbol": "AAPL",
+                "entry_timestamp": "2024-01-01T00:00:00Z",
+                "exit_timestamp": "2024-01-01T01:00:00Z",
+                "pnl": "100.0",
+            },
+            {
+                "trade_id": "trade-b",
+                "strategy_id": "S",
+                "symbol": "AAPL",
+                "entry_timestamp": "2024-01-02T00:00:00Z",
+                "exit_timestamp": "2024-01-02T01:00:00Z",
+                "pnl": "-20.0",
+            },
+            {
+                "trade_id": "trade-c",
+                "strategy_id": "S",
+                "symbol": "MSFT",
+                "entry_timestamp": "2024-01-03T00:00:00Z",
+                "exit_timestamp": "2024-01-03T01:00:00Z",
+                "pnl": "-10.0",
+            },
+            {
+                "trade_id": "trade-d",
+                "strategy_id": "S",
+                "symbol": "MSFT",
+                "entry_timestamp": "2024-01-04T00:00:00Z",
+                "exit_timestamp": "2024-01-04T01:00:00Z",
+                "pnl": "40.0",
+            },
+            {
+                "trade_id": "trade-e",
+                "strategy_id": "S",
+                "symbol": "NVDA",
+                "entry_timestamp": "2024-01-05T00:00:00Z",
+                "exit_timestamp": "2024-01-05T01:00:00Z",
+                "pnl": "-11.0",
+            },
+        ],
+    }
+
+
+def test_equity_curve_generation_includes_drawdown_statistics() -> None:
+    artifact = build_equity_curve_from_trade_ledger(_ledger_payload())
+
+    assert artifact["artifact"] == "equity_curve"
+    assert artifact["artifact_version"] == "1"
+    assert artifact["equity_curve"] == [
+        {"timestamp": "2024-01-01T01:00:00Z", "equity": 100.0},
+        {"timestamp": "2024-01-02T01:00:00Z", "equity": 80.0},
+        {"timestamp": "2024-01-03T01:00:00Z", "equity": 70.0},
+        {"timestamp": "2024-01-04T01:00:00Z", "equity": 110.0},
+        {"timestamp": "2024-01-05T01:00:00Z", "equity": 99.0},
+    ]
+    assert artifact["drawdown_stats"] == {
+        "max_drawdown": 0.3,
+        "recovery_time_steps": 1,
+        "drawdown_distribution": [
+            {
+                "peak_timestamp": "2024-01-01T01:00:00Z",
+                "trough_timestamp": "2024-01-03T01:00:00Z",
+                "recovery_timestamp": "2024-01-04T01:00:00Z",
+                "drawdown": 0.3,
+                "recovery_time_steps": 1,
+            },
+            {
+                "peak_timestamp": "2024-01-04T01:00:00Z",
+                "trough_timestamp": "2024-01-05T01:00:00Z",
+                "recovery_timestamp": None,
+                "drawdown": 0.1,
+                "recovery_time_steps": None,
+            },
+        ],
+    }
+
+
+def test_equity_curve_results_are_order_independent_and_deterministic() -> None:
+    payload = _ledger_payload()
+    reversed_payload = {
+        **payload,
+        "trades": list(reversed(payload["trades"])),  # type: ignore[index]
+    }
+
+    first = build_equity_curve_from_trade_ledger(payload)
+    second = build_equity_curve_from_trade_ledger(reversed_payload)
+
+    bytes_first = canonical_equity_curve_json_bytes(first)
+    bytes_second = canonical_equity_curve_json_bytes(second)
+
+    assert first == second
+    assert bytes_first == bytes_second
+    assert bytes_first.endswith(b"\n")
+    assert b"\r\n" not in bytes_first
+
+
+def test_equity_curve_artifact_write_and_load_round_trip(tmp_path: Path) -> None:
+    artifact = build_equity_curve_from_trade_ledger(_ledger_payload())
+
+    path_a, sha_a = write_equity_curve_artifact(tmp_path / "run-a", artifact)
+    path_b, sha_b = write_equity_curve_artifact(tmp_path / "run-b", artifact)
+
+    bytes_a = path_a.read_bytes()
+    bytes_b = path_b.read_bytes()
+
+    assert bytes_a == bytes_b
+    assert sha_a == sha_b
+    assert hashlib.sha256(bytes_a).hexdigest() == sha_a
+    assert (tmp_path / "run-a" / "equity-curve.sha256").read_text(encoding="utf-8") == f"{sha_a}\n"
+
+    loaded = load_equity_curve_artifact(path_a)
+    assert loaded == artifact

--- a/tests/test_trade_ledger_artifact.py
+++ b/tests/test_trade_ledger_artifact.py
@@ -134,6 +134,19 @@ def test_trade_ledger_generation_from_paper_trading_runtime() -> None:
             },
         },
     }
+    assert ledger["equity_curve_analysis"] == {
+        "artifact": "equity_curve",
+        "artifact_version": "1",
+        "equity_curve": [
+            {"timestamp": "2024-01-02T09:35:00Z", "equity": 2.0},
+            {"timestamp": "2024-01-03T09:30:00Z", "equity": 4.0},
+        ],
+        "drawdown_stats": {
+            "max_drawdown": 0.0,
+            "recovery_time_steps": None,
+            "drawdown_distribution": [],
+        },
+    }
 
     expected_first = {
         "strategy_id": "TEST",
@@ -184,6 +197,7 @@ def test_trade_ledger_serialization_is_deterministic() -> None:
     assert b"\r\n" not in bytes_a
     assert b'"risk_adjusted_metrics"' in bytes_a
     assert b'"performance_report"' in bytes_a
+    assert b'"equity_curve_analysis"' in bytes_a
 
 
 def test_trade_ledger_artifact_can_be_loaded_by_analysis_modules(tmp_path: Path) -> None:
@@ -204,6 +218,8 @@ def test_trade_ledger_artifact_can_be_loaded_by_analysis_modules(tmp_path: Path)
     assert (tmp_path / "trade-ledger.sha256").read_text(encoding="utf-8") == f"{sha_value}\n"
     assert (tmp_path / "performance-report.json").exists()
     assert (tmp_path / "performance-report.sha256").exists()
+    assert (tmp_path / "equity-curve.json").exists()
+    assert (tmp_path / "equity-curve.sha256").exists()
 
 
 def test_trade_ledger_v1_legacy_payload_without_risk_metrics_loads(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #544

## What changed
- Added deterministic equity curve + drawdown analysis module (engine/equity_curve.py).
- Integrated equity curve analysis into trade ledger payload generation.
- Added equity curve artifact writing (equity-curve.json and equity-curve.sha256) during trade-ledger artifact export.
- Extended trade-ledger loading validation for optional equity_curve_analysis.
- Added deterministic tests for:
  - equity curve generation
  - max drawdown calculation
  - recovery time and drawdown distribution
  - order-independence and canonical serialization
  - artifact write/load round-trip
  - trade-ledger integration and artifact emission

## Scope compliance
- Changed only engine/ and 	ests/.
- No API changes.
- No architecture changes.