### PR TITLE
Define bounded authoritative scope for Phase 23 Research Dashboard

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ Status changes therefore follow one update path: update supporting evidence as n
 | Phase 16 | No authoritative in-repo meaning located | `docs/roadmap/execution_roadmap.md` |
 | Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/roadmap/execution_roadmap.md` |
 | Phase 17b | Owner Dashboard sub-phase | `docs/roadmap/execution_roadmap.md` |
-| Phase 23 | Research Dashboard | `docs/phases/phase-23-status.md` |
+| Phase 23 | Research Dashboard bounded to one dedicated research-only dashboard surface; not implied by current `/ui`, analytics, charting, or trading-desk docs | `docs/phases/phase-23-status.md` |
 | Phase 25 | Strategy Lifecycle Management | `docs/phases/phase_25_strategy_lifecycle.md` |
 | Phase 26 | No authoritative in-repo meaning located | `docs/roadmap/execution_roadmap.md` |
 | Phase 27 | Risk Framework | `docs/phases/phase-27-status.md` |
@@ -80,6 +80,9 @@ Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b
 - [Batch execution interface](interfaces/batch_execution.md)
 - [CLI contract](interfaces/cli_contract.md)
 - [Interface usage patterns](interfaces/usage_patterns.md)
+
+### Phase 23 Boundary Note
+Phase 23 is bounded to one dedicated research-only dashboard surface as defined in [Phase 23 status](phases/phase-23-status.md). Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting docs, and Phase 40 trading-desk wording are adjacent references only and must not be read as implied implementation evidence for Phase 23.
 
 ### Phase 24 Reference Materials
 Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.

--- a/docs/phases/phase-23-status.md
+++ b/docs/phases/phase-23-status.md
@@ -7,26 +7,38 @@ NOT IMPLEMENTED
 Phase 23 means `Research Dashboard` in the authoritative taxonomy source:
 `docs/roadmap/execution_roadmap.md`
 
+## Authoritative Bounded Scope
+Phase 23 is the repo-verifiable phase for one dedicated research-only dashboard surface that consolidates research review into a single bounded workspace.
+
+That bounded Phase 23 meaning requires repository evidence for a dashboard artifact that:
+- is explicitly identified as a Research Dashboard
+- is dedicated to research review rather than operator control or trade execution
+- combines research-oriented views into one coherent surface instead of scattering them across unrelated routes, panels, or metrics outputs
+
+## Explicit Phase Boundaries
+Phase 23 is not satisfied by adjacent phases or by overlapping dashboard language.
+
+- Phase 17b is the Owner Dashboard and the existing runtime-served `/ui` operator surface. Operator workbench panels on `/ui` do not count as implied Phase 23 evidence.
+- Phase 30 is the Trading Analytics Layer. Metrics artifacts, performance reports, and analytics outputs do not count as a Research Dashboard by themselves.
+- Phase 39 is Charting & Visual Analysis. Read-only chart panels and visual-analysis surfaces do not count as a Research Dashboard by themselves.
+- Phase 40 is the Trading Desk Dashboard. Broader desk, overview, or professional trading dashboard language does not define or satisfy Phase 23.
+
 ## Verified Repository Evidence
 The current repository review did not confirm a Phase 23 implementation artifact in:
 - `src/**`
 - `engine/**`
 - `tests/**`
-- runtime-facing documentation for a Research Dashboard surface
+- runtime-facing documentation for a dedicated research-only dashboard surface
 
-Repository references to "Research Dashboard" in the audited scope are limited to roadmap and status-tracking documents, not implementation artifacts.
+Repository references to `Research Dashboard` in the audited scope are currently limited to roadmap and status-tracking documents, not implementation artifacts.
 
-## Planned Scope
-- Research data aggregation
-- Internal dashboard views
-- Metrics visualization for analysis workflows
-- No trading execution capability
-
-## Dependencies
-- Data availability layer
-- Metrics computation modules
-- Internal reporting interfaces
+## Non-Evidence Clarification
+The following existing repository surfaces must not be treated as implied Phase 23 implementation evidence unless they are explicitly extended and documented as the bounded Research Dashboard defined above:
+- current operator `/ui` surfaces
+- existing analytics artifacts or metrics reports
+- current charting or visual-analysis surfaces
+- trading-desk or operator-dashboard wording in roadmap or navigation documents
 
 ## Explicit Declaration
-As of this revision, no repository-verifiable code, tests, or runtime documentation were confirmed for Phase 23 Research Dashboard.
+As of this revision, no repository-verifiable code, tests, or runtime documentation were confirmed for the bounded Phase 23 Research Dashboard defined in this file.
 Phase 23 therefore remains NOT IMPLEMENTED.

--- a/docs/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -122,6 +122,7 @@ Market Data
 - Status changes follow one update path: update evidence as needed, then update this master roadmap to change the canonical phase maturity/status label.
 - Secondary docs that describe a phase do not create an independent status authority; they are reconciled to this file.
 - Phase 17b is backend-served at `/ui`; `/owner` is documented only as a frontend development-only route and not as a runtime backend surface.
+- Phase 23 is bounded to one dedicated research-only dashboard surface; current `/ui` operator panels, analytics artifacts, charting surfaces, and trading-desk wording do not count as implied implementation evidence for that phase.
 - Phase 23 still has no verified Research Dashboard implementation artifact in code, tests, or runtime-facing docs.
 - Phase 24 is now treated as implemented because the simulator boundary and non-live constraints are documented consistently; Phase 44 remains broader and only partially implemented.
 - Phase 25 and Phase 27 were corrected away from stale older wording because lifecycle and risk-framework artifacts are already present in the repository.
@@ -482,14 +483,15 @@ Guarantee reproducible research artifacts.
 **Status:** Not Implemented
 
 **Goal**
-Track research dashboard maturity honestly.
+Define one bounded authoritative meaning for the Research Dashboard phase and keep its status evidence-based.
 
 **Current Status Basis**
-- The dedicated phase status file explicitly states that no Research Dashboard implementation artifact was verified.
-- No repo-verifiable code, tests, or runtime-facing docs confirm the dashboard itself.
+- The dedicated phase status file constrains Phase 23 to one dedicated research-only dashboard surface rather than generic dashboard, operator, analytics, charting, or trading-desk language.
+- The repository does not currently contain repo-verifiable code, tests, or runtime-facing docs for that bounded Phase 23 dashboard artifact.
+- Existing evidence for Phase 17b `/ui`, Phase 30 analytics artifacts, Phase 39 read-only charting, and Phase 40 desk-style dashboard scope is explicitly treated as adjacent and non-substitutable.
 
 **Outcome**
-- The roadmap remains honest about this unimplemented phase.
+- The roadmap defines exactly what Phase 23 means, what it does not mean, and why it remains unimplemented.
 
 ---
 
@@ -1276,14 +1278,15 @@ Reproduzierbare Research-Artefakte garantieren.
 **Status:** Not Implemented
 
 **Ziel**
-Den Reifegrad des Research Dashboards ehrlich nachverfolgen.
+Eine klar begrenzte authoritative Bedeutung fuer die Phase Research Dashboard festlegen und den Status evidenzbasiert halten.
 
 **Aktuelle Statusbasis**
-- Die dedizierte Phasen-Statusdatei erklaert explizit, dass kein Research-Dashboard-Implementierungsartefakt verifiziert wurde.
-- Weder Code noch Tests noch runtime-nahe Doku bestaetigen das Dashboard selbst.
+- Die dedizierte Phasen-Statusdatei begrenzt Phase 23 auf eine einzelne dedizierte research-only Dashboard-Surface statt auf allgemeine Dashboard-, Operator-, Analytics-, Charting- oder Trading-Desk-Sprache.
+- Das Repository enthaelt derzeit keinen repo-verifizierbaren Code, keine Tests und keine runtime-nahe Doku fuer dieses begrenzte Phase-23-Dashboard-Artefakt.
+- Vorhandene Evidenz fuer Phase 17b `/ui`, Phase 30 Analytics-Artefakte, Phase 39 read-only Charting und Phase-40-artigen Desk-Scope wird explizit als benachbart und nicht austauschbar behandelt.
 
 **Ergebnis**
-- Die Roadmap bleibt fuer diese nicht implementierte Phase ehrlich.
+- Die Roadmap definiert jetzt exakt, was Phase 23 bedeutet, was sie nicht bedeutet und warum sie weiter nicht implementiert ist.
 
 ---
 


### PR DESCRIPTION
Closes #663

## Summary
- define a bounded authoritative meaning for Phase 23 as one dedicated research-only dashboard surface
- distinguish Phase 23 explicitly from Phase 17b, Phase 30, Phase 39, and Phase 40
- clarify that current `/ui`, analytics, charting, and trading-desk references do not count as implied Phase 23 implementation evidence

## Testing
- `python -m pytest`