### PR TITLE
DOCS-WINDOWS: add first-class Windows/PowerShell local run path

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -10,11 +10,23 @@ This guide provides the single authoritative path for owners to start and access
 ## C. Single Authoritative Start Method (canonical)
 From the repository root, run exactly:
 
+### Bash (macOS/Linux)
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install -e ".[test]"
 PYTHONPATH=src uvicorn api.main:app --reload
+```
+
+### PowerShell (Windows)
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -e ".[test]"
+$env:PYTHONPATH = "src"
+uvicorn api.main:app --reload
 ```
 
 The install step is canonical because it comes from the repository-controlled
@@ -43,8 +55,21 @@ The application is running when the endpoint returns exactly:
 2. Wait until shutdown completes and the terminal prompt returns.
 3. Optional confirmation:
 
+### Bash (macOS/Linux)
+
 ```bash
 curl --fail http://127.0.0.1:8000/health
+```
+
+### PowerShell (Windows)
+
+```powershell
+try {
+  Invoke-WebRequest http://127.0.0.1:8000/health -ErrorAction Stop | Out-Null
+  throw "API still running"
+} catch {
+  if ($_.Exception.Message -eq "API still running") { throw }
+}
 ```
 
 After stopping `uvicorn`, the command exits non-zero because the endpoint is unreachable.
@@ -52,8 +77,16 @@ After stopping `uvicorn`, the command exits non-zero because the endpoint is unr
 ## H. Reset Local Runtime State
 Run from repository root (local development only):
 
+### Bash (macOS/Linux)
+
 ```bash
 rm -f cilly_trading.db
+```
+
+### PowerShell (Windows)
+
+```powershell
+Remove-Item .\cilly_trading.db -ErrorAction SilentlyContinue
 ```
 
 On next API start, SQLite tables are recreated automatically.
@@ -61,12 +94,25 @@ On next API start, SQLite tables are recreated automatically.
 ## I. Troubleshooting
 - If `uvicorn: command not found` appears, activate the virtual environment again:
 
+  Bash (macOS/Linux):
   ```bash
   source .venv/bin/activate
   ```
 
+  PowerShell (Windows):
+  ```powershell
+  .\.venv\Scripts\Activate.ps1
+  ```
+
 - If `/health` does not respond, confirm the start command is running exactly as documented:
 
+  Bash (macOS/Linux):
   ```bash
   PYTHONPATH=src uvicorn api.main:app --reload
+  ```
+
+  PowerShell (Windows):
+  ```powershell
+  $env:PYTHONPATH = "src"
+  uvicorn api.main:app --reload
   ```

--- a/docs/local_run.md
+++ b/docs/local_run.md
@@ -2,6 +2,8 @@
 
 ## TL;DR Quick Start (fresh local setup)
 
+### Bash (macOS/Linux)
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
@@ -9,10 +11,28 @@ python -m pip install -e ".[test]"
 PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
+### PowerShell (Windows)
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -e ".[test]"
+$env:PYTHONPATH = "src"
+uvicorn api.main:app --reload
+```
+
 In a second terminal:
+
+### Bash (macOS/Linux)
 
 ```bash
 curl http://127.0.0.1:8000/health
+```
+
+### PowerShell (Windows)
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/health
 ```
 
 Expected output:
@@ -30,7 +50,15 @@ Expected output:
 
 The canonical local dependency install path is the repository `pyproject.toml`:
 
+### Bash (macOS/Linux)
+
 ```bash
+python -m pip install -e ".[test]"
+```
+
+### PowerShell (Windows)
+
+```powershell
 python -m pip install -e ".[test]"
 ```
 
@@ -42,8 +70,17 @@ versioned in this repository.
 
 The canonical local startup path is:
 
+### Bash (macOS/Linux)
+
 ```bash
 PYTHONPATH=src uvicorn api.main:app --reload
+```
+
+### PowerShell (Windows)
+
+```powershell
+$env:PYTHONPATH = "src"
+uvicorn api.main:app --reload
 ```
 
 Run it from the repository root after venv activation and dependency install.
@@ -73,31 +110,65 @@ for configuration precedence or validation ownership.
 
 There is no installed top-level project CLI command (for example `cilly-trading ...`).
 
-## Step-by-step (fresh clone → analysis request → persisted signals)
+## Step-by-step (fresh clone -> analysis request -> persisted signals)
 
 1) **Create and activate a virtual environment**
+
+### Bash (macOS/Linux)
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 ```
 
+### PowerShell (Windows)
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
 2) **Install dependencies**
+
+### Bash (macOS/Linux)
 
 ```bash
 python -m pip install -e ".[test]"
 ```
 
+### PowerShell (Windows)
+
+```powershell
+python -m pip install -e ".[test]"
+```
+
 3) **Start the API (terminal A)**
+
+### Bash (macOS/Linux)
 
 ```bash
 PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
+### PowerShell (Windows)
+
+```powershell
+$env:PYTHONPATH = "src"
+uvicorn api.main:app --reload
+```
+
 4) **Verify API health (terminal B)**
+
+### Bash (macOS/Linux)
 
 ```bash
 curl http://127.0.0.1:8000/health
+```
+
+### PowerShell (Windows)
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/health
 ```
 
 Expected output:
@@ -108,9 +179,19 @@ Expected output:
 
 5) **Create a demo snapshot and capture `ingestion_run_id` (terminal B)**
 
+### Bash (macOS/Linux)
+
 ```bash
 SNAPSHOT_ID=$(python scripts/create_demo_snapshot.py | awk -F'= ' '/ingestion_run_id/{print $2}')
 echo "$SNAPSHOT_ID"
+```
+
+### PowerShell (Windows)
+
+```powershell
+$snapshotOutput = python scripts/create_demo_snapshot.py
+$SNAPSHOT_ID = ($snapshotOutput | Select-String "ingestion_run_id = ").ToString().Split("= ")[1].Trim()
+$SNAPSHOT_ID
 ```
 
 Expected behavior:
@@ -118,6 +199,8 @@ Expected behavior:
 - this value is required by snapshot-only analysis endpoints
 
 6) **Trigger strategy analysis using the created snapshot (terminal B)**
+
+### Bash (macOS/Linux)
 
 ```bash
 curl -X POST "http://127.0.0.1:8000/strategy/analyze" \
@@ -130,6 +213,24 @@ curl -X POST "http://127.0.0.1:8000/strategy/analyze" \
     \"market_type\": \"stock\",
     \"lookback_days\": 200
   }"
+```
+
+### PowerShell (Windows)
+
+```powershell
+$body = @{
+  ingestion_run_id = $SNAPSHOT_ID
+  symbol = "AAPL"
+  strategy = "RSI2"
+  market_type = "stock"
+  lookback_days = 200
+} | ConvertTo-Json
+
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://127.0.0.1:8000/strategy/analyze" `
+  -ContentType "application/json" `
+  -Body $body
 ```
 
 Expected output shape:
@@ -146,9 +247,20 @@ Expected output shape:
 
 7) **Verify persisted signals (terminal B)**
 
+### Bash (macOS/Linux)
+
 ```bash
 curl -X GET "http://127.0.0.1:8000/signals?strategy=RSI2&ingestion_run_id=$SNAPSHOT_ID&limit=10" \
   -H "Accept: application/json"
+```
+
+### PowerShell (Windows)
+
+```powershell
+Invoke-RestMethod `
+  -Method Get `
+  -Uri "http://127.0.0.1:8000/signals?strategy=RSI2&ingestion_run_id=$SNAPSHOT_ID&limit=10" `
+  -Headers @{ Accept = "application/json" }
 ```
 
 Expected output shape:
@@ -169,16 +281,37 @@ In terminal A (where `uvicorn` runs), press `Ctrl+C` once.
 
 Optional verification:
 
+### Bash (macOS/Linux)
+
 ```bash
 curl --fail http://127.0.0.1:8000/health
+```
+
+### PowerShell (Windows)
+
+```powershell
+try {
+  Invoke-WebRequest http://127.0.0.1:8000/health -ErrorAction Stop | Out-Null
+  throw "API still running"
+} catch {
+  if ($_.Exception.Message -eq "API still running") { throw }
+}
 ```
 
 This returns non-zero after successful stop.
 
 ### Reset local DB (non-Docker)
 
+### Bash (macOS/Linux)
+
 ```bash
 rm -f cilly_trading.db
+```
+
+### PowerShell (Windows)
+
+```powershell
+Remove-Item .\cilly_trading.db -ErrorAction SilentlyContinue
 ```
 
 Then restart API with the canonical startup command.
@@ -211,7 +344,15 @@ Safety note: reset deletes local signals, analysis runs, ingestion runs, and sna
 
 ## Run tests (optional)
 
+### Bash (macOS/Linux)
+
 ```bash
+python -m pytest -q
+```
+
+### PowerShell (Windows)
+
+```powershell
 python -m pytest -q
 ```
 


### PR DESCRIPTION
Closes #652

## Summary
- add a complete PowerShell path to docs/local_run.md for the canonical local workflow
- add a matching Windows/PowerShell path to docs/GETTING_STARTED.md
- use PowerShell-native syntax for activation, environment variables, health checks, and reset commands

## Testing
- python -m pytest -q
- manual step-by-step review of the PowerShell path against the Bash path in the touched docs