### PR TITLE
P33-DATA: Introduce Market Data Provider Interface (#572)

### DIFF
--- a/src/cilly_trading/engine/data/PROVIDER_CONTRACT.md
+++ b/src/cilly_trading/engine/data/PROVIDER_CONTRACT.md
@@ -1,0 +1,37 @@
+# Market Data Provider Contract
+
+## Purpose
+This contract defines the canonical interface for all engine market data providers.
+Backtesting, paper trading, and future live providers must conform to this contract.
+
+## Interface
+`MarketDataProvider` is defined in:
+
+`src/cilly_trading/engine/data/market_data_provider.py`
+
+Required method:
+
+- `iter_candles(request: MarketDataRequest) -> Iterator[Candle]`
+
+## Canonical Candle Schema
+Each `Candle` must expose:
+
+- `timestamp: datetime`
+- `symbol: str`
+- `timeframe: str`
+- `open: Decimal`
+- `high: Decimal`
+- `low: Decimal`
+- `close: Decimal`
+- `volume: Decimal`
+
+## Deterministic Iteration Requirements
+Providers must be deterministic for a logically identical request:
+
+- Candle order must be stable.
+- Repeated calls must produce the same candle sequence.
+- No implicit randomness or non-deterministic ordering is allowed.
+
+## Stability Requirement
+This interface is a compatibility boundary for future providers.
+Changes must be backward compatible unless an explicit versioned migration is introduced.

--- a/src/cilly_trading/engine/data/market_data_provider.py
+++ b/src/cilly_trading/engine/data/market_data_provider.py
@@ -1,0 +1,47 @@
+"""Canonical market data provider contract for engine consumers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Iterator, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class Candle:
+    """Canonical candle payload returned by market data providers."""
+
+    timestamp: datetime
+    symbol: str
+    timeframe: str
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
+
+
+@dataclass(frozen=True)
+class MarketDataRequest:
+    """Canonical request shape accepted by market data providers."""
+
+    symbol: str
+    timeframe: str
+    limit: int | None = None
+
+
+@runtime_checkable
+class MarketDataProvider(Protocol):
+    """Provider protocol for deterministic market data iteration.
+
+    Contract:
+    - For a logically identical request, providers must return candles in a stable order.
+    - Repeated iteration over a request must yield the same sequence of candle objects.
+    - Each yielded candle must contain the canonical OHLCV fields.
+    """
+
+    def iter_candles(self, request: MarketDataRequest) -> Iterator[Candle]:
+        """Yield canonical candles for a request in deterministic order."""
+
+        ...

--- a/tests/data/test_market_data_provider_contract.py
+++ b/tests/data/test_market_data_provider_contract.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import fields
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+
+def _load_provider_module():
+    root = Path(__file__).resolve().parents[2]
+    module_path = root / "src" / "cilly_trading" / "engine" / "data" / "market_data_provider.py"
+    spec = importlib.util.spec_from_file_location("market_data_provider_contract", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load market_data_provider module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+module = _load_provider_module()
+Candle = module.Candle
+MarketDataProvider = module.MarketDataProvider
+MarketDataRequest = module.MarketDataRequest
+
+
+class InMemoryDeterministicProvider:
+    def __init__(self) -> None:
+        self._candles = (
+            Candle(
+                timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
+                symbol="BTC/USDT",
+                timeframe="1H",
+                open=Decimal("100.0"),
+                high=Decimal("101.0"),
+                low=Decimal("99.5"),
+                close=Decimal("100.5"),
+                volume=Decimal("250.0"),
+            ),
+            Candle(
+                timestamp=datetime(2025, 1, 1, 1, tzinfo=timezone.utc),
+                symbol="BTC/USDT",
+                timeframe="1H",
+                open=Decimal("100.5"),
+                high=Decimal("102.0"),
+                low=Decimal("100.0"),
+                close=Decimal("101.0"),
+                volume=Decimal("300.0"),
+            ),
+        )
+
+    def iter_candles(self, request: MarketDataRequest):
+        candles = tuple(
+            candle
+            for candle in self._candles
+            if candle.symbol == request.symbol and candle.timeframe == request.timeframe
+        )
+        if request.limit is not None:
+            return iter(candles[: request.limit])
+        return iter(candles)
+
+
+def test_market_data_provider_runtime_contract() -> None:
+    provider = InMemoryDeterministicProvider()
+    assert isinstance(provider, MarketDataProvider)
+
+
+def test_candle_exposes_canonical_fields() -> None:
+    field_names = tuple(field.name for field in fields(Candle))
+    assert field_names == (
+        "timestamp",
+        "symbol",
+        "timeframe",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    )
+
+
+def test_iter_candles_is_deterministic_for_identical_request() -> None:
+    provider = InMemoryDeterministicProvider()
+    request = MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+
+    first = tuple(provider.iter_candles(request))
+    second = tuple(provider.iter_candles(request))
+
+    assert first == second
+    assert len(first) == 2
+
+
+def test_iter_candles_respects_limit_deterministically() -> None:
+    provider = InMemoryDeterministicProvider()
+    request = MarketDataRequest(symbol="BTC/USDT", timeframe="1H", limit=1)
+
+    first = tuple(provider.iter_candles(request))
+    second = tuple(provider.iter_candles(request))
+
+    assert first == second
+    assert len(first) == 1


### PR DESCRIPTION
Closes #572

## What changed

- Added canonical MarketDataProvider protocol
- Introduced canonical market data models:
  - Candle
  - MarketDataRequest
- Documented deterministic provider contract
- Added deterministic iteration tests
- Added provider interface contract tests

## Files

src/cilly_trading/engine/data/market_data_provider.py
src/cilly_trading/engine/data/PROVIDER_CONTRACT.md
tests/data/test_market_data_provider_contract.py

## Validation

.\.venv\Scripts\python -m pytest

Result:
431 passed, 4 warnings