### PR TITLE
P33-ENGINE: Implement execution pause/resume control

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -51,6 +51,8 @@ from cilly_trading.engine.health.evaluator import (
 from cilly_trading.engine.runtime_controller import (
     LifecycleTransitionError,
     get_runtime_controller,
+    pause_engine_runtime,
+    resume_engine_runtime,
     shutdown_engine_runtime,
     start_engine_runtime,
 )
@@ -495,6 +497,12 @@ class SystemStateResponse(BaseModel):
     metadata: SystemStateMetadataResponse
 
 
+class ExecutionControlResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: str
+
+
 class JournalArtifactItemResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -830,6 +838,34 @@ def system_state() -> SystemStateResponse:
     payload = get_system_state_payload()
     payload["runtime"].setdefault("extensions", [])
     return SystemStateResponse(**payload)
+
+
+@app.post(
+    "/execution/pause",
+    response_model=ExecutionControlResponse,
+    summary="Pause Execution",
+    description="Pause engine execution while preserving runtime ownership and introspection state.",
+)
+def pause_execution() -> ExecutionControlResponse:
+    try:
+        state = pause_engine_runtime()
+    except LifecycleTransitionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return ExecutionControlResponse(state=state)
+
+
+@app.post(
+    "/execution/resume",
+    response_model=ExecutionControlResponse,
+    summary="Resume Execution",
+    description="Resume engine execution after an operator pause.",
+)
+def resume_execution() -> ExecutionControlResponse:
+    try:
+        state = resume_engine_runtime()
+    except LifecycleTransitionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return ExecutionControlResponse(state=state)
 
 
 def _portfolio_position_response(

--- a/src/api/test_execution_control_api.py
+++ b/src/api/test_execution_control_api.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from cilly_trading.engine.runtime_controller import _reset_runtime_controller_for_tests
+
+
+def setup_function() -> None:
+    _reset_runtime_controller_for_tests()
+
+
+def teardown_function() -> None:
+    _reset_runtime_controller_for_tests()
+
+
+def test_execution_pause_endpoint_pauses_runtime_and_updates_state_views() -> None:
+    with TestClient(api_main.app) as client:
+        pause_response = client.post('/execution/pause')
+        introspection_response = client.get('/runtime/introspection')
+        system_state_response = client.get('/system/state')
+
+    assert pause_response.status_code == 200
+    assert pause_response.json() == {'state': 'paused'}
+    assert introspection_response.status_code == 200
+    assert introspection_response.json()['mode'] == 'paused'
+    assert system_state_response.status_code == 200
+    assert system_state_response.json()['status'] == 'paused'
+
+
+def test_execution_resume_endpoint_resumes_runtime() -> None:
+    with TestClient(api_main.app) as client:
+        client.post('/execution/pause')
+        resume_response = client.post('/execution/resume')
+
+    assert resume_response.status_code == 200
+    assert resume_response.json() == {'state': 'running'}
+
+
+def test_execution_pause_endpoint_returns_conflict_when_runtime_not_running(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, 'start_engine_runtime', lambda: 'ready')
+
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/pause')
+
+    assert response.status_code == 409
+    assert "Cannot pause_execution()" in response.json()['detail']

--- a/src/api/test_system_state_api.py
+++ b/src/api/test_system_state_api.py
@@ -75,3 +75,19 @@ def test_system_state_endpoint_is_documented(monkeypatch) -> None:
     get_spec = openapi["paths"]["/system/state"]["get"]
     assert get_spec["summary"] == "System State"
     assert "Read-only system runtime state for operator inspection." in get_spec["description"]
+
+
+def test_system_state_reflects_paused_runtime_mode(monkeypatch) -> None:
+    payload = _build_system_state_payload()
+    payload["status"] = "paused"
+    payload["runtime"]["mode"] = "paused"
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "get_system_state_payload", lambda: payload)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/system/state")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "paused"
+    assert response.json()["runtime"]["mode"] == "paused"

--- a/src/cilly_trading/engine/runtime_controller.py
+++ b/src/cilly_trading/engine/runtime_controller.py
@@ -23,7 +23,7 @@ class EngineRuntimeController:
     """Controls lifecycle transitions for a single engine runtime instance.
 
     The lifecycle follows the contract order:
-    ``init -> ready -> running -> stopping -> stopped``.
+    ``init -> ready -> running <-> paused -> stopping -> stopped``.
     """
 
     _state: str = field(default="init", init=False)
@@ -32,6 +32,7 @@ class EngineRuntimeController:
         "init",
         "ready",
         "running",
+        "paused",
         "stopping",
         "stopped",
     )
@@ -87,6 +88,10 @@ class EngineRuntimeController:
             LifecycleTransitionError: If called before runtime reaches ``running``.
         """
 
+        if self._state == "paused":
+            self._state = "stopped"
+            return self._state
+
         assert_can_shutdown(self._state)
 
         if self._state == "stopped":
@@ -98,6 +103,34 @@ class EngineRuntimeController:
 
         self._state = "stopping"
         self._state = "stopped"
+        return self._state
+
+    def pause_execution(self) -> str:
+        """Pause execution while keeping runtime initialized."""
+
+        if self._state == "paused":
+            return self._state
+
+        if self._state != "running":
+            raise LifecycleTransitionError(
+                f"Cannot pause_execution() while in state '{self._state}'. Expected 'running' or 'paused'."
+            )
+
+        self._state = "paused"
+        return self._state
+
+    def resume_execution(self) -> str:
+        """Resume execution after an operator pause."""
+
+        if self._state == "running":
+            return self._state
+
+        if self._state != "paused":
+            raise LifecycleTransitionError(
+                f"Cannot resume_execution() while in state '{self._state}'. Expected 'paused' or 'running'."
+            )
+
+        self._state = "running"
         return self._state
 
 _RUNTIME_LOCK: Final[Lock] = Lock()
@@ -147,6 +180,22 @@ def shutdown_engine_runtime() -> str:
             return runtime.state
 
         return runtime.shutdown()
+
+
+def pause_engine_runtime() -> str:
+    """Pause execution for the process-wide runtime."""
+
+    with _RUNTIME_LOCK:
+        runtime = _get_or_create_runtime_controller()
+        return runtime.pause_execution()
+
+
+def resume_engine_runtime() -> str:
+    """Resume execution for the process-wide runtime."""
+
+    with _RUNTIME_LOCK:
+        runtime = _get_or_create_runtime_controller()
+        return runtime.resume_execution()
 
 
 def _reset_runtime_controller_for_tests() -> None:

--- a/tests/cilly_trading/engine/test_runtime_controller.py
+++ b/tests/cilly_trading/engine/test_runtime_controller.py
@@ -7,6 +7,8 @@ from cilly_trading.engine.runtime_controller import (
     LifecycleTransitionError,
     _reset_runtime_controller_for_tests,
     get_runtime_controller,
+    pause_engine_runtime,
+    resume_engine_runtime,
     shutdown_engine_runtime,
     start_engine_runtime,
 )
@@ -67,6 +69,28 @@ def test_shutdown_before_running_is_rejected() -> None:
         controller.shutdown()
 
 
+def test_pause_and_resume_transitions_succeed() -> None:
+    controller = EngineRuntimeController()
+
+    controller.init()
+    controller.start()
+
+    assert controller.pause_execution() == "paused"
+    assert controller.resume_execution() == "running"
+    assert controller.state == "running"
+
+
+def test_pause_and_resume_invalid_transitions_are_rejected() -> None:
+    controller = EngineRuntimeController()
+
+    with pytest.raises(LifecycleTransitionError):
+        controller.pause_execution()
+
+    controller.init()
+    with pytest.raises(LifecycleTransitionError):
+        controller.resume_execution()
+
+
 def test_process_runtime_is_singleton_and_started_once() -> None:
     runtime_a = get_runtime_controller()
     runtime_b = get_runtime_controller()
@@ -89,3 +113,16 @@ def test_process_runtime_shutdown_is_best_effort() -> None:
     assert shutdown_engine_runtime() == "stopped"
     assert shutdown_engine_runtime() == "stopped"
     assert runtime.state == "stopped"
+
+
+def test_process_runtime_pause_and_resume_are_idempotent() -> None:
+    runtime = get_runtime_controller()
+
+    start_engine_runtime()
+    assert pause_engine_runtime() == "paused"
+    assert pause_engine_runtime() == "paused"
+    assert runtime.state == "paused"
+
+    assert resume_engine_runtime() == "running"
+    assert resume_engine_runtime() == "running"
+    assert runtime.state == "running"

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 import api.main as api_main
+from cilly_trading.engine.runtime_controller import _reset_runtime_controller_for_tests
 from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 
@@ -235,3 +236,110 @@ def test_engine_requests_work_normally_when_runtime_running(monkeypatch) -> None
 
     assert response.status_code == 422
     assert response.json() == {"detail": "invalid_ingestion_run_id"}
+
+
+def test_engine_requests_are_blocked_when_runtime_paused(tmp_path: Path, monkeypatch) -> None:
+    ingestion_run_id = _setup_analysis_dependencies(tmp_path, monkeypatch)
+
+    def _start() -> str:
+        return "paused"
+
+    def _runtime() -> _RuntimeStateStub:
+        return _RuntimeStateStub("paused")
+
+    def _fail_run_watchlist_analysis(*args, **kwargs):
+        raise AssertionError("run_watchlist_analysis should not be called")
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+    monkeypatch.setattr(api_main, "get_runtime_controller", _runtime)
+    monkeypatch.setattr(api_main, "run_watchlist_analysis", _fail_run_watchlist_analysis)
+
+    with TestClient(api_main.app) as client:
+        response = client.post(
+            "/strategy/analyze",
+            json={
+                "ingestion_run_id": ingestion_run_id,
+                "symbol": "AAPL",
+                "strategy": "RSI2",
+                "market_type": "stock",
+                "lookback_days": 200,
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {
+            "code": "engine_runtime_not_running",
+            "state": "paused",
+        }
+    }
+
+
+def test_pause_during_in_progress_analysis_does_not_interrupt_execution(monkeypatch) -> None:
+    class _Strategy:
+        name = "RSI2"
+
+    class _InMemoryAnalysisRunRepo:
+        def __init__(self) -> None:
+            self._runs: dict[str, dict[str, object]] = {}
+
+        def get_run(self, analysis_run_id: str) -> dict[str, object] | None:
+            return self._runs.get(analysis_run_id)
+
+        def save_run(
+            self,
+            *,
+            analysis_run_id: str,
+            ingestion_run_id: str,
+            request_payload: dict[str, object],
+            result_payload: dict[str, object],
+        ) -> None:
+            self._runs[analysis_run_id] = {
+                "analysis_run_id": analysis_run_id,
+                "ingestion_run_id": ingestion_run_id,
+                "request": request_payload,
+                "result": result_payload,
+            }
+
+    calls = {"run": 0}
+
+    _reset_runtime_controller_for_tests()
+    monkeypatch.setattr(api_main, "_require_ingestion_run", lambda *_: None)
+    monkeypatch.setattr(api_main, "_require_snapshot_ready", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(api_main, "create_strategy", lambda *_: _Strategy())
+    monkeypatch.setattr(api_main, "analysis_run_repo", _InMemoryAnalysisRunRepo())
+    monkeypatch.setattr(api_main, "_resolve_analysis_db_path", lambda: "analysis.db")
+
+    def _run_snapshot_analysis(**kwargs):
+        calls["run"] += 1
+        pause_response = client.post("/execution/pause")
+        assert pause_response.status_code == 200
+        assert pause_response.json() == {"state": "paused"}
+        return [
+            {
+                "symbol": kwargs["symbols"][0],
+                "strategy": "RSI2",
+                "stage": "setup",
+            }
+        ]
+
+    monkeypatch.setattr(api_main, "_run_snapshot_analysis", _run_snapshot_analysis)
+
+    with TestClient(api_main.app) as client:
+        response = client.post(
+            "/analysis/run",
+            json={
+                "ingestion_run_id": str(uuid.uuid4()),
+                "symbol": "AAPL",
+                "strategy": "RSI2",
+                "market_type": "stock",
+                "lookback_days": 200,
+            },
+        )
+        introspection = client.get("/runtime/introspection")
+
+    assert calls["run"] == 1
+    assert response.status_code == 200
+    assert response.json()["signals"][0]["symbol"] == "AAPL"
+    assert introspection.status_code == 200
+    assert introspection.json()["mode"] == "paused"


### PR DESCRIPTION
Closes #564

## What changed
- Added runtime execution pause/resume transitions in EngineRuntimeController
- Added process-level helpers:
  - pause_engine_runtime()
  - resume_engine_runtime()
- Added API endpoints:
  - POST /execution/pause
  - POST /execution/resume
- Added ExecutionControlResponse API model
- Ensured paused state is visible through runtime introspection and system state APIs

## Tests
- Runtime transition tests
- Execution control API endpoint tests
- Paused-state introspection visibility
- Guard interaction tests
- In-progress analysis pause behavior

## Validation
python -m pytest

Result:
423 passed, 4 warnings