### PR TITLE
P35-METRICS: Define canonical telemetry event schema (#587)

### DIFF
--- a/src/cilly_trading/engine/telemetry/__init__.py
+++ b/src/cilly_trading/engine/telemetry/__init__.py
@@ -1,0 +1,17 @@
+"""Canonical telemetry schema for engine observability events."""
+
+from .schema import (
+    CANONICAL_TELEMETRY_EVENT_TYPES,
+    TELEMETRY_SCHEMA_VERSION,
+    TelemetryEvent,
+    build_telemetry_event,
+    serialize_telemetry_event,
+)
+
+__all__ = [
+    "CANONICAL_TELEMETRY_EVENT_TYPES",
+    "TELEMETRY_SCHEMA_VERSION",
+    "TelemetryEvent",
+    "build_telemetry_event",
+    "serialize_telemetry_event",
+]

--- a/src/cilly_trading/engine/telemetry/schema.py
+++ b/src/cilly_trading/engine/telemetry/schema.py
@@ -1,0 +1,109 @@
+"""Canonical telemetry event schema and deterministic serialization."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Mapping
+
+TELEMETRY_SCHEMA_VERSION = "cilly.engine.telemetry.v1"
+
+# Canonical event names by required domain:
+# - analysis runs
+# - signal generation
+# - order submission
+# - guard triggers
+# - provider failover
+CANONICAL_TELEMETRY_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "analysis_run.started",
+        "analysis_run.completed",
+        "signal.generated",
+        "order_submission.attempt",
+        "order_submission.executed",
+        "guard.triggered",
+        "provider_failover.attempt_failed",
+        "provider_failover.exhausted",
+        "provider_failover.recovered",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TelemetryEvent:
+    """Canonical telemetry event."""
+
+    schema_version: str
+    component: str
+    event: str
+    event_index: int
+    timestamp_utc: str
+    payload: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "component": self.component,
+            "event": self.event,
+            "event_index": self.event_index,
+            "payload": self.payload,
+            "schema_version": self.schema_version,
+            "timestamp_utc": self.timestamp_utc,
+        }
+
+
+def build_telemetry_event(
+    *,
+    event: str,
+    event_index: int,
+    timestamp_utc: str,
+    payload: Mapping[str, Any] | None = None,
+) -> TelemetryEvent:
+    """Build and validate a canonical telemetry event."""
+
+    if event not in CANONICAL_TELEMETRY_EVENT_TYPES:
+        raise ValueError(f"unsupported telemetry event type: {event}")
+    if not isinstance(event_index, int) or event_index < 0:
+        raise ValueError("event_index must be a non-negative integer")
+    if not isinstance(timestamp_utc, str) or not timestamp_utc.strip():
+        raise ValueError("timestamp_utc must be a non-empty string")
+
+    canonical_payload = _normalize_mapping(payload or {})
+    return TelemetryEvent(
+        schema_version=TELEMETRY_SCHEMA_VERSION,
+        component="engine",
+        event=event,
+        event_index=event_index,
+        timestamp_utc=timestamp_utc,
+        payload=canonical_payload,
+    )
+
+
+def serialize_telemetry_event(event: TelemetryEvent) -> str:
+    """Serialize a telemetry event in deterministic canonical JSON format."""
+
+    return json.dumps(
+        event.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _normalize_mapping(mapping: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        str(key): _normalize_value(value)
+        for key, value in sorted(mapping.items(), key=lambda item: str(item[0]))
+    }
+
+
+def _normalize_value(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Mapping):
+        return _normalize_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return [_normalize_value(item) for item in value]
+    return str(value)

--- a/tests/engine/test_telemetry_schema.py
+++ b/tests/engine/test_telemetry_schema.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from cilly_trading.engine.telemetry import (
+    CANONICAL_TELEMETRY_EVENT_TYPES,
+    TELEMETRY_SCHEMA_VERSION,
+    build_telemetry_event,
+    serialize_telemetry_event,
+)
+
+
+def test_schema_validation_rejects_unknown_event_type() -> None:
+    with pytest.raises(ValueError, match="unsupported telemetry event type"):
+        build_telemetry_event(
+            event="unknown.event",
+            event_index=0,
+            timestamp_utc="2026-01-01T00:00:00Z",
+            payload={},
+        )
+
+
+def test_schema_validation_rejects_invalid_event_index() -> None:
+    with pytest.raises(ValueError, match="event_index must be a non-negative integer"):
+        build_telemetry_event(
+            event="analysis_run.started",
+            event_index=-1,
+            timestamp_utc="2026-01-01T00:00:00Z",
+            payload={},
+        )
+
+
+def test_serialization_is_deterministic_for_identical_events() -> None:
+    first = build_telemetry_event(
+        event="analysis_run.started",
+        event_index=7,
+        timestamp_utc="2026-02-01T00:00:00Z",
+        payload={
+            "list_payload": [Decimal("1.25"), {"z": 3, "a": 1}],
+            "z_key": "later",
+            "a_key": "first",
+        },
+    )
+    second = build_telemetry_event(
+        event="analysis_run.started",
+        event_index=7,
+        timestamp_utc="2026-02-01T00:00:00Z",
+        payload={
+            "z_key": "later",
+            "a_key": "first",
+            "list_payload": [Decimal("1.25"), {"a": 1, "z": 3}],
+        },
+    )
+
+    assert first.payload == second.payload
+    assert serialize_telemetry_event(first) == serialize_telemetry_event(second)
+    assert serialize_telemetry_event(first) == (
+        '{"component":"engine","event":"analysis_run.started","event_index":7,'
+        '"payload":{"a_key":"first","list_payload":["1.25",{"a":1,"z":3}],"z_key":"later"},'
+        '"schema_version":"cilly.engine.telemetry.v1","timestamp_utc":"2026-02-01T00:00:00Z"}'
+    )
+
+
+def test_event_type_coverage_contains_required_domains() -> None:
+    required = {
+        "analysis_run.started",
+        "analysis_run.completed",
+        "signal.generated",
+        "order_submission.attempt",
+        "order_submission.executed",
+        "guard.triggered",
+        "provider_failover.attempt_failed",
+        "provider_failover.exhausted",
+        "provider_failover.recovered",
+    }
+    assert required.issubset(CANONICAL_TELEMETRY_EVENT_TYPES)
+
+
+def test_schema_version_is_stable() -> None:
+    event = build_telemetry_event(
+        event="signal.generated",
+        event_index=1,
+        timestamp_utc="2026-02-01T00:00:01Z",
+        payload={"signal_id": "sig-1"},
+    )
+    assert event.schema_version == TELEMETRY_SCHEMA_VERSION
+    assert TELEMETRY_SCHEMA_VERSION == "cilly.engine.telemetry.v1"


### PR DESCRIPTION
Closes #587

## What changed
- Added canonical telemetry schema module under src/cilly_trading/engine/telemetry/.
- Defined stable schema version cilly.engine.telemetry.v1.
- Added canonical event type set covering analysis runs, signal generation, order submission, guard triggers, and provider failover, including provider_failover.exhausted.
- Added deterministic telemetry serialization with canonical payload normalization.
- Added engine tests for schema validation, deterministic serialization, required event type coverage, and stable schema version.

## Validation
- Ran full repository test suite
- Result: 473 passed, 4 warnings