### PR TITLE
P16-CONTRACT — Define operator-facing runtime lifecycle control API contract

### DIFF
--- a/docs/api/api_guarantees.md
+++ b/docs/api/api_guarantees.md
@@ -13,10 +13,13 @@ This document separates what the API guarantees from what it explicitly does not
 - The API guarantees that the documented operator roles for the covered control-plane endpoints are limited to `owner`, `operator`, and `read_only`.
 - The API guarantees deterministic denial semantics for protected operator-facing endpoints: unauthenticated requests map to `401 Unauthorized`, and authenticated requests without the required role map to `403 Forbidden` as documented in `docs/external/error_semantics.md`.
 - The API guarantees that the documented operator-facing lifecycle control contract for `POST /execution/start` and `POST /execution/stop` is defined by `docs/architecture/engine_runtime_lifecycle_contract.md`.
+- The API guarantees that the documented start/stop lifecycle controls are `POST` endpoints with no request body or query parameters.
 - The API guarantees that start/stop lifecycle control responses use the same control-plane success body shape as existing pause/resume controls: `{"state":"<runtime_state>"}`.
 - The API guarantees that lifecycle transition conflicts, when defined by the lifecycle contract, use `409 Conflict` with the existing application error shape `{"detail":"<message>"}`.
+- The API guarantees that `POST /execution/start` delegates to the existing start lifecycle semantics: `init` and `ready` resolve to `running`, `running` is idempotent success, and `paused`/`stopping`/`stopped` return controller-authored transition conflicts.
 - The API guarantees that `POST /execution/start` is not a synonym for resume; a paused runtime remains governed by the existing resume semantics.
-- The API guarantees that the documented stop contract follows the existing engine shutdown semantics: `running` stops through `stopping`, `paused` stops directly to `stopped`, and pre-running `init`/`ready` stop requests are accepted as no-op successes that return the unchanged state.
+- The API guarantees that `POST /execution/stop` delegates to the existing shutdown lifecycle semantics: `running` stops through `stopping`, `paused` stops directly to `stopped`, `stopping` completes to `stopped`, `stopped` is idempotent success, and pre-running `init`/`ready` stop requests are accepted as no-op successes that return the unchanged state.
+- The API guarantees that no lifecycle-specific `409 Conflict` is defined for `POST /execution/stop` under the current runtime model.
 
 ## Not guaranteed
 
@@ -29,6 +32,7 @@ This document separates what the API guarantees from what it explicitly does not
 - The API does not guarantee any role model other than the documented `owner`, `operator`, and `read_only` contract for the currently covered control-plane endpoints.
 - The API does not guarantee that `POST /execution/start` or `POST /execution/stop` are already implemented in `src/api/main.py`; this issue defines response semantics and lifecycle behavior, not route delivery.
 - The API does not guarantee any start/stop lifecycle behavior other than the documented state machine and response semantics in `docs/architecture/engine_runtime_lifecycle_contract.md`.
+- The API does not guarantee alternative start/stop response mappings that differ from the current engine-owned lifecycle helpers.
 - The API does not guarantee profitability.
 - The API does not guarantee signal completeness.
 - The API does not guarantee complete snapshot coverage or more than one row per symbol and timeframe.

--- a/docs/architecture/engine_runtime_lifecycle_contract.md
+++ b/docs/architecture/engine_runtime_lifecycle_contract.md
@@ -85,7 +85,10 @@ It is normative for request/response behavior and intentionally separate from ro
 
 ### Common Request and Response Shape
 - Method: `POST`
+- Path-specific endpoints: `POST /execution/start` and `POST /execution/stop`
 - Request body: none
+- Query parameters: none
+- Response media type: `application/json`
 - Success body shape:
 
 ```json
@@ -142,6 +145,28 @@ Purpose: Request that the runtime perform the existing shutdown behavior for the
 - No lifecycle-transition `409 Conflict` is defined for `POST /execution/stop` under the current runtime controller behavior.
 - Requests received in `init` or `ready` are accepted as no-op successes and return the unchanged state.
 - Requests received in `stopping` or `stopped` are accepted as idempotent shutdown completions.
+
+## Endpoint Binding to Existing Lifecycle Helpers
+The documented operator-facing contract is intentionally derived from the existing engine-owned lifecycle helpers.
+An implementation that exposes these endpoints should not make new lifecycle decisions; it should translate helper behavior to HTTP as follows:
+
+| Endpoint | Engine helper | HTTP translation rule |
+| --- | --- | --- |
+| `POST /execution/start` | `start_engine_runtime()` | Return `200 {"state":"running"}` on success. If the helper raises `LifecycleTransitionError`, return `409 {"detail":"<helper message>"}`. |
+| `POST /execution/stop` | `shutdown_engine_runtime()` | Return `200 {"state":"<returned_state>"}` for all lifecycle-controlled outcomes under the current model. |
+
+The following decision table is normative for lifecycle-controlled responses:
+
+| Current runtime state | `POST /execution/start` | `POST /execution/stop` |
+| --- | --- | --- |
+| `init` | `200 {"state":"running"}` | `200 {"state":"init"}` |
+| `ready` | `200 {"state":"running"}` | `200 {"state":"ready"}` |
+| `running` | `200 {"state":"running"}` | `200 {"state":"stopped"}` |
+| `paused` | `409 {"detail":"Cannot ensure running runtime from state 'paused'."}` | `200 {"state":"stopped"}` |
+| `stopping` | `409 {"detail":"Cannot ensure running runtime from state 'stopping'."}` | `200 {"state":"stopped"}` |
+| `stopped` | `409 {"detail":"Cannot ensure running runtime from state 'stopped'."}` | `200 {"state":"stopped"}` |
+
+No other lifecycle-specific status code or response body is part of this contract.
 
 ## Relation to Existing Pause/Resume Controls
 - `POST /execution/start` is not a synonym for `POST /execution/resume`.


### PR DESCRIPTION
Closes #602

## Summary
- document the operator-facing contract for POST /execution/start and POST /execution/stop
- define per-state success and invalid-transition response semantics from the existing runtime lifecycle model
- align API guarantees with the current engine-owned lifecycle helpers and pause/resume boundaries

## Validation
- manual review against the existing runtime controller and invariant helpers
- .\.venv\Scripts\python.exe -m pytest