### PR TITLE
P33-ENGINE #563: Implement Portfolio Position Inspection API

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -35,7 +35,7 @@ from engine.compliance.drawdown_guard import (
     should_block_execution_for_drawdown,
 )
 from engine.compliance.kill_switch import is_kill_switch_active
-from engine.portfolio import PortfolioState
+from engine.portfolio import PortfolioState as CompliancePortfolioState
 from .config import SIGNALS_READ_MAX_LIMIT
 from cilly_trading.db import DEFAULT_DB_PATH
 from cilly_trading.engine.core import (
@@ -55,6 +55,10 @@ from cilly_trading.engine.runtime_controller import (
     start_engine_runtime,
 )
 from .order_events_sqlite import SqliteOrderEventRepository
+from cilly_trading.engine.portfolio import (
+    PortfolioPosition as PortfolioInspectionPosition,
+    load_portfolio_state_from_env,
+)
 from cilly_trading.engine.runtime_introspection import get_runtime_introspection_payload
 from cilly_trading.engine.runtime_state import get_system_state_payload
 from cilly_trading.models import SignalReadItemDTO, SignalReadResponseDTO
@@ -458,6 +462,23 @@ class ComplianceGuardStatusResponse(BaseModel):
     guards: GuardStatusCollectionResponse
 
 
+class PortfolioPositionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    size: float
+    average_price: float
+    unrealized_pnl: float
+    strategy_id: str
+
+
+class PortfolioPositionsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    positions: List[PortfolioPositionResponse]
+    total: int
+
+
 class SystemStateMetadataResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -702,7 +723,7 @@ def _read_float_env(*names: str) -> float | None:
     return None
 
 
-def _load_compliance_guard_status_sources() -> tuple[dict[str, object], PortfolioState]:
+def _load_compliance_guard_status_sources() -> tuple[dict[str, object], CompliancePortfolioState]:
     kill_switch_active = _read_bool_env(
         "CILLY_EXECUTION_KILL_SWITCH_ACTIVE",
         "execution.kill_switch.active",
@@ -737,7 +758,7 @@ def _load_compliance_guard_status_sources() -> tuple[dict[str, object], Portfoli
     if daily_loss_max_abs is not None:
         guard_config["execution.daily_loss.max_abs"] = daily_loss_max_abs
 
-    portfolio_state = PortfolioState(
+    portfolio_state = CompliancePortfolioState(
         peak_equity=peak_equity if peak_equity is not None else 0.0,
         current_equity=current_equity if current_equity is not None else 0.0,
         start_of_day_equity=start_of_day_equity,
@@ -809,6 +830,30 @@ def system_state() -> SystemStateResponse:
     payload = get_system_state_payload()
     payload["runtime"].setdefault("extensions", [])
     return SystemStateResponse(**payload)
+
+
+def _portfolio_position_response(
+    position: PortfolioInspectionPosition,
+) -> PortfolioPositionResponse:
+    return PortfolioPositionResponse(
+        symbol=position.symbol,
+        size=position.size,
+        average_price=position.average_price,
+        unrealized_pnl=position.unrealized_pnl,
+        strategy_id=position.strategy_id,
+    )
+
+
+@app.get(
+    "/portfolio/positions",
+    response_model=PortfolioPositionsResponse,
+    summary="Portfolio Positions",
+    description="Read-only current portfolio positions for operator inspection.",
+)
+def read_portfolio_positions() -> PortfolioPositionsResponse:
+    state = load_portfolio_state_from_env()
+    items = [_portfolio_position_response(position) for position in state.positions]
+    return PortfolioPositionsResponse(positions=items, total=len(items))
 
 
 def _require_engine_runtime_running() -> None:

--- a/src/cilly_trading/engine/portfolio/__init__.py
+++ b/src/cilly_trading/engine/portfolio/__init__.py
@@ -1,0 +1,16 @@
+"""Portfolio state read models for control-plane APIs."""
+
+from .state import (
+    DEFAULT_PORTFOLIO_POSITIONS_ENV,
+    PortfolioPosition,
+    PortfolioState,
+    load_portfolio_state_from_env,
+)
+
+__all__ = (
+    "DEFAULT_PORTFOLIO_POSITIONS_ENV",
+    "PortfolioPosition",
+    "PortfolioState",
+    "load_portfolio_state_from_env",
+)
+

--- a/src/cilly_trading/engine/portfolio/state.py
+++ b/src/cilly_trading/engine/portfolio/state.py
@@ -1,0 +1,92 @@
+"""Read-only portfolio position state for control-plane inspection."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_PORTFOLIO_POSITIONS_ENV = "CILLY_PORTFOLIO_POSITIONS"
+
+
+@dataclass(frozen=True)
+class PortfolioPosition:
+    """Deterministic position model exposed through the control plane."""
+
+    strategy_id: str
+    symbol: str
+    size: float
+    average_price: float
+    unrealized_pnl: float
+
+
+@dataclass(frozen=True)
+class PortfolioState:
+    """Read-only portfolio state containing current positions."""
+
+    positions: tuple[PortfolioPosition, ...]
+
+
+def load_portfolio_state_from_env(
+    *,
+    env_var: str = DEFAULT_PORTFOLIO_POSITIONS_ENV,
+    environ: dict[str, str] | None = None,
+) -> PortfolioState:
+    """Load deterministic portfolio positions from a JSON environment value."""
+
+    source = environ if environ is not None else os.environ
+    raw_payload = source.get(env_var)
+    if not raw_payload:
+        return PortfolioState(positions=tuple())
+
+    payload = json.loads(raw_payload)
+    if not isinstance(payload, list):
+        return PortfolioState(positions=tuple())
+
+    positions = []
+    for item in payload:
+        position = _parse_position(item)
+        if position is None:
+            continue
+        positions.append(position)
+
+    ordered_positions = tuple(
+        sorted(
+            positions,
+            key=lambda item: (
+                item.symbol,
+                item.strategy_id,
+                item.size,
+                item.average_price,
+                item.unrealized_pnl,
+            ),
+        )
+    )
+    return PortfolioState(positions=ordered_positions)
+
+
+def _parse_position(item: Any) -> PortfolioPosition | None:
+    if not isinstance(item, dict):
+        return None
+
+    try:
+        strategy_id = str(item["strategy_id"])
+        symbol = str(item["symbol"])
+        size = float(item["size"])
+        average_price = float(item["average_price"])
+        unrealized_pnl = float(item["unrealized_pnl"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    if not strategy_id or not symbol:
+        return None
+
+    return PortfolioPosition(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        size=size,
+        average_price=average_price,
+        unrealized_pnl=unrealized_pnl,
+    )
+

--- a/tests/test_api_portfolio_positions_read.py
+++ b/tests/test_api_portfolio_positions_read.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from tests.utils.json_schema_validator import validate_json_schema
+
+
+def _test_client(monkeypatch: object) -> TestClient:
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    return TestClient(api_main.app)
+
+
+def test_portfolio_positions_returns_current_positions(monkeypatch) -> None:
+    positions_payload = [
+        {
+            "strategy_id": "alpha",
+            "symbol": "MSFT",
+            "size": 3.0,
+            "average_price": 312.5,
+            "unrealized_pnl": 21.1,
+        },
+        {
+            "strategy_id": "beta",
+            "symbol": "AAPL",
+            "size": -1.0,
+            "average_price": 201.0,
+            "unrealized_pnl": -4.25,
+        },
+    ]
+    monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
+
+    with _test_client(monkeypatch) as client:
+        response = client.get("/portfolio/positions")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 2
+    assert payload["positions"] == [
+        {
+            "symbol": "AAPL",
+            "size": -1.0,
+            "average_price": 201.0,
+            "unrealized_pnl": -4.25,
+            "strategy_id": "beta",
+        },
+        {
+            "symbol": "MSFT",
+            "size": 3.0,
+            "average_price": 312.5,
+            "unrealized_pnl": 21.1,
+            "strategy_id": "alpha",
+        },
+    ]
+
+
+def test_portfolio_positions_response_schema(monkeypatch) -> None:
+    positions_payload = [
+        {
+            "strategy_id": "trend-a",
+            "symbol": "NVDA",
+            "size": 4.5,
+            "average_price": 920.0,
+            "unrealized_pnl": 12.0,
+        }
+    ]
+    monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
+
+    with _test_client(monkeypatch) as client:
+        payload = client.get("/portfolio/positions").json()
+
+    schema = api_main.PortfolioPositionsResponse.model_json_schema()
+    errors = validate_json_schema(payload, schema)
+    assert errors == []
+
+
+def test_portfolio_positions_output_is_deterministic(monkeypatch) -> None:
+    positions_payload = [
+        {
+            "strategy_id": "zeta",
+            "symbol": "TSLA",
+            "size": 2.0,
+            "average_price": 150.0,
+            "unrealized_pnl": 1.0,
+        },
+        {
+            "strategy_id": "alpha",
+            "symbol": "AAPL",
+            "size": 2.0,
+            "average_price": 180.0,
+            "unrealized_pnl": 5.0,
+        },
+        {
+            "strategy_id": "beta",
+            "symbol": "AAPL",
+            "size": 1.0,
+            "average_price": 181.0,
+            "unrealized_pnl": 2.0,
+        },
+    ]
+    monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
+
+    with _test_client(monkeypatch) as client:
+        first = client.get("/portfolio/positions")
+        second = client.get("/portfolio/positions")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert [item["symbol"] for item in first.json()["positions"]] == ["AAPL", "AAPL", "TSLA"]
+    assert [item["strategy_id"] for item in first.json()["positions"][:2]] == ["alpha", "beta"]


### PR DESCRIPTION
Closes #563

## What changed
- Added read-only portfolio inspection model:
  - src/cilly_trading/engine/portfolio/state.py
  - src/cilly_trading/engine/portfolio/__init__.py
- Added GET /portfolio/positions endpoint in src/api/main.py
- Added response models for deterministic position payload
- Added tests for schema validation and deterministic output

## Determinism
Positions are sorted by:
- symbol
- strategy_id
- size
- average_price
- unrealized_pnl

## Read-only behavior
Endpoint only reads state and does not mutate portfolio state.