### PR TITLE
docs: define canonical repository root structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ Use these documents if you need to understand repository scope, test expectation
 - The canonical local runtime path is documented in `docs/local_run.md`.
 - The authoritative audited phase taxonomy is `docs/roadmap/execution_roadmap.md`.
 - The supported package-level public API for `src/api` is `from api import app`.
+- The canonical top-level repository structure is documented in `docs/architecture/repository_root_structure.md`.
+
+## Canonical Repository Structure
+
+The canonical root structure for this repository is defined in
+`docs/architecture/repository_root_structure.md`.
+
+For all future repository changes, the allowed top-level directories are:
+
+- `docs/`
+- `src/`
+- `tests/`
+- `scripts/` when repository-owned automation or developer tooling is required
+- `frontend/` when a repository-owned frontend surface is required
+- `fixtures/` when shared deterministic fixture data is required
+
+Top-level directories outside that set are not canonical destinations for new
+work unless a separate repository decision documents and approves them.
+
+This issue does not move, delete, or rename any existing top-level directories.
+Current extra root folders remain part of the repository's present state until a
+separate cleanup or migration issue addresses them.
 
 ## Public API
 
@@ -54,5 +76,5 @@ The full boundary definition is documented in `docs/api/public_api_boundary.md`.
 ## Local CI Check
 
 ```bash
-pytest -q
+python -m pytest -q
 ```

--- a/docs/architecture/repository_root_structure.md
+++ b/docs/architecture/repository_root_structure.md
@@ -1,0 +1,62 @@
+# Canonical Repository Root Structure
+
+## Purpose
+
+This document defines the canonical top-level repository structure for the
+Cilly Trading Engine repository.
+
+It is the single source of truth for which root directories are allowed for
+future changes. It does not move existing files or folders, and it does not
+change repository architecture.
+
+## Canonical Allowed Root Directories
+
+The allowed canonical top-level directories are:
+
+- `docs/`
+- `src/`
+- `tests/`
+- `scripts/` as an optional root for repository-owned automation, helper
+  scripts, or developer tooling
+- `frontend/` as an optional root when the repository includes a frontend
+  surface
+- `fixtures/` as an optional root for shared deterministic fixtures or test
+  data
+
+## Root Placement Rules
+
+- New documentation belongs under `docs/`.
+- Production Python implementation code belongs under `src/`.
+- Automated tests belong under `tests/`.
+- Helper scripts may be added under `scripts/` only when they are part of the
+  repository workflow.
+- Frontend code may be added under `frontend/` only when the repository owns
+  that surface.
+- Shared deterministic fixtures may be added under `fixtures/` when they are
+  needed by tests, documentation, or bounded local workflows.
+
+No other top-level directory is an allowed default destination for new
+repository content.
+
+If future work requires a new root directory outside this list, that change
+must be explicitly documented and approved by a separate repository decision
+before files are added there.
+
+## Current Repository State
+
+The current repository includes additional top-level directories beyond the
+canonical list above.
+
+Those directories are part of the repository's current state, but they are not
+the canonical model for future structure decisions. This document does not
+delete, rename, move, or normalize them.
+
+## Manual Validation For Issue #680
+
+Manual review for this issue should confirm all of the following:
+
+- this document is reachable from `README.md`
+- the canonical allowed root directories are listed exactly once and without
+  competing alternatives
+- the optional roots are explicitly marked as optional
+- the document does not require any immediate folder moves or deletions


### PR DESCRIPTION
Closes #680

Summary:
- document canonical top-level directories
- add architecture doc for root structure
- link policy from README

Testing:
- python -m pytest -q