### PR TITLE
P37-API — Expose watchlist CRUD API surface

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -66,6 +66,7 @@ from cilly_trading.engine.runtime_state import get_system_state_payload
 from cilly_trading.models import SignalReadItemDTO, SignalReadResponseDTO
 from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
+from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
 from cilly_trading.strategies.registry import (
     StrategyNotRegisteredError,
     create_registered_strategies,
@@ -539,6 +540,41 @@ class DecisionTraceResponse(BaseModel):
     total_entries: int
 
 
+class WatchlistPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1)
+    symbols: List[str] = Field(..., min_length=1)
+
+
+class WatchlistCreateRequest(WatchlistPayload):
+    model_config = ConfigDict(extra="forbid")
+
+    watchlist_id: str = Field(..., min_length=1)
+
+
+class WatchlistResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    watchlist_id: str
+    name: str
+    symbols: List[str]
+
+
+class WatchlistListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[WatchlistResponse]
+    total: int
+
+
+class WatchlistDeleteResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    watchlist_id: str
+    deleted: Literal[True]
+
+
 app = FastAPI(
     title="Cilly Trading Engine API",
     version="0.1.0",
@@ -607,6 +643,7 @@ ANALYSIS_DB_PATH: Optional[str] = None
 signal_repo = SqliteSignalRepository()
 order_event_repo = SqliteOrderEventRepository(db_path=DEFAULT_DB_PATH)
 analysis_run_repo = SqliteAnalysisRunRepository(db_path=DEFAULT_DB_PATH)
+watchlist_repo = SqliteWatchlistRepository(db_path=DEFAULT_DB_PATH)
 
 
 def _is_uuid4(value: str) -> bool:
@@ -1181,10 +1218,83 @@ def _extract_trace_entries(content: Any) -> tuple[Optional[str], List[Dict[str, 
     return trace_id, normalized_entries
 
 
+def _to_watchlist_response(watchlist: Any) -> WatchlistResponse:
+    return WatchlistResponse(
+        watchlist_id=watchlist.watchlist_id,
+        name=watchlist.name,
+        symbols=list(watchlist.symbols),
+    )
+
+
 @app.get("/ingestion/runs", response_model=List[IngestionRunItemResponse])
 def read_ingestion_runs(limit: int = Depends(_get_ingestion_runs_limit)) -> List[IngestionRunItemResponse]:
     rows = analysis_run_repo.list_ingestion_runs(limit=limit)
     return [IngestionRunItemResponse(**row) for row in rows]
+
+
+@app.post("/watchlists", response_model=WatchlistResponse)
+def create_watchlist(
+    req: WatchlistCreateRequest,
+    _: str = Depends(_require_role("operator")),
+) -> WatchlistResponse:
+    try:
+        watchlist = watchlist_repo.create_watchlist(
+            watchlist_id=req.watchlist_id,
+            name=req.name,
+            symbols=req.symbols,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _to_watchlist_response(watchlist)
+
+
+@app.get("/watchlists", response_model=WatchlistListResponse)
+def read_watchlists(
+    _: str = Depends(_require_role("read_only")),
+) -> WatchlistListResponse:
+    items = [_to_watchlist_response(watchlist) for watchlist in watchlist_repo.list_watchlists()]
+    return WatchlistListResponse(items=items, total=len(items))
+
+
+@app.get("/watchlists/{watchlist_id}", response_model=WatchlistResponse)
+def read_watchlist(
+    watchlist_id: str,
+    _: str = Depends(_require_role("read_only")),
+) -> WatchlistResponse:
+    watchlist = watchlist_repo.get_watchlist(watchlist_id)
+    if watchlist is None:
+        raise HTTPException(status_code=404, detail="watchlist_not_found")
+    return _to_watchlist_response(watchlist)
+
+
+@app.put("/watchlists/{watchlist_id}", response_model=WatchlistResponse)
+def update_watchlist(
+    watchlist_id: str,
+    req: WatchlistPayload,
+    _: str = Depends(_require_role("operator")),
+) -> WatchlistResponse:
+    try:
+        watchlist = watchlist_repo.update_watchlist(
+            watchlist_id=watchlist_id,
+            name=req.name,
+            symbols=req.symbols,
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="watchlist_not_found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _to_watchlist_response(watchlist)
+
+
+@app.delete("/watchlists/{watchlist_id}", response_model=WatchlistDeleteResponse)
+def delete_watchlist(
+    watchlist_id: str,
+    _: str = Depends(_require_role("operator")),
+) -> WatchlistDeleteResponse:
+    deleted = watchlist_repo.delete_watchlist(watchlist_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="watchlist_not_found")
+    return WatchlistDeleteResponse(watchlist_id=watchlist_id, deleted=True)
 
 
 @app.get("/journal/artifacts", response_model=JournalArtifactListResponse)

--- a/tests/test_api_watchlists.py
+++ b/tests/test_api_watchlists.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
+
+
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+OPERATOR_HEADERS = {api_main.ROLE_HEADER_NAME: "operator"}
+OWNER_HEADERS = {api_main.ROLE_HEADER_NAME: "owner"}
+
+
+def _make_repo(tmp_path: Path) -> SqliteWatchlistRepository:
+    return SqliteWatchlistRepository(db_path=tmp_path / "watchlists.db")
+
+
+def test_watchlist_create_endpoint_persists_and_reads_back(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        create_response = client.post(
+            "/watchlists",
+            headers=OPERATOR_HEADERS,
+            json={
+                "watchlist_id": "tech-growth",
+                "name": "Tech Growth",
+                "symbols": ["NVDA", "MSFT", "AAPL"],
+            },
+        )
+        read_response = client.get(
+            "/watchlists/tech-growth",
+            headers=READ_ONLY_HEADERS,
+        )
+
+    assert create_response.status_code == 200
+    assert create_response.json() == {
+        "watchlist_id": "tech-growth",
+        "name": "Tech Growth",
+        "symbols": ["NVDA", "MSFT", "AAPL"],
+    }
+
+    assert read_response.status_code == 200
+    assert read_response.json() == create_response.json()
+
+
+def test_watchlist_list_endpoint_is_deterministic(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="beta-list",
+        name="Beta",
+        symbols=["TSLA", "META"],
+    )
+    repo.create_watchlist(
+        watchlist_id="alpha-list",
+        name="Alpha",
+        symbols=["MSFT", "AAPL"],
+    )
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/watchlists", headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "watchlist_id": "alpha-list",
+                "name": "Alpha",
+                "symbols": ["MSFT", "AAPL"],
+            },
+            {
+                "watchlist_id": "beta-list",
+                "name": "Beta",
+                "symbols": ["TSLA", "META"],
+            },
+        ],
+        "total": 2,
+    }
+
+
+def test_watchlist_update_endpoint_allows_owner_and_replaces_membership(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="swing-core",
+        name="Swing Core",
+        symbols=["AAPL", "MSFT"],
+    )
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.put(
+            "/watchlists/swing-core",
+            headers=OWNER_HEADERS,
+            json={
+                "name": "Swing Updated",
+                "symbols": ["NVDA", "AMD", "AAPL"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "watchlist_id": "swing-core",
+        "name": "Swing Updated",
+        "symbols": ["NVDA", "AMD", "AAPL"],
+    }
+
+
+def test_watchlist_delete_endpoint_removes_watchlist(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="to-delete",
+        name="Delete Me",
+        symbols=["BTC/USDT"],
+    )
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        delete_response = client.delete(
+            "/watchlists/to-delete",
+            headers=OPERATOR_HEADERS,
+        )
+        read_response = client.get(
+            "/watchlists/to-delete",
+            headers=READ_ONLY_HEADERS,
+        )
+
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {
+        "watchlist_id": "to-delete",
+        "deleted": True,
+    }
+    assert read_response.status_code == 404
+    assert read_response.json() == {"detail": "watchlist_not_found"}
+
+
+def test_watchlist_create_rejects_invalid_payload_without_persisting(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.post(
+            "/watchlists",
+            headers=OPERATOR_HEADERS,
+            json={
+                "watchlist_id": "broken-list",
+                "name": "Broken",
+                "symbols": ["AAPL", " "],
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "watchlist symbols must not contain empty values"}
+    assert repo.get_watchlist("broken-list") is None
+    assert repo.list_watchlists() == []
+
+
+def test_watchlist_update_rejects_invalid_payload_without_partial_persistence(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _make_repo(tmp_path)
+    repo.create_watchlist(
+        watchlist_id="core-list",
+        name="Core",
+        symbols=["AAPL", "MSFT"],
+    )
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.put(
+            "/watchlists/core-list",
+            headers=OPERATOR_HEADERS,
+            json={
+                "name": "Core",
+                "symbols": ["NVDA", "NVDA"],
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "watchlist name and symbols must remain unique"}
+
+    stored = repo.get_watchlist("core-list")
+    assert stored is not None
+    assert stored.name == "Core"
+    assert stored.symbols == ("AAPL", "MSFT")
+
+
+def test_watchlist_endpoints_require_authenticated_role(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/watchlists")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "unauthorized"}
+
+
+def test_watchlist_mutations_forbid_read_only_role(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "watchlist_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.post(
+            "/watchlists",
+            headers=READ_ONLY_HEADERS,
+            json={
+                "watchlist_id": "read-only-write",
+                "name": "Read Only",
+                "symbols": ["AAPL"],
+            },
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "forbidden"}
+    assert repo.list_watchlists() == []


### PR DESCRIPTION
Closes #633

## Summary
- add bounded watchlist CRUD endpoints on the FastAPI operator-facing API
- reuse the existing X-Cilly-Role access model for read and mutation paths
- add focused FastAPI tests for success, validation failure, unauthorized, and forbidden cases

## Testing
- .\.venv\Scripts\python -m pytest