### PR TITLE
P35-API: Implement Engine Health Endpoint (#589)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -683,6 +683,73 @@ def _strategy_display_name(strategy_key: str) -> str:
 @app.get("/health")
 def health() -> Dict[str, str]:
     _assert_phase_13_read_only_endpoint("/health")
+    return _runtime_health_payload()
+
+
+@app.get("/health/engine")
+def health_engine() -> Dict[str, Any]:
+    payload = _runtime_health_payload()
+    mode = payload["mode"]
+    ready = mode in {"ready", "running", "paused"}
+
+    return {
+        "subsystem": "engine",
+        "status": payload["status"],
+        "ready": ready,
+        "mode": mode,
+        "reason": payload["reason"],
+        "checked_at": payload["checked_at"],
+    }
+
+
+@app.get("/health/data")
+def health_data() -> Dict[str, Any]:
+    checked_at = _health_now()
+    db_path = Path(_resolve_analysis_db_path())
+    ready = db_path.exists()
+    status: Literal["healthy", "unavailable"] = "healthy" if ready else "unavailable"
+    reason = "data_source_available" if ready else "data_source_unavailable"
+
+    return {
+        "subsystem": "data",
+        "status": status,
+        "ready": ready,
+        "reason": reason,
+        "checked_at": checked_at.isoformat(),
+    }
+
+
+@app.get("/health/guards")
+def health_guards() -> Dict[str, Any]:
+    checked_at = _health_now()
+    guard_status = read_compliance_guard_status()
+    blocking = guard_status.compliance.blocking
+
+    return {
+        "subsystem": "guards",
+        "status": "degraded" if blocking else "healthy",
+        "ready": not blocking,
+        "decision": guard_status.compliance.decision,
+        "blocking": blocking,
+        "guards": {
+            "drawdown_guard": {
+                "enabled": guard_status.guards.drawdown_guard.enabled,
+                "blocking": guard_status.guards.drawdown_guard.blocking,
+            },
+            "daily_loss_guard": {
+                "enabled": guard_status.guards.daily_loss_guard.enabled,
+                "blocking": guard_status.guards.daily_loss_guard.blocking,
+            },
+            "kill_switch": {
+                "active": guard_status.guards.kill_switch.active,
+                "blocking": guard_status.guards.kill_switch.blocking,
+            },
+        },
+        "checked_at": checked_at.isoformat(),
+    }
+
+
+def _runtime_health_payload() -> Dict[str, str]:
     payload = get_runtime_introspection_payload()
     snapshot: RuntimeHealthSnapshot = {
         "mode": payload["mode"],

--- a/tests/api/test_health_endpoints_api.py
+++ b/tests/api/test_health_endpoints_api.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+
+
+def _runtime_payload(mode: str = "running") -> dict[str, object]:
+    return {
+        "schema_version": "v1",
+        "runtime_id": "engine-runtime-123",
+        "mode": mode,
+        "timestamps": {
+            "started_at": "2026-01-01T12:00:00+00:00",
+            "updated_at": "2026-01-01T12:00:00+00:00",
+        },
+        "ownership": {"owner_tag": "engine"},
+    }
+
+
+def test_health_engine_reports_runtime_readiness(monkeypatch) -> None:
+    fixed_now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "get_runtime_introspection_payload", lambda: _runtime_payload("running"))
+    monkeypatch.setattr(api_main, "_health_now", lambda: fixed_now)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/health/engine")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "subsystem": "engine",
+        "status": "healthy",
+        "ready": True,
+        "mode": "running",
+        "reason": "runtime_running_fresh",
+        "checked_at": fixed_now.isoformat(),
+    }
+
+
+def test_health_data_reports_unavailable_when_data_source_is_missing(monkeypatch, tmp_path) -> None:
+    fixed_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    missing_db_path = tmp_path / "missing-analysis.db"
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "ANALYSIS_DB_PATH", str(missing_db_path))
+    monkeypatch.setattr(api_main, "_health_now", lambda: fixed_now)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/health/data")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "subsystem": "data",
+        "status": "unavailable",
+        "ready": False,
+        "reason": "data_source_unavailable",
+        "checked_at": fixed_now.isoformat(),
+    }
+
+
+def test_health_guards_reports_blocking_state(monkeypatch) -> None:
+    fixed_now = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "_health_now", lambda: fixed_now)
+    monkeypatch.setenv("CILLY_EXECUTION_KILL_SWITCH_ACTIVE", "true")
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/health/guards")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "subsystem": "guards",
+        "status": "degraded",
+        "ready": False,
+        "decision": "blocking",
+        "blocking": True,
+        "guards": {
+            "drawdown_guard": {"enabled": False, "blocking": False},
+            "daily_loss_guard": {"enabled": False, "blocking": False},
+            "kill_switch": {"active": True, "blocking": True},
+        },
+        "checked_at": fixed_now.isoformat(),
+    }
+
+
+def test_health_endpoints_are_deterministic_for_identical_state(monkeypatch, tmp_path) -> None:
+    fixed_now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=timezone.utc)
+    existing_db_path = tmp_path / "analysis.db"
+    existing_db_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "get_runtime_introspection_payload", lambda: _runtime_payload("running"))
+    monkeypatch.setattr(api_main, "ANALYSIS_DB_PATH", str(existing_db_path))
+    monkeypatch.setattr(api_main, "_health_now", lambda: fixed_now)
+    monkeypatch.setenv("CILLY_EXECUTION_KILL_SWITCH_ACTIVE", "false")
+
+    with TestClient(api_main.app) as client:
+        for path in ("/health", "/health/engine", "/health/data", "/health/guards"):
+            first = client.get(path).json()
+            second = client.get(path).json()
+            assert first == second


### PR DESCRIPTION
Closes #589

## Summary
- Added /health/engine, /health/data, and /health/guards.
- Kept /health response backward-compatible and refactored its internals to _runtime_health_payload().
- Corrected /health/guards readiness semantics so blocking guard state reports ready=false.
- Added deterministic health endpoint tests under tests/api/.

## Acceptance Criteria Mapping
- Health endpoints implemented: /health, /health/engine, /health/data, /health/guards.
- Engine subsystem readiness reported: /health/engine returns ready, mode, status, and reason.
- Responses deterministic across identical states: tests pin runtime state/time and assert stable repeated responses.

## Tests
- .\.venv\Scripts\python -m pytest
- Result: 483 passed, 4 warnings