### PR TITLE
GOV-TAXONOMY: Reconcile roadmap and phase taxonomy artifacts

### DIFF
--- a/docs/audit/roadmap_compliance_report.md
+++ b/docs/audit/roadmap_compliance_report.md
@@ -4,7 +4,7 @@
 
 This audit is based only on repository-verifiable evidence (code, tests, endpoints, and documentation files).
 
-A canonical `Execution Roadmap` source file for phases 17b/23/24/27/25–31 was not located in the repository; assessment therefore uses concrete repository evidence only.
+The authoritative in-repo source for audited phase taxonomy is `docs/roadmap/execution_roadmap.md`. This report now defers to that roadmap for phase-number meanings and uses this document only for audit findings and traceability.
 
 Owner Dashboard is verifiably backend-served at `/ui` via FastAPI `app.mount("/ui", StaticFiles(..., html=True), ...)` and HTML marker `<title>Owner Dashboard</title>`.
 
@@ -20,20 +20,34 @@ Documentation and implementation are therefore only partially aligned.
 
 ---
 
-## 2. Roadmap Phase Matrix
+## 2. Audited Phase Taxonomy Trace
 
-| Phase | Status | Evidence | Notes |
-|-------|--------|----------|-------|
-| Phase 17b – Owner Dashboard | Partially Implemented | Backend UI mount in `src/api/main.py` (`app.mount("/ui", StaticFiles(..., html=True), name="ui")`); HTML marker in `src/ui/index.html` (`<title>Owner Dashboard</title>`); tests in `tests/health_endpoint.py`; manual trigger endpoint `POST /analysis/run` in `src/api/main.py`; test in `tests/test_api_manual_analysis_trigger.py`; documentation in `docs/ui/owner_dashboard.md`. | `/ui` is confirmed backend-served. `/owner` appears in documentation but no backend route definition was verified. |
-| Hourly Snapshot Runtime | Partially Implemented | `docs/runtime/snapshot_runtime.md` declares in-repo execution capability and external scheduling boundary; `docs/interfaces/batch_execution.md` states no scheduler implementation; no scheduler/cron endpoint verified in `src/api/main.py`. | Runtime execution capability exists in-repo; hourly scheduling is external and not provided by this repository. |
-| Phase 24 – Paper Trading Runtime | Partially Implemented | Simulator in `src/cilly_trading/engine/paper_trading.py`; tests in `tests/test_paper_trading_simulator.py`; documentation reference in `docs/RUNBOOK.md`. | Engine-level simulation exists; documentation still partially misaligned. |
-| Phase 23 – Research Dashboard | Not Implemented | Research Dashboard implementation artifact: Not confirmed (no verified code/docs/tests). | No repository-verified artifact found. |
-| Phase 27 – Risk Framework | Not Implemented | No standalone phase-scoped risk framework module verified; related artifacts include `src/cilly_trading/strategies/config_schema.py`, `tests/strategies/test_strategy_config_schema.py`, `docs/backtesting/metrics_contract.md`. | Risk-related fields exist but no framework-level artifact verified. |
-| Phases 25–31 | Not Implemented | Phase-tagged artifacts: Not confirmed (no verified modules/docs). | No concrete phase-mapped implementation artifacts verified. |
+| Phase | Authoritative meaning | Trace path | Audit note |
+|-------|-----------------------|------------|------------|
+| Phase 5 | External Ready exit gate | `docs/governance/phase-5-exit-criteria.md` | Governance gate, not reassessed for implementation status in this report. |
+| Phase 16 | No authoritative in-repo phase taxonomy artifact located | `docs/roadmap/execution_roadmap.md` | Reviewers should treat the phase as unmapped unless a future governance artifact establishes it. |
+| Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/roadmap/execution_roadmap.md` | Distinct from Phase 17b; secondary index links are navigation only. |
+| Phase 17b | Owner Dashboard | `docs/roadmap/execution_roadmap.md` | This report's Owner Dashboard findings map only to Phase 17b. |
+| Phase 23 | Research Dashboard | `docs/phases/phase-23-status.md` | Status-bearing meaning remains in the dedicated phase artifact. |
+| Phase 25 | Strategy Lifecycle Management | `docs/phases/phase_25_strategy_lifecycle.md` | This taxonomy issue does not reclassify implementation status. |
+| Phase 26 | No authoritative in-repo phase taxonomy artifact located | `docs/roadmap/execution_roadmap.md` | Reviewers should not infer a Phase 26 meaning from adjacent roadmap blocks. |
+| Phase 27 | Risk Framework | `docs/phases/phase-27-status.md` | Distinct from Phase 27b Pipeline Enforcement Layer artifacts. |
 
 ---
 
-## 3. MVP Guardrail Validation
+## 3. Roadmap Phase Matrix
+
+| Phase | Status | Evidence | Notes |
+|-------|--------|----------|-------|
+| Phase 17b - Owner Dashboard | Partially Implemented | Backend UI mount in `src/api/main.py` (`app.mount("/ui", StaticFiles(..., html=True), name="ui")`); HTML marker in `src/ui/index.html` (`<title>Owner Dashboard</title>`); tests in `tests/health_endpoint.py`; manual trigger endpoint `POST /analysis/run` in `src/api/main.py`; test in `tests/test_api_manual_analysis_trigger.py`; documentation in `docs/ui/owner_dashboard.md`. | `/ui` is confirmed backend-served. `/owner` appears in documentation but no backend route definition was verified. |
+| Hourly Snapshot Runtime | Partially Implemented | `docs/runtime/snapshot_runtime.md` declares in-repo execution capability and external scheduling boundary; `docs/interfaces/batch_execution.md` states no scheduler implementation; no scheduler/cron endpoint verified in `src/api/main.py`. | Runtime execution capability exists in-repo; hourly scheduling is external and not provided by this repository. |
+| Phase 24 - Paper Trading Runtime | Partially Implemented | Simulator in `src/cilly_trading/engine/paper_trading.py`; tests in `tests/test_paper_trading_simulator.py`; documentation reference in `docs/RUNBOOK.md`. | Engine-level simulation exists; documentation still partially misaligned. |
+| Phase 23 - Research Dashboard | Not Implemented | Research Dashboard implementation artifact: Not confirmed (no verified code/docs/tests). | No repository-verified artifact found. |
+| Phase 27 - Risk Framework | Not Implemented | No standalone phase-scoped risk framework module verified; related artifacts include `src/cilly_trading/strategies/config_schema.py`, `tests/strategies/test_strategy_config_schema.py`, `docs/backtesting/metrics_contract.md`. | Risk-related fields exist but no framework-level artifact verified. |
+
+---
+
+## 4. MVP Guardrail Validation
 
 ### No live trading implemented
 - **Status:** Validated  
@@ -53,7 +67,7 @@ Documentation and implementation are therefore only partially aligned.
 
 ---
 
-## 4. Architectural Drift Check
+## 5. Architectural Drift Check
 
 ### Findings
 
@@ -83,44 +97,40 @@ Documentation and implementation are therefore only partially aligned.
 
 ---
 
-## 5. Identified Gaps
+## 6. Identified Gaps
 
-1. **Proposed Issue:** `ROADMAP: Add canonical Execution Roadmap source document`  
-   - Add one authoritative roadmap file binding phases to deliverables and acceptance criteria.  
-   - **Phase classification:** Governance / Planning  
-
-2. **Proposed Issue:** `Owner Dashboard route documentation clarification (/ui vs /owner)`  
+1. **Proposed Issue:** `Owner Dashboard route documentation clarification (/ui vs /owner)`  
    - Clarify distinction between backend-served `/ui` and any frontend-dev guidance.  
    - **Phase classification:** Phase 17b  
 
-3. **Proposed Issue:** `Paper-trading documentation alignment`  
+2. **Proposed Issue:** `Paper-trading documentation alignment`  
    - Reconcile documentation statements with implemented simulator artifacts.  
    - **Phase classification:** Phase 24  
 
-4. **Proposed Issue:** `Hourly Snapshot Runtime status declaration`  
+3. **Proposed Issue:** `Hourly Snapshot Runtime status declaration`  
    - Formally declare the operational boundary: in-repo runtime execution capability with external scheduling ownership.  
    - **Phase classification:** Snapshot Runtime  
 
-5. **Proposed Issue:** `Phase 23 status artifact`  
+4. **Proposed Issue:** `Phase 23 status artifact`  
    - Add explicit not-implemented declaration or implementation artifact.  
    - **Phase classification:** Phase 23  
 
-6. **Proposed Issue:** `Phase 27 status artifact`  
+5. **Proposed Issue:** `Phase 27 status artifact`  
    - Add explicit declaration distinguishing framework-level risk system from existing risk-related fields.  
    - **Phase classification:** Phase 27  
 
 ---
 
-## 6. Risk Assessment
+## 7. Risk Assessment
 
 ### Structural risks
-- Missing canonical roadmap source increases interpretation variance.
 - Documentation-to-implementation drift reduces operator clarity.
+- Previously conflicting phase-number meanings can recur if secondary documents stop deferring to the authoritative roadmap.
 
 ### Roadmap ordering risks
 - Paper-trading state drift can mis-sequence dependent phases.
-- Undefined phase artifacts for 23/27/25–31 increase planning ambiguity.
+- Unmapped phases such as 16 and 26 still require future governance artifacts if they are to carry roadmap meaning.
 
 ### Governance risks
-- Guardrail compliance proof weakens without a single roadmap authority artifact.
-- Review decisions may vary without a clear phase-acceptance reference.
+- Guardrail compliance proof weakens if future roadmap or index updates bypass the authoritative taxonomy source.
+- Review decisions may vary again if status artifacts and taxonomy artifacts are edited independently without cross-review.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Cilly Trading Engine – Documentation
+# Cilly Trading Engine - Documentation
 
 ## Start Here
 The Cilly Trading Engine is a deterministic execution and analysis engine for teams that need reproducible workflows, stable interfaces, and controlled change management. This index is intended for new consumers who need a fixed, step-by-step path to start using documented capabilities.
@@ -28,10 +28,25 @@ Use this order:
 - [Version declaration](versioning/declaration.md)
 - [Compatibility gate](versioning/compatibility_gate.md)
 
-## Phase 17–19 Reference
+## Authoritative Phase Taxonomy
+The authoritative in-repo source for audited phase-number meanings is [Execution Roadmap](roadmap/execution_roadmap.md).
 
-### Phase 17 – Consumer Interfaces & Usage Patterns
-This section covers consumer-facing interfaces and documented usage patterns.
+| Phase | Meaning in the authoritative taxonomy | Primary trace |
+|-------|---------------------------------------|---------------|
+| Phase 5 | External Ready exit gate | `docs/governance/phase-5-exit-criteria.md` |
+| Phase 16 | No authoritative in-repo meaning located | `docs/roadmap/execution_roadmap.md` |
+| Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/roadmap/execution_roadmap.md` |
+| Phase 17b | Owner Dashboard sub-phase | `docs/roadmap/execution_roadmap.md` |
+| Phase 23 | Research Dashboard | `docs/phases/phase-23-status.md` |
+| Phase 25 | Strategy Lifecycle Management | `docs/phases/phase_25_strategy_lifecycle.md` |
+| Phase 26 | No authoritative in-repo meaning located | `docs/roadmap/execution_roadmap.md` |
+| Phase 27 | Risk Framework | `docs/phases/phase-27-status.md` |
+
+## Reference Navigation
+The links below are navigation aids only. They do not redefine the authoritative phase taxonomy.
+
+### Phase 17 Reference Materials
+Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b remains the distinct Owner Dashboard sub-phase in the authoritative roadmap.
 - [API guarantees](api/api_guarantees.md)
 - [External API happy path](api/external_api_happy_path.md)
 - [Public API boundary](api/public_api_boundary.md)
@@ -41,16 +56,16 @@ This section covers consumer-facing interfaces and documented usage patterns.
 - [CLI contract](interfaces/cli_contract.md)
 - [Interface usage patterns](interfaces/usage_patterns.md)
 
-### Phase 18 – External Integration & Client Contracts
-This section defines external integration expectations, client contracts, and failure semantics.
+### Phase 18 Reference Materials
+Phase 18 reference links remain navigational and do not override the authoritative audited taxonomy above.
 - [Change policy](external/change_policy.md)
 - [Client types](external/client_types.md)
 - [Contract surface](external/contract_surface.md)
 - [Error semantics](external/error_semantics.md)
 - [Integration assumptions](external/integration_assumptions.md)
 
-### Phase 19 – Versioning & Contract Stability
-This section defines versioning rules and contract stability enforcement.
+### Phase 19 Reference Materials
+Phase 19 reference links remain navigational and do not override the authoritative audited taxonomy above.
 - [Compatibility gate](versioning/compatibility_gate.md)
 - [Change enforcement](versioning/change_enforcement.md)
 - [Version declaration](versioning/declaration.md)

--- a/docs/roadmap/execution_roadmap.md
+++ b/docs/roadmap/execution_roadmap.md
@@ -1,23 +1,44 @@
-# Execution Roadmap – Canonical Source of Truth
+# Execution Roadmap - Authoritative Phase Taxonomy
 
 Status: Authoritative  
-Scope: Phases 17b, 23, 24, 27, 25–31  
+Scope: Audited phase taxonomy for Phases 5, 16, 17, 17b, 23, 25, 26, and 27  
 Owner: Governance  
 
 ## Purpose
-One canonical in-repo roadmap artifact that defines phase goals and acceptance boundaries.
+This file is the single authoritative in-repo source for audited phase-number meanings.
 
 ## How to Use
-- This file is the authoritative source for phase definitions.
-- Issues/PRs should reference the relevant phase.
-- Acceptance evidence requirements must be satisfied for phase completion.
+- Use this file to resolve the meaning of an audited phase number before relying on any secondary roadmap, index, or audit artifact.
+- Treat secondary documents as navigation or status evidence only unless they explicitly defer to this file.
+- If a phase is marked here as "no authoritative in-repo meaning located", do not infer a meaning from neighboring phases or legacy headings.
+
+---
+
+## Audited Phase Taxonomy
+
+| Phase | Authoritative meaning | Source trace |
+|-------|-----------------------|--------------|
+| Phase 5 | External Ready exit gate | `docs/governance/phase-5-exit-criteria.md` |
+| Phase 16 | No authoritative in-repo phase taxonomy artifact was located during the audit. | This roadmap entry is the governing clarification for audited artifacts. |
+| Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | Legacy index references align to this taxonomy; Phase 17b is the audited Owner Dashboard sub-phase. |
+| Phase 17b | Owner Dashboard | Verified by this roadmap entry and supporting runtime/documentation evidence. |
+| Phase 23 | Research Dashboard | `docs/phases/phase-23-status.md` |
+| Phase 25 | Strategy Lifecycle Management | `docs/phases/phase_25_strategy_lifecycle.md` |
+| Phase 26 | No authoritative in-repo phase taxonomy artifact was located during the audit. | This roadmap entry is the governing clarification for audited artifacts. |
+| Phase 27 | Risk Framework | `docs/phases/phase-27-status.md` |
+
+## Taxonomy Guardrails
+- Phase 17 and Phase 17b are not interchangeable: Phase 17 is the umbrella phase, and Phase 17b is the Owner Dashboard sub-phase.
+- Phase 27 and Phase 27b are not interchangeable: Phase 27 is Risk Framework taxonomy; Phase 27b remains a distinct Pipeline Enforcement Layer artifact.
+- Phase 25 and Phase 26 must not be grouped into a shared replacement meaning. Phase 25 is defined above, while Phase 26 remains unmapped in current authoritative in-repo taxonomy.
+- This document establishes taxonomy only. Implementation-status corrections remain scoped to the relevant status artifacts and follow-on issues.
 
 ---
 
 ## Phase 17b
 
 ### Goal
-Define and track the Owner Dashboard phase based on repository-verified artifacts and known documentation/runtime boundary conditions.
+Define and track the Owner Dashboard sub-phase based on repository-verified artifacts and known documentation/runtime boundary conditions.
 
 ### Explicit Deliverables
 - Backend-served Owner Dashboard surface at `/ui` via FastAPI static mount.
@@ -43,7 +64,7 @@ Define Phase 23 status using only repository-verified evidence.
 
 > Governance Note  
 > The implementation status of Phase 23 is explicitly documented in:  
-> docs/phases/phase-23-status.md
+> `docs/phases/phase-23-status.md`
 
 ### Explicit Deliverables
 - Explicit status declaration: Research Dashboard implementation artifact not confirmed in repository.
@@ -59,27 +80,6 @@ Define Phase 23 status using only repository-verified evidence.
 
 ---
 
-## Phase 24
-
-### Goal
-Define and track Paper Trading Runtime status from repository-verified implementation and documentation evidence.
-
-### Explicit Deliverables
-- Paper-trading simulator artifact in engine code.
-- Tests validating paper-trading simulator behavior.
-- Documentation references that describe phase runtime status.
-
-### Explicitly Out of Scope
-- Declaring full alignment while documentation still describes paper trading as unavailable.
-- Expanding scope beyond paper-trading runtime status/evidence alignment.
-
-### Acceptance Evidence Requirements
-- Simulator and related tests remain present and passing for phase-scoped behavior.
-- Documentation is updated to align with verified simulator state before closure.
-- Phase 24 PRs/issues cite concrete repository files for implementation and docs alignment.
-
----
-
 ## Phase 27
 
 ### Goal
@@ -87,7 +87,7 @@ Explicitly distinguish risk-related artifacts from a standalone Risk Framework i
 
 > Governance Note  
 > The implementation status of Phase 27 is explicitly documented in:  
-> docs/phases/phase-27-status.md
+> `docs/phases/phase-27-status.md`
 
 ### Verified Existing Artifacts
 - Risk-related configuration fields exist.
@@ -104,106 +104,3 @@ No standalone Phase 27 Risk Framework module was verified.
 - Standalone repository-verifiable framework module(s).
 - Explicit policy logic definition.
 - Documentation and tests mapped directly to Phase 27 framework scope.
-
----
-
-## Phases 25–31
-
-### Phase 25
-
-#### Goal
-Define Phase 25 status from available repository evidence.
-
-#### Explicit Deliverables
-- Explicit status declaration: phase-tagged artifacts not confirmed in repository.
-
-#### Explicitly Out of Scope
-- Claiming Phase 25 implementation without repository-verified phase-mapped artifacts.
-
-#### Acceptance Evidence Requirements
-- Any status change is supported by repository-verifiable phase-mapped code/docs/tests and linked issue/PR evidence.
-
-### Phase 26
-
-#### Goal
-Define Phase 26 status from available repository evidence.
-
-#### Explicit Deliverables
-- Explicit status declaration: phase-tagged artifacts not confirmed in repository.
-
-#### Explicitly Out of Scope
-- Claiming Phase 26 implementation without repository-verified phase-mapped artifacts.
-
-#### Acceptance Evidence Requirements
-- Any status change is supported by repository-verifiable phase-mapped code/docs/tests and linked issue/PR evidence.
-
-### Phase 27
-
-#### Goal
-Define Phase 27 status from available repository evidence within the 25–31 phase block.
-
-#### Explicit Deliverables
-- Explicit status declaration: phase-tagged artifacts not confirmed in repository for the broader 25–31 set.
-- Refer to the dedicated Phase 27 section above for framework-specific status details.
-
-#### Explicitly Out of Scope
-- Reclassifying Phase 27 as implemented within the 25–31 block without framework-level repository evidence.
-
-#### Acceptance Evidence Requirements
-- Any status change is supported by repository-verifiable phase-mapped code/docs/tests and linked issue/PR evidence.
-
-### Phase 28
-
-#### Goal
-Define Phase 28 status from available repository evidence.
-
-#### Explicit Deliverables
-- Explicit status declaration: phase-tagged artifacts not confirmed in repository.
-
-#### Explicitly Out of Scope
-- Claiming Phase 28 implementation without repository-verified phase-mapped artifacts.
-
-#### Acceptance Evidence Requirements
-- Any status change is supported by repository-verifiable phase-mapped code/docs/tests and linked issue/PR evidence.
-
-### Phase 29
-
-#### Goal
-Define Phase 29 status from available repository evidence.
-
-#### Explicit Deliverables
-- Explicit status declaration: phase-tagged artifacts not confirmed in repository.
-
-#### Explicitly Out of Scope
-- Claiming Phase 29 implementation without repository-verified phase-mapped artifacts.
-
-#### Acceptance Evidence Requirements
-- Any status change is supported by repository-verifiable phase-mapped code/docs/tests and linked issue/PR evidence.
-
-### Phase 30
-
-#### Goal
-Define Phase 30 status from available repository evidence.
-
-#### Explicit Deliverables
-- Explicit status declaration: phase-tagged artifacts not confirmed in repository.
-
-#### Explicitly Out of Scope
-- Claiming Phase 30 implementation without repository-verified phase-mapped artifacts.
-
-#### Acceptance Evidence Requirements
-- Any status change is supported by repository-verifiable phase-mapped code/docs/tests and linked issue/PR evidence.
-
-### Phase 31
-
-#### Goal
-Define Phase 31 status from available repository evidence.
-
-#### Explicit Deliverables
-- Explicit status declaration: phase-tagged artifacts not confirmed in repository.
-
-#### Explicitly Out of Scope
-- Claiming Phase 31 implementation without repository-verified phase-mapped artifacts.
-
-#### Acceptance Evidence Requirements
-- Any status change is supported by repository-verifiable phase-mapped code/docs/tests and linked issue/PR evidence.


### PR DESCRIPTION
Closes #603

## Summary
- establish docs/roadmap/execution_roadmap.md as the authoritative in-repo source for audited phase taxonomy
- align docs/index.md so it defers to the roadmap and treats phase sections as navigation only
- update docs/audit/roadmap_compliance_report.md with a direct audited-phase trace for phases 5, 16, 17, 17b, 23, 25, 26, and 27

## Testing
- python -m pytest
