### PR TITLE
P33-DATA: Implement Local Snapshot Market Data Provider (#573)

### DIFF
--- a/src/cilly_trading/engine/data/market_data_provider.py
+++ b/src/cilly_trading/engine/data/market_data_provider.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Iterator, Protocol, runtime_checkable
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -45,3 +47,77 @@ class MarketDataProvider(Protocol):
         """Yield canonical candles for a request in deterministic order."""
 
         ...
+
+
+class LocalSnapshotProvider:
+    """Market data provider backed by deterministic local snapshot datasets."""
+
+    def __init__(self, dataset_path: str | Path) -> None:
+        self._dataset_path = Path(dataset_path)
+        self._candles = self._load_dataset(self._dataset_path)
+
+    def iter_candles(self, request: MarketDataRequest) -> Iterator[Candle]:
+        candles = tuple(
+            candle
+            for candle in self._candles
+            if candle.symbol == request.symbol and candle.timeframe == request.timeframe
+        )
+        if request.limit is not None:
+            if request.limit < 0:
+                raise ValueError("request.limit must be >= 0")
+            candles = candles[: request.limit]
+        return iter(candles)
+
+    @staticmethod
+    def _load_dataset(dataset_path: Path) -> tuple[Candle, ...]:
+        try:
+            payload = json.loads(dataset_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError("Invalid snapshot dataset") from exc
+
+        if not isinstance(payload, list):
+            raise ValueError("Invalid snapshot dataset")
+
+        normalized: list[tuple[int, Candle]] = []
+        for index, item in enumerate(payload):
+            if not isinstance(item, Mapping):
+                raise ValueError("Invalid snapshot dataset")
+            normalized.append((index, LocalSnapshotProvider._parse_candle(item)))
+
+        ordered = sorted(
+            normalized,
+            key=lambda pair: (
+                pair[1].timestamp,
+                pair[1].symbol,
+                pair[1].timeframe,
+                pair[0],
+            ),
+        )
+        return tuple(candle for _, candle in ordered)
+
+    @staticmethod
+    def _parse_candle(item: Mapping[str, Any]) -> Candle:
+        try:
+            timestamp = LocalSnapshotProvider._parse_timestamp(item["timestamp"])
+            return Candle(
+                timestamp=timestamp,
+                symbol=str(item["symbol"]),
+                timeframe=str(item["timeframe"]),
+                open=Decimal(str(item["open"])),
+                high=Decimal(str(item["high"])),
+                low=Decimal(str(item["low"])),
+                close=Decimal(str(item["close"])),
+                volume=Decimal(str(item["volume"])),
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError("Invalid snapshot dataset") from exc
+
+    @staticmethod
+    def _parse_timestamp(value: Any) -> datetime:
+        if not isinstance(value, str):
+            raise ValueError("Invalid snapshot dataset")
+        normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+        try:
+            return datetime.fromisoformat(normalized)
+        except ValueError as exc:
+            raise ValueError("Invalid snapshot dataset") from exc

--- a/tests/data/test_market_data_provider_contract.py
+++ b/tests/data/test_market_data_provider_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from dataclasses import fields
 from datetime import datetime, timezone
@@ -22,6 +23,7 @@ def _load_provider_module():
 
 module = _load_provider_module()
 Candle = module.Candle
+LocalSnapshotProvider = module.LocalSnapshotProvider
 MarketDataProvider = module.MarketDataProvider
 MarketDataRequest = module.MarketDataRequest
 
@@ -101,3 +103,105 @@ def test_iter_candles_respects_limit_deterministically() -> None:
 
     assert first == second
     assert len(first) == 1
+
+
+def test_local_snapshot_provider_loads_snapshot_dataset(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "snapshots.json"
+    dataset_path.write_text(
+        json.dumps(
+            [
+                {
+                    "timestamp": "2025-01-01T01:00:00+00:00",
+                    "symbol": "BTC/USDT",
+                    "timeframe": "1H",
+                    "open": "100.5",
+                    "high": "102.0",
+                    "low": "100.0",
+                    "close": "101.0",
+                    "volume": "300.0",
+                },
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "symbol": "BTC/USDT",
+                    "timeframe": "1H",
+                    "open": "100.0",
+                    "high": "101.0",
+                    "low": "99.5",
+                    "close": "100.5",
+                    "volume": "250.0",
+                },
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "symbol": "ETH/USDT",
+                    "timeframe": "1H",
+                    "open": "50.0",
+                    "high": "51.0",
+                    "low": "49.5",
+                    "close": "50.5",
+                    "volume": "100.0",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    provider = LocalSnapshotProvider(dataset_path=dataset_path)
+    assert isinstance(provider, MarketDataProvider)
+
+    candles = tuple(provider.iter_candles(MarketDataRequest(symbol="BTC/USDT", timeframe="1H")))
+
+    assert len(candles) == 2
+    assert candles[0].timestamp == datetime(2025, 1, 1, 0, tzinfo=timezone.utc)
+    assert candles[1].timestamp == datetime(2025, 1, 1, 1, tzinfo=timezone.utc)
+
+
+def test_local_snapshot_provider_iteration_order_is_deterministic(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "snapshots.json"
+    dataset_path.write_text(
+        json.dumps(
+            [
+                {
+                    "timestamp": "2025-01-01T02:00:00+00:00",
+                    "symbol": "BTC/USDT",
+                    "timeframe": "1H",
+                    "open": "102.0",
+                    "high": "103.0",
+                    "low": "101.0",
+                    "close": "102.5",
+                    "volume": "320.0",
+                },
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "symbol": "BTC/USDT",
+                    "timeframe": "1H",
+                    "open": "100.0",
+                    "high": "101.0",
+                    "low": "99.5",
+                    "close": "100.5",
+                    "volume": "250.0",
+                },
+                {
+                    "timestamp": "2025-01-01T01:00:00+00:00",
+                    "symbol": "BTC/USDT",
+                    "timeframe": "1H",
+                    "open": "101.0",
+                    "high": "102.0",
+                    "low": "100.0",
+                    "close": "101.5",
+                    "volume": "290.0",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    provider = LocalSnapshotProvider(dataset_path=dataset_path)
+    request = MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+
+    first = tuple(provider.iter_candles(request))
+    second = tuple(provider.iter_candles(request))
+
+    assert first == second
+    assert [candle.timestamp for candle in first] == [
+        datetime(2025, 1, 1, 0, tzinfo=timezone.utc),
+        datetime(2025, 1, 1, 1, tzinfo=timezone.utc),
+        datetime(2025, 1, 1, 2, tzinfo=timezone.utc),
+    ]


### PR DESCRIPTION
Closes #573

## What changed

- Added LocalSnapshotProvider in src/cilly_trading/engine/data/market_data_provider.py
- Implemented loading of local JSON snapshot datasets
- Parsed canonical Candle objects
- Enforced deterministic ordering across loaded snapshots
- Added tests validating:
  - snapshot dataset loading
  - deterministic iteration order
  - MarketDataProvider runtime contract compliance

## Scope check

Only files within allowed paths were modified:

src/cilly_trading/engine/data/*
tests/data/*

No engine execution, strategy, risk, portfolio, or UI modules were modified.

## Validation

python -m pytest

Result:
433 passed, 4 warnings