### PR TITLE
P17-CONTRACT — Define operator access model and endpoint permission contract

### DIFF
--- a/docs/access-policy.md
+++ b/docs/access-policy.md
@@ -1,17 +1,89 @@
 # Access Policy
 
 ## Decision
-The application is accessed locally only. This decision is exclusive and final.
+
+The application is accessed locally only. Within that local-only deployment model, the current operator-facing API in `src/api/main.py` is protected by an explicit three-role contract: `owner`, `operator`, and `read_only`.
 
 ## Supported Access Mode
+
 - Local execution on the user's own machine only.
 
 ## Explicitly Unsupported Access Modes
+
 - Hosted access is unsupported.
 - Cloud access is unsupported.
 - Web access is unsupported.
 - SaaS access is unsupported.
 - Remote access is unsupported.
 
+## Role Meanings
+
+- `owner`: full control-plane authority. May inspect all covered operator endpoints, trigger manual analysis/screener actions, and change engine execution state.
+- `operator`: day-to-day control-plane operator. May inspect all covered operator endpoints and trigger manual analysis/screener actions, but may not change engine execution state.
+- `read_only`: inspection-only consumer. May call covered read-only endpoints, but may not trigger any mutating operator action.
+
+For the covered endpoints in this document, `owner` is a superset of `operator`, and `operator` is a superset of `read_only`.
+
+## Covered Operator-Facing API Surfaces
+
+This contract is normative for the current operator-facing routes defined in `src/api/main.py`:
+
+- health and runtime inspection
+- compliance and portfolio inspection
+- analysis, screener, and ingestion inspection
+- journal and audit inspection
+- execution control
+
+This contract does not cover `/ui` static assets or any future route that is not listed below. Runtime enforcement of this contract belongs in a separate implementation issue.
+
+## Endpoint Permission Contract
+
+Classification rule:
+
+- `read_only`: the endpoint is inspection-only and must not change runtime state or persist new operator-triggered work.
+- `mutating`: the endpoint can change execution state or persist/operator-trigger new work, regardless of HTTP verb conventions.
+
+All covered endpoints are protected. Anonymous access is out of contract. The minimum allowed role for each endpoint is:
+
+| Method | Endpoint | Classification | Minimum allowed role |
+| --- | --- | --- | --- |
+| `GET` | `/health` | `read_only` | `read_only` |
+| `GET` | `/health/engine` | `read_only` | `read_only` |
+| `GET` | `/health/data` | `read_only` | `read_only` |
+| `GET` | `/health/guards` | `read_only` | `read_only` |
+| `GET` | `/compliance/guards/status` | `read_only` | `read_only` |
+| `GET` | `/runtime/introspection` | `read_only` | `read_only` |
+| `GET` | `/system/state` | `read_only` | `read_only` |
+| `GET` | `/portfolio/positions` | `read_only` | `read_only` |
+| `GET` | `/ingestion/runs` | `read_only` | `read_only` |
+| `GET` | `/journal/artifacts` | `read_only` | `read_only` |
+| `GET` | `/journal/artifacts/{run_id}/{artifact_name}` | `read_only` | `read_only` |
+| `GET` | `/journal/decision-trace` | `read_only` | `read_only` |
+| `GET` | `/strategies` | `read_only` | `read_only` |
+| `GET` | `/signals` | `read_only` | `read_only` |
+| `GET` | `/execution/orders` | `read_only` | `read_only` |
+| `GET` | `/screener/v2/results` | `read_only` | `read_only` |
+| `POST` | `/strategy/analyze` | `mutating` | `operator` |
+| `POST` | `/analysis/run` | `mutating` | `operator` |
+| `POST` | `/screener/basic` | `mutating` | `operator` |
+| `POST` | `/execution/pause` | `mutating` | `owner` |
+| `POST` | `/execution/resume` | `mutating` | `owner` |
+
+Effective role permissions derived from the table:
+
+- `read_only` may call every listed `GET` endpoint and no listed `POST` endpoint.
+- `operator` may call every `read_only` endpoint plus `POST /strategy/analyze`, `POST /analysis/run`, and `POST /screener/basic`.
+- `owner` may call every covered endpoint, including `POST /execution/pause` and `POST /execution/resume`.
+
+## Deterministic Denial Behavior
+
+Protected endpoint behavior is deterministic for the covered routes once authorization enforcement is applied:
+
+- If the caller is unauthenticated or the presented credentials do not establish a valid principal, the endpoint returns `401 Unauthorized`.
+- If the caller is authenticated but does not hold the minimum allowed role for the endpoint, the endpoint returns `403 Forbidden`.
+- If the caller holds the required role, the request proceeds to normal endpoint-specific validation and execution.
+- A `401` or `403` response must not perform endpoint side effects.
+
 ## Rationale
-This document establishes one explicit access policy and removes ambiguity by defining exactly one supported mode and listing all unsupported modes in direct terms.
+
+This document makes the current operator control plane reviewable without inference by defining one role vocabulary, one endpoint matrix, and one denial model for the existing routes in `src/api/main.py`.

--- a/docs/api/api_guarantees.md
+++ b/docs/api/api_guarantees.md
@@ -1,6 +1,6 @@
 # API Guarantees vs Non-Guarantees (MVP v1.1)
 
-This document separates what the API guarantees from what it explicitly does not guarantee. It is limited to the currently implemented behavior documented in `docs/api/usage_contract.md`.
+This document separates what the API guarantees from what it explicitly does not guarantee. It is limited to the currently implemented behavior documented in `docs/api/usage_contract.md` plus the operator access contract documented in `docs/access-policy.md`.
 
 ## Guaranteed
 
@@ -8,6 +8,10 @@ This document separates what the API guarantees from what it explicitly does not
 - The API guarantees no implicit live data in analysis requests.
 - The API guarantees that the request and response shapes documented in `docs/api/usage_contract.md` define the MVP v1.1 contract.
 - The API guarantees that the documented field requirements, enums, and ranges in `docs/api/usage_contract.md` define the MVP v1.1 contract.
+- The API guarantees that `docs/access-policy.md` is the authoritative role-to-endpoint contract for the current operator-facing routes in `src/api/main.py`.
+- The API guarantees that every operator-facing endpoint covered by that contract is classified as either `read_only` or `mutating`.
+- The API guarantees that the documented operator roles for the covered control-plane endpoints are limited to `owner`, `operator`, and `read_only`.
+- The API guarantees deterministic denial semantics for protected operator-facing endpoints: unauthenticated requests map to `401 Unauthorized`, and authenticated requests without the required role map to `403 Forbidden` as documented in `docs/external/error_semantics.md`.
 
 ## Not guaranteed
 
@@ -15,6 +19,9 @@ This document separates what the API guarantees from what it explicitly does not
 - The API does not guarantee deterministic results when live data sources are used outside the snapshot-only analysis contract.
 - The API does not guarantee compatibility with request or response shapes not documented in `docs/api/usage_contract.md`.
 - The API does not guarantee schema stability outside the MVP v1.1 contract documented in `docs/api/usage_contract.md`.
+- The API does not guarantee an operator access contract for routes that are not listed in `docs/access-policy.md`.
+- The API does not guarantee anonymous access to any operator-facing route covered by `docs/access-policy.md`.
+- The API does not guarantee any role model other than the documented `owner`, `operator`, and `read_only` contract for the currently covered control-plane endpoints.
 - The API does not guarantee profitability.
 - The API does not guarantee signal completeness.
 - The API does not guarantee complete snapshot coverage or more than one row per symbol and timeframe.

--- a/docs/external/error_semantics.md
+++ b/docs/external/error_semantics.md
@@ -2,39 +2,46 @@
 
 ## Purpose and Scope
 
-This document defines **stable, external-facing error semantics** for users of the CLI and API.
-It is intentionally high level and is **documentation-only**.
+This document defines stable, external-facing error semantics for users of the CLI and API. It is intentionally high level and is documentation-only.
 
 ## Stable Failure Categories (External Perspective)
 
 External failures are grouped into these stable categories:
 
-1. **Validation Failure**
+1. Validation Failure
    - The request, command input, or parameters are invalid, incomplete, or inconsistent with expected input rules.
    - Typical examples include malformed input payloads, missing required fields, or unsupported argument combinations.
 
-2. **Runtime Failure**
-   - The request or command was accepted as syntactically/structurally valid, but execution could not be completed due to operational conditions.
+2. Authentication Failure
+   - The request targets a protected API endpoint, but the caller does not present valid credentials for an authenticated principal.
+   - Typical examples include missing credentials, malformed credentials, expired credentials, or any other condition where identity cannot be established.
+
+3. Authorization Failure
+   - The request targets a protected API endpoint, the caller is authenticated, and the caller's role is not permitted for that endpoint.
+   - Typical examples include a `read_only` caller attempting to invoke an operator-only mutation or an `operator` caller attempting to invoke an owner-only control action.
+
+4. Runtime Failure
+   - The request or command was accepted as syntactically and structurally valid, but execution could not be completed due to operational conditions.
    - Typical examples include dependency unavailability, timeout conditions, or other execution-time interruptions.
 
 These categories are intended as a stable contract at the CLI/API behavior level.
 
-## Validation vs. Runtime Errors
+## Validation vs Authentication vs Authorization vs Runtime
 
 The distinction is:
 
-- **Validation errors** occur **before successful execution can begin** because the supplied input is not acceptable.
-- **Runtime errors** occur **during or after execution begins** when a valid request cannot be completed.
-
-In short: validation is about **input acceptability**; runtime is about **execution outcome**.
+- Validation errors are about input acceptability.
+- Authentication errors are about whether the caller identity is established.
+- Authorization errors are about whether the established caller identity is permitted to use the endpoint.
+- Runtime errors are about execution outcome after an acceptable request is allowed to run.
 
 ## CLI Error Signaling Semantics (High Level)
 
 For CLI consumers:
 
-- CLI invocations signal failure through a **non-successful process exit**.
+- CLI invocations signal failure through a non-successful process exit.
 - Human-readable diagnostics may be emitted to help users understand the failure category and immediate cause.
-- Validation and runtime failures are both surfaced as failures, while preserving the validation-vs-runtime conceptual distinction for interpretation and handling.
+- Validation, authentication, authorization, and runtime failures are all surfaced as failures while preserving their conceptual distinction for interpretation and handling.
 
 This document does not define or modify specific numeric exit-code assignments.
 
@@ -42,33 +49,40 @@ This document does not define or modify specific numeric exit-code assignments.
 
 For API consumers:
 
-- API failures are signaled through **non-success HTTP responses**.
+- API failures are signaled through non-success HTTP responses.
 - Response bodies may include structured error information intended for diagnostics and client handling.
-- Validation and runtime failures remain conceptually distinct categories at the API contract level.
+- Validation, authentication, authorization, and runtime failures remain conceptually distinct categories at the API contract level.
 
-This document does not define or modify specific HTTP status-to-error mappings.
+## Protected Operator Endpoint Semantics
+
+For the protected operator-facing endpoints listed in `docs/access-policy.md`, once authorization enforcement is implemented:
+
+- `401 Unauthorized` is the required response when the caller is not authenticated.
+- `403 Forbidden` is the required response when the caller is authenticated but does not hold the minimum allowed role for the endpoint.
+- `401` and `403` responses must not perform endpoint side effects.
+- Endpoint-specific validation and runtime failures remain separate from authentication and authorization failures.
 
 ## Error Details That Are Not Guaranteed
 
-Unless explicitly documented elsewhere, the following are **not guaranteed to be stable**:
+Unless explicitly documented elsewhere, the following are not guaranteed to be stable:
 
 - Exact wording, phrasing, or localization of human-readable error messages.
 - Internal exception/type names, stack traces, and implementation-specific diagnostics.
 - Ordering, formatting, or incidental fields in verbose/debug output.
-- Correlation/trace identifiers and low-level operational metadata.
+- Correlation or trace identifiers and low-level operational metadata.
 - Any undocumented error payload fields beyond the stable external category semantics described here.
 
-Consumers should rely on documented API/CLI contracts rather than incidental message text or internal implementation details.
+Consumers should rely on documented API and CLI contracts rather than incidental message text or internal implementation details.
 
 ## References and Alignment
 
+- `docs/access-policy.md` is the authoritative reference for current protected operator-facing API endpoint permissions.
 - `docs/interfaces/cli_contract.md` is the authoritative reference for concrete CLI exit-code definitions.
-- This document defines only conceptual, stable failure categories for external interpretation.
-- This document does not redefine CLI exit codes.
+- This document defines stable external error categories and the required `401` versus `403` semantics for covered operator-facing API endpoints.
 
 ## Non-Goals
 
-- No new error codes are introduced.
-- No changes to HTTP status mappings.
-- No runtime logic changes.
-- No changes to internal exception hierarchies.
+- No new runtime behavior is implemented by this document.
+- No authentication or authorization middleware is introduced by this document.
+- No new CLI exit codes are introduced by this document.
+- No internal exception hierarchy is changed by this document.


### PR DESCRIPTION
Closes #601

## Summary
- define the owner, operator, and read_only role meanings for the current operator-facing API
- map every covered route in src/api/main.py to a minimum allowed role
- classify each covered endpoint as read_only or mutating
- document deterministic 401 Unauthorized and 403 Forbidden behavior for protected endpoints

## Testing
- .\.venv\Scripts\python.exe -m pytest