### PR TITLE
DOCS-B3: remove duplication and consolidate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,59 +20,14 @@ Start from these documents:
 - Testing authority: `docs/testing.md`
 - Architecture authority root: `docs/architecture/`
 
-## Canonical Boundaries
-
-- The repository-level documentation index is `docs/index.md`.
-- The canonical documentation structure is defined in
-  `docs/architecture/documentation_structure.md`.
-- The canonical setup path is documented in `docs/GETTING_STARTED.md`.
-- The canonical local runtime path is documented in `docs/local_run.md`.
-- The canonical testing path is documented in `docs/testing.md`.
-- The authoritative audited phase taxonomy is `docs/roadmap/execution_roadmap.md`.
-- The supported package-level public API for `src/api` is `from api import app`.
-- The canonical top-level repository structure is documented in `docs/architecture/repository_root_structure.md`.
-
-## Canonical Repository Structure
-
-The canonical root structure for this repository is defined in
-`docs/architecture/repository_root_structure.md`.
-
-For all future repository changes, the allowed top-level directories are:
-
-- `docs/`
-- `src/`
-- `tests/`
-- `scripts/` when repository-owned automation or developer tooling is required
-- `frontend/` when a repository-owned frontend surface is required
-- `fixtures/` when shared deterministic fixture data is required
-
-Top-level directories outside that set are not canonical destinations for new
-work unless a separate repository decision documents and approves them.
-
-This issue does not move, delete, or rename any existing top-level directories.
-Current extra root folders remain part of the repository's present state until a
-separate cleanup or migration issue addresses them.
-
-## Public API
-
-The Python package-level public API for `src/api` is frozen to a single supported symbol:
-
-- `from api import app`
-
-The full boundary definition is documented in `docs/api/public_api_boundary.md`.
-
 ## Verification Paths
 
 - Operators validating a local environment should start here, then follow
-  `docs/architecture/documentation_structure.md` to the canonical setup and
-  local run documents.
+  `docs/GETTING_STARTED.md` and `docs/local_run.md`.
 - Contributors or reviewers validating behavior and change scope should start
-  here, then use `docs/index.md` and
-  `docs/architecture/documentation_structure.md` to reach the canonical
-  testing and architecture documents.
+  here, then use `docs/testing.md` and `docs/architecture/`.
 
-## Local CI Check
+## Public API
 
-```bash
-python -m pytest -q
-```
+The supported package-level public API for `src/api` is documented in
+`docs/api/public_api_boundary.md`.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,14 +1,23 @@
 # Getting Started (Owner)
 
 ## A. Purpose
-This guide provides the single authoritative path for owners to start and access the application locally. Follow the steps in order to verify the API is running and then stop/reset it cleanly.
-The PowerShell path below is a first-class canonical local workflow for Windows.
+This guide provides the single authoritative setup path for local development.
+Use it to prepare the environment, install the repository, and then hand off to
+the canonical local-run or testing documents.
 
 ## B. Prerequisites
 - Python 3.12+
 - `pip`
+- Git installed
 
-## C. Single Authoritative Start Method (canonical)
+## C. Clone the Repository
+
+```bash
+git clone <repo-url>
+cd Trading-engine
+```
+
+## D. Single Authoritative Setup Method (canonical)
 From the repository root, run exactly:
 
 ### Bash (macOS/Linux)
@@ -17,7 +26,6 @@ From the repository root, run exactly:
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install -e ".[test]"
-PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
 ### PowerShell (Windows)
@@ -26,103 +34,18 @@ PYTHONPATH=src uvicorn api.main:app --reload
 python -m venv .venv
 .\.venv\Scripts\Activate.ps1
 python -m pip install -e ".[test]"
-$env:PYTHONPATH = "src"
-uvicorn api.main:app --reload
 ```
 
 The install step is canonical because it comes from the repository-controlled
 `pyproject.toml`. It replaces older requirements-file-based instructions.
 
-## D. Secondary / utility entrypoints (not canonical)
-- `PYTHONPATH=src python -m api.main`
-- `docker compose up --build`
+## E. Next Steps
 
-Use these only as alternatives. The canonical owner startup path is Section C.
+- To start and verify the local API, continue to `docs/local_run.md`.
+- To run the repository test suite, continue to `docs/testing.md`.
+- To run the deterministic smoke run, continue to `docs/smoke-run.md`.
 
-## E. Single Access Endpoint
-Use this endpoint to access the running application:
-
-- http://127.0.0.1:8000/health
-
-## F. Success Indicator
-The application is running when the endpoint returns exactly:
-
-```json
-{"status":"ok"}
-```
-
-Use the matching shell command in a second terminal:
-
-### Bash (macOS/Linux)
-
-```bash
-curl http://127.0.0.1:8000/health
-```
-
-### PowerShell (Windows)
-
-```powershell
-Invoke-RestMethod http://127.0.0.1:8000/health
-```
-
-## G. Clean Stop Procedure
-1. In the terminal where `uvicorn` is running, press `Ctrl+C` once.
-2. Wait until shutdown completes and the terminal prompt returns.
-3. Optional confirmation:
-
-### Bash (macOS/Linux)
-
-```bash
-curl --fail http://127.0.0.1:8000/health
-```
-
-### PowerShell (Windows)
-
-```powershell
-try {
-  Invoke-WebRequest http://127.0.0.1:8000/health -ErrorAction Stop | Out-Null
-  throw "API still running"
-} catch {
-  if ($_.Exception.Message -eq "API still running") { throw }
-}
-```
-
-After stopping `uvicorn`, the command exits non-zero because the endpoint is unreachable.
-
-## H. Reset Local Runtime State
-Run from repository root (local development only):
-
-### Bash (macOS/Linux)
-
-```bash
-rm -f cilly_trading.db
-```
-
-### PowerShell (Windows)
-
-```powershell
-Remove-Item .\cilly_trading.db -ErrorAction SilentlyContinue
-```
-
-On next API start, SQLite tables are recreated automatically.
-
-## I. Optional shell cleanup
-
-If you want to clear the session variable used by the canonical startup path:
-
-### Bash (macOS/Linux)
-
-```bash
-unset PYTHONPATH
-```
-
-### PowerShell (Windows)
-
-```powershell
-Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
-```
-
-## J. Troubleshooting
+## F. Troubleshooting
 - If `uvicorn: command not found` appears, activate the virtual environment again:
 
   Bash (macOS/Linux):
@@ -133,17 +56,4 @@ Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
   PowerShell (Windows):
   ```powershell
   .\.venv\Scripts\Activate.ps1
-  ```
-
-- If `/health` does not respond, confirm the start command is running exactly as documented:
-
-  Bash (macOS/Linux):
-  ```bash
-  PYTHONPATH=src uvicorn api.main:app --reload
-  ```
-
-  PowerShell (Windows):
-  ```powershell
-  $env:PYTHONPATH = "src"
-  uvicorn api.main:app --reload
   ```

--- a/docs/local_run.md
+++ b/docs/local_run.md
@@ -4,71 +4,10 @@ This document defines the canonical local run path for both PowerShell on
 Windows and Bash on macOS/Linux. The PowerShell commands below are first-class
 instructions, not translations of the Bash path.
 
-## TL;DR Quick Start (fresh local setup)
-
-### Bash (macOS/Linux)
-
-```bash
-python -m venv .venv
-source .venv/bin/activate
-python -m pip install -e ".[test]"
-PYTHONPATH=src uvicorn api.main:app --reload
-```
-
-### PowerShell (Windows)
-
-```powershell
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
-python -m pip install -e ".[test]"
-$env:PYTHONPATH = "src"
-uvicorn api.main:app --reload
-```
-
-In a second terminal:
-
-### Bash (macOS/Linux)
-
-```bash
-curl http://127.0.0.1:8000/health
-```
-
-### PowerShell (Windows)
-
-```powershell
-Invoke-RestMethod http://127.0.0.1:8000/health
-```
-
-Expected output:
-
-```json
-{"status":"ok"}
-```
-
 ## Prerequisites
 
-- Python 3.12+
-- `pip`
-
-## Canonical local setup path
-
-The canonical local dependency install path is the repository `pyproject.toml`:
-
-### Bash (macOS/Linux)
-
-```bash
-python -m pip install -e ".[test]"
-```
-
-### PowerShell (Windows)
-
-```powershell
-python -m pip install -e ".[test]"
-```
-
-Run it from the repository root after activating your virtual environment. This
-installs the project and the repo-defined test extra from files that are
-versioned in this repository.
+- Complete the canonical setup flow in `docs/GETTING_STARTED.md`.
+- Run commands from the repository root.
 
 ## Canonical startup path
 
@@ -114,39 +53,9 @@ for configuration precedence or validation ownership.
 
 There is no installed top-level project CLI command (for example `cilly-trading ...`).
 
-## Step-by-step (fresh clone -> analysis request -> persisted signals)
+## Step-by-step (ready environment -> analysis request -> persisted signals)
 
-1) **Create and activate a virtual environment**
-
-### Bash (macOS/Linux)
-
-```bash
-python -m venv .venv
-source .venv/bin/activate
-```
-
-### PowerShell (Windows)
-
-```powershell
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
-```
-
-2) **Install dependencies**
-
-### Bash (macOS/Linux)
-
-```bash
-python -m pip install -e ".[test]"
-```
-
-### PowerShell (Windows)
-
-```powershell
-python -m pip install -e ".[test]"
-```
-
-3) **Start the API (terminal A)**
+1) **Start the API (terminal A)**
 
 ### Bash (macOS/Linux)
 
@@ -161,7 +70,7 @@ $env:PYTHONPATH = "src"
 uvicorn api.main:app --reload
 ```
 
-4) **Verify API health (terminal B)**
+2) **Verify API health (terminal B)**
 
 ### Bash (macOS/Linux)
 
@@ -181,7 +90,7 @@ Expected output:
 {"status":"ok"}
 ```
 
-5) **Create a demo snapshot and capture `ingestion_run_id` (terminal B)**
+3) **Create a demo snapshot and capture `ingestion_run_id` (terminal B)**
 
 ### Bash (macOS/Linux)
 
@@ -202,7 +111,7 @@ Expected behavior:
 - command prints a UUID value
 - this value is required by snapshot-only analysis endpoints
 
-6) **Trigger strategy analysis using the created snapshot (terminal B)**
+4) **Trigger strategy analysis using the created snapshot (terminal B)**
 
 ### Bash (macOS/Linux)
 
@@ -249,7 +158,7 @@ Expected output shape:
 
 (`signals` may be empty or contain one/more signal objects depending on snapshot data.)
 
-7) **Verify persisted signals (terminal B)**
+5) **Verify persisted signals (terminal B)**
 
 ### Bash (macOS/Linux)
 
@@ -363,20 +272,6 @@ Remove-Item Env:PYTHONPATH -ErrorAction SilentlyContinue
 - Symptom: `{"detail":"invalid_ingestion_run_id"}`
 - Fix: provide a valid UUIDv4 string.
 
-## Run tests (optional)
-
-### Bash (macOS/Linux)
-
-```bash
-python -m pytest -q
-```
-
-### PowerShell (Windows)
-
-```powershell
-python -m pytest -q
-```
-
-See `docs/testing.md` for the canonical test setup and command, and see
-`docs/architecture/configuration_boundary.md` for the canonical configuration
-contract used by follow-up runtime-boundary work.
+For repository tests, use `docs/testing.md`. For the canonical configuration
+contract used by follow-up runtime-boundary work, see
+`docs/architecture/configuration_boundary.md`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,98 +1,24 @@
 # Quickstart - Cilly Trading Engine
 
-## 1. Prerequisites
-- Python 3.12+
-- Git installed
+This document is a navigation shortcut, not a source of truth. Follow the
+canonical documents below in order.
 
-## 2. Clone the Repository
-```bash
-git clone <repo-url>
-cd Trading-engine
-```
+## 1. Set Up the Repository
 
-## 3. Create Virtual Environment
+Use `docs/GETTING_STARTED.md` for the canonical clone, virtual environment, and
+dependency-install steps.
 
-### PowerShell (Windows)
-```powershell
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
-python -m pip install -U pip
-python -m pip install -e ".[test]"
-```
+## 2. Start and Verify the Local API
 
-### Bash (macOS/Linux)
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -U pip
-python -m pip install -e ".[test]"
-```
+Use `docs/local_run.md` for the canonical startup command, `/health`
+verification, API exercise flow, and reset procedure.
 
-The canonical dependency install path is the repository `pyproject.toml` via
-`python -m pip install -e ".[test]"`.
+## 3. Run the Deterministic Smoke Run
 
-## 4. Run Deterministic Smoke Test
+Use `docs/smoke-run.md` for the exact smoke-run command, expected output, and
+exit-code contract.
 
-### PowerShell
-```powershell
-$env:PYTHONPATH = "src"
-python -c "from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())"
-```
+## 4. Run the Test Suite
 
-### Bash
-```bash
-PYTHONPATH=src python -c 'from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())'
-```
-
-## 5. Expected Output (Exact)
-```text
-SMOKE_RUN:START
-SMOKE_RUN:FIXTURES_OK
-SMOKE_RUN:CHECKS_OK
-SMOKE_RUN:END
-```
-
-Exit code must be 0.
-Any deviation indicates a broken environment.
-
-## 6. Start the Local API
-
-Run this from the repository root after the virtual environment is active.
-
-### PowerShell (Windows)
-```powershell
-$env:PYTHONPATH = "src"
-uvicorn api.main:app --reload
-```
-
-### Bash (macOS/Linux)
-```bash
-PYTHONPATH=src uvicorn api.main:app --reload
-```
-
-This is the canonical local startup path documented in `docs/local_run.md`.
-
-## 7. Verify Local Health
-
-In a second terminal:
-
-### PowerShell (Windows)
-```powershell
-Invoke-RestMethod http://127.0.0.1:8000/health
-```
-
-### Bash (macOS/Linux)
-```bash
-curl http://127.0.0.1:8000/health
-```
-
-Expected output:
-
-```json
-{"status":"ok"}
-```
-
-## 8. Stop or Reset
-
-- Stop the running API with `Ctrl+C` in the terminal where `uvicorn` is running.
-- For a full local reset, see `docs/local_run.md` and `docs/GETTING_STARTED.md`.
+Use `docs/testing.md` for the canonical repository test command and links to
+specialized determinism and snapshot docs.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,40 +1,9 @@
 # Testing
 
-## Setup
+## Prerequisites
 
-1) Create and activate a virtualenv:
-
-### PowerShell (Windows)
-
-```powershell
-python -m venv .venv
-.\.venv\Scripts\Activate.ps1
-```
-
-### Bash (macOS/Linux)
-
-```bash
-python -m venv .venv
-source .venv/bin/activate
-```
-
-2) Install test dependencies:
-
-### PowerShell (Windows)
-
-```powershell
-python -m pip install -e ".[test]"
-```
-
-### Bash (macOS/Linux)
-
-```bash
-python -m pip install -e ".[test]"
-```
-
-This is the canonical test setup path because it uses the repository-controlled
-`pyproject.toml` and its `test` optional dependency group. Use Python 3.12+ to
-match the package metadata.
+- Complete the canonical setup flow in `docs/GETTING_STARTED.md`.
+- Use Python 3.12+ to match the package metadata.
 
 ## Run the test suite
 


### PR DESCRIPTION
Closes #685

## Summary
- reduce README and quickstart to navigation-only roles
- keep setup instructions canonical in docs/GETTING_STARTED.md
- keep runtime instructions canonical in docs/local_run.md
- keep repository test entry canonical in docs/testing.md

## Testing
- python -m pytest -q
- $env:PYTHONPATH = "src"; python -c "from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())"
