### PR TITLE
feat(api): add runtime start and stop execution endpoints

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -935,6 +935,31 @@ def system_state(_: str = Depends(_require_role("read_only"))) -> SystemStateRes
 
 
 @app.post(
+    "/execution/start",
+    response_model=ExecutionControlResponse,
+    summary="Start Execution",
+    description="Ensure the engine runtime is in running state using the existing lifecycle start semantics.",
+)
+def start_execution(_: str = Depends(_require_role("owner"))) -> ExecutionControlResponse:
+    try:
+        state = start_engine_runtime()
+    except LifecycleTransitionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return ExecutionControlResponse(state=state)
+
+
+@app.post(
+    "/execution/stop",
+    response_model=ExecutionControlResponse,
+    summary="Stop Execution",
+    description="Stop the engine runtime using the existing lifecycle shutdown semantics.",
+)
+def stop_execution(_: str = Depends(_require_role("owner"))) -> ExecutionControlResponse:
+    state = shutdown_engine_runtime()
+    return ExecutionControlResponse(state=state)
+
+
+@app.post(
     "/execution/pause",
     response_model=ExecutionControlResponse,
     summary="Pause Execution",

--- a/src/api/test_execution_control_api.py
+++ b/src/api/test_execution_control_api.py
@@ -41,6 +41,52 @@ def test_execution_resume_endpoint_resumes_runtime() -> None:
     assert resume_response.json() == {'state': 'running'}
 
 
+def test_execution_start_endpoint_returns_running_when_runtime_is_ready(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, 'start_engine_runtime', lambda: 'running')
+
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/start', headers=OWNER_HEADERS)
+
+    assert response.status_code == 200
+    assert response.json() == {'state': 'running'}
+
+
+def test_execution_start_endpoint_returns_conflict_for_paused_runtime(monkeypatch) -> None:
+    def _start() -> str:
+        raise api_main.LifecycleTransitionError(
+            "Cannot ensure running runtime from state 'paused'."
+        )
+
+    with TestClient(api_main.app) as client:
+        monkeypatch.setattr(api_main, 'start_engine_runtime', _start)
+        response = client.post('/execution/start', headers=OWNER_HEADERS)
+
+    assert response.status_code == 409
+    assert response.json() == {
+        'detail': "Cannot ensure running runtime from state 'paused'."
+    }
+
+
+def test_execution_stop_endpoint_returns_stopped_when_runtime_is_running(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, 'shutdown_engine_runtime', lambda: 'stopped')
+
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/stop', headers=OWNER_HEADERS)
+
+    assert response.status_code == 200
+    assert response.json() == {'state': 'stopped'}
+
+
+def test_execution_stop_endpoint_returns_ready_for_pre_running_no_op(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, 'shutdown_engine_runtime', lambda: 'ready')
+
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/stop', headers=OWNER_HEADERS)
+
+    assert response.status_code == 200
+    assert response.json() == {'state': 'ready'}
+
+
 def test_execution_pause_endpoint_returns_conflict_when_runtime_not_running(monkeypatch) -> None:
     monkeypatch.setattr(api_main, 'start_engine_runtime', lambda: 'ready')
 
@@ -59,9 +105,53 @@ def test_execution_pause_endpoint_requires_authenticated_role() -> None:
     assert response.json() == {'detail': 'unauthorized'}
 
 
+def test_execution_start_endpoint_requires_authenticated_role() -> None:
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/start')
+
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'unauthorized'}
+
+
+def test_execution_stop_endpoint_requires_authenticated_role() -> None:
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/stop')
+
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'unauthorized'}
+
+
 def test_execution_pause_endpoint_forbids_operator_role_without_side_effect() -> None:
     with TestClient(api_main.app) as client:
         response = client.post('/execution/pause', headers=OPERATOR_HEADERS)
+        introspection_response = client.get('/runtime/introspection')
+        system_state_response = client.get('/system/state', headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 403
+    assert response.json() == {'detail': 'forbidden'}
+    assert introspection_response.status_code == 200
+    assert introspection_response.json()['mode'] == 'running'
+    assert system_state_response.status_code == 200
+    assert system_state_response.json()['status'] == 'running'
+
+
+def test_execution_start_endpoint_forbids_operator_role_without_side_effect() -> None:
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/start', headers=OPERATOR_HEADERS)
+        introspection_response = client.get('/runtime/introspection')
+        system_state_response = client.get('/system/state', headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 403
+    assert response.json() == {'detail': 'forbidden'}
+    assert introspection_response.status_code == 200
+    assert introspection_response.json()['mode'] == 'running'
+    assert system_state_response.status_code == 200
+    assert system_state_response.json()['status'] == 'running'
+
+
+def test_execution_stop_endpoint_forbids_operator_role_without_side_effect() -> None:
+    with TestClient(api_main.app) as client:
+        response = client.post('/execution/stop', headers=OPERATOR_HEADERS)
         introspection_response = client.get('/runtime/introspection')
         system_state_response = client.get('/system/state', headers=READ_ONLY_HEADERS)
 

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -22,6 +22,14 @@ class _RuntimeStateStub:
         self.state = state
 
 
+def setup_function() -> None:
+    _reset_runtime_controller_for_tests()
+
+
+def teardown_function() -> None:
+    _reset_runtime_controller_for_tests()
+
+
 def _insert_ingestion_run(
     db_path: Path,
     ingestion_run_id: str,
@@ -348,3 +356,65 @@ def test_pause_during_in_progress_analysis_does_not_interrupt_execution(monkeypa
     assert response.json()["signals"][0]["symbol"] == "AAPL"
     assert introspection.status_code == 200
     assert introspection.json()["mode"] == "paused"
+
+
+def test_execution_start_endpoint_transitions_ready_runtime_to_running() -> None:
+    _reset_runtime_controller_for_tests()
+
+    with TestClient(api_main.app) as client:
+        _reset_runtime_controller_for_tests()
+        runtime = api_main.get_runtime_controller()
+        runtime.init()
+
+        response = client.post("/execution/start", headers=OWNER_HEADERS)
+        introspection = client.get("/runtime/introspection")
+
+    assert response.status_code == 200
+    assert response.json() == {"state": "running"}
+    assert introspection.status_code == 200
+    assert introspection.json()["mode"] == "running"
+
+
+def test_execution_start_endpoint_returns_conflict_for_paused_runtime() -> None:
+    with TestClient(api_main.app) as client:
+        client.post("/execution/pause", headers=OWNER_HEADERS)
+        response = client.post("/execution/start", headers=OWNER_HEADERS)
+        introspection = client.get("/runtime/introspection")
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "Cannot ensure running runtime from state 'paused'."
+    }
+    assert introspection.status_code == 200
+    assert introspection.json()["mode"] == "paused"
+
+
+def test_execution_stop_endpoint_stops_running_runtime() -> None:
+    with TestClient(api_main.app) as client:
+        response = client.post("/execution/stop", headers=OWNER_HEADERS)
+        introspection = client.get("/runtime/introspection")
+
+    assert response.status_code == 200
+    assert response.json() == {"state": "stopped"}
+    assert introspection.status_code == 200
+    assert introspection.json()["mode"] == "stopped"
+
+
+def test_execution_stop_endpoint_returns_ready_when_runtime_not_started(monkeypatch) -> None:
+    def _start() -> str:
+        return "ready"
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start)
+
+    with TestClient(api_main.app) as client:
+        _reset_runtime_controller_for_tests()
+        runtime = api_main.get_runtime_controller()
+        runtime.init()
+
+        response = client.post("/execution/stop", headers=OWNER_HEADERS)
+        introspection = client.get("/runtime/introspection")
+
+    assert response.status_code == 200
+    assert response.json() == {"state": "ready"}
+    assert introspection.status_code == 200
+    assert introspection.json()["mode"] == "ready"


### PR DESCRIPTION
closes #608