### PR TITLE
P33-DATA: Enforce atomic provider failover output boundaries (#578)

### DIFF
--- a/src/cilly_trading/engine/data/PROVIDER_CONTRACT.md
+++ b/src/cilly_trading/engine/data/PROVIDER_CONTRACT.md
@@ -13,6 +13,12 @@ Required method:
 
 - `iter_candles(request: MarketDataRequest) -> Iterator[Candle]`
 
+Provider registry types are also defined in the same module:
+
+- `MarketDataProviderRegistry`
+- `RegisteredMarketDataProvider`
+- `ProviderFailoverExhaustedError`
+
 ## Canonical Candle Schema
 Each `Candle` must expose:
 
@@ -31,6 +37,27 @@ Providers must be deterministic for a logically identical request:
 - Candle order must be stable.
 - Repeated calls must produce the same candle sequence.
 - No implicit randomness or non-deterministic ordering is allowed.
+
+## Provider Registry Behavior
+Provider registration and selection are deterministic:
+
+- Providers are registered with `(name, provider, priority)`.
+- Selection order is sorted by `(priority ASC, name ASC)`.
+- The provider at index `0` is the primary provider.
+- Equal priorities are resolved by provider name to preserve reproducibility.
+
+## Provider Failover Behavior
+Fallback is deterministic and priority-ordered:
+
+- Primary provider is attempted first.
+- On provider failure, the next provider in deterministic order is attempted.
+- Provider failure includes both iterator creation failures (`iter_candles(...)` raising)
+  and iterator-consumption failures (generator/iterator raising during iteration).
+- Failover is atomic per provider attempt: output is emitted only after a provider
+  completes iteration successfully.
+- Partial output from providers that later fail during iteration is discarded.
+- If all providers fail, `ProviderFailoverExhaustedError` is raised with failure details.
+- Failover changes provider source only; canonical candle schema remains unchanged.
 
 ## Validation Requirements
 Incoming OHLCV data must pass deterministic integrity validation before analysis/execution:

--- a/src/cilly_trading/engine/data/market_data_provider.py
+++ b/src/cilly_trading/engine/data/market_data_provider.py
@@ -66,6 +66,15 @@ class MissingCandleInterval:
     missing_count: int
 
 
+@dataclass(frozen=True)
+class RegisteredMarketDataProvider:
+    """Registry entry for deterministic provider ordering and fallback."""
+
+    name: str
+    provider: MarketDataProvider
+    priority: int
+
+
 @runtime_checkable
 class MarketDataProvider(Protocol):
     """Provider protocol for deterministic market data iteration.
@@ -80,6 +89,105 @@ class MarketDataProvider(Protocol):
         """Yield canonical candles for a request in deterministic order."""
 
         ...
+
+
+@dataclass(frozen=True)
+class ProviderAttemptFailure:
+    """Captures a failed provider attempt during failover."""
+
+    provider_name: str
+    reason: str
+
+
+class ProviderFailoverExhaustedError(RuntimeError):
+    """Raised when all registered providers fail for a request."""
+
+    def __init__(self, failures: tuple[ProviderAttemptFailure, ...]) -> None:
+        self.failures = failures
+        details = ", ".join(
+            f"{failure.provider_name}: {failure.reason}" for failure in failures
+        )
+        super().__init__(f"All providers failed: {details}")
+
+
+class MarketDataProviderRegistry:
+    """Deterministic provider registry with priority-based fallback ordering."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, RegisteredMarketDataProvider] = {}
+
+    def register(
+        self, *, name: str, provider: MarketDataProvider, priority: int
+    ) -> None:
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("provider name must be a non-empty string")
+        if not isinstance(priority, int):
+            raise ValueError("provider priority must be an integer")
+        if name in self._entries:
+            raise ValueError(f"provider '{name}' is already registered")
+        self._entries[name] = RegisteredMarketDataProvider(
+            name=name, provider=provider, priority=priority
+        )
+
+    def get_registered(self) -> tuple[RegisteredMarketDataProvider, ...]:
+        """Return providers sorted by deterministic selection order."""
+
+        return tuple(
+            sorted(self._entries.values(), key=lambda entry: (entry.priority, entry.name))
+        )
+
+    def select_provider(self) -> RegisteredMarketDataProvider:
+        """Select primary provider deterministically from registry ordering."""
+
+        entries = self.get_registered()
+        if not entries:
+            raise ValueError("no market data providers are registered")
+        return entries[0]
+
+    def iter_candles_with_failover(
+        self, request: MarketDataRequest
+    ) -> Iterator[Candle]:
+        """Iterate candles using deterministic provider fallback order.
+
+        Failover applies both when creating the iterator and while consuming it.
+        """
+
+        entries = self.get_registered()
+        if not entries:
+            raise ValueError("no market data providers are registered")
+
+        def _iterate() -> Iterator[Candle]:
+            failures: list[ProviderAttemptFailure] = []
+            for entry in entries:
+                try:
+                    iterator = entry.provider.iter_candles(request)
+                except Exception as exc:
+                    failures.append(
+                        ProviderAttemptFailure(
+                            provider_name=entry.name,
+                            reason=f"{type(exc).__name__}: {exc}",
+                        )
+                    )
+                    continue
+
+                try:
+                    buffered = tuple(iterator)
+                except Exception as exc:
+                    failures.append(
+                        ProviderAttemptFailure(
+                            provider_name=entry.name,
+                            reason=f"{type(exc).__name__}: {exc}",
+                        )
+                    )
+                    continue
+
+                for candle in buffered:
+                    yield candle
+                return
+
+            raise ProviderFailoverExhaustedError(tuple(failures))
+
+        return _iterate()
 
 
 class LocalSnapshotProvider:

--- a/tests/data/test_market_data_provider_contract.py
+++ b/tests/data/test_market_data_provider_contract.py
@@ -26,10 +26,13 @@ Candle = module.Candle
 detect_missing_candle_intervals = module.detect_missing_candle_intervals
 LocalSnapshotProvider = module.LocalSnapshotProvider
 MarketDataProvider = module.MarketDataProvider
+MarketDataProviderRegistry = module.MarketDataProviderRegistry
 MarketDataRequest = module.MarketDataRequest
 MissingCandleInterval = module.MissingCandleInterval
+ProviderFailoverExhaustedError = module.ProviderFailoverExhaustedError
 normalize_candle = module.normalize_candle
 normalize_candles = module.normalize_candles
+RegisteredMarketDataProvider = module.RegisteredMarketDataProvider
 serialize_candles_deterministically = module.serialize_candles_deterministically
 timeframe_to_timedelta = module.timeframe_to_timedelta
 
@@ -70,9 +73,275 @@ class InMemoryDeterministicProvider:
         return iter(candles)
 
 
+class AlwaysFailProvider:
+    def __init__(self, message: str = "provider failure") -> None:
+        self._message = message
+
+    def iter_candles(self, request: MarketDataRequest):
+        raise RuntimeError(self._message)
+
+
+class SingleCandleProvider:
+    def __init__(self, candle: Candle) -> None:
+        self._candle = candle
+
+    def iter_candles(self, request: MarketDataRequest):
+        if (
+            request.symbol == self._candle.symbol
+            and request.timeframe == self._candle.timeframe
+        ):
+            return iter((self._candle,))
+        return iter(())
+
+
+class IterationFailProvider:
+    def __init__(self, message: str = "iteration failure") -> None:
+        self._message = message
+
+    def iter_candles(self, request: MarketDataRequest):
+        def _generator():
+            raise RuntimeError(self._message)
+            yield  # pragma: no cover
+
+        return _generator()
+
+
+class PartialThenFailProvider:
+    def __init__(self, candles: tuple[Candle, ...], message: str = "partial failure") -> None:
+        self._candles = candles
+        self._message = message
+
+    def iter_candles(self, request: MarketDataRequest):
+        def _generator():
+            for candle in self._candles:
+                if (
+                    candle.symbol == request.symbol
+                    and candle.timeframe == request.timeframe
+                ):
+                    yield candle
+            raise RuntimeError(self._message)
+
+        return _generator()
+
+
 def test_market_data_provider_runtime_contract() -> None:
     provider = InMemoryDeterministicProvider()
     assert isinstance(provider, MarketDataProvider)
+
+
+def test_provider_registry_registers_provider() -> None:
+    registry = MarketDataProviderRegistry()
+    provider = InMemoryDeterministicProvider()
+    registry.register(name="snapshot", provider=provider, priority=10)
+
+    assert registry.get_registered() == (
+        RegisteredMarketDataProvider(name="snapshot", provider=provider, priority=10),
+    )
+
+
+def test_provider_selection_is_deterministic() -> None:
+    registry = MarketDataProviderRegistry()
+    registry.register(name="zeta", provider=InMemoryDeterministicProvider(), priority=10)
+    registry.register(name="alpha", provider=InMemoryDeterministicProvider(), priority=10)
+    registry.register(name="beta", provider=InMemoryDeterministicProvider(), priority=5)
+
+    selected = registry.select_provider()
+    ordered_names = tuple(entry.name for entry in registry.get_registered())
+
+    assert selected.name == "beta"
+    assert ordered_names == ("beta", "alpha", "zeta")
+
+
+def test_provider_registry_failover_uses_next_priority_provider() -> None:
+    registry = MarketDataProviderRegistry()
+    expected = Candle(
+        timestamp=datetime(2025, 1, 2, 0, tzinfo=timezone.utc),
+        symbol="BTC/USDT",
+        timeframe="1H",
+        open=Decimal("200.0"),
+        high=Decimal("201.0"),
+        low=Decimal("199.0"),
+        close=Decimal("200.5"),
+        volume=Decimal("100.0"),
+    )
+    registry.register(name="primary", provider=AlwaysFailProvider(), priority=1)
+    registry.register(
+        name="fallback", provider=SingleCandleProvider(expected), priority=2
+    )
+
+    candles = tuple(
+        registry.iter_candles_with_failover(
+            MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+        )
+    )
+
+    assert candles == (expected,)
+
+
+def test_provider_registry_failover_raises_when_all_providers_fail() -> None:
+    registry = MarketDataProviderRegistry()
+    registry.register(name="primary", provider=AlwaysFailProvider("p1"), priority=1)
+    registry.register(name="secondary", provider=AlwaysFailProvider("p2"), priority=2)
+
+    try:
+        tuple(
+            registry.iter_candles_with_failover(
+                MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+            )
+        )
+    except ProviderFailoverExhaustedError as exc:
+        assert tuple(failure.provider_name for failure in exc.failures) == (
+            "primary",
+            "secondary",
+        )
+    else:
+        raise AssertionError("Expected ProviderFailoverExhaustedError")
+
+
+def test_provider_registry_failover_handles_iteration_time_failure() -> None:
+    registry = MarketDataProviderRegistry()
+    expected = Candle(
+        timestamp=datetime(2025, 1, 3, 0, tzinfo=timezone.utc),
+        symbol="BTC/USDT",
+        timeframe="1H",
+        open=Decimal("300.0"),
+        high=Decimal("301.0"),
+        low=Decimal("299.0"),
+        close=Decimal("300.5"),
+        volume=Decimal("110.0"),
+    )
+    registry.register(name="primary", provider=IterationFailProvider("iter-p1"), priority=1)
+    registry.register(
+        name="fallback", provider=SingleCandleProvider(expected), priority=2
+    )
+
+    candles = tuple(
+        registry.iter_candles_with_failover(
+            MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+        )
+    )
+
+    assert candles == (expected,)
+
+
+def test_provider_registry_failover_aggregates_iteration_time_failures() -> None:
+    registry = MarketDataProviderRegistry()
+    registry.register(
+        name="primary", provider=IterationFailProvider("iter-p1"), priority=1
+    )
+    registry.register(
+        name="secondary", provider=IterationFailProvider("iter-p2"), priority=2
+    )
+
+    try:
+        tuple(
+            registry.iter_candles_with_failover(
+                MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+            )
+        )
+    except ProviderFailoverExhaustedError as exc:
+        assert tuple(failure.provider_name for failure in exc.failures) == (
+            "primary",
+            "secondary",
+        )
+        assert tuple(failure.reason for failure in exc.failures) == (
+            "RuntimeError: iter-p1",
+            "RuntimeError: iter-p2",
+        )
+    else:
+        raise AssertionError("Expected ProviderFailoverExhaustedError")
+
+
+def test_provider_registry_failover_discards_partial_output_before_fallback() -> None:
+    registry = MarketDataProviderRegistry()
+    partial_candle = Candle(
+        timestamp=datetime(2025, 1, 4, 0, tzinfo=timezone.utc),
+        symbol="BTC/USDT",
+        timeframe="1H",
+        open=Decimal("400.0"),
+        high=Decimal("401.0"),
+        low=Decimal("399.0"),
+        close=Decimal("400.5"),
+        volume=Decimal("120.0"),
+    )
+    fallback_candle = Candle(
+        timestamp=datetime(2025, 1, 4, 1, tzinfo=timezone.utc),
+        symbol="BTC/USDT",
+        timeframe="1H",
+        open=Decimal("401.0"),
+        high=Decimal("402.0"),
+        low=Decimal("400.0"),
+        close=Decimal("401.5"),
+        volume=Decimal("130.0"),
+    )
+    registry.register(
+        name="primary",
+        provider=PartialThenFailProvider((partial_candle,), "partial-p1"),
+        priority=1,
+    )
+    registry.register(
+        name="fallback", provider=SingleCandleProvider(fallback_candle), priority=2
+    )
+
+    candles = tuple(
+        registry.iter_candles_with_failover(
+            MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+        )
+    )
+
+    assert candles == (fallback_candle,)
+
+
+def test_provider_registry_failover_raises_when_all_partial_providers_fail() -> None:
+    registry = MarketDataProviderRegistry()
+    partial_a = Candle(
+        timestamp=datetime(2025, 1, 5, 0, tzinfo=timezone.utc),
+        symbol="BTC/USDT",
+        timeframe="1H",
+        open=Decimal("500.0"),
+        high=Decimal("501.0"),
+        low=Decimal("499.0"),
+        close=Decimal("500.5"),
+        volume=Decimal("140.0"),
+    )
+    partial_b = Candle(
+        timestamp=datetime(2025, 1, 5, 1, tzinfo=timezone.utc),
+        symbol="BTC/USDT",
+        timeframe="1H",
+        open=Decimal("501.0"),
+        high=Decimal("502.0"),
+        low=Decimal("500.0"),
+        close=Decimal("501.5"),
+        volume=Decimal("150.0"),
+    )
+    registry.register(
+        name="primary",
+        provider=PartialThenFailProvider((partial_a,), "partial-p1"),
+        priority=1,
+    )
+    registry.register(
+        name="secondary",
+        provider=PartialThenFailProvider((partial_b,), "partial-p2"),
+        priority=2,
+    )
+
+    try:
+        tuple(
+            registry.iter_candles_with_failover(
+                MarketDataRequest(symbol="BTC/USDT", timeframe="1H")
+            )
+        )
+    except ProviderFailoverExhaustedError as exc:
+        assert tuple(failure.provider_name for failure in exc.failures) == (
+            "primary",
+            "secondary",
+        )
+        assert tuple(failure.reason for failure in exc.failures) == (
+            "RuntimeError: partial-p1",
+            "RuntimeError: partial-p2",
+        )
+    else:
+        raise AssertionError("Expected ProviderFailoverExhaustedError")
 
 
 def test_candle_exposes_canonical_fields() -> None:


### PR DESCRIPTION

Closes #578

## Summary
- Updated iter_candles_with_failover to treat each provider attempt atomically.
- Provider output is now buffered and emitted only after full successful iterator completion.
- If iterator consumption fails at any point, partial output is discarded and fallback proceeds deterministically.
- Preserved deterministic ordering (priority, name) and aggregated failure reporting.

## Tests
- Added regression coverage for partial-yield-then-fail provider with successful fallback.
- Asserted returned candles contain only fallback provider output (no mixed source output).
- Added all-partial-fail regression asserting ProviderFailoverExhaustedError and failure details.
- Full suite passes with:
  - .\.venv\Scripts\python -m pytest -q
