### PR TITLE
Refresh execution roadmap with 45-phase reference

### DIFF
--- a/docs/phases/phase-23-status.md
+++ b/docs/phases/phase-23-status.md
@@ -1,10 +1,20 @@
-# Phase 23 – Research Dashboard
+# Phase 23 - Research Dashboard
 
 ## Status
 NOT IMPLEMENTED
 
-## Verification Source
-Audit #433 did not verify any implementation artifacts.
+## Taxonomy Alignment
+Phase 23 means `Research Dashboard` in the authoritative taxonomy source:
+`docs/roadmap/execution_roadmap.md`
+
+## Verified Repository Evidence
+The current repository review did not confirm a Phase 23 implementation artifact in:
+- `src/**`
+- `engine/**`
+- `tests/**`
+- runtime-facing documentation for a Research Dashboard surface
+
+Repository references to "Research Dashboard" in the audited scope are limited to roadmap and status-tracking documents, not implementation artifacts.
 
 ## Planned Scope
 - Research data aggregation
@@ -18,7 +28,5 @@ Audit #433 did not verify any implementation artifacts.
 - Internal reporting interfaces
 
 ## Explicit Declaration
-As of this document revision, Phase 23 is NOT implemented.
-No UI artifacts, backend services, or integration components exist.
-
-This declaration removes any ambiguity from the execution roadmap.
+As of this revision, no repository-verifiable code, tests, or runtime documentation were confirmed for Phase 23 Research Dashboard.
+Phase 23 therefore remains NOT IMPLEMENTED.

--- a/docs/phases/phase-27-status.md
+++ b/docs/phases/phase-27-status.md
@@ -1,32 +1,28 @@
-# Phase 27 – Risk Framework
+# Phase 27 - Risk Framework
 
 ## Status
-FRAMEWORK NOT IMPLEMENTED
+IMPLEMENTATION ARTIFACTS VERIFIED
+
+## Taxonomy Alignment
+Phase 27 means `Risk Framework` in the authoritative taxonomy source:
+`docs/roadmap/execution_roadmap.md`
+
+This phase remains distinct from Phase 27b pipeline-enforcement artifacts.
 
 ## Verified Existing Artifacts
-The repository contains risk-related configuration fields and metrics.
-These include:
-- Risk-related config schema elements
-- Risk-related metric fields
-- Tests referencing risk-related values
+The repository contains standalone Phase 27 risk-framework artifacts, including:
+- Risk contracts in `src/risk/contracts.py`
+- Concrete risk-gate implementation and guard helpers in `src/cilly_trading/engine/risk/gate.py`
+- Risk framework architecture artifacts in `docs/architecture/risk_framework.md` and `docs/risk/risk_framework.md`
+- Pipeline integration using `RiskGate` in `src/cilly_trading/engine/pipeline/orchestrator.py`
+- Risk-gate tests in `tests/cilly_trading/engine/test_risk_gate.py`
+- Execution-path enforcement tests in `tests/cilly_trading/engine/test_risk_enforcement_bypass.py`, `tests/cilly_trading/engine/test_order_execution_model.py`, and `tests/cilly_trading/engine/test_observability_integration.py`
 
-These artifacts DO NOT constitute a standalone Risk Framework.
+## Current Evidence Boundary
+Verified repository evidence supports that Phase 27 is no longer accurately described as "not implemented" or "no standalone framework artifact verified."
 
-## Not Verified
-No standalone, phase-scoped Risk Framework module,
-engine component, or enforcement layer was verified.
-
-## Acceptance Boundary
-Phase 27 can only be marked as implemented if:
-- A standalone framework-level artifact exists
-- Repository-verifiable module(s) define risk policy logic
-- Documentation and tests explicitly map to Phase 27 framework scope
+This status artifact records verified framework artifacts only. It does not redefine Phase 27 taxonomy and does not treat Phase 27b as interchangeable with Phase 27.
 
 ## Explicit Declaration
-As of this document revision, Phase 27 Risk Framework
-is NOT implemented as a standalone framework artifact.
-
-Existing risk-related metrics/config fields must not be
-interpreted as framework-level completion.
-
-This declaration removes ambiguity between metrics and framework.
+As of this revision, repository-verifiable Risk Framework artifacts exist for Phase 27.
+Phase 27 must not be described in audited status documents as absent or unimplemented where these artifacts are already present.

--- a/docs/phases/phase_25_strategy_lifecycle.md
+++ b/docs/phases/phase_25_strategy_lifecycle.md
@@ -1,16 +1,30 @@
-# Phase 25 — Strategy Lifecycle Management
+# Phase 25 - Strategy Lifecycle Management
 
-**Status:** READY FOR COMPLETION (pending PR merge + CI)
+**Status:** IMPLEMENTED IN REPOSITORY
+
+## Taxonomy Alignment
+Phase 25 means `Strategy Lifecycle Management` in the authoritative taxonomy source:
+`docs/roadmap/execution_roadmap.md`
 
 ## Objective
-Phase 25 introduced the official lifecycle governance framework for strategies, including:
+Phase 25 covers the strategy lifecycle governance artifacts that are verifiably present in this repository:
 - Lifecycle state model
 - Deterministic transition matrix
 - Promotion service API
-- Orchestrator production-only enforcement
+- Production-only execution enforcement in the orchestrator
+
+## Verified Repository Evidence
+- Lifecycle state model: `src/cilly_trading/engine/strategy_lifecycle/model.py`
+- Transition rules: `src/cilly_trading/engine/strategy_lifecycle/transitions.py`
+- Promotion service API: `src/cilly_trading/engine/strategy_lifecycle/service.py`
+- Production-only orchestration enforcement: `src/cilly_trading/engine/pipeline/orchestrator.py`
+- State-model tests: `tests/strategy_lifecycle/test_state_model.py`
+- Transition-matrix tests: `tests/strategy_lifecycle/test_transitions.py`
+- Promotion-service tests: `tests/strategy_lifecycle/test_service.py`
+- Orchestrator enforcement tests: `tests/cilly_trading/engine/test_orchestrator_lifecycle_enforcement.py`
 
 ## Lifecycle States
-The Phase 25 lifecycle model defines four states:
+The verified lifecycle model defines four states:
 - **DRAFT**
 - **EVALUATION**
 - **PRODUCTION**
@@ -20,41 +34,20 @@ The Phase 25 lifecycle model defines four states:
 - **DEPRECATED** is the terminal state. No transitions are permitted out of DEPRECATED.
 
 ## Promotion Rules
-Allowed transitions are strictly limited to:
+Verified allowed transitions are:
 - DRAFT -> EVALUATION
 - DRAFT -> DEPRECATED
 - EVALUATION -> PRODUCTION
 - EVALUATION -> DEPRECATED
 - PRODUCTION -> DEPRECATED
 
-All other transitions are illegal and must be rejected by lifecycle governance.
+All other transitions are rejected by lifecycle governance.
 
 ## Execution Enforcement Rule
 Execution is governed by a strict production-only policy:
 - Only **PRODUCTION** strategies may execute.
-- This rule is enforced in the orchestrator.
+- The orchestrator checks lifecycle state before execution.
 - Non-production strategies are rejected before execution.
-- CI must fail if this guard is removed.
 
-## Linked Pull Requests
-- PR #474 (Closes #474) — Lifecycle Model Design
-- PR #475 (Closes #475) — Lifecycle State Machine Implementation
-- PR #476 (Closes #476) — Production-Only Execution Enforcement
-- PR #477 (Closes #477) — Governance Artifact
-
-## Validation Proof
-- `pytest`
-- Full test suite passing (308 passed, 4 warnings)
-- Enforcement tests present
-- Transition tests present
-
-## Governance Review
-- Review Authority: Codex A
-- Review Decision: APPROVED (pending final merge verification)
-
-## Completion Declaration
-Phase 25 is declared **COMPLETE** only after all of the following are satisfied:
-- All PRs merged
-- CI passing
-- Governance review recorded
-- Artifact committed to main branch
+## Explicit Declaration
+This phase-status artifact is evidence-based. It reflects repository artifacts already present and tested in-tree, rather than pending PR or merge state.

--- a/docs/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -1,0 +1,1593 @@
+# Cilly Trading Engine - Complete Master Roadmap
+Version: Bilingual (English -> Deutsch)
+Status Basis Date: 2026-03-11
+Purpose: Repo-based roadmap aligned to the uploaded 45-phase master reference.
+
+This roadmap replaces the prior working copy at this path.
+
+Reference input:
+- `C:\Users\Serdar Cil\Downloads\cilly_trading_execution_roadmap.md`
+
+Primary status sources:
+- `docs/roadmap/execution_roadmap.md`
+- `docs/audit/roadmap_compliance_report.md`
+- `docs/phases/phase-18-status.md`
+- `docs/phases/phase-23-status.md`
+- `docs/phases/phase_25_strategy_lifecycle.md`
+- `docs/phases/phase-27-status.md`
+- `src/**`
+- `tests/**`
+- runtime and operator documentation under `docs/**`
+
+Status policy used in this file:
+- `Implemented`: repo-verifiable implementation exists without a documented material completion gap for this phase scope.
+- `Partially Implemented`: meaningful implementation exists, but documented scope gaps or runtime/documentation drift remain.
+- `Implemented in Repository`: implementation is clearly present in code and tests and was explicitly corrected from older stale roadmap wording.
+- `Implementation Artifacts Verified`: repo-verifiable artifacts exist, but current governance/audit wording remains more conservative than a flat completion claim.
+- `Not Implemented`: no direct repo-verifiable implementation artifact was confirmed for the phase scope.
+- `Planned`: no substantial in-repo implementation was confirmed for the intended phase capability.
+- `Final Phase`: end-state capability intentionally not treated as active implementation.
+
+---
+
+# ENGLISH VERSION
+
+## System Workflow
+
+Professional trading systems follow this workflow:
+
+Market Data
+-> Strategy Design
+-> Backtesting
+-> Strategy Evaluation
+-> Portfolio Simulation
+-> Paper Trading
+-> Live Trading
+
+---
+
+## Phase Status Overview
+
+| Phase | Title | Status |
+|---|---|---|
+| 1 | Vision & Product Scope | Implemented |
+| 2 | Architecture Blueprint | Implemented |
+| 3 | Repository Structure | Implemented |
+| 4 | Development Environment | Implemented |
+| 5 | Configuration Boundary | Implemented |
+| 6 | Core Domain Models | Implemented |
+| 7 | Indicator Framework | Implemented |
+| 8 | Strategy Framework | Implemented |
+| 9 | Signal Model & Scoring | Implemented |
+| 10 | Engine Orchestrator | Implemented |
+| 11 | Persistence Layer | Implemented |
+| 12 | API Baseline | Implemented |
+| 13 | Runtime Introspection | Implemented |
+| 14 | Compliance Guards | Implemented |
+| 15 | Risk Control Primitives | Implemented |
+| 16 | Runtime Lifecycle Control | Implemented |
+| 17a | Operator Access Model | Implemented |
+| 17b | Owner Dashboard | Partially Implemented |
+| 18 | Deterministic Test Hardening | Implemented |
+| 19 | Logging Framework | Implemented |
+| 20 | Error Handling System | Implemented |
+| 21 | Governance Rules | Implemented |
+| 22 | Artifact Integrity | Implemented |
+| 23 | Research Dashboard Governance | Not Implemented |
+| 24 | Paper Trading Governance | Partially Implemented |
+| 25 | Roadmap Traceability | Implemented in Repository |
+| 26 | Documentation Alignment | Partially Implemented |
+| 27 | Risk Framework Governance | Implementation Artifacts Verified |
+| 28 | Repository Hardening | Implemented |
+| 29 | Trading Journal & Decision Trace | Implemented |
+| 30 | Trading Analytics Layer | Implemented |
+| 31 | Strategy Infrastructure | Implemented |
+| 32 | Operator Control Plane | Implemented |
+| 33 | Data Governance & Execution Runtime | Implemented |
+| 34 | Runtime Stabilization | Implemented |
+| 35 | Observability Layer | Implemented |
+| 36 | Web Activation | Partially Implemented |
+| 37 | Watchlist Engine | Partially Implemented |
+| 38 | Market Data Integration | Partially Implemented |
+| 39 | Charting & Visual Analysis | Planned |
+| 40 | Trading Desk Dashboard | Partially Implemented |
+| 41 | Alerts & Notification System | Planned |
+| 42 | Strategy Lab | Planned |
+| 42b | Backtesting Engine | Implemented in Repository |
+| 43 | Portfolio Simulation | Partially Implemented |
+| 44 | Paper Trading | Partially Implemented |
+| 45 | Live Trading | Final Phase |
+
+## Status Notes
+
+- Phase 17b is backend-served at `/ui`; `/owner` remains a frontend development-only route.
+- Phase 23 still has no verified Research Dashboard implementation artifact in code, tests, or runtime-facing docs.
+- Phase 24 and Phase 44 both benefit from the existing paper-trading simulator, but neither phase is treated as fully complete because the broader workflow and documentation alignment remain incomplete.
+- Phase 25 and Phase 27 were corrected away from stale older wording because lifecycle and risk-framework artifacts are already present in the repository.
+- Phase 35 is marked `Implemented` in this revision because metrics, telemetry, runtime health, guard-trigger monitoring, and integration tests are all present in-repo.
+- Phase 42b is marked `Implemented in Repository` because deterministic backtest runner, CLI, docs, and tests are present.
+
+---
+
+## Phase 1 - Vision & Product Scope
+**Status:** Implemented
+
+**Goal**
+Define what the platform is supposed to do, who it serves, and what remains out of scope in the early system.
+
+**Current Status Basis**
+- MVP and scope documents define deterministic trading-engine intent and explicit non-goals.
+- Role separation and product direction are established in repository documentation.
+
+**Outcome**
+- The project has a clear product identity and controlled scope growth.
+
+---
+
+## Phase 2 - Architecture Blueprint
+**Status:** Implemented
+
+**Goal**
+Define the main technical layers and architectural boundaries.
+
+**Current Status Basis**
+- Repository docs describe layered boundaries across data, strategy, execution, analytics, API, and UI.
+- Current code layout follows modular and deterministic-first separation.
+
+**Outcome**
+- New capabilities can be added without destabilizing the overall platform.
+
+---
+
+## Phase 3 - Repository Structure
+**Status:** Implemented
+
+**Goal**
+Create a disciplined repository layout.
+
+**Current Status Basis**
+- The repo contains clear `src`, `tests`, `docs`, `frontend`, `scripts`, and engine-focused boundaries.
+- Phase-oriented documentation and module grouping are already in use.
+
+**Outcome**
+- Contributors can navigate the codebase with predictable boundaries.
+
+---
+
+## Phase 4 - Development Environment
+**Status:** Implemented
+
+**Goal**
+Make local development reproducible and stable.
+
+**Current Status Basis**
+- Local setup, test commands, Python project metadata, and container files are present.
+- The repo documents canonical local run and test flows.
+
+**Outcome**
+- The project can be started and checked consistently in local environments.
+
+---
+
+## Phase 5 - Configuration Boundary
+**Status:** Implemented
+
+**Goal**
+Define how runtime and strategy configuration is delivered and validated.
+
+**Current Status Basis**
+- Configuration boundary documentation exists and strategy config schema is implemented.
+- Environment-driven runtime inputs and validation boundaries are documented.
+
+**Outcome**
+- Runtime behavior is more predictable and misconfiguration is easier to reason about.
+
+---
+
+## Phase 6 - Core Domain Models
+**Status:** Implemented
+
+**Goal**
+Define the central trading objects used across the platform.
+
+**Current Status Basis**
+- Repository models cover signals, trades, positions, orders, and analysis-related payloads.
+- Persistence, API, analytics, and execution paths share these domain structures.
+
+**Outcome**
+- The system uses a consistent internal model vocabulary.
+
+---
+
+## Phase 7 - Indicator Framework
+**Status:** Implemented
+
+**Goal**
+Provide reusable technical indicator calculations.
+
+**Current Status Basis**
+- Indicator modules exist, including RSI and MACD support.
+- Strategy code consumes deterministic indicator outputs.
+
+**Outcome**
+- Indicator logic is reusable across strategies.
+
+---
+
+## Phase 8 - Strategy Framework
+**Status:** Implemented
+
+**Goal**
+Create a scalable structure for registering and executing strategies.
+
+**Current Status Basis**
+- Strategy registry, validation, configuration schema, and reference strategies are present.
+- Strategy execution is integrated into the engine flow.
+
+**Outcome**
+- Strategies can be added without modifying the core engine architecture.
+
+---
+
+## Phase 9 - Signal Model & Scoring
+**Status:** Implemented
+
+**Goal**
+Standardize how opportunities are represented and prioritized.
+
+**Current Status Basis**
+- Signal payloads include score, stage, entry-zone, confirmation, and metadata fields.
+- Signal persistence and API exposure already use the model consistently.
+
+**Outcome**
+- Signals are comparable, rankable, and reviewable.
+
+---
+
+## Phase 10 - Engine Orchestrator
+**Status:** Implemented
+
+**Goal**
+Coordinate end-to-end analysis across strategies and assets.
+
+**Current Status Basis**
+- Analysis orchestration, watchlist analysis, signal aggregation, and controlled persistence hooks are implemented.
+- Tests cover core orchestration behavior.
+
+**Outcome**
+- The engine can run structured analyses deterministically.
+
+---
+
+## Phase 11 - Persistence Layer
+**Status:** Implemented
+
+**Goal**
+Persist analysis results and runtime artifacts.
+
+**Current Status Basis**
+- SQLite-backed repositories exist for signals, analysis runs, trades, and lineage-style artifacts.
+- Repo initialization and persistence contracts are implemented.
+
+**Outcome**
+- Analysis results and selected runtime artifacts are durable.
+
+---
+
+## Phase 12 - API Baseline
+**Status:** Implemented
+
+**Goal**
+Expose the core engine through HTTP.
+
+**Current Status Basis**
+- The FastAPI application exposes health, analysis, signals, strategies, and related operational endpoints.
+- API usage and boundary docs exist.
+
+**Outcome**
+- The engine is consumable by browsers, scripts, and other tools.
+
+---
+
+## Phase 13 - Runtime Introspection
+**Status:** Implemented
+
+**Goal**
+Expose runtime state safely for operator inspection.
+
+**Current Status Basis**
+- Runtime introspection payloads and supporting runtime metadata contracts are implemented.
+- Tests validate deterministic runtime introspection behavior.
+
+**Outcome**
+- Operators can inspect runtime state without mutating it.
+
+---
+
+## Phase 14 - Compliance Guards
+**Status:** Implemented
+
+**Goal**
+Introduce deterministic safety controls.
+
+**Current Status Basis**
+- Kill-switch, drawdown, and daily-loss guard concepts are implemented in runtime and health-related surfaces.
+- Tests and architecture docs reference the guard model.
+
+**Outcome**
+- Unsafe execution paths can be blocked by explicit guard decisions.
+
+---
+
+## Phase 15 - Risk Control Primitives
+**Status:** Implemented
+
+**Goal**
+Create the building blocks for risk-aware behavior.
+
+**Current Status Basis**
+- Threshold-based risk gates and approval enforcement exist.
+- Risk decisions are used by the execution pipeline and related tests.
+
+**Outcome**
+- Risk management exists as a structured subsystem, not scattered edge handling.
+
+---
+
+## Phase 16 - Runtime Lifecycle Control
+**Status:** Implemented
+
+**Goal**
+Control the operational state of the engine.
+
+**Current Status Basis**
+- Runtime controller primitives and start/stop state flow exist.
+- API and runtime docs reference lifecycle management.
+
+**Outcome**
+- The engine can be managed safely in operation.
+
+---
+
+## Phase 17a - Operator Access Model
+**Status:** Implemented
+
+**Goal**
+Define who is allowed to do what in the system.
+
+**Current Status Basis**
+- Owner/operator-facing documentation and access policy artifacts are present.
+- The system is structured around controlled operator surfaces rather than open user mutation.
+
+**Outcome**
+- The platform starts as a controlled operator tool.
+
+---
+
+## Phase 17b - Owner Dashboard
+**Status:** Partially Implemented
+
+**Goal**
+Provide the first operator-facing UI.
+
+**Current Status Basis**
+- Backend-served UI exists at `/ui`, with static mount and `Owner Dashboard` marker in `src/ui/index.html`.
+- Read-only workbench panels exist for strategies, signals, journal artifacts, decision trace, and trade lifecycle.
+- Audit and documentation still distinguish `/ui` from the frontend-only `/owner` route, so the phase is not treated as unambiguously complete.
+
+**Outcome**
+- The project has a visible operator UI, but route-boundary clarification remains part of the phase story.
+
+---
+
+## Phase 18 - Deterministic Test Hardening
+**Status:** Implemented
+
+**Goal**
+Guarantee reproducible tests and reduce flakiness.
+
+**Current Status Basis**
+- Deterministic testing artifacts and integration coverage exist across runtime, metrics, backtesting, lifecycle, and observability.
+- Snapshot-style and determinism-focused docs are already in-tree.
+
+**Outcome**
+- The test suite is suitable for governance-driven development.
+
+---
+
+## Phase 19 - Logging Framework
+**Status:** Implemented
+
+**Goal**
+Provide structured runtime logging.
+
+**Current Status Basis**
+- Structured engine logging exists with deterministic event ordering.
+- Logging is integrated into runtime and observability tests.
+
+**Outcome**
+- Runtime behavior is observable and debuggable through stable log semantics.
+
+---
+
+## Phase 20 - Error Handling System
+**Status:** Implemented
+
+**Goal**
+Standardize failure handling across the platform.
+
+**Current Status Basis**
+- API validation and runtime error paths are explicitly modeled.
+- Error semantics are documented and covered by tests in several surfaces.
+
+**Outcome**
+- Failures are exposed predictably instead of appearing as silent breakage.
+
+---
+
+## Phase 21 - Governance Rules
+**Status:** Implemented
+
+**Goal**
+Establish disciplined development rules.
+
+**Current Status Basis**
+- Repository governance artifacts, issue/PR guidance, and file-scope rules exist.
+- AI-agent governance and change-scope rules are documented.
+
+**Outcome**
+- Development stays controlled and auditable.
+
+---
+
+## Phase 22 - Artifact Integrity
+**Status:** Implemented
+
+**Goal**
+Guarantee reproducible research artifacts.
+
+**Current Status Basis**
+- Snapshot conventions, deterministic serialization, and artifact-writing utilities are implemented.
+- Docs define artifact and snapshot behavior.
+
+**Outcome**
+- Analysis outputs are reproducible and integrity-aware.
+
+---
+
+## Phase 23 - Research Dashboard Governance
+**Status:** Not Implemented
+
+**Goal**
+Track research dashboard maturity honestly.
+
+**Current Status Basis**
+- The dedicated phase status file explicitly states that no Research Dashboard implementation artifact was verified.
+- No repo-verifiable code, tests, or runtime-facing docs confirm the dashboard itself.
+
+**Outcome**
+- The roadmap remains honest about this unimplemented phase.
+
+---
+
+## Phase 24 - Paper Trading Governance
+**Status:** Partially Implemented
+
+**Goal**
+Prevent premature claims about paper-trading readiness.
+
+**Current Status Basis**
+- Paper-trading simulator code and tests exist in-repo.
+- The audit still reports documentation drift around paper-trading readiness, so the governance phase is not treated as fully cleanly complete.
+
+**Outcome**
+- The repo already contains meaningful paper-trading artifacts, but the documentation/governance story is still partially misaligned.
+
+---
+
+## Phase 25 - Roadmap Traceability
+**Status:** Implemented in Repository
+
+**Goal**
+Map implementation work back to roadmap phases.
+
+**Current Status Basis**
+- The repository now contains explicit phase status artifacts and roadmap-to-implementation references.
+- Strategy lifecycle evidence was explicitly corrected from stale roadmap wording.
+
+**Outcome**
+- Planning is traceable to real implementation work in the repository.
+
+---
+
+## Phase 26 - Documentation Alignment
+**Status:** Partially Implemented
+
+**Goal**
+Ensure documentation reflects implementation reality.
+
+**Current Status Basis**
+- Many docs are aligned and several recent corrections already exist.
+- The roadmap audit still classifies overall alignment as only partially aligned, with specific documentation drift still present.
+
+**Outcome**
+- Documentation alignment work is active and meaningful, but not complete.
+
+---
+
+## Phase 27 - Risk Framework Governance
+**Status:** Implementation Artifacts Verified
+
+**Goal**
+Separate current risk primitives from a future broader risk framework claim.
+
+**Current Status Basis**
+- Risk contracts, a concrete risk gate, pipeline integration, docs, and tests are all present.
+- Current governance wording still treats the phase with caution, so this roadmap uses the evidence-oriented label instead of a simpler blanket completion claim.
+
+**Outcome**
+- The risk framework has real repository artifacts and should no longer be described as absent.
+
+---
+
+## Phase 28 - Repository Hardening
+**Status:** Implemented
+
+**Goal**
+Increase engineering reliability.
+
+**Current Status Basis**
+- Deterministic test coverage, dependency metadata, CI-oriented documentation, and repository standards are present.
+- The repo already behaves as a guarded engineering environment rather than an ad hoc prototype.
+
+**Outcome**
+- The repository is materially hardened for controlled development.
+
+---
+
+## Phase 29 - Trading Journal & Decision Trace
+**Status:** Implemented
+
+**Goal**
+Store and expose the reasoning behind analysis and trading decisions.
+
+**Current Status Basis**
+- Journal artifact APIs, decision trace APIs, journal system modules, and UI/browser surfaces exist.
+- The operator workbench consumes journal-related endpoints.
+
+**Outcome**
+- Strategy and execution reasoning is reviewable in the repository runtime surfaces.
+
+---
+
+## Phase 30 - Trading Analytics Layer
+**Status:** Implemented
+
+**Goal**
+Analyze trade and run performance in a structured way.
+
+**Current Status Basis**
+- Metrics artifacts, backtest metrics, performance report artifacts, and risk-adjusted metrics tests exist.
+- Documentation covers metrics contracts and evaluation outputs.
+
+**Outcome**
+- Strategy performance can be evaluated with deterministic analytics artifacts.
+
+---
+
+## Phase 31 - Strategy Infrastructure
+**Status:** Implemented
+
+**Goal**
+Improve strategy lifecycle and integration infrastructure.
+
+**Current Status Basis**
+- Strategy config schema, registry, validation, metadata, and lifecycle integration are implemented.
+- Multiple strategy-related docs and tests cover these surfaces.
+
+**Outcome**
+- Strategy management is scalable and integrated into higher layers.
+
+---
+
+## Phase 32 - Operator Control Plane
+**Status:** Implemented
+
+**Goal**
+Expose operational control and inspection surfaces.
+
+**Current Status Basis**
+- API endpoints exist for system state, strategies, signals, health, journal, and execution order visibility.
+- The operator workbench reads from those control-plane surfaces.
+
+**Outcome**
+- Operators can inspect and trigger supported system actions from a defined control plane.
+
+---
+
+## Phase 33 - Data Governance & Execution Runtime
+**Status:** Implemented
+
+**Goal**
+Provide deterministic market-data handling and governed execution runtime behavior.
+
+**Current Status Basis**
+- Market-data provider abstraction, failover logic, dataset contracts, execution pipeline, portfolio state API, and runtime controls are implemented.
+- Tests cover failover, runtime integration, and portfolio-related APIs.
+
+**Outcome**
+- The platform has a governed data pipeline and deterministic execution/runtime behavior.
+
+---
+
+## Phase 34 - Runtime Stabilization
+**Status:** Implemented
+
+**Goal**
+Ensure stable runtime behavior across module boundaries.
+
+**Current Status Basis**
+- Health checks, runtime monitoring semantics, integration tests, and runtime docs are already present.
+- The repo contains extensive cross-surface runtime test coverage.
+
+**Outcome**
+- The runtime is stabilized enough to support operator and analytics layers.
+
+---
+
+## Phase 35 - Observability Layer
+**Status:** Implemented
+
+**Goal**
+Provide full operational visibility into engine behavior.
+
+**Current Status Basis**
+- Metrics registry, telemetry schema and emitter, runtime health evaluation, runtime introspection, guard-trigger monitoring, and observability extensions are implemented.
+- Tests cover observability extensions, telemetry schema, guard-trigger telemetry, provider failover telemetry, runtime metrics, and integration flows.
+
+**Outcome**
+- The engine is operationally transparent in the repository today.
+
+---
+
+## Phase 36 - Web Activation
+**Status:** Partially Implemented
+
+**Goal**
+Turn the operator-oriented UI into a usable browser analysis application.
+
+**Current Status Basis**
+- A backend-served UI exists and reads several runtime APIs.
+- The current UI is still primarily an operator workbench shell rather than a fully user-driven browser analysis application with the complete workflow described in the phase.
+
+**Outcome**
+- The web surface is active, but it is not yet the full browser-native analysis experience envisioned by this phase.
+
+---
+
+## Phase 37 - Watchlist Engine
+**Status:** Partially Implemented
+
+**Goal**
+Enable repeatable multi-asset screening.
+
+**Current Status Basis**
+- Watchlist analysis orchestration exists in the engine.
+- No full watchlist CRUD, persistence, ranking workflow, or dedicated watchlist management UI was verified.
+
+**Outcome**
+- Multi-asset analysis exists at engine level, but the full watchlist product workflow remains incomplete.
+
+---
+
+## Phase 38 - Market Data Integration
+**Status:** Partially Implemented
+
+**Goal**
+Support real market-data integrations directly.
+
+**Current Status Basis**
+- Provider abstraction, provider contracts, failover logic, and data guardrails exist.
+- No repo-verifiable direct Yahoo Finance, Binance, or CCXT production integration module was confirmed.
+
+**Outcome**
+- The data-integration foundation exists, but the named real-provider integrations remain incomplete.
+
+---
+
+## Phase 39 - Charting & Visual Analysis
+**Status:** Planned
+
+**Goal**
+Make setups visually interpretable.
+
+**Current Status Basis**
+- No repository charting implementation or visual-analysis module matching this phase scope was verified.
+
+**Outcome**
+- Charting remains future work.
+
+---
+
+## Phase 40 - Trading Desk Dashboard
+**Status:** Partially Implemented
+
+**Goal**
+Provide a central professional trading interface.
+
+**Current Status Basis**
+- The operator workbench already exposes overview, runtime status, analysis runs, screener, signals, journal, decision trace, and trade lifecycle sections.
+- The full trading-desk product scope from the reference roadmap, including heatmaps, leaderboard-style overview, and richer opportunity dashboards, was not fully verified.
+
+**Outcome**
+- A dashboard foundation exists, but the full trading desk vision is not yet complete.
+
+---
+
+## Phase 41 - Alerts & Notification System
+**Status:** Planned
+
+**Goal**
+Notify users automatically when relevant events occur.
+
+**Current Status Basis**
+- No repo-verifiable Telegram, email, browser notification, or alert-routing implementation was confirmed.
+
+**Outcome**
+- Alerts remain planned work.
+
+---
+
+## Phase 42 - Strategy Lab
+**Status:** Planned
+
+**Goal**
+Enable structured experiments with strategy ideas.
+
+**Current Status Basis**
+- No dedicated strategy lab workflow, optimization engine, or comparison UX matching this phase scope was verified.
+
+**Outcome**
+- Strategy lab remains future work.
+
+---
+
+## Phase 42b - Backtesting Engine
+**Status:** Implemented in Repository
+
+**Goal**
+Validate strategies on historical data before simulation and paper trading.
+
+**Current Status Basis**
+- Deterministic backtest runner, CLI entrypoint, backtest docs, artifacts, and tests are present.
+- The repository already supports snapshot-driven backtest execution and deterministic result writing.
+
+**Outcome**
+- Backtesting is no longer just planned; core implementation already exists in the repository.
+
+---
+
+## Phase 43 - Portfolio Simulation
+**Status:** Partially Implemented
+
+**Goal**
+Move from single-signal analysis to portfolio-level evaluation.
+
+**Current Status Basis**
+- Portfolio position state, portfolio API output, capital allocation policy tests, exposure tests, and portfolio enforcement tests exist.
+- A full end-user portfolio simulation workflow matching the complete reference phase scope was not fully verified.
+
+**Outcome**
+- Portfolio simulation primitives and API surfaces exist, but the complete portfolio-simulation product layer is not finished.
+
+---
+
+## Phase 44 - Paper Trading
+**Status:** Partially Implemented
+
+**Goal**
+Simulate real trading with live-like behavior and zero capital risk.
+
+**Current Status Basis**
+- Deterministic paper-trading simulator code, trade persistence integration, PnL tracking, and tests are present.
+- The full phase scope described in the reference roadmap, including a broader paper-trading workflow and dashboard layer, was not fully verified.
+
+**Outcome**
+- Paper-trading simulation exists, but the full user-facing paper-trading phase is not complete.
+
+---
+
+## Phase 45 - Live Trading
+**Status:** Final Phase
+
+**Goal**
+Enable controlled real-capital trading only after all earlier layers are proven.
+
+**Current Status Basis**
+- The audit explicitly confirms that no live-trading endpoint or broker integration runtime was verified.
+- MVP guardrails still exclude live trading.
+
+**Outcome**
+- Live trading remains intentionally gated as the final phase.
+
+---
+
+# DEUTSCHE VERSION
+
+## System-Workflow
+
+Professionelle Trading-Systeme folgen diesem Ablauf:
+
+Marktdaten
+-> Strategie-Design
+-> Backtesting
+-> Strategie-Evaluierung
+-> Portfolio-Simulation
+-> Paper Trading
+-> Live Trading
+
+---
+
+## Phasenstatus-Uebersicht
+
+| Phase | Titel | Status |
+|---|---|---|
+| 1 | Vision & Product Scope | Implemented |
+| 2 | Architecture Blueprint | Implemented |
+| 3 | Repository Structure | Implemented |
+| 4 | Development Environment | Implemented |
+| 5 | Configuration Boundary | Implemented |
+| 6 | Core Domain Models | Implemented |
+| 7 | Indicator Framework | Implemented |
+| 8 | Strategy Framework | Implemented |
+| 9 | Signal Model & Scoring | Implemented |
+| 10 | Engine Orchestrator | Implemented |
+| 11 | Persistence Layer | Implemented |
+| 12 | API Baseline | Implemented |
+| 13 | Runtime Introspection | Implemented |
+| 14 | Compliance Guards | Implemented |
+| 15 | Risk Control Primitives | Implemented |
+| 16 | Runtime Lifecycle Control | Implemented |
+| 17a | Operator Access Model | Implemented |
+| 17b | Owner Dashboard | Partially Implemented |
+| 18 | Deterministic Test Hardening | Implemented |
+| 19 | Logging Framework | Implemented |
+| 20 | Error Handling System | Implemented |
+| 21 | Governance Rules | Implemented |
+| 22 | Artifact Integrity | Implemented |
+| 23 | Research Dashboard Governance | Not Implemented |
+| 24 | Paper Trading Governance | Partially Implemented |
+| 25 | Roadmap Traceability | Implemented in Repository |
+| 26 | Documentation Alignment | Partially Implemented |
+| 27 | Risk Framework Governance | Implementation Artifacts Verified |
+| 28 | Repository Hardening | Implemented |
+| 29 | Trading Journal & Decision Trace | Implemented |
+| 30 | Trading Analytics Layer | Implemented |
+| 31 | Strategy Infrastructure | Implemented |
+| 32 | Operator Control Plane | Implemented |
+| 33 | Data Governance & Execution Runtime | Implemented |
+| 34 | Runtime Stabilization | Implemented |
+| 35 | Observability Layer | Implemented |
+| 36 | Web Activation | Partially Implemented |
+| 37 | Watchlist Engine | Partially Implemented |
+| 38 | Market Data Integration | Partially Implemented |
+| 39 | Charting & Visual Analysis | Planned |
+| 40 | Trading Desk Dashboard | Partially Implemented |
+| 41 | Alerts & Notification System | Planned |
+| 42 | Strategy Lab | Planned |
+| 42b | Backtesting Engine | Implemented in Repository |
+| 43 | Portfolio Simulation | Partially Implemented |
+| 44 | Paper Trading | Partially Implemented |
+| 45 | Live Trading | Final Phase |
+
+## Status-Hinweise
+
+- Phase 17b wird im Backend unter `/ui` ausgeliefert; `/owner` bleibt eine Frontend-Development-Route.
+- Fuer Phase 23 wurde weiterhin kein verifizierter Research-Dashboard-Implementierungsartefakt bestaetigt.
+- Phase 24 und Phase 44 profitieren beide vom vorhandenen Paper-Trading-Simulator, gelten aber wegen offener Workflow- und Doku-Luecken nicht als vollstaendig abgeschlossen.
+- Phase 25 und Phase 27 wurden gegen veraltete Roadmap-Aussagen korrigiert, weil Lifecycle- und Risk-Framework-Artefakte bereits im Repo vorhanden sind.
+- Phase 35 ist in dieser Fassung `Implemented`, weil Metrics, Telemetry, Runtime Health, Guard-Trigger-Monitoring und Integrationstests bereits vorhanden sind.
+- Phase 42b ist `Implemented in Repository`, weil deterministischer Backtest-Runner, CLI, Doku und Tests existieren.
+
+---
+
+## Phase 1 - Vision & Product Scope
+**Status:** Implemented
+
+**Ziel**
+Definieren, was die Plattform leisten soll, fuer wen sie gebaut wird und was in fruehen Stadien ausserhalb des Scopes liegt.
+
+**Aktuelle Statusbasis**
+- MVP- und Scope-Dokumente definieren die deterministische Trading-Engine-Ausrichtung und klare Nicht-Ziele.
+- Rollen und Produktausrichtung sind in der Repository-Dokumentation festgelegt.
+
+**Ergebnis**
+- Das Projekt besitzt eine klare Produktidentitaet und kontrolliertes Scope-Wachstum.
+
+---
+
+## Phase 2 - Architecture Blueprint
+**Status:** Implemented
+
+**Ziel**
+Die technischen Hauptschichten und Architekturgrenzen definieren.
+
+**Aktuelle Statusbasis**
+- Die Doku beschreibt Schichten fuer Daten, Strategie, Execution, Analytics, API und UI.
+- Der aktuelle Code folgt einer modularen und deterministischen Trennung.
+
+**Ergebnis**
+- Neue Faehigkeiten koennen ergaenzt werden, ohne die Gesamtplattform zu destabilisieren.
+
+---
+
+## Phase 3 - Repository Structure
+**Status:** Implemented
+
+**Ziel**
+Ein diszipliniertes Repository-Layout schaffen.
+
+**Aktuelle Statusbasis**
+- Das Repo besitzt klare Grenzen zwischen `src`, `tests`, `docs`, `frontend`, `scripts` und Engine-Modulen.
+- Phasenorientierte Dokumentation und Modulgruppierung werden bereits genutzt.
+
+**Ergebnis**
+- Mitwirkende koennen die Codebasis mit klaren Grenzen navigieren.
+
+---
+
+## Phase 4 - Development Environment
+**Status:** Implemented
+
+**Ziel**
+Lokale Entwicklung reproduzierbar und stabil machen.
+
+**Aktuelle Statusbasis**
+- Lokales Setup, Testbefehle, Python-Projektmetadaten und Container-Dateien sind vorhanden.
+- Das Repo dokumentiert einen kanonischen lokalen Run- und Test-Flow.
+
+**Ergebnis**
+- Das Projekt kann in lokalen Umgebungen konsistent gestartet und geprueft werden.
+
+---
+
+## Phase 5 - Configuration Boundary
+**Status:** Implemented
+
+**Ziel**
+Definieren, wie Runtime- und Strategie-Konfiguration geliefert und validiert wird.
+
+**Aktuelle Statusbasis**
+- Es gibt Dokumentation zur Konfigurationsgrenze und eine implementierte Strategie-Config-Schema-Schicht.
+- Environment-getriebene Runtime-Inputs und Validierungsgrenzen sind dokumentiert.
+
+**Ergebnis**
+- Runtime-Verhalten ist vorhersehbarer und Fehlkonfigurationen sind leichter einzuordnen.
+
+---
+
+## Phase 6 - Core Domain Models
+**Status:** Implemented
+
+**Ziel**
+Die zentralen Trading-Objekte systemweit definieren.
+
+**Aktuelle Statusbasis**
+- Repository-Modelle decken Signale, Trades, Positionen, Orders und Analyse-Payloads ab.
+- Persistenz, API, Analytics und Execution nutzen diese Strukturen gemeinsam.
+
+**Ergebnis**
+- Das System verwendet ein konsistentes internes Modellvokabular.
+
+---
+
+## Phase 7 - Indicator Framework
+**Status:** Implemented
+
+**Ziel**
+Wiederverwendbare technische Indikator-Berechnungen bereitstellen.
+
+**Aktuelle Statusbasis**
+- Indikator-Module wie RSI und MACD sind vorhanden.
+- Strategie-Code nutzt deterministische Indikator-Ausgaben.
+
+**Ergebnis**
+- Indikator-Logik ist strategienuebergreifend wiederverwendbar.
+
+---
+
+## Phase 8 - Strategy Framework
+**Status:** Implemented
+
+**Ziel**
+Eine skalierbare Struktur fuer Registrierung und Ausfuehrung von Strategien schaffen.
+
+**Aktuelle Statusbasis**
+- Strategie-Registry, Validierung, Konfigurationsschema und Referenzstrategien sind vorhanden.
+- Strategie-Ausfuehrung ist in den Engine-Flow integriert.
+
+**Ergebnis**
+- Strategien koennen ohne Umbau des Engine-Kerns hinzugefuegt werden.
+
+---
+
+## Phase 9 - Signal Model & Scoring
+**Status:** Implemented
+
+**Ziel**
+Standardisieren, wie Chancen dargestellt und priorisiert werden.
+
+**Aktuelle Statusbasis**
+- Signal-Payloads enthalten Score, Stage, Entry-Zone, Confirmation und Metadaten.
+- Persistenz und API verwenden das Modell konsistent.
+
+**Ergebnis**
+- Signale sind vergleichbar, filterbar und rankbar.
+
+---
+
+## Phase 10 - Engine Orchestrator
+**Status:** Implemented
+
+**Ziel**
+End-to-End-Analyse ueber Strategien und Assets koordinieren.
+
+**Aktuelle Statusbasis**
+- Analyse-Orchestrierung, Watchlist-Analyse, Signal-Aggregation und kontrollierte Persistenz-Hooks sind implementiert.
+- Tests decken das zentrale Orchestrator-Verhalten ab.
+
+**Ergebnis**
+- Die Engine kann strukturierte Analysen deterministisch ausfuehren.
+
+---
+
+## Phase 11 - Persistence Layer
+**Status:** Implemented
+
+**Ziel**
+Analyseergebnisse und Runtime-Artefakte dauerhaft speichern.
+
+**Aktuelle Statusbasis**
+- SQLite-Repositories fuer Signale, Analysis Runs, Trades und Lineage-/Artefakt-Daten sind vorhanden.
+- Repo-Initialisierung und Persistenzgrenzen sind implementiert.
+
+**Ergebnis**
+- Analyseergebnisse und ausgewaehlte Runtime-Artefakte sind dauerhaft verfuegbar.
+
+---
+
+## Phase 12 - API Baseline
+**Status:** Implemented
+
+**Ziel**
+Die Kern-Engine ueber HTTP bereitstellen.
+
+**Aktuelle Statusbasis**
+- Die FastAPI-App bietet Health-, Analyse-, Signal-, Strategie- und weitere operative Endpunkte.
+- API-Nutzungs- und Boundary-Dokumentation sind vorhanden.
+
+**Ergebnis**
+- Die Engine ist von Browsern, Skripten und Tools konsumierbar.
+
+---
+
+## Phase 13 - Runtime Introspection
+**Status:** Implemented
+
+**Ziel**
+Runtime-Zustand sicher fuer Operator-Inspektion sichtbar machen.
+
+**Aktuelle Statusbasis**
+- Runtime-Introspection-Payloads und zugehoerige Runtime-Metadaten sind implementiert.
+- Tests validieren deterministisches Introspection-Verhalten.
+
+**Ergebnis**
+- Operatoren koennen den Runtime-Zustand inspizieren, ohne ihn zu veraendern.
+
+---
+
+## Phase 14 - Compliance Guards
+**Status:** Implemented
+
+**Ziel**
+Deterministische Safety-Controls einfuehren.
+
+**Aktuelle Statusbasis**
+- Kill-Switch-, Drawdown- und Daily-Loss-Guard-Konzepte sind in Runtime- und Health-Surfaces vorhanden.
+- Tests und Architektur-Doku referenzieren das Guard-Modell.
+
+**Ergebnis**
+- Unsichere Execution-Pfade koennen durch explizite Guard-Entscheidungen blockiert werden.
+
+---
+
+## Phase 15 - Risk Control Primitives
+**Status:** Implemented
+
+**Ziel**
+Bausteine fuer risikobewusstes Verhalten schaffen.
+
+**Aktuelle Statusbasis**
+- Threshold-basierte Risk Gates und Approval-Enforcement existieren.
+- Risk Decisions werden von der Execution-Pipeline und Tests genutzt.
+
+**Ergebnis**
+- Risikomanagement existiert als strukturiertes Subsystem.
+
+---
+
+## Phase 16 - Runtime Lifecycle Control
+**Status:** Implemented
+
+**Ziel**
+Den operativen Zustand der Engine steuern.
+
+**Aktuelle Statusbasis**
+- Runtime-Controller-Primitiven und Start-/Stop-State-Flow sind vorhanden.
+- API und Runtime-Doku referenzieren Lifecycle-Management.
+
+**Ergebnis**
+- Die Engine kann im Betrieb sicher verwaltet werden.
+
+---
+
+## Phase 17a - Operator Access Model
+**Status:** Implemented
+
+**Ziel**
+Definieren, wer im System welche Aktionen ausfuehren darf.
+
+**Aktuelle Statusbasis**
+- Owner-/Operator-bezogene Dokumentation und Access-Policy-Artefakte sind vorhanden.
+- Das System ist auf kontrollierte Operator-Flaechen statt offene Mutation ausgerichtet.
+
+**Ergebnis**
+- Die Plattform startet als kontrolliertes Operator-Tool.
+
+---
+
+## Phase 17b - Owner Dashboard
+**Status:** Partially Implemented
+
+**Ziel**
+Die erste operatorseitige UI bereitstellen.
+
+**Aktuelle Statusbasis**
+- Eine backend-ausgelieferte UI existiert unter `/ui`, inklusive Static Mount und `Owner Dashboard`-Marker in `src/ui/index.html`.
+- Es gibt read-only-Workbench-Panels fuer Strategien, Signale, Journal-Artefakte, Decision Trace und Trade Lifecycle.
+- Audit und Doku unterscheiden weiter zwischen `/ui` und der frontend-only Route `/owner`, daher wird die Phase nicht als vollstaendig eindeutig abgeschlossen behandelt.
+
+**Ergebnis**
+- Das Projekt besitzt eine sichtbare Operator-UI, aber die Routenabgrenzung bleibt Teil der Phasengeschichte.
+
+---
+
+## Phase 18 - Deterministic Test Hardening
+**Status:** Implemented
+
+**Ziel**
+Reproduzierbare Tests garantieren und Flakiness senken.
+
+**Aktuelle Statusbasis**
+- Deterministische Testartefakte und Integrationsabdeckung existieren ueber Runtime, Metrics, Backtesting, Lifecycle und Observability.
+- Snapshot- und Determinismus-Doku ist vorhanden.
+
+**Ergebnis**
+- Die Test-Suite ist fuer governance-getriebene Entwicklung geeignet.
+
+---
+
+## Phase 19 - Logging Framework
+**Status:** Implemented
+
+**Ziel**
+Strukturiertes Runtime-Logging bereitstellen.
+
+**Aktuelle Statusbasis**
+- Strukturiertes Engine-Logging mit deterministischer Event-Reihenfolge ist implementiert.
+- Logging ist in Runtime- und Observability-Tests integriert.
+
+**Ergebnis**
+- Runtime-Verhalten ist ueber stabile Log-Semantik beobachtbar und debuggbar.
+
+---
+
+## Phase 20 - Error Handling System
+**Status:** Implemented
+
+**Ziel**
+Fehlerbehandlung plattformweit standardisieren.
+
+**Aktuelle Statusbasis**
+- API-Validierung und Runtime-Fehlerpfade sind explizit modelliert.
+- Error-Semantics sind dokumentiert und in mehreren Flaechen getestet.
+
+**Ergebnis**
+- Fehler treten vorhersagbar auf statt still zu scheitern.
+
+---
+
+## Phase 21 - Governance Rules
+**Status:** Implemented
+
+**Ziel**
+Disziplinierte Entwicklungsregeln etablieren.
+
+**Aktuelle Statusbasis**
+- Governance-Artefakte, Issue-/PR-Richtlinien und File-Scope-Regeln sind vorhanden.
+- Auch KI-Agenten-Regeln und Scope-Grenzen sind dokumentiert.
+
+**Ergebnis**
+- Entwicklung bleibt kontrolliert und auditierbar.
+
+---
+
+## Phase 22 - Artifact Integrity
+**Status:** Implemented
+
+**Ziel**
+Reproduzierbare Research-Artefakte garantieren.
+
+**Aktuelle Statusbasis**
+- Snapshot-Konventionen, deterministische Serialisierung und Artefakt-Schreiblogik sind implementiert.
+- Doku definiert Artefakt- und Snapshot-Verhalten.
+
+**Ergebnis**
+- Analyse-Ausgaben sind reproduzierbar und integritaetsbewusst.
+
+---
+
+## Phase 23 - Research Dashboard Governance
+**Status:** Not Implemented
+
+**Ziel**
+Den Reifegrad des Research Dashboards ehrlich nachverfolgen.
+
+**Aktuelle Statusbasis**
+- Die dedizierte Phasen-Statusdatei erklaert explizit, dass kein Research-Dashboard-Implementierungsartefakt verifiziert wurde.
+- Weder Code noch Tests noch runtime-nahe Doku bestaetigen das Dashboard selbst.
+
+**Ergebnis**
+- Die Roadmap bleibt fuer diese nicht implementierte Phase ehrlich.
+
+---
+
+## Phase 24 - Paper Trading Governance
+**Status:** Partially Implemented
+
+**Ziel**
+Vorzeitige Aussagen zur Paper-Trading-Reife verhindern.
+
+**Aktuelle Statusbasis**
+- Paper-Trading-Simulator-Code und zugehoerige Tests existieren bereits im Repo.
+- Das Audit meldet weiterhin Dokumentationsdrift rund um Paper-Trading-Readiness, daher gilt die Governance-Phase nicht als sauber abgeschlossen.
+
+**Ergebnis**
+- Das Repo enthaelt bereits sinnvolle Paper-Trading-Artefakte, aber die Governance-/Doku-Lage ist noch nicht voll konsistent.
+
+---
+
+## Phase 25 - Roadmap Traceability
+**Status:** Implemented in Repository
+
+**Ziel**
+Implementierungsarbeit auf Roadmap-Phasen zurueckfuehren.
+
+**Aktuelle Statusbasis**
+- Das Repo enthaelt explizite Phase-Status-Artefakte und Referenzen von Roadmap zu Implementierung.
+- Lifecycle-Evidenz wurde bereits gegen veraltete Roadmap-Aussagen korrigiert.
+
+**Ergebnis**
+- Planung ist im Repository auf echte Implementierungsarbeit rueckfuehrbar.
+
+---
+
+## Phase 26 - Documentation Alignment
+**Status:** Partially Implemented
+
+**Ziel**
+Sicherstellen, dass Dokumentation die Implementierungsrealitaet widerspiegelt.
+
+**Aktuelle Statusbasis**
+- Viele Docs sind bereits angepasst und mehrere Korrekturen existieren.
+- Das Roadmap-Audit stuft den Gesamtzustand aber weiterhin nur als teilweise aligned ein und nennt konkrete Doku-Drift.
+
+**Ergebnis**
+- Dokumentationsabgleich ist deutlich vorangekommen, aber nicht abgeschlossen.
+
+---
+
+## Phase 27 - Risk Framework Governance
+**Status:** Implementation Artifacts Verified
+
+**Ziel**
+Aktuelle Risiko-Primitiven sauber von einem spaeteren breiteren Risk-Framework-Claim trennen.
+
+**Aktuelle Statusbasis**
+- Risk Contracts, konkretes Risk Gate, Pipeline-Integration, Doku und Tests sind vorhanden.
+- Die aktuelle Governance-Sprache bleibt vorsichtig, daher nutzt diese Roadmap ein evidenzorientiertes Label statt einer pauschalen Abschlussbehauptung.
+
+**Ergebnis**
+- Das Risk Framework hat reale Repository-Artefakte und darf nicht mehr als fehlend beschrieben werden.
+
+---
+
+## Phase 28 - Repository Hardening
+**Status:** Implemented
+
+**Ziel**
+Engineering-Zuverlaessigkeit erhoehen.
+
+**Aktuelle Statusbasis**
+- Deterministische Tests, Dependency-Metadaten, CI-orientierte Doku und Repository-Standards sind vorhanden.
+- Das Repo arbeitet bereits wie eine kontrollierte Engineering-Umgebung und nicht wie ein loses Experiment.
+
+**Ergebnis**
+- Das Repository ist fuer kontrollierte Entwicklung materiell gehaertet.
+
+---
+
+## Phase 29 - Trading Journal & Decision Trace
+**Status:** Implemented
+
+**Ziel**
+Die Begruendung hinter Analyse- und Trading-Entscheidungen speichern und anzeigen.
+
+**Aktuelle Statusbasis**
+- Journal-Artefakt-APIs, Decision-Trace-APIs, Journal-Systemmodule und UI-Surfaces sind vorhanden.
+- Die Operator-Workbench konsumiert journalbezogene Endpunkte.
+
+**Ergebnis**
+- Strategie- und Execution-Begruendungen sind im Runtime-System reviewbar.
+
+---
+
+## Phase 30 - Trading Analytics Layer
+**Status:** Implemented
+
+**Ziel**
+Trade- und Run-Performance strukturiert auswerten.
+
+**Aktuelle Statusbasis**
+- Metrics-Artefakte, Backtest-Metrics, Performance-Report-Artefakte und risk-adjusted metrics Tests sind vorhanden.
+- Doku beschreibt Metrics-Contracts und Evaluierungsoutputs.
+
+**Ergebnis**
+- Strategie-Performance kann mit deterministischen Analytics-Artefakten bewertet werden.
+
+---
+
+## Phase 31 - Strategy Infrastructure
+**Status:** Implemented
+
+**Ziel**
+Strategie-Lifecycle und Integrationsinfrastruktur verbessern.
+
+**Aktuelle Statusbasis**
+- Strategie-Config-Schema, Registry, Validierung, Metadaten und Lifecycle-Integration sind implementiert.
+- Mehrere Strategie-Dokus und Tests decken diese Flaechen ab.
+
+**Ergebnis**
+- Strategie-Management ist skalierbar und in hoehere Schichten eingebunden.
+
+---
+
+## Phase 32 - Operator Control Plane
+**Status:** Implemented
+
+**Ziel**
+Operative Kontroll- und Inspektionsflaechen bereitstellen.
+
+**Aktuelle Statusbasis**
+- API-Endpunkte existieren fuer System State, Strategien, Signale, Health, Journal und Execution-Order-Sichtbarkeit.
+- Die Operator-Workbench greift auf diese Control-Plane-Surfaces zu.
+
+**Ergebnis**
+- Operatoren koennen unterstuetzte Systemaktionen ueber eine definierte Control Plane inspizieren und ausloesen.
+
+---
+
+## Phase 33 - Data Governance & Execution Runtime
+**Status:** Implemented
+
+**Ziel**
+Deterministische Marktdatenverarbeitung und governte Execution-Runtime bereitstellen.
+
+**Aktuelle Statusbasis**
+- Market-Data-Provider-Abstraktion, Failover-Logik, Dataset-Contracts, Execution-Pipeline, Portfolio-State-API und Runtime-Controls sind implementiert.
+- Tests decken Failover, Runtime-Integration und portfolio-nahe APIs ab.
+
+**Ergebnis**
+- Die Plattform besitzt eine governte Datenpipeline und deterministisches Runtime-/Execution-Verhalten.
+
+---
+
+## Phase 34 - Runtime Stabilization
+**Status:** Implemented
+
+**Ziel**
+Stabiles Runtime-Verhalten ueber Modulgrenzen hinweg sicherstellen.
+
+**Aktuelle Statusbasis**
+- Health Checks, Runtime-Monitoring-Semantik, Integrationstests und Runtime-Dokumentation sind vorhanden.
+- Das Repo enthaelt breite cross-surface Runtime-Testabdeckung.
+
+**Ergebnis**
+- Die Runtime ist stabil genug fuer Operator- und Analytics-Schichten.
+
+---
+
+## Phase 35 - Observability Layer
+**Status:** Implemented
+
+**Ziel**
+Vollstaendige operative Sichtbarkeit des Engine-Verhaltens herstellen.
+
+**Aktuelle Statusbasis**
+- Metrics Registry, Telemetry-Schema und Emitter, Runtime-Health-Evaluation, Runtime-Introspection, Guard-Trigger-Monitoring und Observability-Extensions sind implementiert.
+- Tests decken Observability-Extensions, Telemetry-Schema, Guard-Trigger-Telemetry, Provider-Failover-Telemetry, Runtime-Metrics und Integrationsfluesse ab.
+
+**Ergebnis**
+- Die Engine ist im Repository heute operativ transparent.
+
+---
+
+## Phase 36 - Web Activation
+**Status:** Partially Implemented
+
+**Ziel**
+Die operatororientierte UI in eine nutzbare browserbasierte Analyseanwendung verwandeln.
+
+**Aktuelle Statusbasis**
+- Eine backend-ausgelieferte UI existiert bereits und liest mehrere Runtime-APIs aus.
+- Die aktuelle UI ist weiterhin vor allem eine Operator-Workbench-Shell und noch nicht die vollstaendige browsernative Analyseanwendung der Phase.
+
+**Ergebnis**
+- Die Web-Flaeche ist aktiv, aber noch nicht der volle Analyse-Workflow fuer Endnutzer.
+
+---
+
+## Phase 37 - Watchlist Engine
+**Status:** Partially Implemented
+
+**Ziel**
+Wiederholbares Multi-Asset-Screening ermoeglichen.
+
+**Aktuelle Statusbasis**
+- Watchlist-Analyse-Orchestrierung existiert bereits in der Engine.
+- Eine vollstaendige Watchlist-CRUD-, Persistenz- und UI-Workflow-Schicht wurde nicht verifiziert.
+
+**Ergebnis**
+- Multi-Asset-Analyse existiert auf Engine-Level, aber der volle Watchlist-Produkt-Workflow ist unvollstaendig.
+
+---
+
+## Phase 38 - Market Data Integration
+**Status:** Partially Implemented
+
+**Ziel**
+Reale Marktdaten-Integrationen direkt unterstuetzen.
+
+**Aktuelle Statusbasis**
+- Provider-Abstraktion, Provider-Contracts, Failover-Logik und Data-Guardrails sind vorhanden.
+- Eine direkte Yahoo-Finance-, Binance- oder CCXT-Produktionsintegration wurde im Repo nicht bestaetigt.
+
+**Ergebnis**
+- Das Fundament fuer Datenintegration existiert, aber die konkret benannten Provider-Integrationen sind noch unvollstaendig.
+
+---
+
+## Phase 39 - Charting & Visual Analysis
+**Status:** Planned
+
+**Ziel**
+Setups visuell interpretierbar machen.
+
+**Aktuelle Statusbasis**
+- Es wurde keine Charting-Implementierung oder Visual-Analysis-Schicht im Sinne dieser Phase bestaetigt.
+
+**Ergebnis**
+- Charting bleibt Zukunftsarbeit.
+
+---
+
+## Phase 40 - Trading Desk Dashboard
+**Status:** Partially Implemented
+
+**Ziel**
+Eine zentrale professionelle Trading-Oberflaeche bereitstellen.
+
+**Aktuelle Statusbasis**
+- Die Operator-Workbench besitzt bereits Overview-, Runtime-, Analysis-, Screener-, Signal-, Journal-, Decision-Trace- und Trade-Lifecycle-Sektionen.
+- Der volle Trading-Desk-Scope aus der Referenz, etwa Heatmaps, reichere Opportunity-Dashboards und Leaderboards, wurde nicht voll verifiziert.
+
+**Ergebnis**
+- Ein Dashboard-Fundament existiert, aber die komplette Trading-Desk-Vision ist noch nicht erreicht.
+
+---
+
+## Phase 41 - Alerts & Notification System
+**Status:** Planned
+
+**Ziel**
+Nutzer automatisch ueber relevante Ereignisse informieren.
+
+**Aktuelle Statusbasis**
+- Es wurden keine Telegram-, E-Mail-, Browser-Notification- oder Alert-Routing-Implementierungen bestaetigt.
+
+**Ergebnis**
+- Alerts bleiben geplante Arbeit.
+
+---
+
+## Phase 42 - Strategy Lab
+**Status:** Planned
+
+**Ziel**
+Strukturierte Experimente mit Strategieideen ermoeglichen.
+
+**Aktuelle Statusbasis**
+- Es wurde kein dedizierter Strategy-Lab-Workflow, keine Optimierungsengine und keine Vergleichs-UX bestaetigt.
+
+**Ergebnis**
+- Strategy Lab bleibt Zukunftsarbeit.
+
+---
+
+## Phase 42b - Backtesting Engine
+**Status:** Implemented in Repository
+
+**Ziel**
+Strategien auf historischen Daten validieren, bevor sie in Simulation und Paper Trading gehen.
+
+**Aktuelle Statusbasis**
+- Deterministischer Backtest-Runner, CLI-Einstiegspunkt, Backtest-Doku, Artefakte und Tests sind vorhanden.
+- Das Repo unterstuetzt bereits snapshot-getriebene Backtest-Ausfuehrung und deterministische Ergebnis-Schreibung.
+
+**Ergebnis**
+- Backtesting ist nicht mehr nur geplant; die Kern-Implementierung existiert bereits im Repository.
+
+---
+
+## Phase 43 - Portfolio Simulation
+**Status:** Partially Implemented
+
+**Ziel**
+Von Einzel-Signal-Analyse zu Bewertung auf Portfolio-Ebene wechseln.
+
+**Aktuelle Statusbasis**
+- Portfolio-Position-State, Portfolio-API-Ausgabe, Capital-Allocation-Policy-Tests, Exposure-Tests und Portfolio-Enforcement-Tests sind vorhanden.
+- Ein vollstaendiger Endnutzer-Portfolio-Simulations-Workflow im kompletten Referenz-Scope wurde nicht voll verifiziert.
+
+**Ergebnis**
+- Portfolio-Simulations-Primitiven und API-Surfaces existieren, aber die komplette Produkt-Schicht ist nicht fertig.
+
+---
+
+## Phase 44 - Paper Trading
+**Status:** Partially Implemented
+
+**Ziel**
+Reales Trading mit live-aehnlichem Verhalten ohne Kapitalrisiko simulieren.
+
+**Aktuelle Statusbasis**
+- Deterministischer Paper-Trading-Simulator, Trade-Persistenz-Integration, PnL-Tracking und Tests sind vorhanden.
+- Der volle Phasen-Scope aus der Referenz, inklusive breiterem Workflow und Dashboard-Layer, wurde nicht voll bestaetigt.
+
+**Ergebnis**
+- Paper-Trading-Simulation existiert, aber die komplette user-facing Phase ist noch nicht abgeschlossen.
+
+---
+
+## Phase 45 - Live Trading
+**Status:** Final Phase
+
+**Ziel**
+Kontrolliertes Trading mit echtem Kapital erst nach erfolgreicher Validierung aller frueheren Ebenen ermoeglichen.
+
+**Aktuelle Statusbasis**
+- Das Audit bestaetigt explizit, dass weder Live-Trading-Endpunkte noch Broker-Integration-Runtime verifiziert wurden.
+- MVP-Guardrails schliessen Live Trading weiterhin aus.
+
+**Ergebnis**
+- Live Trading bleibt bewusst als finale Phase gegatet.

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,9 @@
+﻿Closes #592
+
+## Summary
+- remove helper-level guard telemetry reconstruction from the observability integration test
+- keep integrated coverage limited to runtime surfaces that are actually emitted end-to-end
+- verify deterministic structured logs, provider failover telemetry, runtime metrics, and health endpoints across healthy and failure scenarios
+
+## Testing
+- .\.venv\Scripts\python.exe -m pytest

--- a/pr_body_604.md
+++ b/pr_body_604.md
@@ -1,0 +1,9 @@
+﻿Closes #604
+
+## Summary
+- document /ui as the backend-served runtime operator dashboard surface
+- document /owner as a frontend development-only route
+- remove wording that could imply /ui and /owner are interchangeable runtime entrypoints
+
+## Testing
+- .\.venv\Scripts\python.exe -m pytest --import-mode=importlib

--- a/pr_body_605.md
+++ b/pr_body_605.md
@@ -1,0 +1,7 @@
+﻿Closes #605
+
+## Summary
+- define the canonical runtime, environment, and strategy configuration boundary
+- document validation ownership, defaulting expectations, and precedence rules
+- identify the narrow initial implementation file scope for follow-up work
+- link local-run and Phase 5 governance docs to the new boundary contract

--- a/pr_body_606.md
+++ b/pr_body_606.md
@@ -1,0 +1,9 @@
+﻿Closes #606
+
+## Summary
+- align the React manual analysis request payload with the canonical /analysis/run contract
+- update the owner dashboard to render the canonical manual analysis response fields
+- tighten frontend tests to fail on unsupported request or response fields
+
+## Testing
+- npm test

--- a/pr_body_607.md
+++ b/pr_body_607.md
@@ -1,0 +1,11 @@
+﻿Closes #607
+
+## Summary
+- enforce role checks on covered operator-facing API routes using a minimal header-based role dependency
+- require owner for /execution/pause and /execution/resume
+- require operator for /analysis/run
+- require ead_only for /system/state and /compliance/guards/status
+- add focused API tests for allowed, forbidden, and unauthorized behavior on covered routes only
+
+## Testing
+- .\.venv\Scripts\python.exe -m pytest src/api/test_execution_control_api.py src/api/test_operator_analysis_trigger_api.py src/api/test_system_state_api.py src/api/test_guard_compliance_status_api.py


### PR DESCRIPTION
## Summary
- replace `docs/roadmap/cilly_trading_execution_roadmap_updated.md` with the new 45-phase roadmap derived from the uploaded master reference
- re-evaluate and document each phase status with repo-verifiable artifacts, keeping English and German sections aligned and noting key evidentiary boundaries for contentious items such as Phases 17b, 23, 25, 27, 35, 42b, 43, 44, and 45
- preserve the governance taxonomy file while aligning the updated roadmap with the audit and phase artifacts, per acceptance criteria

## Testing
- Not run (not requested)