### PR TITLE
DOCS-README: make root README the canonical repository entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,42 @@
 # Cilly Trading Engine
 
-MVP v1 – Engine → SQLite → API → Trading Desk  
+The Cilly Trading Engine repository contains a deterministic trading-analysis and execution platform with documented API, CLI, UI, runtime, and governance surfaces. This repository is the canonical entrypoint for navigating those materials.
 
-- Core architecture and scope: `docs/mvp_v1.md`
-- Strategy configuration schema (RSI2, Turtle): `docs/strategy-configs.md`
-- Local run & test commands: `docs/local_run.md`
-- Canonical output snapshots (golden masters): `docs/snapshot-testing.md`
+The current repository state supports local runtime, deterministic smoke-run and test workflows, and bounded operator-facing UI and API surfaces. It should not be read as a production-readiness declaration.
+
+## Start Here
+
+Choose the path that matches your role:
+
+### Operators
+
+Use these documents if you need to run, verify, or operate the platform locally.
+
+- Quick local setup: `docs/quickstart.md`
+- Canonical local runtime path: `docs/local_run.md`
+- Owner startup and reset cheatsheet: `docs/OWNER_RUNBOOK.md`
+- Working runbook and quality gate expectations: `docs/RUNBOOK.md`
+- Runtime and health references: `docs/health.md`, `docs/runtime_status_and_health.md`
+- Paper-trading boundary: `docs/paper_trading.md`
+
+### Contributors and Reviewers
+
+Use these documents if you need to understand repository scope, test expectations, interfaces, or roadmap/governance boundaries.
+
 - Documentation index: `docs/index.md`
-- Execution Roadmap (Canonical): `docs/roadmap/execution_roadmap.md`
+- Testing entrypoint: `docs/testing.md`
+- Getting started path for owners/local access: `docs/GETTING_STARTED.md`
+- Public Python API boundary: `docs/api/public_api_boundary.md`
+- Authoritative roadmap and phase taxonomy: `docs/roadmap/execution_roadmap.md`
+- Strategy configuration references: `docs/strategy-configs.md`
+- Snapshot/golden-master guidance: `docs/snapshot-testing.md`
 
-## Local CI checks
+## Canonical Boundaries
 
-```bash
-python -m compileall .
-pytest
-```
+- The repository-level documentation index is `docs/index.md`.
+- The canonical local runtime path is documented in `docs/local_run.md`.
+- The authoritative audited phase taxonomy is `docs/roadmap/execution_roadmap.md`.
+- The supported package-level public API for `src/api` is `from api import app`.
 
 ## Public API
 
@@ -22,10 +44,15 @@ The Python package-level public API for `src/api` is frozen to a single supporte
 
 - `from api import app`
 
-Boundary policy:
+The full boundary definition is documented in `docs/api/public_api_boundary.md`.
 
-- Only symbols exported via `src/api/__init__.py` are considered public/stable.
-- All other modules and symbols under `src/api/**` are internal and may change without notice.
+## Verification Paths
 
-See `docs/api/public_api_boundary.md` for the full boundary definition.
+- Operators validating a local environment should start with `docs/quickstart.md`, then use `docs/local_run.md` and `docs/OWNER_RUNBOOK.md`.
+- Contributors or reviewers validating behavior and change scope should start with `docs/index.md`, then use `docs/testing.md`, `docs/api/public_api_boundary.md`, and `docs/roadmap/execution_roadmap.md`.
 
+## Local CI Check
+
+```bash
+pytest -q
+```


### PR DESCRIPTION
Closes #650

## Summary
- redesign root README as a concise, navigation-first repository entrypoint
- add explicit top-level routes for operators
- add explicit top-level routes for contributors/reviewers
- replace stale MVP wording with bounded current-state platform wording
- preserve the documented public API boundary reference in README

## Testing
python -m pytest -q
553 passed, 4 warnings in 54.63s