### PR TITLE
fix(P33-DATA): canonicalize dataset identity timestamps (#576)

### DIFF
--- a/src/cilly_trading/engine/data/DATASET_CONTRACT.md
+++ b/src/cilly_trading/engine/data/DATASET_CONTRACT.md
@@ -1,0 +1,76 @@
+﻿# Canonical Market Dataset Contract
+
+## Purpose
+This contract defines the canonical metadata for market datasets used by backtesting and analysis.
+It is a deterministic compatibility boundary for data identity, validation, and reproducibility.
+
+## Schema Definition
+The canonical metadata schema is defined as:
+
+- `CANONICAL_MARKET_DATASET_METADATA_SCHEMA`
+
+in:
+
+- `src/cilly_trading/engine/data/market_dataset_contract.py`
+
+Required fields:
+
+- `dataset_id` (string)
+- `symbol` (string)
+- `timeframe` (string)
+- `source` (string)
+- `start_timestamp` (ISO-8601 datetime string with timezone)
+- `end_timestamp` (ISO-8601 datetime string with timezone)
+- `row_count` (integer, `>= 0`)
+- `created_at` (ISO-8601 datetime string with timezone)
+- `content_sha256` (64-char SHA-256 hex digest)
+
+Optional fields:
+
+- `contract_version` (string)
+
+## Dataset Identity Rules
+`dataset_id` must be deterministic and is computed as SHA-256 of canonical JSON over the identity fields:
+
+- `symbol`
+- `timeframe`
+- `source`
+- `start_timestamp`
+- `end_timestamp`
+- `row_count`
+- `content_sha256`
+
+Identity implementation:
+
+- `DATASET_IDENTITY_FIELDS`
+- `compute_dataset_identity(metadata)`
+
+Before hashing, `start_timestamp` and `end_timestamp` are canonicalized to timezone-aware UTC ISO-8601 strings.
+Equivalent representations (for example `Z` vs `+00:00`, or non-UTC offsets representing the same instant) produce the same `dataset_id`.
+
+`created_at` is intentionally excluded from identity so logically identical datasets produce the same `dataset_id`.
+
+## Integrity Verification Fields
+Deterministic integrity verification uses:
+
+- `row_count` to validate expected dataset length
+- `content_sha256` to validate dataset content digest
+
+Validation enforces:
+
+- required fields are present
+- field types are correct
+- timestamps are valid timezone-aware ISO-8601 values
+- `start_timestamp <= end_timestamp`
+- `dataset_id` equals the deterministic identity derived from canonical identity fields
+
+Validation implementation:
+
+- `validate_market_dataset_metadata(payload)`
+
+## Metadata Construction
+Use:
+
+- `build_market_dataset_metadata(...)`
+
+to construct canonical metadata with a deterministic `dataset_id` and validation.

--- a/src/cilly_trading/engine/data/market_dataset_contract.py
+++ b/src/cilly_trading/engine/data/market_dataset_contract.py
@@ -1,0 +1,199 @@
+﻿"""Canonical market dataset contract for deterministic metadata and identity."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+DATASET_CONTRACT_VERSION = "1.0.0"
+
+DATASET_IDENTITY_FIELDS: tuple[str, ...] = (
+    "symbol",
+    "timeframe",
+    "source",
+    "start_timestamp",
+    "end_timestamp",
+    "row_count",
+    "content_sha256",
+)
+
+CANONICAL_MARKET_DATASET_METADATA_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://cilly-trading.dev/schemas/market-dataset-metadata.json",
+    "title": "CanonicalMarketDatasetMetadata",
+    "type": "object",
+    "required": [
+        "dataset_id",
+        "symbol",
+        "timeframe",
+        "source",
+        "start_timestamp",
+        "end_timestamp",
+        "row_count",
+        "created_at",
+        "content_sha256",
+    ],
+    "additionalProperties": False,
+    "properties": {
+        "dataset_id": {"type": "string", "minLength": 1},
+        "symbol": {"type": "string", "minLength": 1},
+        "timeframe": {"type": "string", "minLength": 1},
+        "source": {"type": "string", "minLength": 1},
+        "start_timestamp": {"type": "string", "format": "date-time"},
+        "end_timestamp": {"type": "string", "format": "date-time"},
+        "row_count": {"type": "integer", "minimum": 0},
+        "created_at": {"type": "string", "format": "date-time"},
+        "content_sha256": {
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{64}$",
+        },
+        "contract_version": {"type": "string", "minLength": 1},
+    },
+}
+
+
+class DatasetMetadataValidationError(ValueError):
+    """Raised when canonical dataset metadata validation fails."""
+
+
+def _parse_iso8601(value: Any, field_name: str) -> datetime:
+    if not isinstance(value, str):
+        raise DatasetMetadataValidationError(f"{field_name} must be a string")
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise DatasetMetadataValidationError(
+            f"{field_name} must be a valid ISO-8601 timestamp"
+        ) from exc
+
+    if parsed.tzinfo is None:
+        raise DatasetMetadataValidationError(
+            f"{field_name} must include timezone information"
+        )
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_identity_payload(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    identity_payload: dict[str, Any] = {}
+    for field in DATASET_IDENTITY_FIELDS:
+        if field not in metadata:
+            raise DatasetMetadataValidationError(
+                f"missing identity field for dataset_id: {field}"
+            )
+        value = metadata[field]
+        if field in ("start_timestamp", "end_timestamp"):
+            value = _parse_iso8601(value, field).isoformat()
+        identity_payload[field] = value
+    return identity_payload
+
+
+def compute_dataset_identity(metadata: Mapping[str, Any]) -> str:
+    """Compute deterministic dataset identity from canonical identity fields."""
+
+    identity_payload = _normalize_identity_payload(metadata)
+    canonical = json.dumps(identity_payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_market_dataset_metadata(
+    *,
+    symbol: str,
+    timeframe: str,
+    source: str,
+    start_timestamp: str,
+    end_timestamp: str,
+    row_count: int,
+    content_sha256: str,
+    created_at: str | None = None,
+    contract_version: str = DATASET_CONTRACT_VERSION,
+) -> dict[str, Any]:
+    """Build canonical market dataset metadata with deterministic dataset_id."""
+
+    metadata: dict[str, Any] = {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "source": source,
+        "start_timestamp": start_timestamp,
+        "end_timestamp": end_timestamp,
+        "row_count": row_count,
+        "content_sha256": content_sha256,
+        "created_at": created_at
+        or datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat(),
+        "contract_version": contract_version,
+    }
+    metadata["dataset_id"] = compute_dataset_identity(metadata)
+    return validate_market_dataset_metadata(metadata)
+
+
+def validate_market_dataset_metadata(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate canonical market dataset metadata payload."""
+
+    if not isinstance(payload, Mapping):
+        raise DatasetMetadataValidationError("metadata payload must be an object")
+
+    required_fields = tuple(CANONICAL_MARKET_DATASET_METADATA_SCHEMA["required"])
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        raise DatasetMetadataValidationError(
+            f"missing required metadata field(s): {', '.join(missing)}"
+        )
+
+    allowed_fields = set(CANONICAL_MARKET_DATASET_METADATA_SCHEMA["properties"].keys())
+    extra_fields = [field for field in payload if field not in allowed_fields]
+    if extra_fields:
+        raise DatasetMetadataValidationError(
+            f"unknown metadata field(s): {', '.join(extra_fields)}"
+        )
+
+    dataset_id = payload["dataset_id"]
+    if not isinstance(dataset_id, str) or not dataset_id:
+        raise DatasetMetadataValidationError("dataset_id must be a non-empty string")
+
+    for field_name in ("symbol", "timeframe", "source"):
+        value = payload[field_name]
+        if not isinstance(value, str) or not value:
+            raise DatasetMetadataValidationError(
+                f"{field_name} must be a non-empty string"
+            )
+
+    row_count = payload["row_count"]
+    if not isinstance(row_count, int) or isinstance(row_count, bool):
+        raise DatasetMetadataValidationError("row_count must be an integer")
+    if row_count < 0:
+        raise DatasetMetadataValidationError("row_count must be >= 0")
+
+    start = _parse_iso8601(payload["start_timestamp"], "start_timestamp")
+    end = _parse_iso8601(payload["end_timestamp"], "end_timestamp")
+    _parse_iso8601(payload["created_at"], "created_at")
+
+    if start > end:
+        raise DatasetMetadataValidationError(
+            "start_timestamp must be <= end_timestamp"
+        )
+
+    content_sha256 = payload["content_sha256"]
+    if (
+        not isinstance(content_sha256, str)
+        or len(content_sha256) != 64
+        or any(char not in "0123456789abcdefABCDEF" for char in content_sha256)
+    ):
+        raise DatasetMetadataValidationError(
+            "content_sha256 must be a valid 64-char SHA-256 hex digest"
+        )
+
+    expected_dataset_id = compute_dataset_identity(payload)
+    if dataset_id != expected_dataset_id:
+        raise DatasetMetadataValidationError(
+            "dataset_id does not match canonical identity fields"
+        )
+
+    normalized = dict(payload)
+    normalized["start_timestamp"] = start.isoformat()
+    normalized["end_timestamp"] = end.isoformat()
+    normalized["created_at"] = _parse_iso8601(
+        payload["created_at"], "created_at"
+    ).isoformat()
+    return normalized

--- a/tests/data/test_market_dataset_contract.py
+++ b/tests/data/test_market_dataset_contract.py
@@ -1,0 +1,171 @@
+﻿from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_contract_module():
+    root = Path(__file__).resolve().parents[2]
+    module_path = (
+        root / "src" / "cilly_trading" / "engine" / "data" / "market_dataset_contract.py"
+    )
+    spec = importlib.util.spec_from_file_location("market_dataset_contract", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load market_dataset_contract module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+module = _load_contract_module()
+build_market_dataset_metadata = module.build_market_dataset_metadata
+compute_dataset_identity = module.compute_dataset_identity
+validate_market_dataset_metadata = module.validate_market_dataset_metadata
+DatasetMetadataValidationError = module.DatasetMetadataValidationError
+CANONICAL_MARKET_DATASET_METADATA_SCHEMA = module.CANONICAL_MARKET_DATASET_METADATA_SCHEMA
+
+
+def _valid_payload() -> dict[str, object]:
+    payload = {
+        "symbol": "BTC/USDT",
+        "timeframe": "1H",
+        "source": "binance.spot.ohlcv",
+        "start_timestamp": "2025-01-01T00:00:00+00:00",
+        "end_timestamp": "2025-01-02T00:00:00+00:00",
+        "row_count": 24,
+        "created_at": "2025-01-03T12:00:00+00:00",
+        "content_sha256": "a" * 64,
+    }
+    payload["dataset_id"] = compute_dataset_identity(payload)
+    return payload
+
+
+def test_schema_defines_required_canonical_fields() -> None:
+    required = set(CANONICAL_MARKET_DATASET_METADATA_SCHEMA["required"])
+    assert {
+        "dataset_id",
+        "symbol",
+        "timeframe",
+        "source",
+        "start_timestamp",
+        "end_timestamp",
+        "row_count",
+        "created_at",
+    }.issubset(required)
+
+
+def test_validate_market_dataset_metadata_accepts_valid_payload() -> None:
+    validated = validate_market_dataset_metadata(_valid_payload())
+
+    assert validated["dataset_id"]
+    assert validated["symbol"] == "BTC/USDT"
+    assert validated["row_count"] == 24
+
+
+def test_validate_market_dataset_metadata_rejects_missing_required_field() -> None:
+    invalid = _valid_payload()
+    invalid.pop("source")
+
+    try:
+        validate_market_dataset_metadata(invalid)
+    except DatasetMetadataValidationError as exc:
+        assert "missing required metadata field" in str(exc)
+    else:
+        raise AssertionError("Expected validation failure for missing required field")
+
+
+def test_validate_market_dataset_metadata_rejects_incorrect_type() -> None:
+    invalid = _valid_payload()
+    invalid["row_count"] = "24"
+
+    try:
+        validate_market_dataset_metadata(invalid)
+    except DatasetMetadataValidationError as exc:
+        assert "row_count must be an integer" in str(exc)
+    else:
+        raise AssertionError("Expected validation failure for incorrect row_count type")
+
+
+def test_compute_dataset_identity_is_deterministic_for_logically_identical_datasets() -> None:
+    first = _valid_payload()
+    second = _valid_payload()
+    second["created_at"] = "2025-02-01T00:00:00+00:00"
+
+    first_id = compute_dataset_identity(first)
+    second_id = compute_dataset_identity(second)
+
+    assert first_id == second_id
+
+
+def test_compute_dataset_identity_normalizes_z_and_utc_offset_timestamps() -> None:
+    from_z = _valid_payload()
+    from_z["start_timestamp"] = "2025-01-01T00:00:00Z"
+    from_z["end_timestamp"] = "2025-01-02T00:00:00Z"
+
+    from_offset = _valid_payload()
+    from_offset["start_timestamp"] = "2025-01-01T00:00:00+00:00"
+    from_offset["end_timestamp"] = "2025-01-02T00:00:00+00:00"
+
+    assert compute_dataset_identity(from_z) == compute_dataset_identity(from_offset)
+
+
+def test_compute_dataset_identity_normalizes_non_utc_offsets_to_same_instant() -> None:
+    utc_payload = _valid_payload()
+    utc_payload["start_timestamp"] = "2025-01-01T00:00:00+00:00"
+    utc_payload["end_timestamp"] = "2025-01-01T01:00:00+00:00"
+
+    non_utc_payload = _valid_payload()
+    non_utc_payload["start_timestamp"] = "2024-12-31T19:00:00-05:00"
+    non_utc_payload["end_timestamp"] = "2024-12-31T20:00:00-05:00"
+
+    assert compute_dataset_identity(utc_payload) == compute_dataset_identity(
+        non_utc_payload
+    )
+
+
+def test_validate_market_dataset_metadata_rejects_non_deterministic_dataset_id() -> None:
+    invalid = _valid_payload()
+    invalid["dataset_id"] = "f" * 64
+
+    try:
+        validate_market_dataset_metadata(invalid)
+    except DatasetMetadataValidationError as exc:
+        assert "dataset_id does not match canonical identity fields" in str(exc)
+    else:
+        raise AssertionError("Expected validation failure for non-canonical dataset_id")
+
+
+def test_validate_market_dataset_metadata_compares_against_canonicalized_identity() -> None:
+    canonical_base = _valid_payload()
+    canonical_base["start_timestamp"] = "2025-01-01T00:00:00+00:00"
+    canonical_base["end_timestamp"] = "2025-01-02T00:00:00+00:00"
+    canonical_dataset_id = compute_dataset_identity(canonical_base)
+
+    equivalent_payload = _valid_payload()
+    equivalent_payload["start_timestamp"] = "2025-01-01T00:00:00Z"
+    equivalent_payload["end_timestamp"] = "2025-01-02T00:00:00Z"
+    equivalent_payload["dataset_id"] = canonical_dataset_id
+
+    validated = validate_market_dataset_metadata(equivalent_payload)
+    assert validated["dataset_id"] == canonical_dataset_id
+    assert validated["start_timestamp"] == "2025-01-01T00:00:00+00:00"
+    assert validated["end_timestamp"] == "2025-01-02T00:00:00+00:00"
+
+
+def test_build_market_dataset_metadata_creates_canonical_payload() -> None:
+    built = build_market_dataset_metadata(
+        symbol="ETH/USDT",
+        timeframe="4H",
+        source="kraken.spot.ohlcv",
+        start_timestamp="2025-01-01T00:00:00+00:00",
+        end_timestamp="2025-01-02T00:00:00+00:00",
+        row_count=6,
+        content_sha256="b" * 64,
+        created_at="2025-01-04T00:00:00+00:00",
+    )
+
+    assert built["dataset_id"] == compute_dataset_identity(built)
+    assert built["symbol"] == "ETH/USDT"
+    assert built["row_count"] == 6


### PR DESCRIPTION

Closes #576

## Summary
- Canonicalized start_timestamp and end_timestamp to UTC ISO-8601 before hashing
- Validation compares dataset_id against canonical identity
- Added deterministic identity tests for equivalent timestamps
- Updated dataset contract documentation
