### PR TITLE
Align Phase 23 status surfaces to the bounded governance definition

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ Status changes therefore follow one update path: update supporting evidence as n
 | Phase 16 | No authoritative in-repo meaning located | `docs/roadmap/execution_roadmap.md` |
 | Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/roadmap/execution_roadmap.md` |
 | Phase 17b | Owner Dashboard sub-phase | `docs/roadmap/execution_roadmap.md` |
-| Phase 23 | Research Dashboard bounded to one dedicated research-only dashboard surface; not implied by current `/ui`, analytics, charting, or trading-desk docs | `docs/phases/phase-23-status.md` |
+| Phase 23 | `Research Dashboard`: one dedicated research-only dashboard surface; it remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact | `docs/phases/phase-23-status.md` |
 | Phase 25 | Strategy Lifecycle Management | `docs/phases/phase_25_strategy_lifecycle.md` |
 | Phase 26 | No authoritative in-repo meaning located | `docs/roadmap/execution_roadmap.md` |
 | Phase 27 | Risk Framework | `docs/phases/phase-27-status.md` |
@@ -82,7 +82,7 @@ Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b
 - [Interface usage patterns](interfaces/usage_patterns.md)
 
 ### Phase 23 Boundary Note
-Phase 23 is bounded to one dedicated research-only dashboard surface as defined in [Phase 23 status](phases/phase-23-status.md). Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting docs, and Phase 40 trading-desk wording are adjacent references only and must not be read as implied implementation evidence for Phase 23.
+Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface as defined in [Phase 23 status](phases/phase-23-status.md). It remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact. Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting docs, and Phase 40 trading-desk wording are adjacent references only and are insufficient on their own to claim Phase 23 implementation.
 
 ### Phase 24 Reference Materials
 Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.

--- a/docs/phases/phase-23-status.md
+++ b/docs/phases/phase-23-status.md
@@ -7,6 +7,11 @@ NOT IMPLEMENTED
 Phase 23 means `Research Dashboard` in the authoritative taxonomy source:
 `docs/roadmap/execution_roadmap.md`
 
+## Canonical Bounded Message
+Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface.
+Phase 23 remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact.
+Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting surfaces, and Phase 40 trading-desk wording are adjacent only and do not count on their own as Phase 23 implementation evidence.
+
 ## Authoritative Bounded Scope
 Phase 23 is the repo-verifiable phase for one dedicated research-only dashboard surface that consolidates research review into a single bounded workspace.
 
@@ -14,6 +19,36 @@ That bounded Phase 23 meaning requires repository evidence for a dashboard artif
 - is explicitly identified as a Research Dashboard
 - is dedicated to research review rather than operator control or trade execution
 - combines research-oriented views into one coherent surface instead of scattering them across unrelated routes, panels, or metrics outputs
+
+## Minimum Repo-Verifiable Evidence Contract
+A Phase 23 claim must be supported by one coherent minimum artifact set inside the repository. Reviewers should treat the phase as `NOT IMPLEMENTED` unless all three required evidence classes below are present for the same bounded Research Dashboard surface.
+
+### Required evidence class 1: bounded dashboard contract
+The repository must contain documentation that identifies one concrete Research Dashboard surface and lets a reviewer distinguish it from adjacent phases. That documentation must:
+- name the surface as the Research Dashboard
+- state the runtime entrypoint, route, or launch surface being claimed
+- describe the bounded research-only purpose of the surface
+- identify the core research views or panels that are part of the claimed dashboard
+
+### Required evidence class 2: runtime or UI implementation artifact
+The repository must contain at least one implementation artifact for that same bounded surface. Acceptable evidence includes:
+- runtime-served UI files or frontend assets that clearly render the named Research Dashboard surface
+- backend route, mount, or handler code that serves or exposes the claimed dashboard surface
+- a bounded UI contract document tied to existing runtime code and endpoints for that dashboard surface
+
+### Required evidence class 3: verification artifact
+The repository must contain at least one verification artifact that checks the same bounded dashboard claim. Acceptable evidence includes:
+- tests that assert the dashboard route, mount, rendered marker, or bounded research panels
+- reviewable manual verification instructions that reference the exact route, marker, and research-only surface being claimed
+- a bounded contract or checklist that a reviewer can apply directly to repo artifacts without guessing
+
+## Classification Rule
+Use the following gate when reviewing future Phase 23 claims:
+- `NOT IMPLEMENTED`: any required evidence class above is missing, or the artifacts do not point to the same bounded Research Dashboard surface
+- `PARTIALLY IMPLEMENTED`: all three required evidence classes are present, but the documented dashboard scope is explicitly incomplete or only some of the defined research views are implemented
+- `IMPLEMENTED`: all three required evidence classes are present and they support the complete bounded Research Dashboard scope being claimed in repository docs
+
+Reviewers should reject a status advance when the artifacts require inference across unrelated surfaces instead of demonstrating one coherent dashboard contract.
 
 ## Explicit Phase Boundaries
 Phase 23 is not satisfied by adjacent phases or by overlapping dashboard language.
@@ -31,8 +66,18 @@ The current repository review did not confirm a Phase 23 implementation artifact
 - runtime-facing documentation for a dedicated research-only dashboard surface
 
 Repository references to `Research Dashboard` in the audited scope are currently limited to roadmap and status-tracking documents, not implementation artifacts.
+The current repository therefore fails all three required evidence classes in the minimum Phase 23 evidence contract above.
 
 ## Non-Evidence Clarification
+The following artifact classes are insufficient on their own to claim Phase 23 implementation progress, even if they mention dashboards, research, analysis, or review:
+- roadmap, status, or navigation wording that names a Research Dashboard but is not tied to a concrete runtime surface
+- generic dashboard language without a bounded route, mount, or named research-only UI surface
+- standalone analytics outputs, metrics reports, or performance summaries
+- standalone chart panels, visual-analysis widgets, or chart data contracts
+- operator-dashboard, trading-desk, or broader `/ui` documentation that is not explicitly bounded as the Research Dashboard
+- endpoint lists, schemas, or data models that could support a dashboard but do not prove a dashboard surface exists
+- tests that only cover underlying data endpoints or analytics logic without checking a bounded dashboard surface
+
 The following existing repository surfaces must not be treated as implied Phase 23 implementation evidence unless they are explicitly extended and documented as the bounded Research Dashboard defined above:
 - current operator `/ui` surfaces
 - existing analytics artifacts or metrics reports

--- a/docs/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -92,7 +92,7 @@ Market Data
 | 20 | Error Handling System | Implemented |
 | 21 | Governance Rules | Implemented |
 | 22 | Artifact Integrity | Implemented |
-| 23 | Research Dashboard Governance | Not Implemented |
+| 23 | Research Dashboard | Not Implemented |
 | 24 | Paper Trading Governance | Implemented |
 | 25 | Roadmap Traceability | Implemented in Repository |
 | 26 | Documentation Alignment | Implemented |
@@ -122,9 +122,9 @@ Market Data
 - Status changes follow one update path: update evidence as needed, then update this master roadmap to change the canonical phase maturity/status label.
 - Secondary docs that describe a phase do not create an independent status authority; they are reconciled to this file.
 - Phase 17b is backend-served at `/ui`; `/owner` is documented only as a frontend development-only route and not as a runtime backend surface.
-- Phase 23 is bounded to one dedicated research-only dashboard surface; current `/ui` operator panels, analytics artifacts, charting surfaces, and trading-desk wording do not count as implied implementation evidence for that phase.
-- Phase 23 now has an explicit minimum repo-verifiable evidence contract: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact must all exist for the same claimed surface before status can advance beyond `Not Implemented`.
-- Phase 23 still has no verified Research Dashboard implementation artifact in code, tests, or runtime-facing docs, so it does not satisfy that evidence contract.
+- Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface.
+- Phase 23 remains `Not Implemented` because the repository does not yet contain the full minimum evidence contract for one coherent Research Dashboard surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface.
+- Current `/ui` operator panels, analytics artifacts, charting surfaces, and trading-desk wording are adjacent only and do not count on their own as Phase 23 implementation evidence.
 - Phase 24 is now treated as implemented because the simulator boundary and non-live constraints are documented consistently; Phase 44 remains broader and only partially implemented.
 - Phase 25 and Phase 27 were corrected away from stale older wording because lifecycle and risk-framework artifacts are already present in the repository.
 - Phase 35 is marked `Implemented` in this revision because metrics, telemetry, runtime health, guard-trigger monitoring, and integration tests are all present in-repo.
@@ -480,20 +480,19 @@ Guarantee reproducible research artifacts.
 
 ---
 
-## Phase 23 - Research Dashboard Governance
+## Phase 23 - Research Dashboard
 **Status:** Not Implemented
 
 **Goal**
-Define one bounded authoritative meaning for the Research Dashboard phase and keep its status evidence-based.
+Align the bounded Phase 23 `Research Dashboard` meaning and keep its status evidence-based.
 
 **Current Status Basis**
-- The dedicated phase status file constrains Phase 23 to one dedicated research-only dashboard surface rather than generic dashboard, operator, analytics, charting, or trading-desk language.
-- The dedicated phase status file now defines a minimum evidence gate requiring a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface before Phase 23 can be advanced.
-- The repository does not currently contain repo-verifiable code, tests, or runtime-facing docs for that bounded Phase 23 dashboard artifact, so the minimum evidence gate is not met.
-- Existing evidence for Phase 17b `/ui`, Phase 30 analytics artifacts, Phase 39 read-only charting, and Phase 40 desk-style dashboard scope is explicitly treated as adjacent and non-substitutable.
+- Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface.
+- Phase 23 remains `Not Implemented` because the repository does not yet contain the full minimum evidence contract for one coherent Research Dashboard surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface.
+- Existing evidence from Phase 17b `/ui`, Phase 30 analytics artifacts, Phase 39 read-only charting, and Phase 40 desk-style dashboard wording is adjacent only and does not count on its own as Phase 23 implementation evidence.
 
 **Outcome**
-- The roadmap defines exactly what Phase 23 means, what evidence is required to advance it, what does not count on its own, and why it remains unimplemented.
+- The roadmap now presents the same bounded Phase 23 message as the phase status and index surfaces, without changing the non-implementation status.
 
 ---
 
@@ -894,7 +893,7 @@ Marktdaten
 | 20 | Error Handling System | Implemented |
 | 21 | Governance Rules | Implemented |
 | 22 | Artifact Integrity | Implemented |
-| 23 | Research Dashboard Governance | Not Implemented |
+| 23 | Research Dashboard | Not Implemented |
 | 24 | Paper Trading Governance | Implemented |
 | 25 | Roadmap Traceability | Implemented in Repository |
 | 26 | Documentation Alignment | Implemented |
@@ -922,9 +921,9 @@ Marktdaten
 ## Status-Hinweise
 
 - Phase 17b wird im Backend unter `/ui` ausgeliefert; `/owner` ist nur als Frontend-Development-Route dokumentiert und keine Runtime-Backend-Surface.
-- Phase 23 ist auf eine einzelne dedizierte research-only Dashboard-Surface begrenzt; aktuelle `/ui`-Operator-Panels, Analytics-Artefakte, Charting-Surfaces und Trading-Desk-Sprache gelten nicht als implizite Implementierungsevidenz fuer diese Phase.
-- Phase 23 hat jetzt einen expliziten minimalen repo-verifizierbaren Evidenzvertrag: Ein begrenzter Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt muessen fuer dieselbe beanspruchte Surface gemeinsam vorliegen, bevor der Status ueber `Not Implemented` hinaus angehoben werden darf.
-- Fuer Phase 23 wurde weiterhin kein verifizierter Research-Dashboard-Implementierungsartefakt in Code, Tests oder runtime-naher Dokumentation bestaetigt; der Evidenzvertrag ist daher nicht erfuellt.
+- Phase 23 bedeutet `Research Dashboard`: eine einzelne dedizierte research-only Dashboard-Surface.
+- Phase 23 bleibt `Not Implemented`, weil das Repository noch nicht den vollstaendigen minimalen Evidenzvertrag fuer eine zusammenhaengende Research-Dashboard-Surface enthaelt: einen begrenzten Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt fuer dieselbe beanspruchte Surface.
+- Aktuelle `/ui`-Operator-Panels, Analytics-Artefakte, Charting-Surfaces und Trading-Desk-Sprache sind nur benachbart und zaehlen fuer sich allein nicht als Phase-23-Implementierungsevidenz.
 - Phase 24 gilt jetzt als implementiert, weil Simulator-Grenzen und Non-Live-Constraints konsistent dokumentiert sind; Phase 44 bleibt als breitere Produktphase nur teilweise implementiert.
 - Phase 25 und Phase 27 wurden gegen veraltete Roadmap-Aussagen korrigiert, weil Lifecycle- und Risk-Framework-Artefakte bereits im Repo vorhanden sind.
 - Phase 35 ist in dieser Fassung `Implemented`, weil Metrics, Telemetry, Runtime Health, Guard-Trigger-Monitoring und Integrationstests bereits vorhanden sind.
@@ -1278,20 +1277,19 @@ Reproduzierbare Research-Artefakte garantieren.
 
 ---
 
-## Phase 23 - Research Dashboard Governance
+## Phase 23 - Research Dashboard
 **Status:** Not Implemented
 
 **Ziel**
-Eine klar begrenzte authoritative Bedeutung fuer die Phase Research Dashboard festlegen und den Status evidenzbasiert halten.
+Die klar begrenzte Phase-23-Bedeutung `Research Dashboard` angleichen und den Status evidenzbasiert halten.
 
 **Aktuelle Statusbasis**
-- Die dedizierte Phasen-Statusdatei begrenzt Phase 23 auf eine einzelne dedizierte research-only Dashboard-Surface statt auf allgemeine Dashboard-, Operator-, Analytics-, Charting- oder Trading-Desk-Sprache.
-- Die dedizierte Phasen-Statusdatei definiert jetzt einen minimalen Evidenz-Gate, der einen begrenzten Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt fuer dieselbe beanspruchte Surface verlangt, bevor Phase 23 angehoben werden kann.
-- Das Repository enthaelt derzeit keinen repo-verifizierbaren Code, keine Tests und keine runtime-nahe Doku fuer dieses begrenzte Phase-23-Dashboard-Artefakt; der minimale Evidenz-Gate ist daher nicht erfuellt.
-- Vorhandene Evidenz fuer Phase 17b `/ui`, Phase 30 Analytics-Artefakte, Phase 39 read-only Charting und Phase-40-artigen Desk-Scope wird explizit als benachbart und nicht austauschbar behandelt.
+- Phase 23 bedeutet `Research Dashboard`: eine einzelne dedizierte research-only Dashboard-Surface.
+- Phase 23 bleibt `Not Implemented`, weil das Repository noch nicht den vollstaendigen minimalen Evidenzvertrag fuer eine zusammenhaengende Research-Dashboard-Surface enthaelt: einen begrenzten Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt fuer dieselbe beanspruchte Surface.
+- Vorhandene Evidenz aus Phase 17b `/ui`, Phase 30 Analytics-Artefakten, Phase 39 read-only Charting und Phase-40-artiger Trading-Desk-Sprache ist nur benachbart und zaehlt fuer sich allein nicht als Phase-23-Implementierungsevidenz.
 
 **Ergebnis**
-- Die Roadmap definiert jetzt exakt, was Phase 23 bedeutet, welche Evidenz fuer eine Statusanhebung erforderlich ist, was fuer sich allein nicht ausreicht und warum die Phase weiter nicht implementiert ist.
+- Die Roadmap zeigt jetzt dieselbe begrenzte Phase-23-Aussage wie Phasenstatus und Index, ohne den Nicht-Implementiert-Status zu veraendern.
 
 ---
 


### PR DESCRIPTION
Closes #665

## Summary
- align Phase 23 wording across the primary roadmap and navigation surfaces
- keep the master roadmap, phase status file, and index on one bounded Research Dashboard message
- preserve the non-implementation status until the bounded evidence contract is satisfied

## Testing
- `python -m pytest -q`
- manual cross-read of `docs/phases/phase-23-status.md`, `docs/index.md`, and `docs/roadmap/cilly_trading_execution_roadmap_updated.md`