### PR TITLE
DOCS-B3: define canonical documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,37 +4,30 @@ The Cilly Trading Engine repository contains a deterministic trading-analysis an
 
 The current repository state supports local runtime, deterministic smoke-run and test workflows, and bounded operator-facing UI and API surfaces. It should not be read as a production-readiness declaration.
 
-## Start Here
+## Documentation Entry Point
 
-Choose the path that matches your role:
+`README.md` is an entry point only. It provides navigation into the canonical
+documentation structure and does not act as the source of truth for setup,
+local run, testing, or architecture topics.
 
-### Operators
+Start from these documents:
 
-Use these documents if you need to run, verify, or operate the platform locally.
-
-- Quick local setup (PowerShell and Bash): `docs/quickstart.md`
-- Canonical local runtime path (PowerShell and Bash): `docs/local_run.md`
-- Owner startup and reset cheatsheet: `docs/OWNER_RUNBOOK.md`
-- Working runbook and quality gate expectations: `docs/RUNBOOK.md`
-- Runtime and health references: `docs/health.md`, `docs/runtime_status_and_health.md`
-- Paper-trading boundary: `docs/paper_trading.md`
-
-### Contributors and Reviewers
-
-Use these documents if you need to understand repository scope, test expectations, interfaces, or roadmap/governance boundaries.
-
-- Documentation index: `docs/index.md`
-- Testing entrypoint: `docs/testing.md`
-- Getting started path for owners/local access: `docs/GETTING_STARTED.md`
-- Public Python API boundary: `docs/api/public_api_boundary.md`
-- Authoritative roadmap and phase taxonomy: `docs/roadmap/execution_roadmap.md`
-- Strategy configuration references: `docs/strategy-configs.md`
-- Snapshot/golden-master guidance: `docs/snapshot-testing.md`
+- Canonical documentation structure and navigation flow:
+  `docs/architecture/documentation_structure.md`
+- Repository documentation index: `docs/index.md`
+- Setup authority: `docs/GETTING_STARTED.md`
+- Local run authority: `docs/local_run.md`
+- Testing authority: `docs/testing.md`
+- Architecture authority root: `docs/architecture/`
 
 ## Canonical Boundaries
 
 - The repository-level documentation index is `docs/index.md`.
+- The canonical documentation structure is defined in
+  `docs/architecture/documentation_structure.md`.
+- The canonical setup path is documented in `docs/GETTING_STARTED.md`.
 - The canonical local runtime path is documented in `docs/local_run.md`.
+- The canonical testing path is documented in `docs/testing.md`.
 - The authoritative audited phase taxonomy is `docs/roadmap/execution_roadmap.md`.
 - The supported package-level public API for `src/api` is `from api import app`.
 - The canonical top-level repository structure is documented in `docs/architecture/repository_root_structure.md`.
@@ -70,8 +63,13 @@ The full boundary definition is documented in `docs/api/public_api_boundary.md`.
 
 ## Verification Paths
 
-- Operators validating a local environment should start with `docs/quickstart.md`, then use `docs/local_run.md` and `docs/OWNER_RUNBOOK.md`. Windows users should follow the PowerShell command blocks in those docs directly.
-- Contributors or reviewers validating behavior and change scope should start with `docs/index.md`, then use `docs/testing.md`, `docs/api/public_api_boundary.md`, and `docs/roadmap/execution_roadmap.md`.
+- Operators validating a local environment should start here, then follow
+  `docs/architecture/documentation_structure.md` to the canonical setup and
+  local run documents.
+- Contributors or reviewers validating behavior and change scope should start
+  here, then use `docs/index.md` and
+  `docs/architecture/documentation_structure.md` to reach the canonical
+  testing and architecture documents.
 
 ## Local CI Check
 

--- a/docs/architecture/documentation_structure.md
+++ b/docs/architecture/documentation_structure.md
@@ -1,0 +1,72 @@
+# Canonical Documentation Structure
+
+## Purpose
+
+This document defines the canonical documentation structure for the Cilly
+Trading Engine repository.
+
+It establishes exactly one authoritative location for each in-scope topic and
+defines how readers should navigate between those documents. It does not move
+files, edit existing documentation content, or delete any current documents.
+
+## README Role
+
+`README.md` is the repository entry point only.
+
+- It may introduce the repository and route readers to canonical documents.
+- It must not become the source of truth for setup, local run, testing, or
+  architecture content.
+- Topic-specific instructions belong in their canonical documentation file, not
+  in `README.md`.
+
+## Canonical Topic Ownership
+
+The authoritative file or directory for each in-scope topic is:
+
+- Setup: `docs/GETTING_STARTED.md`
+- Local run: `docs/local_run.md`
+- Testing: `docs/testing.md`
+- Architecture: `docs/architecture/`
+
+Within this structure, each topic has exactly one source of truth:
+
+- Setup content is authoritative only in `docs/GETTING_STARTED.md`.
+- Local run content is authoritative only in `docs/local_run.md`.
+- Testing content is authoritative only in `docs/testing.md`.
+- Architecture content is authoritative only under `docs/architecture/`.
+
+If other existing documents mention one of these topics, those documents are
+supporting or historical references and must defer to the canonical location
+above rather than redefine the topic.
+
+## Navigation Flow
+
+The required navigation flow is:
+
+1. Start at `README.md`.
+2. Follow `README.md` to this document for canonical structure and ownership.
+3. From this document, navigate to the authoritative topic document:
+   `docs/GETTING_STARTED.md`, `docs/local_run.md`, `docs/testing.md`, or
+   `docs/architecture/`.
+4. From a topic document, follow links only to supporting documents that do not
+   replace the topic's canonical source of truth.
+
+## Structure Rules
+
+- New setup documentation must consolidate into `docs/GETTING_STARTED.md`.
+- New local run documentation must consolidate into `docs/local_run.md`.
+- New testing documentation must consolidate into `docs/testing.md`.
+- New architecture documentation must live under `docs/architecture/`.
+- `README.md` must continue to function as a navigation entry point only.
+- No in-scope topic may have multiple authoritative files.
+
+## Manual Validation For Issue #684
+
+Manual review for this issue should confirm all of the following:
+
+- `README.md` points to this document as the canonical documentation structure.
+- `README.md` is positioned as an entry point only, not as a topic authority.
+- Setup, local run, testing, and architecture each have exactly one
+  authoritative location defined here.
+- The navigation flow from `README.md` to the canonical topic documents is
+  explicit and unambiguous.


### PR DESCRIPTION
Closes #684

## Summary
- define the canonical documentation structure in docs/architecture/documentation_structure.md
- assign exactly one authoritative location for setup, local run, testing, and architecture
- update README.md to act as the repository entry point only

## Validation
- manual validation of canonical ownership and navigation flow
- python -m pytest -q
