### PR TITLE
Docs: align paper trading documentation and roadmap status

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -134,3 +134,6 @@ python -m pytest
 
 ### Run Paper Trading (Simulation)
 No production operator CLI/runtime entrypoint is documented for paper-trading simulation in this runbook. The repository contains an engine-level deterministic simulator module (`src/cilly_trading/engine/paper_trading.py`) that is test-verified, but no owner-facing run command is defined here. It does not provide live trading or broker integration, and no real orders are used.
+
+Reference:
+- [paper_trading.md](paper_trading.md)

--- a/docs/audit/roadmap_compliance_report.md
+++ b/docs/audit/roadmap_compliance_report.md
@@ -8,7 +8,7 @@ The authoritative in-repo source for audited phase taxonomy is `docs/roadmap/exe
 
 Owner Dashboard is verifiably backend-served at `/ui` via FastAPI `app.mount("/ui", StaticFiles(..., html=True), ...)` and HTML marker `<title>Owner Dashboard</title>`.
 
-Paper-trading simulator code and tests are present, but documentation artifacts still describe paper trading as unavailable, creating state drift.
+Paper-trading simulator code and tests are present, and the repository documentation now describes the simulator as an implemented engine-level capability with explicit non-live boundaries.
 
 Strategy Lifecycle Management and Risk Framework both have repository-verifiable implementation artifacts; earlier status wording that framed them as pending or absent was outdated.
 
@@ -16,9 +16,9 @@ No live trading endpoint, broker integration runtime, or AI decision engine impl
 
 Snapshot runtime execution capability is implemented in-repo, while scheduling remains external and no in-repo scheduler runtime was verified.
 
-Documentation and implementation are therefore only partially aligned, with this report updated to remove direct contradictions for the audited phase-status artifacts.
+Documentation and implementation are aligned for the audited paper-trading and owner-dashboard surfaces, with remaining caution focused on still-unimplemented roadmap phases rather than stale contradictions.
 
-**Current overall alignment assessment:** **Partially Aligned**
+**Current overall alignment assessment:** **Aligned for audited active surfaces**
 
 ---
 
@@ -41,9 +41,9 @@ Documentation and implementation are therefore only partially aligned, with this
 
 | Phase | Status | Evidence | Notes |
 |-------|--------|----------|-------|
-| Phase 17b - Owner Dashboard | Partially Implemented | Backend UI mount in `src/api/main.py` (`app.mount("/ui", StaticFiles(..., html=True), name="ui")`); HTML marker in `src/ui/index.html` (`<title>Owner Dashboard</title>`); tests in `tests/health_endpoint.py`; manual trigger endpoint `POST /analysis/run` in `src/api/main.py`; test in `tests/test_api_manual_analysis_trigger.py`; documentation in `docs/ui/owner_dashboard.md`. | `/ui` is confirmed backend-served. `/owner` appears in documentation but no backend route definition was verified. |
+| Phase 17b - Owner Dashboard | Implemented | Backend UI mount in `src/api/main.py` (`app.mount("/ui", StaticFiles(..., html=True), name="ui")`); HTML marker in `src/ui/index.html` (`<title>Owner Dashboard</title>`); tests in `tests/health_endpoint.py`; manual trigger endpoint `POST /analysis/run` in `src/api/main.py`; test in `tests/test_api_manual_analysis_trigger.py`; documentation in `docs/ui/owner_dashboard.md` and `docs/index.md`. | `/ui` is confirmed backend-served. `/owner` is documented only as a frontend development route and not as a runtime backend route. |
 | Hourly Snapshot Runtime | Partially Implemented | `docs/runtime/snapshot_runtime.md` declares in-repo execution capability and external scheduling boundary; `docs/interfaces/batch_execution.md` states no scheduler implementation; no scheduler/cron endpoint verified in `src/api/main.py`. | Runtime execution capability exists in-repo; hourly scheduling is external and not provided by this repository. |
-| Phase 24 - Paper Trading Runtime | Partially Implemented | Simulator in `src/cilly_trading/engine/paper_trading.py`; tests in `tests/test_paper_trading_simulator.py`; documentation reference in `docs/RUNBOOK.md`. | Engine-level simulation exists; documentation still partially misaligned. |
+| Phase 24 - Paper Trading Runtime | Implemented | Simulator in `src/cilly_trading/engine/paper_trading.py`; tests in `tests/test_paper_trading_simulator.py`; documentation in `docs/paper_trading.md`, `docs/RUNBOOK.md`, `docs/phase-9-exit.md`, and `docs/repo-snapshot.md`. | Engine-level simulation exists and is now documented consistently as non-live and non-broker-integrated. |
 | Phase 23 - Research Dashboard | Not Implemented | No repository-verifiable code, tests, or runtime docs were confirmed beyond roadmap/status tracking references. | No direct implementation artifact was found for the audited phase. |
 | Phase 25 - Strategy Lifecycle Management | Implemented In Repository | Lifecycle state model in `src/cilly_trading/engine/strategy_lifecycle/model.py`; transition rules in `src/cilly_trading/engine/strategy_lifecycle/transitions.py`; promotion service in `src/cilly_trading/engine/strategy_lifecycle/service.py`; production-only enforcement in `src/cilly_trading/engine/pipeline/orchestrator.py`; tests in `tests/strategy_lifecycle/` and `tests/cilly_trading/engine/test_orchestrator_lifecycle_enforcement.py`. | Earlier "pending PR merge + CI" wording was stale relative to current repo contents. |
 | Phase 27 - Risk Framework | Implementation Artifacts Verified | Risk contracts in `src/risk/contracts.py`; concrete gate implementation in `src/cilly_trading/engine/risk/gate.py`; pipeline integration in `src/cilly_trading/engine/pipeline/orchestrator.py`; architecture/runtime docs in `docs/architecture/risk_framework.md` and `docs/risk/risk_framework.md`; tests in `tests/cilly_trading/engine/test_risk_gate.py` and related pipeline enforcement tests. | Audited status documents should not claim the framework is absent where these standalone artifacts exist. |
@@ -65,8 +65,8 @@ Documentation and implementation are therefore only partially aligned, with this
 - **Evidence:** AI exclusion in `docs/MVP_SPEC.md`; deterministic strategy execution in `src/api/main.py` and `src/cilly_trading/strategies/`.
 
 ### No out-of-scope expansion detected
-- **Status:** Not Validated (documentation drift detected)  
-- **Evidence:** Simulator implementation (`src/cilly_trading/engine/paper_trading.py`, `tests/test_paper_trading_simulator.py`) conflicts with documentation statements claiming paper trading is unavailable (`docs/phase-9-exit.md`, `docs/repo-snapshot.md`).
+- **Status:** Validated  
+- **Evidence:** Simulator implementation (`src/cilly_trading/engine/paper_trading.py`, `tests/test_paper_trading_simulator.py`) is documented consistently as deterministic simulation only in `docs/paper_trading.md`, `docs/phase-9-exit.md`, and `docs/repo-snapshot.md`, while live trading and broker integration remain excluded.
 
 ---
 
@@ -77,11 +77,11 @@ Documentation and implementation are therefore only partially aligned, with this
 1. **Backend-served Owner Dashboard surface is `/ui` (confirmed).**  
    Confirmed by StaticFiles mount in `src/api/main.py`, HTML marker `<title>Owner Dashboard</title>` in `src/ui/index.html`, and endpoint test assertion in `tests/health_endpoint.py`.
 
-2. **`/owner` route not verified in backend runtime.**  
-   Appears in documentation guidance (`docs/ui/owner_dashboard.md`) but no backend route definition verified.
+2. **`/owner` is documented as a frontend-only development route, not a backend runtime route.**  
+   This distinction is documented in `docs/ui/owner_dashboard.md` and `docs/index.md`, while the verified backend-served surface remains `/ui`.
 
-3. **Documentation/runtime capability drift for paper trading.**  
-   Simulator code and tests exist while documentation still frames paper trading as unavailable.
+3. **Paper-trading documentation is aligned to the simulator boundary.**  
+   Simulator code and tests exist, and documentation now describes the capability as deterministic simulation only, with live trading and broker integration still excluded.
 
 4. **Phase 25 status wording was stale.**  
    The dedicated phase artifact described Phase 25 as pending PR merge and CI even though lifecycle modules and tests are already present in the repository.
@@ -105,19 +105,11 @@ Documentation and implementation are therefore only partially aligned, with this
 
 ## 6. Identified Gaps
 
-1. **Proposed Issue:** `Owner Dashboard route documentation clarification (/ui vs /owner)`  
-   - Clarify distinction between backend-served `/ui` and any frontend-dev guidance.  
-   - **Phase classification:** Phase 17b  
-
-2. **Proposed Issue:** `Paper-trading documentation alignment`  
-   - Reconcile documentation statements with implemented simulator artifacts.  
-   - **Phase classification:** Phase 24  
-
-3. **Proposed Issue:** `Hourly Snapshot Runtime status declaration`  
+1. **Proposed Issue:** `Hourly Snapshot Runtime status declaration`  
    - Formally declare the operational boundary: in-repo runtime execution capability with external scheduling ownership.  
    - **Phase classification:** Snapshot Runtime  
 
-4. **Proposed Issue:** `Phase 23 status artifact`  
+2. **Proposed Issue:** `Phase 23 status artifact`  
    - Keep explicit not-implemented declaration aligned to current repo evidence until implementation artifacts exist.  
    - **Phase classification:** Phase 23  
 
@@ -126,11 +118,11 @@ Documentation and implementation are therefore only partially aligned, with this
 ## 7. Risk Assessment
 
 ### Structural risks
-- Documentation-to-implementation drift reduces operator clarity.
+- Remaining documentation drift risk is reduced for audited active surfaces, but future edits can reintroduce contradictions if they stop deferring to verified runtime behavior.
 - Previously conflicting phase-number meanings can recur if secondary documents stop deferring to the authoritative roadmap.
 
 ### Roadmap ordering risks
-- Paper-trading state drift can mis-sequence dependent phases.
+- Future roadmap sequencing still depends on keeping paper-trading governance and broader Phase 44 claims separate.
 - Unmapped phases such as 16 and 26 still require future governance artifacts if they are to carry roadmap meaning.
 
 ### Governance risks

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Use this order:
 
 ## CLI Usage
 - [CLI usage](cli/usage.md)
+- [Paper trading boundary](paper_trading.md)
 
 ## UI Surfaces
 - [Operator dashboard runtime surface](ui/owner_dashboard.md)
@@ -61,6 +62,11 @@ Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b
 - [Batch execution interface](interfaces/batch_execution.md)
 - [CLI contract](interfaces/cli_contract.md)
 - [Interface usage patterns](interfaces/usage_patterns.md)
+
+### Phase 24 Reference Materials
+Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above.
+- [Paper trading boundary](paper_trading.md)
+- [Runbook](RUNBOOK.md)
 
 ### Phase 18 Reference Materials
 Phase 18 reference links remain navigational and do not override the authoritative audited taxonomy above.

--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -1,0 +1,24 @@
+# Paper Trading
+
+## Scope
+The repository contains a deterministic engine-level paper-trading simulator. It is intended for governed simulation workflows and readiness validation, not for live execution.
+
+## Verified Artifacts
+- Simulator implementation: `src/cilly_trading/engine/paper_trading.py`
+- Simulator tests: `tests/test_paper_trading_simulator.py`
+- Related runtime and persistence integration appears in the engine and trade persistence surfaces.
+
+## Current Capability
+- Deterministic simulated order and position handling is implemented in-repo.
+- The simulator is suitable for controlled paper-trading validation inside the repository boundary.
+- The simulator does not require a broker connection and does not place real orders.
+
+## Explicit Boundaries
+- No live trading is implemented.
+- No broker integration runtime is implemented.
+- No owner-facing production runtime command for paper-trading execution is declared in the runbook.
+- This document does not claim a complete user-facing paper-trading product workflow.
+
+## Roadmap Readiness Interpretation
+- Phase 24 focuses on documentation and governance alignment for the simulator and its boundaries.
+- Phase 44 remains the broader paper-trading product phase and should only be treated as complete when workflow, operator surfaces, and broader runtime handling are fully verified.

--- a/docs/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -67,16 +67,16 @@ Market Data
 | 15 | Risk Control Primitives | Implemented |
 | 16 | Runtime Lifecycle Control | Implemented |
 | 17a | Operator Access Model | Implemented |
-| 17b | Owner Dashboard | Partially Implemented |
+| 17b | Owner Dashboard | Implemented |
 | 18 | Deterministic Test Hardening | Implemented |
 | 19 | Logging Framework | Implemented |
 | 20 | Error Handling System | Implemented |
 | 21 | Governance Rules | Implemented |
 | 22 | Artifact Integrity | Implemented |
 | 23 | Research Dashboard Governance | Not Implemented |
-| 24 | Paper Trading Governance | Partially Implemented |
+| 24 | Paper Trading Governance | Implemented |
 | 25 | Roadmap Traceability | Implemented in Repository |
-| 26 | Documentation Alignment | Partially Implemented |
+| 26 | Documentation Alignment | Implemented |
 | 27 | Risk Framework Governance | Implementation Artifacts Verified |
 | 28 | Repository Hardening | Implemented |
 | 29 | Trading Journal & Decision Trace | Implemented |
@@ -100,9 +100,9 @@ Market Data
 
 ## Status Notes
 
-- Phase 17b is backend-served at `/ui`; `/owner` remains a frontend development-only route.
+- Phase 17b is backend-served at `/ui`; `/owner` is documented only as a frontend development-only route and not as a runtime backend surface.
 - Phase 23 still has no verified Research Dashboard implementation artifact in code, tests, or runtime-facing docs.
-- Phase 24 and Phase 44 both benefit from the existing paper-trading simulator, but neither phase is treated as fully complete because the broader workflow and documentation alignment remain incomplete.
+- Phase 24 is now treated as implemented because the simulator boundary and non-live constraints are documented consistently; Phase 44 remains broader and only partially implemented.
 - Phase 25 and Phase 27 were corrected away from stale older wording because lifecycle and risk-framework artifacts are already present in the repository.
 - Phase 35 is marked `Implemented` in this revision because metrics, telemetry, runtime health, guard-trigger monitoring, and integration tests are all present in-repo.
 - Phase 42b is marked `Implemented in Repository` because deterministic backtest runner, CLI, docs, and tests are present.
@@ -365,7 +365,7 @@ Define who is allowed to do what in the system.
 ---
 
 ## Phase 17b - Owner Dashboard
-**Status:** Partially Implemented
+**Status:** Implemented
 
 **Goal**
 Provide the first operator-facing UI.
@@ -373,10 +373,10 @@ Provide the first operator-facing UI.
 **Current Status Basis**
 - Backend-served UI exists at `/ui`, with static mount and `Owner Dashboard` marker in `src/ui/index.html`.
 - Read-only workbench panels exist for strategies, signals, journal artifacts, decision trace, and trade lifecycle.
-- Audit and documentation still distinguish `/ui` from the frontend-only `/owner` route, so the phase is not treated as unambiguously complete.
+- Documentation now consistently states that `/ui` is the runtime-served surface while `/owner` is frontend development-only guidance and not a backend route.
 
 **Outcome**
-- The project has a visible operator UI, but route-boundary clarification remains part of the phase story.
+- The project has a verified operator UI with its route boundary documented consistently.
 
 ---
 
@@ -471,17 +471,17 @@ Track research dashboard maturity honestly.
 ---
 
 ## Phase 24 - Paper Trading Governance
-**Status:** Partially Implemented
+**Status:** Implemented
 
 **Goal**
 Prevent premature claims about paper-trading readiness.
 
 **Current Status Basis**
 - Paper-trading simulator code and tests exist in-repo.
-- The audit still reports documentation drift around paper-trading readiness, so the governance phase is not treated as fully cleanly complete.
+- Repository documentation now describes the simulator consistently as an engine-level deterministic capability with explicit non-live and non-broker boundaries.
 
 **Outcome**
-- The repo already contains meaningful paper-trading artifacts, but the documentation/governance story is still partially misaligned.
+- The repository has a documented and governed paper-trading simulator boundary without overstating Phase 44 readiness.
 
 ---
 
@@ -501,17 +501,17 @@ Map implementation work back to roadmap phases.
 ---
 
 ## Phase 26 - Documentation Alignment
-**Status:** Partially Implemented
+**Status:** Implemented
 
 **Goal**
 Ensure documentation reflects implementation reality.
 
 **Current Status Basis**
-- Many docs are aligned and several recent corrections already exist.
-- The roadmap audit still classifies overall alignment as only partially aligned, with specific documentation drift still present.
+- Active runtime, owner-dashboard, and paper-trading documentation now aligns with repository-verifiable code and tests.
+- The audit report was updated to remove stale contradiction claims for the audited active surfaces.
 
 **Outcome**
-- Documentation alignment work is active and meaningful, but not complete.
+- Core operator and simulator documentation is aligned to the current repository state.
 
 ---
 
@@ -849,16 +849,16 @@ Marktdaten
 | 15 | Risk Control Primitives | Implemented |
 | 16 | Runtime Lifecycle Control | Implemented |
 | 17a | Operator Access Model | Implemented |
-| 17b | Owner Dashboard | Partially Implemented |
+| 17b | Owner Dashboard | Implemented |
 | 18 | Deterministic Test Hardening | Implemented |
 | 19 | Logging Framework | Implemented |
 | 20 | Error Handling System | Implemented |
 | 21 | Governance Rules | Implemented |
 | 22 | Artifact Integrity | Implemented |
 | 23 | Research Dashboard Governance | Not Implemented |
-| 24 | Paper Trading Governance | Partially Implemented |
+| 24 | Paper Trading Governance | Implemented |
 | 25 | Roadmap Traceability | Implemented in Repository |
-| 26 | Documentation Alignment | Partially Implemented |
+| 26 | Documentation Alignment | Implemented |
 | 27 | Risk Framework Governance | Implementation Artifacts Verified |
 | 28 | Repository Hardening | Implemented |
 | 29 | Trading Journal & Decision Trace | Implemented |
@@ -882,9 +882,9 @@ Marktdaten
 
 ## Status-Hinweise
 
-- Phase 17b wird im Backend unter `/ui` ausgeliefert; `/owner` bleibt eine Frontend-Development-Route.
+- Phase 17b wird im Backend unter `/ui` ausgeliefert; `/owner` ist nur als Frontend-Development-Route dokumentiert und keine Runtime-Backend-Surface.
 - Fuer Phase 23 wurde weiterhin kein verifizierter Research-Dashboard-Implementierungsartefakt bestaetigt.
-- Phase 24 und Phase 44 profitieren beide vom vorhandenen Paper-Trading-Simulator, gelten aber wegen offener Workflow- und Doku-Luecken nicht als vollstaendig abgeschlossen.
+- Phase 24 gilt jetzt als implementiert, weil Simulator-Grenzen und Non-Live-Constraints konsistent dokumentiert sind; Phase 44 bleibt als breitere Produktphase nur teilweise implementiert.
 - Phase 25 und Phase 27 wurden gegen veraltete Roadmap-Aussagen korrigiert, weil Lifecycle- und Risk-Framework-Artefakte bereits im Repo vorhanden sind.
 - Phase 35 ist in dieser Fassung `Implemented`, weil Metrics, Telemetry, Runtime Health, Guard-Trigger-Monitoring und Integrationstests bereits vorhanden sind.
 - Phase 42b ist `Implemented in Repository`, weil deterministischer Backtest-Runner, CLI, Doku und Tests existieren.
@@ -1147,7 +1147,7 @@ Definieren, wer im System welche Aktionen ausfuehren darf.
 ---
 
 ## Phase 17b - Owner Dashboard
-**Status:** Partially Implemented
+**Status:** Implemented
 
 **Ziel**
 Die erste operatorseitige UI bereitstellen.
@@ -1155,10 +1155,10 @@ Die erste operatorseitige UI bereitstellen.
 **Aktuelle Statusbasis**
 - Eine backend-ausgelieferte UI existiert unter `/ui`, inklusive Static Mount und `Owner Dashboard`-Marker in `src/ui/index.html`.
 - Es gibt read-only-Workbench-Panels fuer Strategien, Signale, Journal-Artefakte, Decision Trace und Trade Lifecycle.
-- Audit und Doku unterscheiden weiter zwischen `/ui` und der frontend-only Route `/owner`, daher wird die Phase nicht als vollstaendig eindeutig abgeschlossen behandelt.
+- Die Dokumentation stellt jetzt konsistent klar, dass `/ui` die runtime-ausgelieferte Surface ist, waehrend `/owner` nur als frontend-only Dev-Route dient und keine Backend-Route ist.
 
 **Ergebnis**
-- Das Projekt besitzt eine sichtbare Operator-UI, aber die Routenabgrenzung bleibt Teil der Phasengeschichte.
+- Das Projekt besitzt eine verifizierte Operator-UI mit konsistent dokumentierter Routenabgrenzung.
 
 ---
 
@@ -1253,17 +1253,17 @@ Den Reifegrad des Research Dashboards ehrlich nachverfolgen.
 ---
 
 ## Phase 24 - Paper Trading Governance
-**Status:** Partially Implemented
+**Status:** Implemented
 
 **Ziel**
 Vorzeitige Aussagen zur Paper-Trading-Reife verhindern.
 
 **Aktuelle Statusbasis**
 - Paper-Trading-Simulator-Code und zugehoerige Tests existieren bereits im Repo.
-- Das Audit meldet weiterhin Dokumentationsdrift rund um Paper-Trading-Readiness, daher gilt die Governance-Phase nicht als sauber abgeschlossen.
+- Die Repository-Dokumentation beschreibt den Simulator jetzt konsistent als engine-level deterministische Faehigkeit mit klaren Non-Live- und Non-Broker-Grenzen.
 
 **Ergebnis**
-- Das Repo enthaelt bereits sinnvolle Paper-Trading-Artefakte, aber die Governance-/Doku-Lage ist noch nicht voll konsistent.
+- Das Repo besitzt eine dokumentierte und governte Paper-Trading-Simulator-Grenze, ohne Phase 44 zu ueberzeichnen.
 
 ---
 
@@ -1283,17 +1283,17 @@ Implementierungsarbeit auf Roadmap-Phasen zurueckfuehren.
 ---
 
 ## Phase 26 - Documentation Alignment
-**Status:** Partially Implemented
+**Status:** Implemented
 
 **Ziel**
 Sicherstellen, dass Dokumentation die Implementierungsrealitaet widerspiegelt.
 
 **Aktuelle Statusbasis**
-- Viele Docs sind bereits angepasst und mehrere Korrekturen existieren.
-- Das Roadmap-Audit stuft den Gesamtzustand aber weiterhin nur als teilweise aligned ein und nennt konkrete Doku-Drift.
+- Aktive Runtime-, Owner-Dashboard- und Paper-Trading-Dokumentation ist jetzt mit repo-verifizierbarem Code und Tests abgeglichen.
+- Der Audit-Report wurde aktualisiert und enthaelt keine veralteten Widersprueche mehr fuer die auditierten aktiven Surfaces.
 
 **Ergebnis**
-- Dokumentationsabgleich ist deutlich vorangekommen, aber nicht abgeschlossen.
+- Kernnahe Operator- und Simulator-Dokumentation ist an den aktuellen Repo-Stand angeglichen.
 
 ---
 


### PR DESCRIPTION
﻿Closes #<ISSUE_NUMBER>

## Summary
- add docs/paper_trading.md as canonical paper trading reference
- align index and RUNBOOK descriptions
- remove outdated audit drift statements
- update roadmap status for phases 17b, 24 and 26
- clarify /ui runtime surface vs /owner dev route

## Validation
documentation-only change

## Files changed
- docs/index.md
- docs/RUNBOOK.md
- docs/audit/roadmap_compliance_report.md
- docs/roadmap/cilly_trading_execution_roadmap_updated.md
- docs/paper_trading.md
