### PR TITLE
Document Phase 37 watchlist planning package

### DIFF
--- a/docs/phases/phase-37-issue-01-watchlist-persistence.md
+++ b/docs/phases/phase-37-issue-01-watchlist-persistence.md
@@ -1,0 +1,52 @@
+## Title
+Watchlist persistence contract and repository
+
+## Suggested labels
+`phase:37`, `api`, `testing`
+
+## Suggested milestone
+`Phase 37A - Watchlist Foundation`
+
+## Goal
+Introduce a deterministic watchlist persistence boundary so named watchlists and their symbol membership can be stored and read by the runtime without changing the existing engine architecture.
+
+## Context (optional)
+Phase 37 is currently only partially implemented. Engine-level multi-asset analysis already exists, but no repository-verified watchlist CRUD or persistence layer has been confirmed.
+
+## IN SCOPE
+- Define a watchlist persistence model suitable for local SQLite-backed storage
+- Implement repository methods for create, list, read, update, and delete watchlists
+- Preserve deterministic symbol ordering and stable identifiers
+- Add focused repository tests for CRUD and ordering behavior
+
+## OUT OF SCOPE
+- New execution architecture
+- UI work
+- Ranking response contracts
+- Roadmap or status documentation changes beyond code comments if strictly required
+
+## Acceptance Criteria
+1. A watchlist can be created with a stable identifier, a human-readable name, and a symbol list.
+2. A stored watchlist can be read back with deterministic symbol ordering.
+3. A watchlist can be updated and deleted through the repository boundary.
+4. Repository tests cover create, read, list, update, delete, duplicate-name or duplicate-id handling, and empty-symbol validation behavior.
+
+## Test Requirements
+- Add repository-focused pytest coverage for watchlist CRUD behavior
+- Verify deterministic ordering for symbols and list results
+- Verify failure behavior does not partially persist invalid watchlists
+
+## Files allowed to change
+- src/cilly_trading/repositories/**
+- src/cilly_trading/db/**
+- tests/**
+
+## Files NOT allowed to change
+- src/ui/**
+- frontend/**
+- docs/roadmap/**
+- docs/ui/**
+- engine/**
+
+## Notes / Risks
+Keep the implementation local and SQLite-backed. Do not introduce a new storage subsystem or external service dependency.

--- a/docs/phases/phase-37-issue-02-watchlist-crud-api.md
+++ b/docs/phases/phase-37-issue-02-watchlist-crud-api.md
@@ -1,0 +1,53 @@
+## Title
+Watchlist CRUD API surface
+
+## Suggested labels
+`phase:37`, `api`, `testing`
+
+## Suggested milestone
+`Phase 37A - Watchlist Foundation`
+
+## Goal
+Expose a bounded operator-facing API for watchlist CRUD on top of the new watchlist repository boundary.
+
+## Context (optional)
+The current API already supports manual analysis and screener access, but there is no verified watchlist management surface for Phase 37.
+
+## IN SCOPE
+- Add watchlist create, list, read, update, and delete endpoints
+- Reuse the existing local/operator API style in `src/api/main.py`
+- Apply the existing role model consistently to the new endpoints
+- Add focused API tests for allowed, forbidden, and invalid requests
+
+## OUT OF SCOPE
+- Browser workflow implementation in `/ui`
+- Watchlist execution/ranking behavior beyond CRUD
+- Charting, alerts, or portfolio simulation
+- Broad access-policy redesign
+
+## Acceptance Criteria
+1. The API exposes bounded watchlist CRUD endpoints with deterministic request and response shapes.
+2. Operator and owner roles may perform watchlist mutation; read_only may only inspect watchlists if a read endpoint is exposed.
+3. Invalid payloads return deterministic validation errors and do not partially persist state.
+4. API tests cover success, validation failure, unauthorized, and forbidden cases.
+
+## Test Requirements
+- Add FastAPI tests for each CRUD endpoint
+- Verify role enforcement matches the current access-policy style
+- Verify list responses and symbol arrays are deterministic
+
+## Files allowed to change
+- src/api/main.py
+- src/api/test_*.py
+- src/cilly_trading/repositories/**
+- tests/**
+
+## Files NOT allowed to change
+- src/ui/**
+- frontend/**
+- docs/roadmap/**
+- docs/ui/**
+- src/cilly_trading/engine/**
+
+## Notes / Risks
+Keep endpoint naming and response style aligned with existing API conventions. Do not redesign unrelated request models.

--- a/docs/phases/phase-37-issue-03-watchlist-execution-ranking.md
+++ b/docs/phases/phase-37-issue-03-watchlist-execution-ranking.md
@@ -1,0 +1,54 @@
+## Title
+Watchlist execution and ranking workflow
+
+## Suggested labels
+`phase:37`, `api`, `testing`
+
+## Suggested milestone
+`Phase 37A - Watchlist Foundation`
+
+## Goal
+Add a dedicated watchlist execution workflow that runs analysis for a persisted watchlist and returns deterministic ranked results suitable for later UI consumption.
+
+## Context (optional)
+The engine already supports watchlist-style multi-symbol analysis, but no full Phase 37 product workflow has been verified for persisted watchlists and ranking output.
+
+## IN SCOPE
+- Connect persisted watchlists to the existing analysis orchestration
+- Add a dedicated endpoint to execute analysis for a saved watchlist
+- Define and return a deterministic ranking/result payload for the watchlist run
+- Add tests for ranking order, symbol isolation, and empty-result behavior
+
+## OUT OF SCOPE
+- New strategy logic
+- New market data provider integrations
+- UI rendering
+- Heatmaps, leaderboards, or trading-desk features
+
+## Acceptance Criteria
+1. A saved watchlist can be analyzed through a dedicated API path using the existing engine orchestration.
+2. The response contains deterministic ranked results derived from the produced signals.
+3. Symbol-level failures remain isolated and do not crash the whole watchlist run unless the whole request is invalid.
+4. Tests cover ranking order, empty-result behavior, and partial-failure isolation.
+
+## Test Requirements
+- Add API and/or engine integration tests for persisted-watchlist execution
+- Verify deterministic ordering for ranked items
+- Verify existing screener behavior is not regressed by the new watchlist path
+
+## Files allowed to change
+- src/api/main.py
+- src/cilly_trading/engine/core.py
+- src/cilly_trading/repositories/**
+- tests/**
+- docs/api/usage_contract.md
+
+## Files NOT allowed to change
+- src/ui/**
+- frontend/**
+- docs/ui/**
+- docs/roadmap/**
+- src/cilly_trading/engine/marketdata/**
+
+## Notes / Risks
+This issue must stay within the current engine boundaries. Reuse existing orchestration instead of introducing a second execution path.

--- a/docs/phases/phase-37-issue-04-runtime-ui-watchlists.md
+++ b/docs/phases/phase-37-issue-04-runtime-ui-watchlists.md
@@ -1,0 +1,54 @@
+## Title
+Runtime /ui watchlist management and execution flow
+
+## Suggested labels
+`phase:37`, `ui`, `testing`
+
+## Suggested milestone
+`Phase 37B - Watchlist Product Surface`
+
+## Goal
+Extend the backend-served `/ui` runtime surface with a dedicated watchlist management and execution workflow for Phase 37.
+
+## Context (optional)
+Phase 36 explicitly stops before watchlist CRUD, persistence, ranking, and dedicated watchlist UI. This issue adds only the bounded browser workflow needed for Phase 37.
+
+## IN SCOPE
+- Add watchlist management UI to the runtime-served `/ui` surface
+- Allow creating, selecting, editing, deleting, and executing watchlists from the browser
+- Render ranked watchlist results using the new API surface
+- Add focused runtime-surface tests for the new watchlist workflow
+
+## OUT OF SCOPE
+- `/owner` runtime routing
+- Charting or visual-analysis widgets
+- Trading-desk heatmaps or leaderboard views
+- Alerts, paper trading, or live trading controls
+
+## Acceptance Criteria
+1. `/ui` exposes a watchlist section that supports create, list, update, delete, and execute actions against the backend runtime API.
+2. The browser surface renders ranked watchlist results for a completed watchlist run.
+3. The watchlist workflow remains clearly bounded to Phase 37 and does not claim Phase 39 or Phase 40 features.
+4. Runtime-surface tests verify the new watchlist UI markers and the wired API workflow.
+
+## Test Requirements
+- Add or extend `/ui` runtime surface tests
+- Verify the watchlist controls are present in the backend-served page
+- Verify the browser workflow uses the watchlist API rather than ad hoc client-only state
+
+## Files allowed to change
+- src/ui/index.html
+- src/api/main.py
+- src/api/test_operator_workbench_surface.py
+- tests/test_ui_runtime_browser_flow.py
+- tests/**
+
+## Files NOT allowed to change
+- frontend/src/**
+- docs/roadmap/**
+- docs/phases/**
+- src/cilly_trading/engine/marketdata/**
+- src/cilly_trading/engine/backtest_runner.py
+
+## Notes / Risks
+`/ui` remains the canonical runtime surface. Do not reframe `/owner` as a backend runtime route.

--- a/docs/phases/phase-37-issue-05-phase-37-doc-alignment.md
+++ b/docs/phases/phase-37-issue-05-phase-37-doc-alignment.md
@@ -1,0 +1,51 @@
+## Title
+Phase 37 status and contract alignment
+
+## Suggested labels
+`phase:37`, `docs`, `governance`
+
+## Suggested milestone
+`Phase 37B - Watchlist Product Surface`
+
+## Goal
+Document the repository-verified Phase 37 contract and status using the implementation evidence produced by the watchlist foundation, API, and `/ui` issues.
+
+## Context (optional)
+Phase 36 explicitly excludes watchlist CRUD, persistence, ranking, and dedicated watchlist management UI. Once those artifacts exist, the repository needs a canonical Phase 37 status/contract update.
+
+## IN SCOPE
+- Add a dedicated Phase 37 contract or status artifact
+- Update roadmap wording to reflect repository-verified implementation reality
+- Update `/ui` and API documentation to distinguish Phase 37 from later phases
+- Link evidence to the implemented code and tests
+
+## OUT OF SCOPE
+- Implementing missing watchlist functionality
+- Market data provider expansion
+- Charting, alerts, or trading-desk product claims
+- Rewriting unrelated roadmap phases
+
+## Acceptance Criteria
+1. A canonical Phase 37 documentation artifact exists and states the verified scope in repository terms.
+2. Roadmap wording for Phase 37 is aligned with actual code and tests, without overstating later phases.
+3. The `/ui` and API docs describe the bounded watchlist workflow consistently.
+4. The documentation points to repository evidence for watchlist CRUD, persistence, execution, ranking, and `/ui` behavior.
+
+## Test Requirements
+- Documentation review against implemented endpoints, runtime page markers, and tests
+- No contradictory wording remains in the touched docs for Phase 37 scope
+
+## Files allowed to change
+- docs/roadmap/**
+- docs/ui/**
+- docs/api/**
+- docs/phases/**
+- docs/index.md
+
+## Files NOT allowed to change
+- src/**
+- tests/**
+- frontend/**
+
+## Notes / Risks
+Keep status wording evidence-based. Do not mark later phases as implemented through implication.

--- a/docs/phases/phase-37-watchlist-engine-milestones.md
+++ b/docs/phases/phase-37-watchlist-engine-milestones.md
@@ -1,0 +1,43 @@
+# Phase 37 Watchlist Engine Milestones
+
+## Milestone 1
+
+**Title:** `Phase 37A - Watchlist Foundation`
+
+**Purpose**
+
+Create the persistence, API, and execution foundations for watchlists without overstating the broader product workflow.
+
+**Exit Condition**
+
+Watchlists are storable, readable, updatable, deletable, and executable through a bounded API path that returns deterministic ranked results.
+
+**Planned Issues**
+
+1. `Watchlist persistence contract and repository`
+2. `Watchlist CRUD API surface`
+3. `Watchlist execution and ranking workflow`
+
+## Milestone 2
+
+**Title:** `Phase 37B - Watchlist Product Surface`
+
+**Purpose**
+
+Extend the runtime-served `/ui` surface with watchlist management and align the repository documentation to Phase 37 implementation evidence.
+
+**Exit Condition**
+
+An operator can manage and execute watchlists from the runtime-served `/ui`, review ranked results, and the repository documentation reflects the verified Phase 37 scope without implying later phases.
+
+**Planned Issues**
+
+1. `Runtime /ui watchlist management and execution flow`
+2. `Phase 37 status and contract alignment`
+
+## Suggested GitHub Creation Order
+
+1. Create milestone `Phase 37A - Watchlist Foundation`
+2. Create milestone `Phase 37B - Watchlist Product Surface`
+3. Create label `phase:37`
+4. Create the five issues and assign them to the milestones in package order

--- a/docs/phases/phase-37-watchlist-engine-package.md
+++ b/docs/phases/phase-37-watchlist-engine-package.md
@@ -1,0 +1,68 @@
+# Phase 37 Watchlist Engine Planning Package
+
+## Purpose
+
+This file is the local planning index for the Phase 37 Watchlist Engine work package.
+
+It prepares GitHub-ready milestone and issue content without pushing anything to GitHub yet.
+
+## Scope Summary
+
+Phase 37 remains bounded to:
+
+- watchlist CRUD
+- watchlist persistence
+- persisted watchlist execution
+- deterministic ranking results
+- dedicated runtime-served `/ui` watchlist workflow
+- evidence-based Phase 37 documentation alignment
+
+Phase 37 remains explicitly out of scope for:
+
+- market data provider expansion
+- charting and visual analysis
+- trading-desk heatmaps or leaderboards
+- alerts and notifications
+- strategy lab workflows
+- paper-trading product workflows
+- live-trading workflows
+
+## Labels
+
+Reuse existing repository labels if they already exist in GitHub:
+
+- `api`
+- `ui`
+- `docs`
+- `testing`
+- `governance`
+
+Add this new phase label when the GitHub objects are created:
+
+- `phase:37`
+
+## Milestones
+
+- [Phase 37 milestones](phase-37-watchlist-engine-milestones.md)
+
+## Issue Drafts
+
+1. [Issue 1 - Watchlist persistence contract and repository](phase-37-issue-01-watchlist-persistence.md)
+2. [Issue 2 - Watchlist CRUD API surface](phase-37-issue-02-watchlist-crud-api.md)
+3. [Issue 3 - Watchlist execution and ranking workflow](phase-37-issue-03-watchlist-execution-ranking.md)
+4. [Issue 4 - Runtime /ui watchlist management and execution flow](phase-37-issue-04-runtime-ui-watchlists.md)
+5. [Issue 5 - Phase 37 status and contract alignment](phase-37-issue-05-phase-37-doc-alignment.md)
+
+## Recommended Sequencing
+
+1. Issue 1 in Milestone `Phase 37A - Watchlist Foundation`
+2. Issue 2 in Milestone `Phase 37A - Watchlist Foundation`
+3. Issue 3 in Milestone `Phase 37A - Watchlist Foundation`
+4. Issue 4 in Milestone `Phase 37B - Watchlist Product Surface`
+5. Issue 5 in Milestone `Phase 37B - Watchlist Product Surface`
+
+## Notes
+
+- The issue drafts follow the repository issue template structure from `.github/ISSUE_TEMPLATE/issue.md`.
+- The package is intentionally local-only and can be copied into GitHub later without reformatting.
+- The issue set keeps implementation and documentation scope separated so later PRs can stay narrow and reviewable.


### PR DESCRIPTION
## Summary
- capture the Phase 37 watchlist planning package, including milestones and issue drafts, inside `docs/phases`
- define the persistence, API, execution, UI, and status issues to align with the requested governance in `phase-37-watchlist-engine-package.md`
- outline milestones, labels, and sequencing so the repo can later publish the GitHub artifacts directly
- Closes #<IssueID>

## Testing
- Not run (not requested)