### PR TITLE
DOCS: add first-class Windows PowerShell local-run path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Choose the path that matches your role:
 
 Use these documents if you need to run, verify, or operate the platform locally.
 
-- Quick local setup: `docs/quickstart.md`
-- Canonical local runtime path: `docs/local_run.md`
+- Quick local setup (PowerShell and Bash): `docs/quickstart.md`
+- Canonical local runtime path (PowerShell and Bash): `docs/local_run.md`
 - Owner startup and reset cheatsheet: `docs/OWNER_RUNBOOK.md`
 - Working runbook and quality gate expectations: `docs/RUNBOOK.md`
 - Runtime and health references: `docs/health.md`, `docs/runtime_status_and_health.md`
@@ -48,7 +48,7 @@ The full boundary definition is documented in `docs/api/public_api_boundary.md`.
 
 ## Verification Paths
 
-- Operators validating a local environment should start with `docs/quickstart.md`, then use `docs/local_run.md` and `docs/OWNER_RUNBOOK.md`.
+- Operators validating a local environment should start with `docs/quickstart.md`, then use `docs/local_run.md` and `docs/OWNER_RUNBOOK.md`. Windows users should follow the PowerShell command blocks in those docs directly.
 - Contributors or reviewers validating behavior and change scope should start with `docs/index.md`, then use `docs/testing.md`, `docs/api/public_api_boundary.md`, and `docs/roadmap/execution_roadmap.md`.
 
 ## Local CI Check

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,6 +2,7 @@
 
 ## A. Purpose
 This guide provides the single authoritative path for owners to start and access the application locally. Follow the steps in order to verify the API is running and then stop/reset it cleanly.
+The PowerShell path below is a first-class canonical local workflow for Windows.
 
 ## B. Prerequisites
 - Python 3.12+
@@ -50,6 +51,20 @@ The application is running when the endpoint returns exactly:
 {"status":"ok"}
 ```
 
+Use the matching shell command in a second terminal:
+
+### Bash (macOS/Linux)
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+### PowerShell (Windows)
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/health
+```
+
 ## G. Clean Stop Procedure
 1. In the terminal where `uvicorn` is running, press `Ctrl+C` once.
 2. Wait until shutdown completes and the terminal prompt returns.
@@ -91,7 +106,23 @@ Remove-Item .\cilly_trading.db -ErrorAction SilentlyContinue
 
 On next API start, SQLite tables are recreated automatically.
 
-## I. Troubleshooting
+## I. Optional shell cleanup
+
+If you want to clear the session variable used by the canonical startup path:
+
+### Bash (macOS/Linux)
+
+```bash
+unset PYTHONPATH
+```
+
+### PowerShell (Windows)
+
+```powershell
+Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
+```
+
+## J. Troubleshooting
 - If `uvicorn: command not found` appears, activate the virtual environment again:
 
   Bash (macOS/Linux):

--- a/docs/local_run.md
+++ b/docs/local_run.md
@@ -1,5 +1,9 @@
 # Local Development: Run & Analyze
 
+This document defines the canonical local run path for both PowerShell on
+Windows and Bash on macOS/Linux. The PowerShell commands below are first-class
+instructions, not translations of the Bash path.
+
 ## TL;DR Quick Start (fresh local setup)
 
 ### Bash (macOS/Linux)
@@ -323,6 +327,23 @@ docker compose down -v
 ```
 
 Safety note: reset deletes local signals, analysis runs, ingestion runs, and snapshot rows.
+
+### Optional shell cleanup after stopping
+
+If you want to clear the local shell session variable used by the canonical
+startup path:
+
+### Bash (macOS/Linux)
+
+```bash
+unset PYTHONPATH
+```
+
+### PowerShell (Windows)
+
+```powershell
+Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
+```
 
 ## Common setup errors & fixes
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-# Quickstart – Cilly Trading Engine
+# Quickstart - Cilly Trading Engine
 
 ## 1. Prerequisites
 - Python 3.12+
@@ -35,7 +35,7 @@ The canonical dependency install path is the repository `pyproject.toml` via
 
 ### PowerShell
 ```powershell
-$env:PYTHONPATH="src"
+$env:PYTHONPATH = "src"
 python -c "from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())"
 ```
 
@@ -54,3 +54,45 @@ SMOKE_RUN:END
 
 Exit code must be 0.
 Any deviation indicates a broken environment.
+
+## 6. Start the Local API
+
+Run this from the repository root after the virtual environment is active.
+
+### PowerShell (Windows)
+```powershell
+$env:PYTHONPATH = "src"
+uvicorn api.main:app --reload
+```
+
+### Bash (macOS/Linux)
+```bash
+PYTHONPATH=src uvicorn api.main:app --reload
+```
+
+This is the canonical local startup path documented in `docs/local_run.md`.
+
+## 7. Verify Local Health
+
+In a second terminal:
+
+### PowerShell (Windows)
+```powershell
+Invoke-RestMethod http://127.0.0.1:8000/health
+```
+
+### Bash (macOS/Linux)
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Expected output:
+
+```json
+{"status":"ok"}
+```
+
+## 8. Stop or Reset
+
+- Stop the running API with `Ctrl+C` in the terminal where `uvicorn` is running.
+- For a full local reset, see `docs/local_run.md` and `docs/GETTING_STARTED.md`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,12 +4,29 @@
 
 1) Create and activate a virtualenv:
 
+### PowerShell (Windows)
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+### Bash (macOS/Linux)
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 ```
 
 2) Install test dependencies:
+
+### PowerShell (Windows)
+
+```powershell
+python -m pip install -e ".[test]"
+```
+
+### Bash (macOS/Linux)
 
 ```bash
 python -m pip install -e ".[test]"
@@ -20,6 +37,14 @@ This is the canonical test setup path because it uses the repository-controlled
 match the package metadata.
 
 ## Run the test suite
+
+### PowerShell (Windows)
+
+```powershell
+python -m pytest -q
+```
+
+### Bash (macOS/Linux)
 
 ```bash
 python -m pytest -q


### PR DESCRIPTION
## Summary
- make Windows/PowerShell a first-class local-run path across the primary setup and run docs
- extend quickstart from smoke-test-only guidance to a complete local runtime flow for Windows users
- align testing docs with the canonical install contract and add PowerShell-native examples

## What changed
- README.md
  - add a clearer navigation cue that quickstart and local-run docs contain both PowerShell and Bash paths
  - point Windows users directly to the PowerShell command blocks

- docs/GETTING_STARTED.md
  - make the Windows PowerShell path explicit as a first-class option
  - add direct PowerShell health verification
  - add matching shell cleanup guidance

- docs/local_run.md
  - strengthen the document as the canonical local-run path for both shells
  - add explicit PowerShell/Bash session cleanup guidance after stop/reset

- docs/quickstart.md
  - extend the flow beyond the smoke test
  - document PowerShell venv creation and activation
  - document install from the canonical pyproject-based contract
  - document local uvicorn startup and /health verification
  - document reset/cleanup guidance for Windows users

- docs/testing.md
  - add PowerShell setup and test-run blocks
  - remove the Bash-only bias from testing instructions

## Why
The repository was already aligned on setup contract and roadmap authority, but the primary local-run and testing docs did not yet provide a clearly verifiable first-class Windows/PowerShell path. This change closes that remaining documentation gap without changing runtime behavior or packaging design.

## Verification
- ran python -m pytest -q
- result: 553 passed, 4 warnings

## Notes
- the install contract remains aligned to the existing repository packaging metadata
- this PR is documentation-only and does not change runtime behavior
- local PowerShell activation still depends on the user's machine execution policy, which remains outside repo control