### PR TITLE
docs: define single-source rule for phase maturity and status

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,10 @@ Use this order:
 
 ## Authoritative Phase Taxonomy
 The authoritative in-repo source for audited phase-number meanings is [Execution Roadmap](roadmap/execution_roadmap.md).
-The broader [Complete Master Roadmap](roadmap/cilly_trading_execution_roadmap_updated.md) is a navigation and status document and must defer to that execution roadmap wherever audited phase meaning is concerned.
+The authoritative in-repo source for phase maturity/status is the broader [Complete Master Roadmap](roadmap/cilly_trading_execution_roadmap_updated.md).
+The execution roadmap governs audited phase meaning and taxonomy only, while the master roadmap governs canonical phase maturity/status.
+Per-phase status files, audit artifacts, and the index are derived navigation or evidence surfaces and must defer to those two authorities.
+Status changes therefore follow one update path: update supporting evidence as needed, then update the master roadmap to change the canonical phase maturity/status.
 
 | Phase | Meaning in the authoritative taxonomy | Primary trace |
 |-------|---------------------------------------|---------------|
@@ -63,10 +66,10 @@ The broader [Complete Master Roadmap](roadmap/cilly_trading_execution_roadmap_up
 | Phase 37 | Watchlist Engine | `docs/phases/phase-37-status.md` |
 
 ## Reference Navigation
-The links below, including the broader master roadmap, are navigation aids only. They do not redefine the authoritative phase taxonomy.
+The links below are navigation aids only. They do not redefine the authoritative phase taxonomy or the canonical phase maturity/status in the master roadmap.
 
 ### Phase 17 Reference Materials
-Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b remains the distinct Owner Dashboard sub-phase in the authoritative roadmap.
+Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b remains the distinct Owner Dashboard sub-phase in the authoritative roadmap. Any status wording in the links below is derived and must defer to the master roadmap.
 - [Operator dashboard runtime surface](ui/owner_dashboard.md)
 - [Phase 36 /ui web activation contract](ui/phase-36-web-activation-contract.md)
 - [API guarantees](api/api_guarantees.md)
@@ -79,18 +82,18 @@ Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b
 - [Interface usage patterns](interfaces/usage_patterns.md)
 
 ### Phase 24 Reference Materials
-Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above.
+Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
 - [Paper trading boundary](paper_trading.md)
 - [Runbook](RUNBOOK.md)
 
 ### Phase 37 Reference Materials
-Phase 37 reference links remain navigational and do not override the authoritative audited taxonomy above.
+Phase 37 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
 - [Phase 37 watchlist engine status](phases/phase-37-status.md)
 - [Operator dashboard runtime surface](ui/owner_dashboard.md)
 - [API usage contract](api/usage_contract.md)
 
 ### Phase 18 Reference Materials
-Phase 18 reference links remain navigational and do not override the authoritative audited taxonomy above.
+Phase 18 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
 - [Change policy](external/change_policy.md)
 - [Client types](external/client_types.md)
 - [Contract surface](external/contract_surface.md)
@@ -98,7 +101,7 @@ Phase 18 reference links remain navigational and do not override the authoritati
 - [Integration assumptions](external/integration_assumptions.md)
 
 ### Phase 19 Reference Materials
-Phase 19 reference links remain navigational and do not override the authoritative audited taxonomy above.
+Phase 19 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
 - [Compatibility gate](versioning/compatibility_gate.md)
 - [Change enforcement](versioning/change_enforcement.md)
 - [Version declaration](versioning/declaration.md)

--- a/docs/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -21,8 +21,15 @@ Primary status sources:
 
 Authority model used in this file:
 - `docs/roadmap/execution_roadmap.md` is the authoritative in-repo source for audited phase meaning and taxonomy.
-- This master roadmap is the broader navigation and status document for the 45-phase reference, but it does not redefine audited phase meanings that are governed by the authoritative execution roadmap.
-- Where this file references an audited phase that is covered by the authoritative execution roadmap, phase meaning must defer to that file and any conflicting wording here should be read as non-authoritative.
+- This master roadmap is the single authoritative in-repo source for phase maturity/status across the 45-phase reference set.
+- Per-phase status artifacts, audit reports, indexes, and other roadmap/navigation documents are evidence-bearing or explanatory surfaces only; they do not set canonical phase maturity/status unless their change is also reflected in this file.
+- This file does not redefine audited phase meanings that are governed by the authoritative execution roadmap.
+- Where this file references an audited phase that is covered by the authoritative execution roadmap, phase meaning must defer to that file and any conflicting wording here should be read as non-authoritative for taxonomy.
+
+Status update path:
+- Update supporting evidence first, as needed, in the relevant per-phase or audit artifact.
+- Update this file to record the canonical phase maturity/status change.
+- Treat any secondary document that has not yet been reconciled to this file as stale derived documentation rather than as a competing status source.
 
 Status policy used in this file:
 - `Implemented`: repo-verifiable implementation exists without a documented material completion gap for this phase scope.
@@ -40,7 +47,8 @@ Status policy used in this file:
 ## Authority Relationship
 
 - `docs/roadmap/execution_roadmap.md` governs audited phase meaning.
-- This document governs the broader master-roadmap view, sequencing, and status labels for the 45-phase reference set.
+- This document governs the broader master-roadmap view, sequencing, and the canonical phase maturity/status labels for the 45-phase reference set.
+- Per-phase status files, audit artifacts, and index/navigation pages may explain or evidence a phase, but they remain derived surfaces for status and must defer to this document for the canonical maturity/status label.
 - For audited phases, this document must defer to the authoritative execution roadmap for taxonomy and phase-name interpretation.
 
 ## System Workflow
@@ -111,6 +119,8 @@ Market Data
 
 ## Status Notes
 
+- Status changes follow one update path: update evidence as needed, then update this master roadmap to change the canonical phase maturity/status label.
+- Secondary docs that describe a phase do not create an independent status authority; they are reconciled to this file.
 - Phase 17b is backend-served at `/ui`; `/owner` is documented only as a frontend development-only route and not as a runtime backend surface.
 - Phase 23 still has no verified Research Dashboard implementation artifact in code, tests, or runtime-facing docs.
 - Phase 24 is now treated as implemented because the simulator boundary and non-live constraints are documented consistently; Phase 44 remains broader and only partially implemented.

--- a/docs/roadmap/execution_roadmap.md
+++ b/docs/roadmap/execution_roadmap.md
@@ -9,12 +9,20 @@ This file is the single authoritative in-repo source for audited phase-number me
 
 ## Authority Relationship
 - This file governs the meaning of the audited phase numbers listed below.
-- The master roadmap at `docs/roadmap/cilly_trading_execution_roadmap_updated.md` may summarize broader sequencing and implementation-status context, but it must defer to this file for audited phase meaning.
+- The master roadmap at `docs/roadmap/cilly_trading_execution_roadmap_updated.md` is the single authoritative in-repo source for phase maturity/status labels and status-change decisions.
+- This file does not authoritatively set phase maturity/status labels. Any status wording here, in a per-phase artifact, or in an index must defer to the master roadmap for canonical maturity/status.
+- The master roadmap may summarize broader sequencing and implementation-status context, but it must defer to this file for audited phase meaning.
 - If wording in a secondary roadmap, index, or audit artifact conflicts with the audited phase meanings defined here, this file controls the taxonomy interpretation.
+
+## Status Update Rule
+- Taxonomy updates follow this file.
+- Phase maturity/status updates follow `docs/roadmap/cilly_trading_execution_roadmap_updated.md`.
+- Per-phase status artifacts, audit reports, and index/navigation documents may provide evidence, scoped detail, or traceability, but they do not become canonical status sources unless the master roadmap is updated to reflect the change.
+- Reviewers should reject status changes that update a secondary document without also updating the master roadmap.
 
 ## How to Use
 - Use this file to resolve the meaning of an audited phase number before relying on any secondary roadmap, index, or audit artifact.
-- Treat secondary documents as navigation or status evidence only unless they explicitly defer to this file.
+- Treat secondary documents as navigation or status evidence only unless they explicitly defer to this file for taxonomy and to the master roadmap for phase maturity/status.
 - If a phase is marked here as "no authoritative in-repo meaning located", do not infer a meaning from neighboring phases or legacy headings.
 
 ---
@@ -37,7 +45,7 @@ This file is the single authoritative in-repo source for audited phase-number me
 - Phase 17 and Phase 17b are not interchangeable: Phase 17 is the umbrella phase, and Phase 17b is the Owner Dashboard sub-phase.
 - Phase 27 and Phase 27b are not interchangeable: Phase 27 is Risk Framework taxonomy; Phase 27b remains a distinct Pipeline Enforcement Layer artifact.
 - Phase 25 and Phase 26 must not be grouped into a shared replacement meaning. Phase 25 is defined above, while Phase 26 remains unmapped in current authoritative in-repo taxonomy.
-- This document establishes taxonomy only. Implementation-status corrections remain scoped to the relevant status artifacts and follow-on issues.
+- This document establishes taxonomy only. Canonical implementation-status corrections must be made in `docs/roadmap/cilly_trading_execution_roadmap_updated.md`, with any supporting per-phase artifacts updated as derived evidence.
 
 ---
 


### PR DESCRIPTION
Closes #655

## Summary
- define a single authoritative in-repo source for phase maturity/status
- keep execution_roadmap.md as taxonomy authority only
- mark index, per-phase status files, and audit/navigation docs as derived status surfaces
- document one update path for future status changes

## Testing
- python -m pytest -q