### PR TITLE
P37-ENGINE: implement watchlist persistence contract and repository

### DIFF
--- a/src/cilly_trading/db/init_db.py
+++ b/src/cilly_trading/db/init_db.py
@@ -1,8 +1,8 @@
 """
-Init-Skript für die SQLite-Datenbank der Cilly Trading Engine.
+Init-Skript fuer die SQLite-Datenbank der Cilly Trading Engine.
 
 - Legt die Datei `cilly_trading.db` im Projektverzeichnis an (falls nicht vorhanden).
-- Erzeugt die Tabellen `signals`, `trades` und `analysis_runs`
+- Erzeugt die Tabellen `signals`, `trades`, `analysis_runs` und `watchlists`
   entsprechend der MVP-Spezifikation.
 """
 
@@ -12,7 +12,7 @@ import sqlite3
 from pathlib import Path
 from typing import Optional
 
-# Standard-Pfad für die Datenbankdatei (kann später per ENV konfiguriert werden)
+# Standard-Pfad fuer die Datenbankdatei (kann spaeter per ENV konfiguriert werden)
 DEFAULT_DB_PATH = Path("cilly_trading.db")
 
 
@@ -25,12 +25,12 @@ def get_connection(db_path: Optional[Path] = None) -> sqlite3.Connection:
     if db_path is None:
         db_path = DEFAULT_DB_PATH
 
-    # ensure parent dir exists (falls später in Unterordnern gespeichert wird)
+    # ensure parent dir exists (falls spaeter in Unterordnern gespeichert wird)
     if db_path.parent and not db_path.parent.exists():
         db_path.parent.mkdir(parents=True, exist_ok=True)
 
     conn = sqlite3.connect(db_path)
-    # bessere Row-Funktionalität: Zugriff per Spaltenname möglich
+    # bessere Row-Funktionalitaet: Zugriff per Spaltenname moeglich
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -39,7 +39,7 @@ def init_db(db_path: Optional[Path] = None) -> None:
     """
     Initialisiert die SQLite-Datenbank:
     - erzeugt Datei (falls nicht vorhanden)
-    - legt Tabellen `signals` und `trades` an (wenn sie noch nicht existieren)
+    - legt Tabellen an (wenn sie noch nicht existieren)
     """
     conn = get_connection(db_path)
     cur = conn.cursor()
@@ -196,12 +196,53 @@ def init_db(db_path: Optional[Path] = None) -> None:
         """
     )
 
+    # Tabelle: watchlists
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS watchlists (
+            watchlist_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_watchlists_name
+          ON watchlists(name, watchlist_id);
+        """
+    )
+
+    # Tabelle: watchlist_symbols
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS watchlist_symbols (
+            watchlist_id TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            symbol TEXT NOT NULL,
+            PRIMARY KEY (watchlist_id, position),
+            FOREIGN KEY (watchlist_id) REFERENCES watchlists(watchlist_id) ON DELETE CASCADE
+        );
+        """
+    )
+    cur.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_watchlist_symbols_unique_membership
+          ON watchlist_symbols(watchlist_id, symbol);
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_watchlist_symbols_lookup
+          ON watchlist_symbols(watchlist_id, position, symbol);
+        """
+    )
+
     conn.commit()
     conn.close()
 
 
 if __name__ == "__main__":
-    # Für lokalen Aufruf:
+    # Fuer lokalen Aufruf:
     # python -m src.cilly_trading.db.init_db
     init_db()
     print(f"SQLite-Datenbank initialisiert unter: {DEFAULT_DB_PATH.resolve()}")

--- a/src/cilly_trading/repositories/__init__.py
+++ b/src/cilly_trading/repositories/__init__.py
@@ -1,5 +1,5 @@
 """
-Repository-Interfaces für die Cilly Trading Engine.
+Repository-Interfaces fuer die Cilly Trading Engine.
 
 Engine und API verwenden diese Interfaces, um mit der Persistenzschicht zu arbeiten.
 Die konkrete Implementierung im MVP nutzt SQLite.
@@ -7,14 +7,15 @@ Die konkrete Implementierung im MVP nutzt SQLite.
 
 from __future__ import annotations
 
-from typing import Protocol, List
+from dataclasses import dataclass
+from typing import List, Optional, Protocol
 
 from cilly_trading.models import Signal, Trade
 
 
 class SignalRepository(Protocol):
     """
-    Abstraktes Interface für das Speichern und Laden von Signals.
+    Abstraktes Interface fuer das Speichern und Laden von Signals.
     """
 
     def save_signals(self, signals: List[Signal]) -> None:
@@ -27,19 +28,19 @@ class SignalRepository(Protocol):
         """
         Liefert die letzten `limit` Signals, absteigend nach id.
 
-        (Für MVP: einfache Variante ohne komplexe Filter.)
+        (Fuer MVP: einfache Variante ohne komplexe Filter.)
         """
         ...
 
 
 class TradeRepository(Protocol):
     """
-    Abstraktes Interface für das Speichern und Laden von Trades.
+    Abstraktes Interface fuer das Speichern und Laden von Trades.
     """
 
     def save_trade(self, trade: Trade) -> int:
         """
-        Speichert einen Trade und gibt die neue Trade-ID zurück.
+        Speichert einen Trade und gibt die neue Trade-ID zurueck.
         """
         ...
 
@@ -50,4 +51,42 @@ class TradeRepository(Protocol):
         ...
 
 
-__all__ = ["SignalRepository", "TradeRepository"]
+@dataclass(frozen=True)
+class Watchlist:
+    """Deterministic watchlist payload for repository persistence."""
+
+    watchlist_id: str
+    name: str
+    symbols: tuple[str, ...]
+
+
+class WatchlistRepository(Protocol):
+    """Abstract persistence boundary for named watchlists."""
+
+    def create_watchlist(self, *, watchlist_id: str, name: str, symbols: List[str]) -> Watchlist:
+        """Persist a new watchlist."""
+        ...
+
+    def get_watchlist(self, watchlist_id: str) -> Optional[Watchlist]:
+        """Load a watchlist by ID."""
+        ...
+
+    def list_watchlists(self) -> List[Watchlist]:
+        """List all watchlists in deterministic order."""
+        ...
+
+    def update_watchlist(self, *, watchlist_id: str, name: str, symbols: List[str]) -> Watchlist:
+        """Replace the stored name and ordered symbol membership for a watchlist."""
+        ...
+
+    def delete_watchlist(self, watchlist_id: str) -> bool:
+        """Delete a watchlist and its symbol membership."""
+        ...
+
+
+__all__ = [
+    "SignalRepository",
+    "TradeRepository",
+    "Watchlist",
+    "WatchlistRepository",
+]

--- a/src/cilly_trading/repositories/watchlists_sqlite.py
+++ b/src/cilly_trading/repositories/watchlists_sqlite.py
@@ -1,0 +1,209 @@
+"""SQLite repository for deterministic watchlist persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import List, Optional
+
+from cilly_trading.db import DEFAULT_DB_PATH, init_db
+from cilly_trading.repositories import Watchlist, WatchlistRepository
+
+
+class SqliteWatchlistRepository(WatchlistRepository):
+    """Persist named watchlists and ordered symbol membership in SQLite."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        if db_path is None:
+            db_path = DEFAULT_DB_PATH
+
+        self._db_path = Path(db_path)
+        init_db(self._db_path)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON;")
+        return conn
+
+    def _validate_payload(self, *, watchlist_id: str, name: str, symbols: List[str]) -> List[str]:
+        normalized_symbols = [symbol.strip() for symbol in symbols]
+        if not watchlist_id.strip():
+            raise ValueError("watchlist_id must not be empty")
+        if not name.strip():
+            raise ValueError("name must not be empty")
+        if not normalized_symbols:
+            raise ValueError("watchlist symbols must not be empty")
+        if any(not symbol for symbol in normalized_symbols):
+            raise ValueError("watchlist symbols must not contain empty values")
+        return normalized_symbols
+
+    def _build_watchlist(self, row: sqlite3.Row, *, symbols: tuple[str, ...]) -> Watchlist:
+        return Watchlist(
+            watchlist_id=row["watchlist_id"],
+            name=row["name"],
+            symbols=symbols,
+        )
+
+    def _get_symbols(self, conn: sqlite3.Connection, watchlist_id: str) -> tuple[str, ...]:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT symbol
+            FROM watchlist_symbols
+            WHERE watchlist_id = ?
+            ORDER BY position ASC, symbol ASC;
+            """,
+            (watchlist_id,),
+        )
+        return tuple(row["symbol"] for row in cur.fetchall())
+
+    def create_watchlist(self, *, watchlist_id: str, name: str, symbols: List[str]) -> Watchlist:
+        normalized_symbols = self._validate_payload(
+            watchlist_id=watchlist_id,
+            name=name,
+            symbols=symbols,
+        )
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute("BEGIN;")
+            cur.execute(
+                """
+                INSERT INTO watchlists (watchlist_id, name)
+                VALUES (?, ?);
+                """,
+                (watchlist_id, name),
+            )
+            cur.executemany(
+                """
+                INSERT INTO watchlist_symbols (watchlist_id, position, symbol)
+                VALUES (?, ?, ?);
+                """,
+                [
+                    (watchlist_id, position, symbol)
+                    for position, symbol in enumerate(normalized_symbols)
+                ],
+            )
+            conn.commit()
+        except sqlite3.IntegrityError as exc:
+            conn.rollback()
+            raise ValueError("watchlist_id, name, and symbols must be unique within a watchlist") from exc
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        result = self.get_watchlist(watchlist_id)
+        if result is None:
+            raise RuntimeError("created watchlist could not be reloaded")
+        return result
+
+    def get_watchlist(self, watchlist_id: str) -> Optional[Watchlist]:
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT watchlist_id, name
+                FROM watchlists
+                WHERE watchlist_id = ?
+                LIMIT 1;
+                """,
+                (watchlist_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return self._build_watchlist(row, symbols=self._get_symbols(conn, watchlist_id))
+        finally:
+            conn.close()
+
+    def list_watchlists(self) -> List[Watchlist]:
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT watchlist_id, name
+                FROM watchlists
+                ORDER BY name ASC, watchlist_id ASC;
+                """
+            )
+            rows = cur.fetchall()
+            return [
+                self._build_watchlist(row, symbols=self._get_symbols(conn, row["watchlist_id"]))
+                for row in rows
+            ]
+        finally:
+            conn.close()
+
+    def update_watchlist(self, *, watchlist_id: str, name: str, symbols: List[str]) -> Watchlist:
+        normalized_symbols = self._validate_payload(
+            watchlist_id=watchlist_id,
+            name=name,
+            symbols=symbols,
+        )
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute("BEGIN;")
+            cur.execute(
+                """
+                UPDATE watchlists
+                SET name = ?
+                WHERE watchlist_id = ?;
+                """,
+                (name, watchlist_id),
+            )
+            if cur.rowcount == 0:
+                conn.rollback()
+                raise KeyError(f"watchlist not found: {watchlist_id}")
+            cur.execute(
+                """
+                DELETE FROM watchlist_symbols
+                WHERE watchlist_id = ?;
+                """,
+                (watchlist_id,),
+            )
+            cur.executemany(
+                """
+                INSERT INTO watchlist_symbols (watchlist_id, position, symbol)
+                VALUES (?, ?, ?);
+                """,
+                [
+                    (watchlist_id, position, symbol)
+                    for position, symbol in enumerate(normalized_symbols)
+                ],
+            )
+            conn.commit()
+        except sqlite3.IntegrityError as exc:
+            conn.rollback()
+            raise ValueError("watchlist name and symbols must remain unique") from exc
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        result = self.get_watchlist(watchlist_id)
+        if result is None:
+            raise RuntimeError("updated watchlist could not be reloaded")
+        return result
+
+    def delete_watchlist(self, watchlist_id: str) -> bool:
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                DELETE FROM watchlists
+                WHERE watchlist_id = ?;
+                """,
+                (watchlist_id,),
+            )
+            conn.commit()
+            return cur.rowcount > 0
+        finally:
+            conn.close()

--- a/tests/test_watchlist_repository_sqlite.py
+++ b/tests/test_watchlist_repository_sqlite.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.repositories import Watchlist
+from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
+
+
+def _make_repo(tmp_path: Path) -> SqliteWatchlistRepository:
+    db_path = tmp_path / "test_watchlists.db"
+    return SqliteWatchlistRepository(db_path=db_path)
+
+
+def test_create_and_get_watchlist_preserves_symbol_order(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    created = repo.create_watchlist(
+        watchlist_id="wl-tech",
+        name="Tech Leaders",
+        symbols=["MSFT", "AAPL", "NVDA"],
+    )
+
+    assert created == Watchlist(
+        watchlist_id="wl-tech",
+        name="Tech Leaders",
+        symbols=("MSFT", "AAPL", "NVDA"),
+    )
+    assert repo.get_watchlist("wl-tech") == created
+
+
+def test_list_watchlists_is_deterministically_sorted(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    repo.create_watchlist(watchlist_id="wl-z", name="Zulu", symbols=["ZBRA"])
+    repo.create_watchlist(watchlist_id="wl-b", name="Bravo", symbols=["AMD"])
+    repo.create_watchlist(watchlist_id="wl-a", name="Alpha", symbols=["AAPL"])
+
+    items = repo.list_watchlists()
+
+    assert [(item.watchlist_id, item.name) for item in items] == [
+        ("wl-a", "Alpha"),
+        ("wl-b", "Bravo"),
+        ("wl-z", "Zulu"),
+    ]
+
+
+def test_update_watchlist_replaces_name_and_symbols(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="wl-growth",
+        name="Growth",
+        symbols=["SHOP", "MELI"],
+    )
+
+    updated = repo.update_watchlist(
+        watchlist_id="wl-growth",
+        name="Growth Updated",
+        symbols=["TSLA", "AMZN", "META"],
+    )
+
+    assert updated == Watchlist(
+        watchlist_id="wl-growth",
+        name="Growth Updated",
+        symbols=("TSLA", "AMZN", "META"),
+    )
+    assert repo.get_watchlist("wl-growth") == updated
+
+
+def test_delete_watchlist_removes_watchlist_and_symbols(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="wl-delete",
+        name="Delete Me",
+        symbols=["IBM", "ORCL"],
+    )
+
+    assert repo.delete_watchlist("wl-delete") is True
+    assert repo.delete_watchlist("wl-delete") is False
+    assert repo.get_watchlist("wl-delete") is None
+    assert repo.list_watchlists() == []
+
+
+def test_create_watchlist_rejects_duplicate_identifier(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="wl-dup",
+        name="Primary",
+        symbols=["AAPL"],
+    )
+
+    with pytest.raises(ValueError, match="unique"):
+        repo.create_watchlist(
+            watchlist_id="wl-dup",
+            name="Secondary",
+            symbols=["MSFT"],
+        )
+
+    assert repo.list_watchlists() == [
+        Watchlist(watchlist_id="wl-dup", name="Primary", symbols=("AAPL",))
+    ]
+
+
+def test_create_watchlist_rejects_duplicate_name(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="wl-first",
+        name="Shared Name",
+        symbols=["AAPL"],
+    )
+
+    with pytest.raises(ValueError, match="unique"):
+        repo.create_watchlist(
+            watchlist_id="wl-second",
+            name="Shared Name",
+            symbols=["MSFT"],
+        )
+
+    assert repo.get_watchlist("wl-second") is None
+
+
+def test_update_watchlist_rejects_duplicate_name_without_partial_persist(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="wl-one",
+        name="One",
+        symbols=["AAPL", "MSFT"],
+    )
+    repo.create_watchlist(
+        watchlist_id="wl-two",
+        name="Two",
+        symbols=["NVDA"],
+    )
+
+    with pytest.raises(ValueError, match="unique"):
+        repo.update_watchlist(
+            watchlist_id="wl-two",
+            name="One",
+            symbols=["TSLA", "AMZN"],
+        )
+
+    assert repo.get_watchlist("wl-two") == Watchlist(
+        watchlist_id="wl-two",
+        name="Two",
+        symbols=("NVDA",),
+    )
+
+
+def test_create_watchlist_rejects_empty_symbols_without_persisting_header(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        repo.create_watchlist(
+            watchlist_id="wl-empty",
+            name="Empty",
+            symbols=[],
+        )
+
+    assert repo.get_watchlist("wl-empty") is None
+    assert repo.list_watchlists() == []
+
+
+def test_update_watchlist_rejects_empty_symbols_without_partial_persist(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    original = repo.create_watchlist(
+        watchlist_id="wl-keep",
+        name="Keep",
+        symbols=["QQQ", "SPY"],
+    )
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        repo.update_watchlist(
+            watchlist_id="wl-keep",
+            name="Keep Changed",
+            symbols=[],
+        )
+
+    assert repo.get_watchlist("wl-keep") == original
+
+
+def test_create_watchlist_rollback_clears_header_on_symbol_membership_failure(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="unique"):
+        repo.create_watchlist(
+            watchlist_id="wl-bad-membership",
+            name="Bad Membership",
+            symbols=["AAPL", "AAPL"],
+        )
+
+    assert repo.get_watchlist("wl-bad-membership") is None
+    assert repo.list_watchlists() == []
+
+
+def test_update_missing_watchlist_raises_keyerror(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+
+    with pytest.raises(KeyError, match="watchlist not found"):
+        repo.update_watchlist(
+            watchlist_id="wl-missing",
+            name="Missing",
+            symbols=["AAPL"],
+        )
+
+
+def test_storage_uses_order_positions_for_symbol_reload(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="wl-order",
+        name="Ordering",
+        symbols=["MSFT", "AAPL", "NVDA"],
+    )
+
+    db_path = tmp_path / "test_watchlists.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            """
+            SELECT position, symbol
+            FROM watchlist_symbols
+            WHERE watchlist_id = ?
+            ORDER BY position ASC;
+            """,
+            ("wl-order",),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [(0, "MSFT"), (1, "AAPL"), (2, "NVDA")]


### PR DESCRIPTION
Closes #632
## Summary
- add docs/paper_trading.md as canonical paper trading reference
- align index and RUNBOOK descriptions
- remove outdated audit drift statements
- update roadmap status for phases 17b, 24 and 26
- clarify /ui runtime surface vs /owner dev route

## Validation
documentation-only change

## Files changed
- docs/index.md
- docs/RUNBOOK.md
- docs/audit/roadmap_compliance_report.md
- docs/roadmap/cilly_trading_execution_roadmap_updated.md
- docs/paper_trading.md
