### PR TITLE
DOCS-SETUP: define canonical local setup and prerequisite contract

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,7 +4,7 @@
 This guide provides the single authoritative path for owners to start and access the application locally. Follow the steps in order to verify the API is running and then stop/reset it cleanly.
 
 ## B. Prerequisites
-- Python 3.10+
+- Python 3.12+
 - `pip`
 
 ## C. Single Authoritative Start Method (canonical)
@@ -13,9 +13,12 @@ From the repository root, run exactly:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+python -m pip install -e ".[test]"
 PYTHONPATH=src uvicorn api.main:app --reload
 ```
+
+The install step is canonical because it comes from the repository-controlled
+`pyproject.toml`. It replaces older requirements-file-based instructions.
 
 ## D. Secondary / utility entrypoints (not canonical)
 - `PYTHONPATH=src python -m api.main`

--- a/docs/local_run.md
+++ b/docs/local_run.md
@@ -5,7 +5,7 @@
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+python -m pip install -e ".[test]"
 PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
@@ -23,8 +23,20 @@ Expected output:
 
 ## Prerequisites
 
-- Python 3.10+
+- Python 3.12+
 - `pip`
+
+## Canonical local setup path
+
+The canonical local dependency install path is the repository `pyproject.toml`:
+
+```bash
+python -m pip install -e ".[test]"
+```
+
+Run it from the repository root after activating your virtual environment. This
+installs the project and the repo-defined test extra from files that are
+versioned in this repository.
 
 ## Canonical startup path
 
@@ -73,7 +85,7 @@ source .venv/bin/activate
 2) **Install dependencies**
 
 ```bash
-pip install -r requirements.txt
+python -m pip install -e ".[test]"
 ```
 
 3) **Start the API (terminal A)**
@@ -200,7 +212,7 @@ Safety note: reset deletes local signals, analysis runs, ingestion runs, and sna
 ## Run tests (optional)
 
 ```bash
-python -m pytest
+python -m pytest -q
 ```
 
 See `docs/testing.md` for the canonical test setup and command, and see

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,7 +1,7 @@
 # Quickstart – Cilly Trading Engine
 
 ## 1. Prerequisites
-- Python 3.10+
+- Python 3.12+
 - Git installed
 
 ## 2. Clone the Repository
@@ -17,7 +17,7 @@ cd Trading-engine
 python -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install -U pip
-python -m pip install -r requirements.txt
+python -m pip install -e ".[test]"
 ```
 
 ### Bash (macOS/Linux)
@@ -25,10 +25,11 @@ python -m pip install -r requirements.txt
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install -U pip
-python -m pip install -r requirements.txt
+python -m pip install -e ".[test]"
 ```
 
-This repository includes `requirements.txt`, so install dependencies with that file.
+The canonical dependency install path is the repository `pyproject.toml` via
+`python -m pip install -e ".[test]"`.
 
 ## 4. Run Deterministic Smoke Test
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,13 +12,17 @@ source .venv/bin/activate
 2) Install test dependencies:
 
 ```bash
-pip install -r requirements-dev.txt
+python -m pip install -e ".[test]"
 ```
+
+This is the canonical test setup path because it uses the repository-controlled
+`pyproject.toml` and its `test` optional dependency group. Use Python 3.12+ to
+match the package metadata.
 
 ## Run the test suite
 
 ```bash
-pytest -q
+python -m pytest -q
 ```
 
 ## Notes


### PR DESCRIPTION
Closes #651

## Summary
- align setup and testing docs to one canonical install path using pyproject.toml
- standardize the documented Python prerequisite to 3.12+
- remove references to missing requirements.txt and requirements-dev.txt files

## Verification
- manually cross-reviewed touched docs against pyproject.toml and the repo root file set
- ran python -m pytest -q