### PR TITLE
P33-ENGINE: Persist execution journal artifacts in deterministic run pipeline (#566)

### DIFF
--- a/src/cilly_trading/engine/backtest_runner.py
+++ b/src/cilly_trading/engine/backtest_runner.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Protocol, Sequence, Tuple
 
+from cilly_trading.engine.journal.execution_journal import (
+    build_execution_journal_artifact,
+    write_execution_journal_artifact,
+)
 from cilly_trading.engine.result_artifact import write_artifact
 
 
@@ -122,12 +126,83 @@ class BacktestRunner:
             invocation_log=invocation_log,
             config=config,
         )
-        return write_artifact(
+        artifact_path, artifact_sha256 = write_artifact(
             output_dir=config.output_dir,
             payload=payload,
             artifact_name=config.artifact_name,
             hash_name=config.hash_name,
         )
+        self._write_execution_journal(
+            processed_snapshots=processed_snapshots,
+            invocation_log=invocation_log,
+            config=config,
+        )
+        return artifact_path, artifact_sha256
+
+    def _write_execution_journal(
+        self,
+        *,
+        processed_snapshots: List[Dict[str, Any]],
+        invocation_log: List[str],
+        config: BacktestRunnerConfig,
+    ) -> None:
+        events: List[Dict[str, Any]] = []
+        snapshot_lookup = {
+            str(snapshot.get("id", "")): snapshot for snapshot in processed_snapshots
+        }
+
+        for index, invocation in enumerate(invocation_log, start=1):
+            if invocation == "on_run_start":
+                events.append(
+                    {
+                        "event_id": f"{config.run_id}:run_start",
+                        "phase": "run",
+                        "status": "started",
+                        "sequence": index,
+                        "snapshot_id": "",
+                        "timestamp": "",
+                        "metadata": {"hook": invocation},
+                    }
+                )
+                continue
+
+            if invocation == "on_run_end":
+                events.append(
+                    {
+                        "event_id": f"{config.run_id}:run_end",
+                        "phase": "run",
+                        "status": "completed",
+                        "sequence": index,
+                        "snapshot_id": "",
+                        "timestamp": "",
+                        "metadata": {"hook": invocation},
+                    }
+                )
+                continue
+
+            if invocation.startswith("on_snapshot:"):
+                snapshot_id = invocation.split(":", 1)[1]
+                snapshot_payload = snapshot_lookup.get(snapshot_id, {})
+                snapshot_timestamp = snapshot_payload.get("timestamp")
+                events.append(
+                    {
+                        "event_id": f"{config.run_id}:snapshot:{snapshot_id}",
+                        "phase": "snapshot",
+                        "status": "processed",
+                        "sequence": index,
+                        "snapshot_id": snapshot_id,
+                        "timestamp": "" if snapshot_timestamp is None else str(snapshot_timestamp),
+                        "metadata": {"hook": invocation},
+                    }
+                )
+
+        execution_journal = build_execution_journal_artifact(
+            run_id=config.run_id,
+            lifecycle_events=events,
+            deterministic=True,
+            created_at="",
+        )
+        write_execution_journal_artifact(config.output_dir, execution_journal)
 
     def _build_payload(
         self,

--- a/src/cilly_trading/engine/journal/__init__.py
+++ b/src/cilly_trading/engine/journal/__init__.py
@@ -1,0 +1,17 @@
+"""Journal artifacts for deterministic engine auditability."""
+
+from cilly_trading.engine.journal.execution_journal import (
+    EXECUTION_JOURNAL_SCHEMA,
+    build_execution_journal_artifact,
+    canonical_execution_journal_json_bytes,
+    load_execution_journal_artifact,
+    write_execution_journal_artifact,
+)
+
+__all__ = [
+    "EXECUTION_JOURNAL_SCHEMA",
+    "build_execution_journal_artifact",
+    "canonical_execution_journal_json_bytes",
+    "load_execution_journal_artifact",
+    "write_execution_journal_artifact",
+]

--- a/src/cilly_trading/engine/journal/execution_journal.py
+++ b/src/cilly_trading/engine/journal/execution_journal.py
@@ -1,0 +1,127 @@
+"""Deterministic execution journal artifact helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from cilly_trading.engine.journal.system import (
+    canonical_journal_json_bytes,
+    load_journal_artifact,
+    write_journal_artifact,
+)
+
+EXECUTION_JOURNAL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["artifact", "artifact_version", "run", "lifecycle"],
+    "additionalProperties": False,
+    "properties": {
+        "artifact": {"type": "string", "enum": ["execution_journal"]},
+        "artifact_version": {"type": "string", "enum": ["1"]},
+        "run": {
+            "type": "object",
+            "required": ["run_id", "deterministic", "created_at"],
+            "additionalProperties": False,
+            "properties": {
+                "run_id": {"type": "string"},
+                "deterministic": {"type": "boolean"},
+                "created_at": {"type": "string"},
+            },
+        },
+        "lifecycle": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/lifecycle_event"},
+        },
+    },
+    "$defs": {
+        "lifecycle_event": {
+            "type": "object",
+            "required": ["event_id", "phase", "status", "sequence", "snapshot_id", "timestamp", "metadata"],
+            "additionalProperties": False,
+            "properties": {
+                "event_id": {"type": "string"},
+                "phase": {"type": "string"},
+                "status": {"type": "string"},
+                "sequence": {"type": "integer"},
+                "snapshot_id": {"type": "string"},
+                "timestamp": {"type": "string"},
+                "metadata": {"type": "object"},
+            },
+        }
+    },
+}
+
+
+def _normalize_lifecycle_events(events: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for event in events:
+        normalized.append(
+            {
+                "event_id": str(event["event_id"]),
+                "phase": str(event["phase"]),
+                "status": str(event["status"]),
+                "sequence": int(event["sequence"]),
+                "snapshot_id": "" if event.get("snapshot_id") is None else str(event.get("snapshot_id")),
+                "timestamp": "" if event.get("timestamp") is None else str(event.get("timestamp")),
+                "metadata": dict(event.get("metadata", {})),
+            }
+        )
+
+    normalized.sort(
+        key=lambda event: (
+            event["sequence"],
+            event["event_id"],
+            event["phase"],
+            event["status"],
+            event["snapshot_id"] or "",
+            event["timestamp"] or "",
+        )
+    )
+    return normalized
+
+
+def build_execution_journal_artifact(
+    *,
+    run_id: str,
+    lifecycle_events: Iterable[Mapping[str, Any]],
+    deterministic: bool = True,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    """Build deterministic execution journal payload for a run."""
+    return {
+        "artifact": "execution_journal",
+        "artifact_version": "1",
+        "run": {
+            "run_id": str(run_id),
+            "deterministic": bool(deterministic),
+            "created_at": "" if created_at is None else str(created_at),
+        },
+        "lifecycle": _normalize_lifecycle_events(lifecycle_events),
+    }
+
+
+def canonical_execution_journal_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    """Serialize execution journal payload into canonical JSON bytes."""
+    return canonical_journal_json_bytes(payload)
+
+
+def write_execution_journal_artifact(
+    run_dir: Path,
+    payload: Mapping[str, Any],
+    *,
+    artifact_name: str = "execution-journal.json",
+    hash_name: str = "execution-journal.sha256",
+) -> tuple[Path, str]:
+    """Write execution journal artifact and SHA sidecar under the run directory."""
+    return write_journal_artifact(
+        run_dir=run_dir,
+        payload=payload,
+        artifact_name=artifact_name,
+        hash_name=hash_name,
+        serializer=canonical_execution_journal_json_bytes,
+    )
+
+
+def load_execution_journal_artifact(path: Path) -> dict[str, Any]:
+    """Load execution journal artifact payload."""
+    return load_journal_artifact(path)

--- a/src/cilly_trading/engine/journal/system.py
+++ b/src/cilly_trading/engine/journal/system.py
@@ -1,0 +1,52 @@
+"""Shared deterministic journal artifact IO helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+def canonical_journal_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    """Serialize a journal payload into canonical UTF-8 JSON bytes with trailing LF."""
+    return (
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def write_journal_artifact(
+    *,
+    run_dir: Path,
+    payload: Mapping[str, Any],
+    artifact_name: str,
+    hash_name: str,
+    serializer: Callable[[Mapping[str, Any]], bytes] = canonical_journal_json_bytes,
+) -> tuple[Path, str]:
+    """Write deterministic journal and SHA-256 sidecar into the run directory."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    artifact_bytes = serializer(payload)
+    artifact_path = run_dir / artifact_name
+    artifact_path.write_bytes(artifact_bytes)
+
+    artifact_sha256 = hashlib.sha256(artifact_bytes).hexdigest()
+    hash_path = run_dir / hash_name
+    hash_path.write_text(f"{artifact_sha256}\n", encoding="utf-8")
+
+    return artifact_path, artifact_sha256
+
+
+def load_journal_artifact(path: Path) -> dict[str, Any]:
+    """Load a JSON journal artifact from disk."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("journal artifact payload must be a JSON object")
+    return payload

--- a/tests/cilly_trading/engine/test_backtest_runner.py
+++ b/tests/cilly_trading/engine/test_backtest_runner.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Mapping
 import pytest
 
 from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerConfig
+from cilly_trading.engine.journal.execution_journal import EXECUTION_JOURNAL_SCHEMA
+from tests.utils.json_schema_validator import validate_json_schema
 
 
 class SpyStrategy:
@@ -172,3 +174,33 @@ def test_snapshot_linkage_mixed_error(tmp_path: Path) -> None:
             strategy_factory=strategy_factory,
             config=BacktestRunnerConfig(output_dir=tmp_path / "mixed-mode"),
         )
+
+
+def test_backtest_runner_persists_execution_journal_artifacts(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    run_dir = tmp_path / "run-integration"
+    runner.run(
+        snapshots=_sample_snapshots(),
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=run_dir, run_id="run-integration"),
+    )
+
+    journal_path = run_dir / "execution-journal.json"
+    hash_path = run_dir / "execution-journal.sha256"
+
+    assert journal_path.exists()
+    assert hash_path.exists()
+
+    journal_payload = json.loads(journal_path.read_text(encoding="utf-8"))
+    validation_errors = validate_json_schema(journal_payload, EXECUTION_JOURNAL_SCHEMA)
+    assert validation_errors == []
+    assert journal_payload["run"]["run_id"] == "run-integration"
+
+    phases = [(event["phase"], event["status"]) for event in journal_payload["lifecycle"]]
+    assert phases[0] == ("run", "started")
+    assert phases[-1] == ("run", "completed")
+    assert any(phase == ("snapshot", "processed") for phase in phases)

--- a/tests/journal/test_execution_journal.py
+++ b/tests/journal/test_execution_journal.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from cilly_trading.engine.journal.execution_journal import (
+    EXECUTION_JOURNAL_SCHEMA,
+    build_execution_journal_artifact,
+    canonical_execution_journal_json_bytes,
+    load_execution_journal_artifact,
+    write_execution_journal_artifact,
+)
+from tests.utils.json_schema_validator import validate_json_schema
+
+
+def _lifecycle_events() -> list[dict[str, object]]:
+    return [
+        {
+            "event_id": "evt-run-end",
+            "phase": "run",
+            "status": "completed",
+            "sequence": 3,
+            "snapshot_id": None,
+            "timestamp": "2024-01-01T00:02:00Z",
+            "metadata": {"processed": 2},
+        },
+        {
+            "event_id": "evt-s1",
+            "phase": "snapshot",
+            "status": "processed",
+            "sequence": 2,
+            "snapshot_id": "s1",
+            "timestamp": "2024-01-01T00:01:00Z",
+            "metadata": {"symbol": "AAPL"},
+        },
+        {
+            "event_id": "evt-run-start",
+            "phase": "run",
+            "status": "started",
+            "sequence": 1,
+            "snapshot_id": None,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "metadata": {"mode": "backtest"},
+        },
+    ]
+
+
+def test_execution_journal_artifact_generation_and_run_level_storage(tmp_path: Path) -> None:
+    payload = build_execution_journal_artifact(
+        run_id="run-001",
+        lifecycle_events=_lifecycle_events(),
+        deterministic=True,
+        created_at=None,
+    )
+
+    artifact_path, sha_value = write_execution_journal_artifact(tmp_path / "runs" / "run-001", payload)
+
+    assert artifact_path == tmp_path / "runs" / "run-001" / "execution-journal.json"
+    assert artifact_path.exists()
+    assert (tmp_path / "runs" / "run-001" / "execution-journal.sha256").read_text(
+        encoding="utf-8"
+    ) == f"{sha_value}\n"
+
+    loaded_payload = load_execution_journal_artifact(artifact_path)
+    assert loaded_payload == payload
+
+
+def test_execution_journal_schema_validation() -> None:
+    payload = build_execution_journal_artifact(
+        run_id="run-001",
+        lifecycle_events=_lifecycle_events(),
+    )
+    errors = validate_json_schema(payload, EXECUTION_JOURNAL_SCHEMA)
+    assert errors == []
+
+    invalid_payload = dict(payload)
+    invalid_payload.pop("run")
+    invalid_errors = validate_json_schema(invalid_payload, EXECUTION_JOURNAL_SCHEMA)
+    assert any(error.message == "Missing required property: run" for error in invalid_errors)
+
+
+def test_execution_journal_serialization_is_deterministic() -> None:
+    payload_a = build_execution_journal_artifact(
+        run_id="run-001",
+        lifecycle_events=_lifecycle_events(),
+    )
+    payload_b = build_execution_journal_artifact(
+        run_id="run-001",
+        lifecycle_events=list(reversed(_lifecycle_events())),
+    )
+
+    bytes_a = canonical_execution_journal_json_bytes(payload_a)
+    bytes_b = canonical_execution_journal_json_bytes(payload_b)
+
+    assert payload_a == payload_b
+    assert bytes_a == bytes_b
+    assert bytes_a.endswith(b"\n")
+    assert b"\r\n" not in bytes_a
+    assert hashlib.sha256(bytes_a).hexdigest() == hashlib.sha256(bytes_b).hexdigest()


### PR DESCRIPTION
Closes #566

## Summary
Integrates execution journal persistence into the real deterministic run artifact flow.

## Changes
- Backtest run pipeline now automatically writes:
  - execution-journal.json
  - execution-journal.sha256
  into the run output directory.
- Execution lifecycle is derived from the actual invocation log and processed snapshots.
- Added integration-style run test verifying:
  - files are created automatically by BacktestRunner.run(...)
  - payload is schema-valid
  - run lifecycle events include run start, snapshot processing, and run completion
- Deterministic serialization and existing schema checks remain covered.

## Validation
.\.venv\Scripts\python -m pytest -q

Result:
427 passed, 4 warnings