### PR TITLE
P37-DOCS: align Phase 37 watchlist status and contract artifacts

### DIFF
--- a/docs/api/usage_contract.md
+++ b/docs/api/usage_contract.md
@@ -120,6 +120,15 @@ Canonical success response example:
 - For this operator contract, valid payload decisions come from the canonical request table above and the error table in the `POST /analysis/run` section below.
 - A successful response with `signals: []` is still a valid completed run.
 
+## Phase 37 Watchlist Workflow
+
+The repository now includes a bounded Phase 37 watchlist workflow on top of the existing snapshot-only analysis surface.
+
+- Persistence and CRUD are exposed through `/watchlists` routes.
+- Execution and ranking are exposed through `POST /watchlists/{watchlist_id}/execute`.
+- The workflow is bounded to saved watchlists, snapshot-only execution, deterministic ranking, and isolated symbol failures.
+- This API contract does not imply later-phase charting, alerts, trading-desk, or broader market-data-product claims.
+
 ## Common Conventions
 
 ### Snapshot-first analysis contract
@@ -699,6 +708,217 @@ curl -s -X POST http://localhost:8000/analysis/run \
 
 ---
 
+## POST /watchlists
+
+### Purpose
+
+Create a persisted watchlist with a stable identifier, display name, and ordered symbol membership.
+
+### Request
+
+**Request body:**
+
+| Name | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `watchlist_id` | string | required | none | Stable saved-watchlist identifier. |
+| `name` | string | required | none | Human-readable watchlist name. |
+| `symbols` | array of strings | required | none | Ordered symbol list. Must not be empty. |
+
+**Validation rules:**
+
+- Mutation requires an operator-capable role.
+- `symbols` must not be empty and must not contain empty values.
+- Duplicate names or identifiers are rejected.
+
+### Success response
+
+- **Status:** `200 OK`
+- **Body:**
+  ```json
+  {
+    "watchlist_id": "tech-growth",
+    "name": "Tech Growth",
+    "symbols": ["MSFT", "AAPL", "NVDA"]
+  }
+  ```
+
+### Errors
+
+| Status | Error body shape | Error detail | Trigger |
+| --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+| 403 | `{"detail":"forbidden"}` | `forbidden` | Caller role cannot mutate watchlists. |
+| 422 | `{"detail":"watchlist symbols must not contain empty values"}` | `watchlist symbols must not contain empty values` | Symbol list contains empty members. |
+| 422 | `{"detail":"watchlist name and symbols must remain unique"}` | `watchlist name and symbols must remain unique` | Duplicate identifier or name. |
+| 422 | Pydantic validation list | varies | Invalid request body such as missing fields. |
+
+---
+
+## GET /watchlists
+
+### Purpose
+
+Read the saved watchlist inventory in deterministic order.
+
+### Request
+
+No request body.
+
+**Validation rules:**
+
+- Read access requires a valid authenticated role header and a role permitted to inspect watchlists.
+
+### Success response
+
+- **Status:** `200 OK`
+- **Body:**
+  ```json
+  {
+    "items": [
+      {
+        "watchlist_id": "alpha-list",
+        "name": "Alpha",
+        "symbols": ["AAPL"]
+      }
+    ],
+    "total": 1
+  }
+  ```
+
+**Empty/no-result behavior:** Returns `items: []` and `total: 0` when no watchlists are stored.
+
+### Errors
+
+| Status | Error body shape | Error detail | Trigger |
+| --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+| 403 | `{"detail":"forbidden"}` | `forbidden` | Caller has a valid role but lacks read access. |
+
+---
+
+## GET /watchlists/{watchlist_id}
+
+### Purpose
+
+Read one persisted watchlist by identifier.
+
+### Request
+
+**Path parameters:**
+
+| Name | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `watchlist_id` | string | required | Saved watchlist identifier. |
+
+### Success response
+
+- **Status:** `200 OK`
+- **Body:**
+  ```json
+  {
+    "watchlist_id": "tech-growth",
+    "name": "Tech Growth",
+    "symbols": ["MSFT", "AAPL", "NVDA"]
+  }
+  ```
+
+### Errors
+
+| Status | Error body shape | Error detail | Trigger |
+| --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+| 403 | `{"detail":"forbidden"}` | `forbidden` | Caller has a valid role but lacks read access. |
+| 404 | `{"detail":"watchlist_not_found"}` | `watchlist_not_found` | `watchlist_id` does not exist. |
+
+---
+
+## PUT /watchlists/{watchlist_id}
+
+### Purpose
+
+Replace the saved watchlist name and symbol membership for an existing watchlist.
+
+### Request
+
+**Path parameters:**
+
+| Name | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `watchlist_id` | string | required | Saved watchlist identifier. |
+
+**Request body:**
+
+| Name | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `name` | string | required | none | Replacement display name. |
+| `symbols` | array of strings | required | none | Replacement ordered symbol list. Must not be empty. |
+
+**Validation rules:**
+
+- Mutation requires an operator-capable role.
+- Missing watchlists return `404`.
+- Invalid updates do not partially persist.
+
+### Success response
+
+- **Status:** `200 OK`
+- **Body:**
+  ```json
+  {
+    "watchlist_id": "tech-growth",
+    "name": "Phase 37 Ranked Tech",
+    "symbols": ["NVDA", "MSFT"]
+  }
+  ```
+
+### Errors
+
+| Status | Error body shape | Error detail | Trigger |
+| --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+| 403 | `{"detail":"forbidden"}` | `forbidden` | Caller role cannot mutate watchlists. |
+| 404 | `{"detail":"watchlist_not_found"}` | `watchlist_not_found` | `watchlist_id` does not exist. |
+| 422 | `{"detail":"watchlist symbols must not contain empty values"}` | `watchlist symbols must not contain empty values` | Symbol list contains empty members. |
+| 422 | `{"detail":"watchlist name and symbols must remain unique"}` | `watchlist name and symbols must remain unique` | New state conflicts with another watchlist. |
+| 422 | Pydantic validation list | varies | Invalid request body. |
+
+---
+
+## DELETE /watchlists/{watchlist_id}
+
+### Purpose
+
+Delete a persisted watchlist.
+
+### Request
+
+**Path parameters:**
+
+| Name | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `watchlist_id` | string | required | Saved watchlist identifier. |
+
+### Success response
+
+- **Status:** `200 OK`
+- **Body:**
+  ```json
+  {
+    "watchlist_id": "tech-growth",
+    "deleted": true
+  }
+  ```
+
+### Errors
+
+| Status | Error body shape | Error detail | Trigger |
+| --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+| 403 | `{"detail":"forbidden"}` | `forbidden` | Caller role cannot mutate watchlists. |
+| 404 | `{"detail":"watchlist_not_found"}` | `watchlist_not_found` | `watchlist_id` does not exist. |
+
+---
+
 ## POST /watchlists/{watchlist_id}/execute
 
 ### Purpose
@@ -726,6 +946,7 @@ Run the persisted watchlist workflow against a saved watchlist and return determ
 
 - `watchlist_id` must identify an existing saved watchlist, otherwise `404`.
 - `ingestion_run_id` must be a valid UUIDv4 and must exist.
+- Mutation-level watchlist CRUD happens through the `/watchlists` routes above; this endpoint only executes an already-saved watchlist.
 - Unlike `/screener/basic`, this endpoint does not require every watchlist symbol to be snapshot-ready up front. Snapshot failures for individual symbols are isolated into the response `failures` array.
 
 ### Success response
@@ -774,6 +995,7 @@ Run the persisted watchlist workflow against a saved watchlist and return determ
 - Only `setup` signals with `score >= min_score` participate in ranking.
 - Ranked items are sorted deterministically by `score DESC`, then `signal_strength DESC`, then `symbol ASC`.
 - `rank` is the 1-based position after deterministic sorting.
+- The response is designed for the bounded Phase 37 `/ui` workflow and does not, by itself, imply later trading-desk or charting capability.
 
 **Empty/no-result behavior:** Returns `ranked_results: []` when no qualifying setup signals are produced. Symbol-level failures may still be present in `failures`.
 
@@ -781,6 +1003,8 @@ Run the persisted watchlist workflow against a saved watchlist and return determ
 
 | Status | Error body shape | Error detail | Trigger |
 | --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+| 403 | `{"detail":"forbidden"}` | `forbidden` | Caller has a valid role but lacks execution privileges. |
 | 404 | `{"detail":"watchlist_not_found"}` | `watchlist_not_found` | `watchlist_id` does not exist. |
 | 422 | `{"detail":"invalid_ingestion_run_id"}` | `invalid_ingestion_run_id` | `ingestion_run_id` is not a valid UUIDv4 string. |
 | 422 | `{"detail":"ingestion_run_not_found"}` | `ingestion_run_not_found` | `ingestion_run_id` does not exist in the repository. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,8 +26,10 @@ Use this order:
 - [Operator dashboard runtime surface](ui/owner_dashboard.md)
   - Runtime-served operator UI is `/ui`.
   - The current Phase 36 browser workflow uses `/system/state`, `POST /analysis/run`, `/strategies`, `/signals`, `/journal/artifacts`, `/journal/decision-trace`, and `/execution/orders`.
+  - The current Phase 37 browser workflow on the same `/ui` surface uses `/watchlists`, `/watchlists/{watchlist_id}`, and `POST /watchlists/{watchlist_id}/execute`.
   - `/owner` is not a canonical runtime entrypoint.
 - [Phase 36 web activation evidence](roadmap/phase-36-web-activation-evidence.md)
+- [Phase 37 watchlist engine status](phases/phase-37-status.md)
 
 ## Versioning & Governance
 - [Versioning model](versioning/model.md)
@@ -50,6 +52,7 @@ The authoritative in-repo source for audited phase-number meanings is [Execution
 | Phase 25 | Strategy Lifecycle Management | `docs/phases/phase_25_strategy_lifecycle.md` |
 | Phase 26 | No authoritative in-repo meaning located | `docs/roadmap/execution_roadmap.md` |
 | Phase 27 | Risk Framework | `docs/phases/phase-27-status.md` |
+| Phase 37 | Watchlist Engine | `docs/phases/phase-37-status.md` |
 
 ## Reference Navigation
 The links below are navigation aids only. They do not redefine the authoritative phase taxonomy.
@@ -71,6 +74,12 @@ Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b
 Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above.
 - [Paper trading boundary](paper_trading.md)
 - [Runbook](RUNBOOK.md)
+
+### Phase 37 Reference Materials
+Phase 37 reference links remain navigational and do not override the authoritative audited taxonomy above.
+- [Phase 37 watchlist engine status](phases/phase-37-status.md)
+- [Operator dashboard runtime surface](ui/owner_dashboard.md)
+- [API usage contract](api/usage_contract.md)
 
 ### Phase 18 Reference Materials
 Phase 18 reference links remain navigational and do not override the authoritative audited taxonomy above.

--- a/docs/phases/phase-37-status.md
+++ b/docs/phases/phase-37-status.md
@@ -1,0 +1,68 @@
+# Phase 37 - Watchlist Engine Status
+
+Status: Implemented in Repository  
+Scope: Repository-verified watchlist persistence, CRUD API, execution/ranking workflow, and bounded `/ui` watchlist surface  
+Owner: Governance
+
+## Purpose
+This file is the canonical Phase 37 status and contract artifact for the repository-verified watchlist workflow.
+
+It documents only the Phase 37 behavior that is verifiable in the current repository through code, runtime-facing docs, and tests.
+
+## Verified Phase 37 Scope
+
+### Persistence boundary
+- SQLite-backed watchlist persistence exists through `cilly_trading.repositories.watchlists_sqlite.SqliteWatchlistRepository`.
+- Stored watchlists preserve deterministic symbol ordering.
+- Create and update paths reject invalid or conflicting payloads without partial persistence.
+
+### API boundary
+- `POST /watchlists` creates a saved watchlist.
+- `GET /watchlists` lists saved watchlists deterministically.
+- `GET /watchlists/{watchlist_id}` reads one saved watchlist.
+- `PUT /watchlists/{watchlist_id}` replaces a saved watchlist name and membership.
+- `DELETE /watchlists/{watchlist_id}` deletes a saved watchlist.
+- `POST /watchlists/{watchlist_id}/execute` runs snapshot-only analysis for a saved watchlist and returns deterministic ranked results plus isolated symbol failures.
+
+### Runtime `/ui` boundary
+- The backend-served runtime page at `/ui` includes watchlist management and execution markers.
+- The page references the implemented watchlist CRUD and execution routes.
+- The browser workflow remains bounded to watchlist management/execution on the existing operator workbench rather than implying later trading-desk scope.
+
+## Repository Evidence
+
+| Area | Repository evidence |
+| --- | --- |
+| Persistence implementation | `src/cilly_trading/repositories/watchlists_sqlite.py` |
+| API request/response models and endpoints | `src/api/main.py` |
+| Runtime `/ui` watchlist shell markers | `src/ui/index.html` |
+| Repository CRUD tests | `tests/test_watchlist_repository_sqlite.py` |
+| API CRUD and execution tests | `tests/test_api_watchlists.py` |
+| Runtime `/ui` watchlist markers | `src/api/test_operator_workbench_surface.py` |
+| Runtime browser workflow using watchlist APIs | `tests/test_ui_runtime_browser_flow.py` |
+
+## Verified Behavior
+
+### Watchlist persistence and CRUD
+- Watchlists are stored with `watchlist_id`, human-readable `name`, and ordered `symbols`.
+- Repository and API validation reject duplicate identifiers, duplicate names, empty symbol members, and invalid update operations.
+- Read paths are deterministic and return stable symbol order.
+
+### Watchlist execution and ranking
+- Watchlist execution is snapshot-only and requires `ingestion_run_id`.
+- Ranking is returned through `ranked_results`.
+- Symbol-level snapshot failures are isolated into `failures` instead of failing the full request when the request itself is otherwise valid.
+- The endpoint reuses persisted analysis-run artifacts when the deterministic execution identity already exists.
+
+### `/ui` watchlist behavior
+- The current `/ui` workbench includes watchlist management, execution, ranked-results, and failure-list panels.
+- The runtime browser flow covers create, list, update, read, execute, and delete behavior against the watchlist API surface.
+
+## Explicit Boundaries
+- Phase 37 does not claim market-data provider expansion beyond the current snapshot/runtime behavior.
+- Phase 37 does not claim Phase 39 charting or visual-analysis features.
+- Phase 37 does not claim Phase 40 trading-desk, leaderboard, heatmap, or richer dashboard capability.
+- Phase 37 does not claim alerts, paper-trading product workflows, or live-trading product scope.
+
+## Documentation Alignment Rule
+When Phase 37 status is referenced elsewhere in `docs/**`, that wording should align to this file and to the authoritative roadmap entry in `docs/roadmap/execution_roadmap.md`.

--- a/docs/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -87,7 +87,7 @@ Market Data
 | 34 | Runtime Stabilization | Implemented |
 | 35 | Observability Layer | Implemented |
 | 36 | Web Activation | Partially Implemented |
-| 37 | Watchlist Engine | Partially Implemented |
+| 37 | Watchlist Engine | Implemented in Repository |
 | 38 | Market Data Integration | Partially Implemented |
 | 39 | Charting & Visual Analysis | Planned |
 | 40 | Trading Desk Dashboard | Partially Implemented |
@@ -105,6 +105,7 @@ Market Data
 - Phase 24 is now treated as implemented because the simulator boundary and non-live constraints are documented consistently; Phase 44 remains broader and only partially implemented.
 - Phase 25 and Phase 27 were corrected away from stale older wording because lifecycle and risk-framework artifacts are already present in the repository.
 - Phase 35 is marked `Implemented` in this revision because metrics, telemetry, runtime health, guard-trigger monitoring, and integration tests are all present in-repo.
+- Phase 37 is marked `Implemented in Repository` in this revision because watchlist persistence, CRUD API, execution/ranking, `/ui` behavior, and tests are now all present in-repo.
 - Phase 42b is marked `Implemented in Repository` because deterministic backtest runner, CLI, docs, and tests are present.
 
 ---
@@ -666,17 +667,20 @@ Turn the operator-oriented UI into a usable browser analysis application.
 ---
 
 ## Phase 37 - Watchlist Engine
-**Status:** Partially Implemented
+**Status:** Implemented in Repository
 
 **Goal**
 Enable repeatable multi-asset screening.
 
 **Current Status Basis**
-- Watchlist analysis orchestration exists in the engine.
-- No full watchlist CRUD, persistence, ranking workflow, or dedicated watchlist management UI was verified.
+- Watchlist persistence is implemented through the SQLite watchlist repository and is covered by repository tests.
+- The FastAPI surface exposes watchlist create, list, read, update, delete, and execute endpoints with role-guarded behavior.
+- Watchlist execution returns deterministic ranked results and isolated symbol failures for snapshot-only runs.
+- The backend-served `/ui` workbench includes watchlist management and execution panels and is covered by runtime-surface and browser-flow tests.
+- The bounded Phase 37 contract is documented in `docs/phases/phase-37-status.md`.
 
 **Outcome**
-- Multi-asset analysis exists at engine level, but the full watchlist product workflow remains incomplete.
+- The repository contains a verified watchlist workflow for persistence, CRUD, execution, ranking, and bounded `/ui` behavior without implying later trading-desk, charting, alerting, or broader product claims.
 
 ---
 
@@ -869,7 +873,7 @@ Marktdaten
 | 34 | Runtime Stabilization | Implemented |
 | 35 | Observability Layer | Implemented |
 | 36 | Web Activation | Partially Implemented |
-| 37 | Watchlist Engine | Partially Implemented |
+| 37 | Watchlist Engine | Implemented in Repository |
 | 38 | Market Data Integration | Partially Implemented |
 | 39 | Charting & Visual Analysis | Planned |
 | 40 | Trading Desk Dashboard | Partially Implemented |
@@ -1448,17 +1452,20 @@ Die operatororientierte UI in eine nutzbare browserbasierte Analyseanwendung ver
 ---
 
 ## Phase 37 - Watchlist Engine
-**Status:** Partially Implemented
+**Status:** Implemented in Repository
 
 **Ziel**
 Wiederholbares Multi-Asset-Screening ermoeglichen.
 
 **Aktuelle Statusbasis**
-- Watchlist-Analyse-Orchestrierung existiert bereits in der Engine.
-- Eine vollstaendige Watchlist-CRUD-, Persistenz- und UI-Workflow-Schicht wurde nicht verifiziert.
+- Watchlist-Persistenz ist ueber das SQLite-Watchlist-Repository implementiert und durch Repository-Tests abgesichert.
+- Die FastAPI-Surface stellt Create-, List-, Read-, Update-, Delete- und Execute-Endpunkte fuer Watchlists mit rollenbasierter Begrenzung bereit.
+- Watchlist-Execution liefert deterministische Ranked Results und isolierte Symbol-Fehler fuer snapshot-only Runs.
+- Die backend-ausgelieferte `/ui`-Workbench enthaelt Watchlist-Management- und Execution-Panels und ist durch Runtime-Surface- und Browser-Flow-Tests abgedeckt.
+- Der begrenzte Phase-37-Vertrag ist in `docs/phases/phase-37-status.md` dokumentiert.
 
 **Ergebnis**
-- Multi-Asset-Analyse existiert auf Engine-Level, aber der volle Watchlist-Produkt-Workflow ist unvollstaendig.
+- Das Repository enthaelt einen verifizierten Watchlist-Workflow fuer Persistenz, CRUD, Execution, Ranking und begrenztes `/ui`-Verhalten, ohne spaetere Trading-Desk-, Charting-, Alerting- oder breitere Produkt-Claims zu implizieren.
 
 ---
 

--- a/docs/roadmap/execution_roadmap.md
+++ b/docs/roadmap/execution_roadmap.md
@@ -1,7 +1,7 @@
 # Execution Roadmap - Authoritative Phase Taxonomy
 
 Status: Authoritative  
-Scope: Audited phase taxonomy for Phases 5, 16, 17, 17b, 23, 25, 26, and 27  
+Scope: Audited phase taxonomy for Phases 5, 16, 17, 17b, 23, 25, 26, 27, and 37  
 Owner: Governance  
 
 ## Purpose
@@ -26,6 +26,7 @@ This file is the single authoritative in-repo source for audited phase-number me
 | Phase 25 | Strategy Lifecycle Management | `docs/phases/phase_25_strategy_lifecycle.md` |
 | Phase 26 | No authoritative in-repo phase taxonomy artifact was located during the audit. | This roadmap entry is the governing clarification for audited artifacts. |
 | Phase 27 | Risk Framework | `docs/phases/phase-27-status.md` |
+| Phase 37 | Watchlist Engine | `docs/phases/phase-37-status.md` |
 
 ## Taxonomy Guardrails
 - Phase 17 and Phase 17b are not interchangeable: Phase 17 is the umbrella phase, and Phase 17b is the Owner Dashboard sub-phase.
@@ -42,7 +43,7 @@ Define and track the Owner Dashboard sub-phase based on repository-verified arti
 
 ### Explicit Deliverables
 - Backend-served Owner Dashboard surface at `/ui` via FastAPI static mount.
-- Owner Dashboard HTML marker (`<title>Owner Dashboard</title>`) in the served UI.
+- Repository-served `/ui` runtime artifact from `src/ui/index.html`.
 - Manual trigger endpoint `POST /analysis/run` associated with owner-operator flow.
 - Evidence-backed documentation and tests for the above artifacts.
 
@@ -51,7 +52,7 @@ Define and track the Owner Dashboard sub-phase based on repository-verified arti
 - Claiming Phase 17b as fully implemented while route documentation mismatch remains unresolved.
 
 ### Acceptance Evidence Requirements
-- Repository evidence in code and tests confirms `/ui` serving behavior and Owner Dashboard marker.
+- Repository evidence in code and tests confirms `/ui` serving behavior and the current runtime artifact.
 - Repository evidence confirms `POST /analysis/run` exists and is tested.
 - Documentation references are present and aligned with verified backend route behavior.
 
@@ -104,3 +105,28 @@ No standalone Phase 27 Risk Framework module was verified.
 - Standalone repository-verifiable framework module(s).
 - Explicit policy logic definition.
 - Documentation and tests mapped directly to Phase 27 framework scope.
+
+---
+
+## Phase 37
+
+### Goal
+Define Phase 37 using the bounded watchlist workflow that is verifiable in the repository.
+
+> Governance Note  
+> The implementation status of Phase 37 is explicitly documented in:  
+> `docs/phases/phase-37-status.md`
+
+### Verified Existing Artifacts
+- SQLite-backed watchlist persistence and CRUD behavior.
+- Watchlist CRUD API endpoints and deterministic response models.
+- Snapshot-only watchlist execution with deterministic ranking output and isolated symbol failures.
+- Backend-served `/ui` watchlist management and execution markers tied to the implemented API routes.
+
+### Explicitly Out of Scope
+- Claiming Phase 37 as market-data expansion, charting, alerts, or trading-desk completion.
+- Treating Phase 37 evidence as proof of later dashboard/product phases.
+
+### Acceptance Evidence Requirements
+- Repository-verifiable code and tests exist for watchlist persistence, CRUD, execution, ranking, and `/ui` watchlist behavior.
+- Roadmap and runtime-facing docs describe the watchlist workflow as bounded Phase 37 scope rather than as later-phase product completion.

--- a/docs/ui/owner_dashboard.md
+++ b/docs/ui/owner_dashboard.md
@@ -3,7 +3,7 @@
 ## Overview
 The operator-facing runtime surface is the backend-served workbench at `/ui`.
 
-This page is served from `src/ui/index.html` through the FastAPI static mount in `src/api/main.py`. For runtime documentation, `/ui` is the authoritative browser surface and `docs/ui/phase-36-web-activation-contract.md` is the authoritative Phase 36 contract.
+This page is served from `src/ui/index.html` through the FastAPI static mount in `src/api/main.py`. For runtime documentation, `/ui` is the authoritative browser surface, `docs/ui/phase-36-web-activation-contract.md` is the authoritative Phase 36 contract, and `docs/phases/phase-37-status.md` defines the bounded watchlist workflow now present on the same runtime page.
 
 ## Runtime Route
 - Runtime route: `/ui`
@@ -21,6 +21,9 @@ The current `/ui` page exposes these visible sections in the runtime shell:
 - Journal Artifacts
 - Decision Trace
 - Screener
+- Manage Watchlists
+- Watchlist Execution
+- Watchlist Ranked Results
 - Trade Lifecycle
 - Audit Trail
 
@@ -36,10 +39,21 @@ The runtime page currently performs this browser-served work:
 | Analysis Results | Returned `analysis_run_id` and signals are rendered in the page |
 | Strategy List | Read-only metadata fetched from `GET /strategies` |
 | Signals | Read-only latest signal list fetched from `GET /signals` |
+| Watchlist Management | Create, list, read, update, and delete saved watchlists through `/watchlists` routes |
+| Watchlist Execution | Execute a saved watchlist through `POST /watchlists/{watchlist_id}/execute` |
+| Watchlist Ranking Output | Render `ranked_results` and `failures` returned by the watchlist execution route |
 | Journal Artifacts | Read-only artifact browser fetched from `GET /journal/artifacts` |
 | Artifact Preview | Selected artifact content fetched from `GET /journal/artifacts/{run_id}/{artifact_name}` |
 | Decision Trace | Read-only trace viewer fetched from `GET /journal/decision-trace` |
 | Trade Lifecycle | Read-only order lifecycle viewer fetched from `GET /execution/orders` |
+
+## Phase Boundary
+The current `/ui` surface now spans two documented boundaries:
+
+- Phase 36: backend-served browser activation and the original operator workbench shell
+- Phase 37: bounded watchlist management, persisted watchlist execution, and ranked-result rendering on that same shell
+
+This does not imply Phase 39 charting, Phase 40 trading-desk expansion, alerts, or broader later-phase product workflows.
 
 ## /owner Separation
 `/owner` is not part of the runtime-served operator surface.
@@ -59,15 +73,15 @@ The frontend route structure in `frontend/src/App.tsx` may still reference `/own
 ## Evidence Pointers
 Use these repository artifacts when validating this document:
 
-1. `src/api/main.py` mounts `/ui` and defines `GET /system/state`, `POST /analysis/run`, `GET /strategies`, `GET /signals`, `GET /journal/artifacts`, `GET /journal/decision-trace`, and `GET /execution/orders`.
-2. `src/ui/index.html` contains the runtime shell and the implemented browser workflow.
-3. `tests/health_endpoint.py` verifies the runtime page title and route reachability.
-4. `src/api/test_operator_workbench_surface.py` verifies the `/ui` shell markers and linked runtime endpoints.
-5. `tests/test_ui_runtime_browser_flow.py` verifies the browser workflow uses the existing runtime API surface.
+1. `src/api/main.py` mounts `/ui` and defines `GET /system/state`, `POST /analysis/run`, watchlist CRUD routes, `POST /watchlists/{watchlist_id}/execute`, `GET /strategies`, `GET /signals`, `GET /journal/artifacts`, `GET /journal/decision-trace`, and `GET /execution/orders`.
+2. `src/ui/index.html` contains the runtime shell and the implemented browser workflow, including watchlist panels and result markers.
+3. `tests/api/test_health_endpoints_api.py` verifies the runtime health endpoint surface.
+4. `src/api/test_operator_workbench_surface.py` verifies the `/ui` shell markers, watchlist panels, and linked runtime endpoints.
+5. `tests/test_ui_runtime_browser_flow.py` verifies the browser workflow uses the existing runtime API surface for watchlist CRUD and execution as well as the existing operator routes.
 
 ## Verification Outcome
 A reviewer should find:
 
 - `/ui` is the runtime-served operator surface
 - `/owner` is not a runtime-equivalent route
-- the current workbench supports a bounded Phase 36 browser workflow without claiming later watchlist, trading-desk, alerts, paper-trading product, or live-trading scope
+- the current workbench supports the bounded Phase 36 and Phase 37 browser workflows without claiming later charting, trading-desk, alerts, paper-trading product, or live-trading scope


### PR DESCRIPTION
Closes #636

## Summary
- add a canonical Phase 37 status/contract artifact for the repository-verified watchlist workflow
- align roadmap wording with implemented watchlist persistence, CRUD, execution, ranking, and /ui behavior
- update API and /ui docs to describe the bounded Phase 37 workflow without implying later phases

## Validation
- run python -m pytest
- confirm watchlist persistence, CRUD, execution, ranking, and /ui evidence links point to existing code and tests