### PR TITLE
Define authority relationship between master roadmap and in-repo taxonomy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,7 @@ Use this order:
 
 ## Authoritative Phase Taxonomy
 The authoritative in-repo source for audited phase-number meanings is [Execution Roadmap](roadmap/execution_roadmap.md).
+The broader [Complete Master Roadmap](roadmap/cilly_trading_execution_roadmap_updated.md) is a navigation and status document and must defer to that execution roadmap wherever audited phase meaning is concerned.
 
 | Phase | Meaning in the authoritative taxonomy | Primary trace |
 |-------|---------------------------------------|---------------|
@@ -62,7 +63,7 @@ The authoritative in-repo source for audited phase-number meanings is [Execution
 | Phase 37 | Watchlist Engine | `docs/phases/phase-37-status.md` |
 
 ## Reference Navigation
-The links below are navigation aids only. They do not redefine the authoritative phase taxonomy.
+The links below, including the broader master roadmap, are navigation aids only. They do not redefine the authoritative phase taxonomy.
 
 ### Phase 17 Reference Materials
 Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b remains the distinct Owner Dashboard sub-phase in the authoritative roadmap.

--- a/docs/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -19,6 +19,11 @@ Primary status sources:
 - `tests/**`
 - runtime and operator documentation under `docs/**`
 
+Authority model used in this file:
+- `docs/roadmap/execution_roadmap.md` is the authoritative in-repo source for audited phase meaning and taxonomy.
+- This master roadmap is the broader navigation and status document for the 45-phase reference, but it does not redefine audited phase meanings that are governed by the authoritative execution roadmap.
+- Where this file references an audited phase that is covered by the authoritative execution roadmap, phase meaning must defer to that file and any conflicting wording here should be read as non-authoritative.
+
 Status policy used in this file:
 - `Implemented`: repo-verifiable implementation exists without a documented material completion gap for this phase scope.
 - `Partially Implemented`: meaningful implementation exists, but documented scope gaps or runtime/documentation drift remain.
@@ -31,6 +36,12 @@ Status policy used in this file:
 ---
 
 # ENGLISH VERSION
+
+## Authority Relationship
+
+- `docs/roadmap/execution_roadmap.md` governs audited phase meaning.
+- This document governs the broader master-roadmap view, sequencing, and status labels for the 45-phase reference set.
+- For audited phases, this document must defer to the authoritative execution roadmap for taxonomy and phase-name interpretation.
 
 ## System Workflow
 
@@ -821,6 +832,12 @@ Enable controlled real-capital trading only after all earlier layers are proven.
 ---
 
 # DEUTSCHE VERSION
+
+## Authority Relationship
+
+- `docs/roadmap/execution_roadmap.md` steuert die autoritative Bedeutung der auditierten Phasen.
+- Dieses Dokument steuert die breitere Master-Roadmap-Sicht, die Einordnung im 45-Phasen-Referenzmodell und die hier verwendeten Statuslabels.
+- Fuer auditierte Phasen muss dieses Dokument bei Taxonomie und Phasenbedeutung auf die autoritative Execution-Roadmap verweisen.
 
 ## System-Workflow
 

--- a/docs/roadmap/execution_roadmap.md
+++ b/docs/roadmap/execution_roadmap.md
@@ -7,6 +7,11 @@ Owner: Governance
 ## Purpose
 This file is the single authoritative in-repo source for audited phase-number meanings.
 
+## Authority Relationship
+- This file governs the meaning of the audited phase numbers listed below.
+- The master roadmap at `docs/roadmap/cilly_trading_execution_roadmap_updated.md` may summarize broader sequencing and implementation-status context, but it must defer to this file for audited phase meaning.
+- If wording in a secondary roadmap, index, or audit artifact conflicts with the audited phase meanings defined here, this file controls the taxonomy interpretation.
+
 ## How to Use
 - Use this file to resolve the meaning of an audited phase number before relying on any secondary roadmap, index, or audit artifact.
 - Treat secondary documents as navigation or status evidence only unless they explicitly defer to this file.


### PR DESCRIPTION
Closes #654

## Summary
- declare docs/roadmap/execution_roadmap.md as the authoritative in-repo source for audited phase meaning
- define how the complete master roadmap must defer to that authoritative taxonomy
- align docs/index.md navigation wording with the same authority model

## Testing
- manual cross-review of the touched roadmap and index docs for explicit authority wording and no contradictory claims
- python -m pytest