### PR TITLE
ENG-P40X: establish runtime hardening baseline

### DIFF
--- a/docs/operations/access-policy.md
+++ b/docs/operations/access-policy.md
@@ -34,7 +34,7 @@ This contract is normative for the current operator-facing routes defined in `sr
 - journal and audit inspection
 - execution control
 
-This contract does not cover `/ui` static assets or any future route that is not listed below. Runtime enforcement of this contract belongs in a separate implementation issue.
+This contract does not cover `/ui` static assets or any future route that is not listed below.
 
 ## Endpoint Permission Contract
 
@@ -66,6 +66,8 @@ All covered endpoints are protected. Anonymous access is out of contract. The mi
 | `POST` | `/strategy/analyze` | `mutating` | `operator` |
 | `POST` | `/analysis/run` | `mutating` | `operator` |
 | `POST` | `/screener/basic` | `mutating` | `operator` |
+| `POST` | `/execution/start` | `mutating` | `owner` |
+| `POST` | `/execution/stop` | `mutating` | `owner` |
 | `POST` | `/execution/pause` | `mutating` | `owner` |
 | `POST` | `/execution/resume` | `mutating` | `owner` |
 
@@ -73,7 +75,7 @@ Effective role permissions derived from the table:
 
 - `read_only` may call every listed `GET` endpoint and no listed `POST` endpoint.
 - `operator` may call every `read_only` endpoint plus `POST /strategy/analyze`, `POST /analysis/run`, and `POST /screener/basic`.
-- `owner` may call every covered endpoint, including `POST /execution/pause` and `POST /execution/resume`.
+- `owner` may call every covered endpoint, including `POST /execution/start`, `POST /execution/stop`, `POST /execution/pause`, and `POST /execution/resume`.
 
 ## Deterministic Denial Behavior
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -889,13 +889,13 @@ def _strategy_display_name(strategy_key: str) -> str:
 
 
 @app.get("/health")
-def health() -> Dict[str, str]:
+def health(_: str = Depends(_require_role("read_only"))) -> Dict[str, str]:
     _assert_phase_13_read_only_endpoint("/health")
     return _runtime_health_payload()
 
 
 @app.get("/health/engine")
-def health_engine() -> Dict[str, Any]:
+def health_engine(_: str = Depends(_require_role("read_only"))) -> Dict[str, Any]:
     payload = _runtime_health_payload()
     mode = payload["mode"]
     ready = mode in {"ready", "running", "paused"}
@@ -911,7 +911,7 @@ def health_engine() -> Dict[str, Any]:
 
 
 @app.get("/health/data")
-def health_data() -> Dict[str, Any]:
+def health_data(_: str = Depends(_require_role("read_only"))) -> Dict[str, Any]:
     checked_at = _health_now()
     db_path = Path(_resolve_analysis_db_path())
     ready = db_path.exists()
@@ -928,7 +928,7 @@ def health_data() -> Dict[str, Any]:
 
 
 @app.get("/health/guards")
-def health_guards() -> Dict[str, Any]:
+def health_guards(_: str = Depends(_require_role("read_only"))) -> Dict[str, Any]:
     checked_at = _health_now()
     guard_status = read_compliance_guard_status()
     blocking = guard_status.compliance.blocking
@@ -1099,7 +1099,7 @@ def read_compliance_guard_status(
 
 
 @app.get("/runtime/introspection", response_model=RuntimeIntrospectionResponse)
-def runtime_introspection() -> RuntimeIntrospectionResponse:
+def runtime_introspection(_: str = Depends(_require_role("read_only"))) -> RuntimeIntrospectionResponse:
     _assert_phase_13_read_only_endpoint("/runtime/introspection")
     payload = get_runtime_introspection_payload()
     payload.setdefault("extensions", [])
@@ -1189,7 +1189,9 @@ def _portfolio_position_response(
     summary="Portfolio Positions",
     description="Read-only current portfolio positions for operator inspection.",
 )
-def read_portfolio_positions() -> PortfolioPositionsResponse:
+def read_portfolio_positions(
+    _: str = Depends(_require_role("read_only")),
+) -> PortfolioPositionsResponse:
     state = load_portfolio_state_from_env()
     items = [_portfolio_position_response(position) for position in state.positions]
     return PortfolioPositionsResponse(positions=items, total=len(items))
@@ -1374,7 +1376,10 @@ def _to_watchlist_response(watchlist: Any) -> WatchlistResponse:
 
 
 @app.get("/ingestion/runs", response_model=List[IngestionRunItemResponse])
-def read_ingestion_runs(limit: int = Depends(_get_ingestion_runs_limit)) -> List[IngestionRunItemResponse]:
+def read_ingestion_runs(
+    limit: int = Depends(_get_ingestion_runs_limit),
+    _: str = Depends(_require_role("read_only")),
+) -> List[IngestionRunItemResponse]:
     rows = analysis_run_repo.list_ingestion_runs(limit=limit)
     return [IngestionRunItemResponse(**row) for row in rows]
 
@@ -1533,6 +1538,7 @@ def execute_watchlist(
 def read_journal_artifacts(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
+    _: str = Depends(_require_role("read_only")),
 ) -> JournalArtifactListResponse:
     files = _iter_journal_artifact_files()
     files.sort(key=lambda item: item[1].stat().st_mtime, reverse=True)
@@ -1558,7 +1564,11 @@ def read_journal_artifacts(
     "/journal/artifacts/{run_id}/{artifact_name}",
     response_model=JournalArtifactContentResponse,
 )
-def read_journal_artifact_content(run_id: str, artifact_name: str) -> JournalArtifactContentResponse:
+def read_journal_artifact_content(
+    run_id: str,
+    artifact_name: str,
+    _: str = Depends(_require_role("read_only")),
+) -> JournalArtifactContentResponse:
     path = _resolve_journal_artifact_path(run_id=run_id, artifact_name=artifact_name)
     content_type, content = _read_journal_artifact_content(path)
     return JournalArtifactContentResponse(
@@ -1573,6 +1583,7 @@ def read_journal_artifact_content(run_id: str, artifact_name: str) -> JournalArt
 def read_decision_trace(
     run_id: str = Query(..., min_length=1),
     artifact_name: str = Query(default="audit.json", min_length=1),
+    _: str = Depends(_require_role("read_only")),
 ) -> DecisionTraceResponse:
     path = _resolve_journal_artifact_path(run_id=run_id, artifact_name=artifact_name)
     _, content = _read_journal_artifact_content(path)
@@ -1587,7 +1598,7 @@ def read_decision_trace(
 
 
 @app.get("/strategies", response_model=StrategyMetadataResponse)
-def read_strategies() -> StrategyMetadataResponse:
+def read_strategies(_: str = Depends(_require_role("read_only"))) -> StrategyMetadataResponse:
     items: List[StrategyMetadataItemResponse] = []
     for strategy_key in get_registered_strategy_keys():
         default_config = default_strategy_configs.get(strategy_key, {})
@@ -1603,7 +1614,10 @@ def read_strategies() -> StrategyMetadataResponse:
 
 
 @app.get("/signals", response_model=SignalReadResponseDTO)
-def read_signals(params: SignalsReadQuery = Depends(_get_signals_query)) -> SignalReadResponseDTO:
+def read_signals(
+    params: SignalsReadQuery = Depends(_get_signals_query),
+    _: str = Depends(_require_role("read_only")),
+) -> SignalReadResponseDTO:
     effective_from = params.from_ or params.start
     effective_to = params.to or params.end
     items, total = signal_repo.read_signals(
@@ -1647,6 +1661,7 @@ def read_signals(params: SignalsReadQuery = Depends(_get_signals_query)) -> Sign
 @app.get("/execution/orders", response_model=ExecutionOrdersReadResponse)
 def read_execution_orders(
     params: ExecutionOrdersReadQuery = Depends(_get_execution_orders_query),
+    _: str = Depends(_require_role("read_only")),
 ) -> ExecutionOrdersReadResponse:
     items, total = order_event_repo.read_order_events(
         symbol=params.symbol,
@@ -1669,6 +1684,7 @@ def read_execution_orders(
 @app.get("/screener/v2/results", response_model=ScreenerResultsResponse)
 def read_screener_results(
     params: ScreenerResultsQuery = Depends(_get_screener_results_query),
+    _: str = Depends(_require_role("read_only")),
 ) -> ScreenerResultsResponse:
     items = signal_repo.read_screener_results(
         strategy=params.strategy,
@@ -1684,7 +1700,10 @@ def read_screener_results(
 
 
 @app.post("/strategy/analyze", response_model=StrategyAnalyzeResponse)
-def analyze_strategy(req: StrategyAnalyzeRequest) -> StrategyAnalyzeResponse:
+def analyze_strategy(
+    req: StrategyAnalyzeRequest,
+    _: str = Depends(_require_role("operator")),
+) -> StrategyAnalyzeResponse:
     logger.info(
         "Strategy analyze start: symbol=%s strategy=%s market_type=%s lookback_days=%s",
         req.symbol,
@@ -1876,7 +1895,10 @@ def manual_analysis(
 
 
 @app.post("/screener/basic", response_model=ScreenerResponse)
-def basic_screener(req: ScreenerRequest) -> ScreenerResponse:
+def basic_screener(
+    req: ScreenerRequest,
+    _: str = Depends(_require_role("operator")),
+) -> ScreenerResponse:
     _require_ingestion_run(req.ingestion_run_id)
     if req.symbols is None or len(req.symbols) == 0:
         if req.market_type == "stock":

--- a/src/api/test_execution_control_api.py
+++ b/src/api/test_execution_control_api.py
@@ -21,7 +21,7 @@ def teardown_function() -> None:
 def test_execution_pause_endpoint_pauses_runtime_and_updates_state_views() -> None:
     with TestClient(api_main.app) as client:
         pause_response = client.post('/execution/pause', headers=OWNER_HEADERS)
-        introspection_response = client.get('/runtime/introspection')
+        introspection_response = client.get('/runtime/introspection', headers=READ_ONLY_HEADERS)
         system_state_response = client.get('/system/state', headers=READ_ONLY_HEADERS)
 
     assert pause_response.status_code == 200
@@ -124,7 +124,7 @@ def test_execution_stop_endpoint_requires_authenticated_role() -> None:
 def test_execution_pause_endpoint_forbids_operator_role_without_side_effect() -> None:
     with TestClient(api_main.app) as client:
         response = client.post('/execution/pause', headers=OPERATOR_HEADERS)
-        introspection_response = client.get('/runtime/introspection')
+        introspection_response = client.get('/runtime/introspection', headers=READ_ONLY_HEADERS)
         system_state_response = client.get('/system/state', headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 403
@@ -138,7 +138,7 @@ def test_execution_pause_endpoint_forbids_operator_role_without_side_effect() ->
 def test_execution_start_endpoint_forbids_operator_role_without_side_effect() -> None:
     with TestClient(api_main.app) as client:
         response = client.post('/execution/start', headers=OPERATOR_HEADERS)
-        introspection_response = client.get('/runtime/introspection')
+        introspection_response = client.get('/runtime/introspection', headers=READ_ONLY_HEADERS)
         system_state_response = client.get('/system/state', headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 403
@@ -152,7 +152,7 @@ def test_execution_start_endpoint_forbids_operator_role_without_side_effect() ->
 def test_execution_stop_endpoint_forbids_operator_role_without_side_effect() -> None:
     with TestClient(api_main.app) as client:
         response = client.post('/execution/stop', headers=OPERATOR_HEADERS)
-        introspection_response = client.get('/runtime/introspection')
+        introspection_response = client.get('/runtime/introspection', headers=READ_ONLY_HEADERS)
         system_state_response = client.get('/system/state', headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 403
@@ -161,3 +161,11 @@ def test_execution_stop_endpoint_forbids_operator_role_without_side_effect() -> 
     assert introspection_response.json()['mode'] == 'running'
     assert system_state_response.status_code == 200
     assert system_state_response.json()['status'] == 'running'
+
+
+def test_runtime_introspection_requires_authenticated_role() -> None:
+    with TestClient(api_main.app) as client:
+        response = client.get('/runtime/introspection')
+
+    assert response.status_code == 401
+    assert response.json() == {'detail': 'unauthorized'}

--- a/src/api/test_journal_trace_api.py
+++ b/src/api/test_journal_trace_api.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _write_artifact(root: Path, run_id: str, artifact_name: str, payload: object) -> None:
     run_dir = root / run_id
@@ -27,7 +29,7 @@ def test_journal_artifacts_endpoint_lists_available_artifacts(monkeypatch, tmp_p
     monkeypatch.setattr(api_main, "JOURNAL_ARTIFACTS_ROOT", artifacts_root)
 
     with TestClient(api_main.app) as client:
-        response = client.get("/journal/artifacts")
+        response = client.get("/journal/artifacts", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     payload = response.json()
@@ -62,6 +64,7 @@ def test_decision_trace_endpoint_returns_trace_entries_from_artifact(
     with TestClient(api_main.app) as client:
         response = client.get(
             "/journal/decision-trace",
+            headers=READ_ONLY_HEADERS,
             params={"run_id": "run-trace", "artifact_name": "decision_trace.json"},
         )
 
@@ -72,4 +75,3 @@ def test_decision_trace_endpoint_returns_trace_entries_from_artifact(
     assert payload["total_entries"] == 2
     assert payload["entries"][0]["step"] == "risk_check"
     assert payload["entries"][1]["reason"] == "approved"
-

--- a/src/api/test_operator_workbench_surface.py
+++ b/src/api/test_operator_workbench_surface.py
@@ -4,6 +4,8 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def test_operator_workbench_ui_surface_is_reachable(monkeypatch) -> None:
     def _start() -> str:
@@ -73,7 +75,7 @@ def test_operator_workbench_strategy_metadata_read_api(monkeypatch) -> None:
     monkeypatch.setattr(api_main, "start_engine_runtime", _start)
 
     with TestClient(api_main.app) as client:
-        response = client.get("/strategies")
+        response = client.get("/strategies", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     payload = response.json()

--- a/src/cilly_trading/repositories/analysis_runs_sqlite.py
+++ b/src/cilly_trading/repositories/analysis_runs_sqlite.py
@@ -149,29 +149,54 @@ class SqliteAnalysisRunRepository:
             request_payload: Request-Daten als JSON-serialisierbares Dict.
             result_payload: Ergebnis-Daten als JSON-serialisierbares Dict.
         """
+        serialized_request = json.dumps(request_payload, sort_keys=True)
+        serialized_result = json.dumps(result_payload, sort_keys=True)
         conn = self._get_connection()
-        cur = conn.cursor()
-        cur.execute(
-            """
-            INSERT INTO analysis_runs (
-                analysis_run_id,
-                ingestion_run_id,
-                request_payload,
-                result_payload,
-                created_at
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO analysis_runs (
+                    analysis_run_id,
+                    ingestion_run_id,
+                    request_payload,
+                    result_payload,
+                    created_at
+                )
+                VALUES (?, ?, ?, ?, ?);
+                """,
+                (
+                    analysis_run_id,
+                    ingestion_run_id,
+                    serialized_request,
+                    serialized_result,
+                    datetime.now(timezone.utc).isoformat(),
+                ),
             )
-            VALUES (?, ?, ?, ?, ?);
-            """,
-            (
-                analysis_run_id,
-                ingestion_run_id,
-                json.dumps(request_payload, sort_keys=True),
-                json.dumps(result_payload, sort_keys=True),
-                datetime.now(timezone.utc).isoformat(),
-            ),
-        )
-        conn.commit()
-        conn.close()
+            conn.commit()
+        except sqlite3.IntegrityError:
+            conn.rollback()
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT ingestion_run_id, request_payload, result_payload
+                FROM analysis_runs
+                WHERE analysis_run_id = ?;
+                """,
+                (analysis_run_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise
+            if (
+                row["ingestion_run_id"] == ingestion_run_id
+                and row["request_payload"] == serialized_request
+                and row["result_payload"] == serialized_result
+            ):
+                return
+            raise ValueError("analysis_run_id already exists with different persisted payload")
+        finally:
+            conn.close()
 
     def save_analysis_run(
         self,

--- a/tests/api/test_health_endpoints_api.py
+++ b/tests/api/test_health_endpoints_api.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _runtime_payload(mode: str = "running") -> dict[str, object]:
     return {
@@ -28,7 +30,7 @@ def test_health_engine_reports_runtime_readiness(monkeypatch) -> None:
     monkeypatch.setattr(api_main, "_health_now", lambda: fixed_now)
 
     with TestClient(api_main.app) as client:
-        response = client.get("/health/engine")
+        response = client.get("/health/engine", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json() == {
@@ -50,7 +52,7 @@ def test_health_data_reports_unavailable_when_data_source_is_missing(monkeypatch
     monkeypatch.setattr(api_main, "_health_now", lambda: fixed_now)
 
     with TestClient(api_main.app) as client:
-        response = client.get("/health/data")
+        response = client.get("/health/data", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json() == {
@@ -70,7 +72,7 @@ def test_health_guards_reports_blocking_state(monkeypatch) -> None:
     monkeypatch.setenv("CILLY_EXECUTION_KILL_SWITCH_ACTIVE", "true")
 
     with TestClient(api_main.app) as client:
-        response = client.get("/health/guards")
+        response = client.get("/health/guards", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json() == {
@@ -101,6 +103,6 @@ def test_health_endpoints_are_deterministic_for_identical_state(monkeypatch, tmp
 
     with TestClient(api_main.app) as client:
         for path in ("/health", "/health/engine", "/health/data", "/health/guards"):
-            first = client.get(path).json()
-            second = client.get(path).json()
+            first = client.get(path, headers=READ_ONLY_HEADERS).json()
+            second = client.get(path, headers=READ_ONLY_HEADERS).json()
             assert first == second

--- a/tests/cilly_trading/engine/test_observability_integration.py
+++ b/tests/cilly_trading/engine/test_observability_integration.py
@@ -33,6 +33,8 @@ from cilly_trading.engine.telemetry.emitter import (
     reset_telemetry_emission_for_tests,
 )
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _load_provider_module():
     root = Path(__file__).resolve().parents[3]
@@ -232,10 +234,10 @@ def _configure_health_environment(
 def _read_health_payloads() -> dict[str, dict[str, Any]]:
     with TestClient(api_main.app) as client:
         return {
-            "/health": client.get("/health").json(),
-            "/health/engine": client.get("/health/engine").json(),
-            "/health/data": client.get("/health/data").json(),
-            "/health/guards": client.get("/health/guards").json(),
+            "/health": client.get("/health", headers=READ_ONLY_HEADERS).json(),
+            "/health/engine": client.get("/health/engine", headers=READ_ONLY_HEADERS).json(),
+            "/health/data": client.get("/health/data", headers=READ_ONLY_HEADERS).json(),
+            "/health/guards": client.get("/health/guards", headers=READ_ONLY_HEADERS).json(),
         }
 
 

--- a/tests/test_api_execution_orders_read.py
+++ b/tests/test_api_execution_orders_read.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 import api.main as api_main
 from api.order_events_sqlite import SqliteOrderEventRepository
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _make_repo(tmp_path: Path) -> SqliteOrderEventRepository:
     db_path = tmp_path / "order_events.db"
@@ -44,7 +46,11 @@ def test_execution_orders_api_contract(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
     monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
     with TestClient(api_main.app) as client:
-        response = client.get("/execution/orders", params={"limit": 10, "offset": 0})
+        response = client.get(
+            "/execution/orders",
+            headers=READ_ONLY_HEADERS,
+            params={"limit": 10, "offset": 0},
+        )
         openapi = client.get("/openapi.json").json()
 
     assert response.status_code == 200
@@ -92,8 +98,8 @@ def test_execution_orders_are_deterministically_sorted(tmp_path: Path, monkeypat
     monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
     monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
     with TestClient(api_main.app) as client:
-        first = client.get("/execution/orders")
-        second = client.get("/execution/orders")
+        first = client.get("/execution/orders", headers=READ_ONLY_HEADERS)
+        second = client.get("/execution/orders", headers=READ_ONLY_HEADERS)
 
     assert first.status_code == 200
     assert second.status_code == 200
@@ -135,12 +141,17 @@ def test_execution_orders_filtering_and_pagination(tmp_path: Path, monkeypatch) 
     monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
     monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
     with TestClient(api_main.app) as client:
-        by_symbol = client.get("/execution/orders", params={"symbol": "AAPL"})
-        by_strategy = client.get("/execution/orders", params={"strategy": "RSI2"})
-        by_run = client.get("/execution/orders", params={"run_id": "run-1"})
-        by_order = client.get("/execution/orders", params={"order_id": "a-1"})
+        by_symbol = client.get("/execution/orders", headers=READ_ONLY_HEADERS, params={"symbol": "AAPL"})
+        by_strategy = client.get(
+            "/execution/orders",
+            headers=READ_ONLY_HEADERS,
+            params={"strategy": "RSI2"},
+        )
+        by_run = client.get("/execution/orders", headers=READ_ONLY_HEADERS, params={"run_id": "run-1"})
+        by_order = client.get("/execution/orders", headers=READ_ONLY_HEADERS, params={"order_id": "a-1"})
         paged = client.get(
             "/execution/orders",
+            headers=READ_ONLY_HEADERS,
             params={"symbol": "AAPL", "strategy": "RSI2", "limit": 1, "offset": 1},
         )
 
@@ -172,3 +183,16 @@ def test_execution_orders_filtering_and_pagination(tmp_path: Path, monkeypatch) 
     assert paged_payload["limit"] == 1
     assert paged_payload["offset"] == 1
     assert len(paged_payload["items"]) == 1
+
+
+def test_execution_orders_require_authenticated_role(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "order_event_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/execution/orders")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "unauthorized"}

--- a/tests/test_api_ingestion_runs_read.py
+++ b/tests/test_api_ingestion_runs_read.py
@@ -8,6 +8,8 @@ from fastapi.testclient import TestClient
 import api.main as api_main
 from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _insert_ingestion_run(
     db_path: Path,
@@ -61,7 +63,7 @@ def test_ingestion_runs_ordering_and_limit(monkeypatch, tmp_path: Path) -> None:
 
     client = TestClient(api_main.app)
 
-    response = client.get("/ingestion/runs", params={"limit": 2})
+    response = client.get("/ingestion/runs", headers=READ_ONLY_HEADERS, params={"limit": 2})
     assert response.status_code == 200
 
     payload = response.json()
@@ -95,11 +97,11 @@ def test_ingestion_runs_limit_defaults_and_caps(monkeypatch, tmp_path: Path) -> 
 
     client = TestClient(api_main.app)
 
-    default_response = client.get("/ingestion/runs")
+    default_response = client.get("/ingestion/runs", headers=READ_ONLY_HEADERS)
     assert default_response.status_code == 200
     assert len(default_response.json()) == 20
 
-    capped_response = client.get("/ingestion/runs", params={"limit": 200})
+    capped_response = client.get("/ingestion/runs", headers=READ_ONLY_HEADERS, params={"limit": 200})
     assert capped_response.status_code == 200
     capped_payload = capped_response.json()
     assert len(capped_payload) == 100

--- a/tests/test_api_manual_analysis_trigger.py
+++ b/tests/test_api_manual_analysis_trigger.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 import api.main as api_main
@@ -425,3 +426,72 @@ def test_manual_analysis_strategy_config_float_idempotent(
     assert response_third.status_code == 200
     third_body = response_third.json()
     assert third_body["analysis_run_id"] != first_body["analysis_run_id"]
+
+
+def test_manual_analysis_requires_authenticated_role(tmp_path: Path, monkeypatch) -> None:
+    signal_repo = _make_signal_repo(tmp_path)
+    analysis_repo = _make_analysis_repo(tmp_path)
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
+
+    client = TestClient(api_main.app)
+    response = client.post(
+        "/analysis/run",
+        json={
+            "ingestion_run_id": str(uuid.uuid4()),
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "market_type": "stock",
+            "lookback_days": 200,
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "unauthorized"}
+
+
+def test_analysis_run_repository_duplicate_save_is_idempotent(tmp_path: Path) -> None:
+    repo = _make_analysis_repo(tmp_path)
+    run_id = "run-001"
+    request_payload = {"symbol": "AAPL", "strategy": "RSI2"}
+    result_payload = {"analysis_run_id": run_id, "signals": []}
+
+    repo.save_run(
+        analysis_run_id=run_id,
+        ingestion_run_id="ingestion-001",
+        request_payload=request_payload,
+        result_payload=result_payload,
+    )
+    repo.save_run(
+        analysis_run_id=run_id,
+        ingestion_run_id="ingestion-001",
+        request_payload=request_payload,
+        result_payload=result_payload,
+    )
+
+    saved = repo.get_run(run_id)
+    assert saved is not None
+    assert saved["ingestion_run_id"] == "ingestion-001"
+    assert saved["request"] == request_payload
+    assert saved["result"] == result_payload
+
+
+def test_analysis_run_repository_rejects_conflicting_duplicate_save(tmp_path: Path) -> None:
+    repo = _make_analysis_repo(tmp_path)
+    run_id = "run-001"
+
+    repo.save_run(
+        analysis_run_id=run_id,
+        ingestion_run_id="ingestion-001",
+        request_payload={"symbol": "AAPL", "strategy": "RSI2"},
+        result_payload={"analysis_run_id": run_id, "signals": []},
+    )
+
+    with pytest.raises(ValueError, match="analysis_run_id already exists"):
+        repo.save_run(
+            analysis_run_id=run_id,
+            ingestion_run_id="ingestion-002",
+            request_payload={"symbol": "MSFT", "strategy": "RSI2"},
+            result_payload={"analysis_run_id": run_id, "signals": [{"symbol": "MSFT"}]},
+        )

--- a/tests/test_api_portfolio_positions_read.py
+++ b/tests/test_api_portfolio_positions_read.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 import api.main as api_main
 from tests.utils.json_schema_validator import validate_json_schema
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _test_client(monkeypatch: object) -> TestClient:
     monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
@@ -33,7 +35,7 @@ def test_portfolio_positions_returns_current_positions(monkeypatch) -> None:
     monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
 
     with _test_client(monkeypatch) as client:
-        response = client.get("/portfolio/positions")
+        response = client.get("/portfolio/positions", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     payload = response.json()
@@ -69,7 +71,7 @@ def test_portfolio_positions_response_schema(monkeypatch) -> None:
     monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
 
     with _test_client(monkeypatch) as client:
-        payload = client.get("/portfolio/positions").json()
+        payload = client.get("/portfolio/positions", headers=READ_ONLY_HEADERS).json()
 
     schema = api_main.PortfolioPositionsResponse.model_json_schema()
     errors = validate_json_schema(payload, schema)
@@ -103,8 +105,8 @@ def test_portfolio_positions_output_is_deterministic(monkeypatch) -> None:
     monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
 
     with _test_client(monkeypatch) as client:
-        first = client.get("/portfolio/positions")
-        second = client.get("/portfolio/positions")
+        first = client.get("/portfolio/positions", headers=READ_ONLY_HEADERS)
+        second = client.get("/portfolio/positions", headers=READ_ONLY_HEADERS)
 
     assert first.status_code == 200
     assert second.status_code == 200

--- a/tests/test_api_screener_results_read.py
+++ b/tests/test_api_screener_results_read.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 import api.main as api_main
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _make_repo(tmp_path: Path) -> SqliteSignalRepository:
     db_path = tmp_path / "screener_results.db"
@@ -48,6 +50,7 @@ def test_read_screener_results_ordering_and_min_score(tmp_path: Path, monkeypatc
 
     response = client.get(
         "/screener/v2/results",
+        headers=READ_ONLY_HEADERS,
         params={
             "strategy": "RSI2",
             "timeframe": "D1",
@@ -85,6 +88,7 @@ def test_read_screener_results_filters_strategy_and_timeframe(
 
     response = client.get(
         "/screener/v2/results",
+        headers=READ_ONLY_HEADERS,
         params={
             "strategy": "TURTLE",
             "timeframe": "H1",
@@ -95,3 +99,17 @@ def test_read_screener_results_filters_strategy_and_timeframe(
 
     assert payload["total"] == 3
     assert [item["symbol"] for item in payload["items"]] == ["AAC", "BBB", "AAA"]
+
+
+def test_read_screener_results_requires_authenticated_role(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "signal_repo", repo)
+    client = TestClient(api_main.app)
+
+    response = client.get(
+        "/screener/v2/results",
+        params={"strategy": "RSI2", "timeframe": "D1"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "unauthorized"}

--- a/tests/test_api_signals_read.py
+++ b/tests/test_api_signals_read.py
@@ -8,6 +8,8 @@ import api.main as api_main
 from api.config import SIGNALS_READ_MAX_LIMIT
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _make_repo(tmp_path: Path) -> SqliteSignalRepository:
     db_path = tmp_path / "signals_read.db"
@@ -47,6 +49,7 @@ def test_read_signals_happy_path(tmp_path: Path, monkeypatch) -> None:
 
     response = client.get(
         "/signals",
+        headers=READ_ONLY_HEADERS,
         params={
             "symbol": "AAPL",
             "from": "2025-01-01T00:00:00+00:00",
@@ -68,6 +71,7 @@ def test_read_signals_happy_path(tmp_path: Path, monkeypatch) -> None:
 
     response_desc = client.get(
         "/signals",
+        headers=READ_ONLY_HEADERS,
         params={
             "symbol": "AAPL",
             "sort": "created_at_desc",
@@ -90,7 +94,7 @@ def test_read_signals_empty_result(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(api_main, "signal_repo", repo)
     client = TestClient(api_main.app)
 
-    response = client.get("/signals", params={"symbol": "MISSING"})
+    response = client.get("/signals", headers=READ_ONLY_HEADERS, params={"symbol": "MISSING"})
     assert response.status_code == 200
     payload = response.json()
     assert payload["items"] == []
@@ -108,7 +112,7 @@ def test_read_signals_invalid_params(tmp_path: Path, monkeypatch) -> None:
         {"limit": 0},
         {"from": "2025-01-02T00:00:00+00:00", "to": "2025-01-01T00:00:00+00:00"},
     ]:
-        response = client.get("/signals", params=params)
+        response = client.get("/signals", headers=READ_ONLY_HEADERS, params=params)
         assert response.status_code == 422
 
 
@@ -119,7 +123,7 @@ def test_read_signals_limit_boundary(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(api_main, "signal_repo", repo)
     client = TestClient(api_main.app)
 
-    response = client.get("/signals", params={"limit": SIGNALS_READ_MAX_LIMIT})
+    response = client.get("/signals", headers=READ_ONLY_HEADERS, params={"limit": SIGNALS_READ_MAX_LIMIT})
     assert response.status_code == 200
 
 
@@ -136,7 +140,11 @@ def test_read_signals_time_filters_start_end(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setattr(api_main, "signal_repo", repo)
     client = TestClient(api_main.app)
 
-    response_start = client.get("/signals", params={"start": "2025-01-02T00:00:00+00:00"})
+    response_start = client.get(
+        "/signals",
+        headers=READ_ONLY_HEADERS,
+        params={"start": "2025-01-02T00:00:00+00:00"},
+    )
     assert response_start.status_code == 200
     payload_start = response_start.json()
     assert payload_start["total"] == 2
@@ -145,7 +153,11 @@ def test_read_signals_time_filters_start_end(tmp_path: Path, monkeypatch) -> Non
         "2025-01-02T00:00:00+00:00",
     ]
 
-    response_end = client.get("/signals", params={"end": "2025-01-02T00:00:00+00:00"})
+    response_end = client.get(
+        "/signals",
+        headers=READ_ONLY_HEADERS,
+        params={"end": "2025-01-02T00:00:00+00:00"},
+    )
     assert response_end.status_code == 200
     payload_end = response_end.json()
     assert payload_end["total"] == 2
@@ -156,6 +168,7 @@ def test_read_signals_time_filters_start_end(tmp_path: Path, monkeypatch) -> Non
 
     response_range = client.get(
         "/signals",
+        headers=READ_ONLY_HEADERS,
         params={
             "start": "2025-01-02T00:00:00+00:00",
             "end": "2025-01-02T00:00:00+00:00",
@@ -180,7 +193,11 @@ def test_read_signals_filters_strategy_and_preset(tmp_path: Path, monkeypatch) -
     monkeypatch.setattr(api_main, "signal_repo", repo)
     client = TestClient(api_main.app)
 
-    response = client.get("/signals", params={"strategy": "RSI2", "preset": "H1"})
+    response = client.get(
+        "/signals",
+        headers=READ_ONLY_HEADERS,
+        params={"strategy": "RSI2", "preset": "H1"},
+    )
     assert response.status_code == 200
     payload = response.json()
     assert payload["total"] == 1
@@ -199,9 +216,20 @@ def test_read_signals_default_limit_applied(tmp_path: Path, monkeypatch) -> None
     monkeypatch.setattr(api_main, "signal_repo", repo)
     client = TestClient(api_main.app)
 
-    response = client.get("/signals")
+    response = client.get("/signals", headers=READ_ONLY_HEADERS)
     assert response.status_code == 200
     payload = response.json()
     assert payload["limit"] == 50
     assert payload["total"] == 60
     assert len(payload["items"]) == 50
+
+
+def test_read_signals_requires_authenticated_role(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "signal_repo", repo)
+    client = TestClient(api_main.app)
+
+    response = client.get("/signals")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "unauthorized"}

--- a/tests/test_api_smoke_engine_db_api.py
+++ b/tests/test_api_smoke_engine_db_api.py
@@ -11,6 +11,8 @@ from cilly_trading.engine.core import EngineConfig, run_watchlist_analysis
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 from cilly_trading.strategies.rsi2 import Rsi2Strategy
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 def _make_repo(tmp_path: Path) -> SqliteSignalRepository:
     db_path = tmp_path / "api_smoke.db"
@@ -68,7 +70,11 @@ def test_api_smoke_engine_db_api(tmp_path: Path, monkeypatch) -> None:
     assert len(signals) >= 1
 
     client = TestClient(api_main.app)
-    response = client.get("/signals", params={"symbol": "AAPL", "strategy": "RSI2"})
+    response = client.get(
+        "/signals",
+        headers=READ_ONLY_HEADERS,
+        params={"symbol": "AAPL", "strategy": "RSI2"},
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -88,7 +94,7 @@ def test_api_smoke_signals_empty(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(api_main, "signal_repo", repo)
 
     client = TestClient(api_main.app)
-    response = client.get("/signals")
+    response = client.get("/signals", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     payload = response.json()

--- a/tests/test_api_snapshot_first_enforcement.py
+++ b/tests/test_api_snapshot_first_enforcement.py
@@ -104,6 +104,7 @@ def test_strategy_analyze_requires_ingestion_run_id() -> None:
     client = TestClient(api_main.app)
     response = client.post(
         "/strategy/analyze",
+        headers=OPERATOR_HEADERS,
         json={
             "symbol": "AAPL",
             "strategy": "RSI2",
@@ -119,6 +120,7 @@ def test_screener_basic_requires_ingestion_run_id() -> None:
     client = TestClient(api_main.app)
     response = client.post(
         "/screener/basic",
+        headers=OPERATOR_HEADERS,
         json={
             "market_type": "stock",
             "lookback_days": 200,
@@ -169,6 +171,7 @@ def test_strategy_analyze_accepts_valid_ingestion_run_id(tmp_path: Path, monkeyp
     client = TestClient(api_main.app)
     response = client.post(
         "/strategy/analyze",
+        headers=OPERATOR_HEADERS,
         json={
             "ingestion_run_id": ingestion_run_id,
             "symbol": "AAPL",
@@ -212,6 +215,7 @@ def test_strategy_analyze_rejects_missing_snapshot(tmp_path: Path, monkeypatch) 
     client = TestClient(api_main.app)
     response = client.post(
         "/strategy/analyze",
+        headers=OPERATOR_HEADERS,
         json={
             "ingestion_run_id": ingestion_run_id,
             "symbol": "AAPL",
@@ -260,6 +264,7 @@ def test_strategy_analyze_rejects_invalid_snapshot_rows(tmp_path: Path, monkeypa
     client = TestClient(api_main.app)
     response = client.post(
         "/strategy/analyze",
+        headers=OPERATOR_HEADERS,
         json={
             "ingestion_run_id": ingestion_run_id,
             "symbol": "AAPL",
@@ -312,6 +317,7 @@ def test_screener_basic_rejects_partial_snapshots(tmp_path: Path, monkeypatch) -
     client = TestClient(api_main.app)
     response = client.post(
         "/screener/basic",
+        headers=OPERATOR_HEADERS,
         json={
             "ingestion_run_id": ingestion_run_id,
             "market_type": "stock",
@@ -365,6 +371,7 @@ def test_screener_basic_accepts_ready_snapshots(tmp_path: Path, monkeypatch) -> 
     client = TestClient(api_main.app)
     response = client.post(
         "/screener/basic",
+        headers=OPERATOR_HEADERS,
         json={
             "ingestion_run_id": ingestion_run_id,
             "market_type": "stock",

--- a/tests/test_api_strategy_analyze_presets.py
+++ b/tests/test_api_strategy_analyze_presets.py
@@ -13,6 +13,8 @@ from cilly_trading.engine import core as engine_core
 from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 
+OPERATOR_HEADERS = {api_main.ROLE_HEADER_NAME: "operator"}
+
 
 def _make_repo(tmp_path: Path) -> SqliteSignalRepository:
     db_path = tmp_path / "strategy_analyze.db"
@@ -133,7 +135,7 @@ def test_strategy_analyze_multi_presets_returns_results(tmp_path: Path, monkeypa
         "strategy_config": {"oversold_threshold": 15.0},
     }
 
-    response = client.post("/strategy/analyze", json=payload)
+    response = client.post("/strategy/analyze", headers=OPERATOR_HEADERS, json=payload)
 
     assert response.status_code == 200
     data = response.json()
@@ -162,7 +164,7 @@ def test_strategy_analyze_duplicate_preset_ids_rejected(
         "preset_ids": ["dup", "dup"],
     }
 
-    response = client.post("/strategy/analyze", json=payload)
+    response = client.post("/strategy/analyze", headers=OPERATOR_HEADERS, json=payload)
 
     assert response.status_code == 422
 
@@ -182,7 +184,7 @@ def test_strategy_analyze_missing_preset_id_rejected(
         "preset_ids": [],
     }
 
-    response = client.post("/strategy/analyze", json=payload)
+    response = client.post("/strategy/analyze", headers=OPERATOR_HEADERS, json=payload)
 
     assert response.status_code == 422
 
@@ -200,8 +202,8 @@ def test_strategy_analyze_deterministic_output(tmp_path: Path, monkeypatch) -> N
         "strategy_config": {"oversold_threshold": 15.0},
     }
 
-    response_one = client.post("/strategy/analyze", json=payload)
-    response_two = client.post("/strategy/analyze", json=payload)
+    response_one = client.post("/strategy/analyze", headers=OPERATOR_HEADERS, json=payload)
+    response_two = client.post("/strategy/analyze", headers=OPERATOR_HEADERS, json=payload)
 
     assert response_one.status_code == 200
     assert response_two.status_code == 200
@@ -223,7 +225,7 @@ def test_strategy_analyze_single_preset_backwards_compatible(
         "strategy_config": {"oversold_threshold": 15.0},
     }
 
-    response = client.post("/strategy/analyze", json=payload)
+    response = client.post("/strategy/analyze", headers=OPERATOR_HEADERS, json=payload)
 
     assert response.status_code == 200
     data = response.json()

--- a/tests/test_phase13_read_only_enforcement.py
+++ b/tests/test_phase13_read_only_enforcement.py
@@ -9,6 +9,8 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 @dataclass
 class _RuntimeStateStub:
@@ -89,7 +91,7 @@ def test_phase13_endpoints_are_side_effect_free(path: str, monkeypatch: pytest.M
     detector.capture_before()
 
     with TestClient(api_main.app) as client:
-        response = client.get(path)
+        response = client.get(path, headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     detector.assert_no_side_effects()

--- a/tests/test_runtime_introspection.py
+++ b/tests/test_runtime_introspection.py
@@ -5,6 +5,8 @@ import api.main as api_main
 from cilly_trading.engine.observability_extensions import RuntimeObservabilityRegistry
 import cilly_trading.engine.runtime_introspection as runtime_introspection
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 class _RuntimeStateStub:
     def __init__(self, state: str) -> None:
@@ -34,8 +36,8 @@ def test_runtime_introspection_contract_is_explicit_and_stable(monkeypatch) -> N
     monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
 
     with TestClient(api_main.app) as client:
-        first = client.get("/runtime/introspection")
-        second = client.get("/runtime/introspection")
+        first = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
+        second = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
 
     assert first.status_code == 200
     assert second.status_code == 200
@@ -97,7 +99,7 @@ def test_runtime_introspection_triggers_no_persistence_writes(monkeypatch) -> No
     monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
 
     with TestClient(api_main.app) as client:
-        response = client.get("/runtime/introspection")
+        response = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
 
@@ -111,6 +113,6 @@ def test_runtime_introspection_is_deterministic_across_repeated_calls(monkeypatc
     monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
 
     with TestClient(api_main.app) as client:
-        payloads = [client.get("/runtime/introspection").json() for _ in range(5)]
+        payloads = [client.get("/runtime/introspection", headers=READ_ONLY_HEADERS).json() for _ in range(5)]
 
     assert payloads[0] == payloads[1] == payloads[2] == payloads[3] == payloads[4]

--- a/tests/test_runtime_introspection_snapshot.py
+++ b/tests/test_runtime_introspection_snapshot.py
@@ -10,6 +10,8 @@ import api.main as api_main
 import cilly_trading.engine.runtime_introspection as runtime_introspection
 from cilly_trading.engine.observability_extensions import RuntimeObservabilityRegistry
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 class _RuntimeStateStub:
     def __init__(self, state: str) -> None:
@@ -37,7 +39,7 @@ def test_runtime_introspection_snapshot_with_extensions(monkeypatch) -> None:
     )
 
     with TestClient(api_main.app) as client:
-        payload = client.get("/runtime/introspection").json()
+        payload = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS).json()
 
     snapshot_path = Path(__file__).parent / "fixtures" / "runtime_introspection_snapshot.json"
     expected = json.loads(snapshot_path.read_text())

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -15,6 +15,7 @@ from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 
 OWNER_HEADERS = {api_main.ROLE_HEADER_NAME: "owner"}
 OPERATOR_HEADERS = {api_main.ROLE_HEADER_NAME: "operator"}
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
 
 
 class _RuntimeStateStub:
@@ -213,7 +214,7 @@ def test_engine_requests_are_blocked_when_runtime_not_running(tmp_path: Path, mo
                 },
             ),
         ]:
-            headers = OPERATOR_HEADERS if path == "/analysis/run" else None
+            headers = OPERATOR_HEADERS
             response = client.post(path, headers=headers, json=payload)
             assert response.status_code == 503
             assert response.json() == {
@@ -237,6 +238,7 @@ def test_engine_requests_work_normally_when_runtime_running(monkeypatch) -> None
     with TestClient(api_main.app) as client:
         response = client.post(
             "/strategy/analyze",
+            headers=OPERATOR_HEADERS,
             json={
                 "ingestion_run_id": "not-a-uuid",
                 "symbol": "AAPL",
@@ -269,6 +271,7 @@ def test_engine_requests_are_blocked_when_runtime_paused(tmp_path: Path, monkeyp
     with TestClient(api_main.app) as client:
         response = client.post(
             "/strategy/analyze",
+            headers=OPERATOR_HEADERS,
             json={
                 "ingestion_run_id": ingestion_run_id,
                 "symbol": "AAPL",
@@ -349,7 +352,7 @@ def test_pause_during_in_progress_analysis_does_not_interrupt_execution(monkeypa
                 "lookback_days": 200,
             },
         )
-        introspection = client.get("/runtime/introspection")
+        introspection = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
 
     assert calls["run"] == 1
     assert response.status_code == 200
@@ -367,7 +370,7 @@ def test_execution_start_endpoint_transitions_ready_runtime_to_running() -> None
         runtime.init()
 
         response = client.post("/execution/start", headers=OWNER_HEADERS)
-        introspection = client.get("/runtime/introspection")
+        introspection = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json() == {"state": "running"}
@@ -379,7 +382,7 @@ def test_execution_start_endpoint_returns_conflict_for_paused_runtime() -> None:
     with TestClient(api_main.app) as client:
         client.post("/execution/pause", headers=OWNER_HEADERS)
         response = client.post("/execution/start", headers=OWNER_HEADERS)
-        introspection = client.get("/runtime/introspection")
+        introspection = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 409
     assert response.json() == {
@@ -392,7 +395,7 @@ def test_execution_start_endpoint_returns_conflict_for_paused_runtime() -> None:
 def test_execution_stop_endpoint_stops_running_runtime() -> None:
     with TestClient(api_main.app) as client:
         response = client.post("/execution/stop", headers=OWNER_HEADERS)
-        introspection = client.get("/runtime/introspection")
+        introspection = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json() == {"state": "stopped"}
@@ -412,7 +415,7 @@ def test_execution_stop_endpoint_returns_ready_when_runtime_not_started(monkeypa
         runtime.init()
 
         response = client.post("/execution/stop", headers=OWNER_HEADERS)
-        introspection = client.get("/runtime/introspection")
+        introspection = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json() == {"state": "ready"}

--- a/tests/test_ui_runtime_browser_flow.py
+++ b/tests/test_ui_runtime_browser_flow.py
@@ -248,6 +248,7 @@ def test_ui_browser_flow_uses_existing_runtime_api_surface(tmp_path: Path, monke
 
         signals_response = client.get(
             "/signals",
+            headers=READ_ONLY_HEADERS,
             params={
                 "ingestion_run_id": ingestion_run_id,
                 "symbol": "AAPL",


### PR DESCRIPTION
Closes #722

## Summary
- enforce documented role-based access control across runtime/control-plane endpoints
- harden duplicate analysis run persistence so identical retries are deterministic
- add regression and negative coverage for corrected runtime/API behavior
- align access-policy documentation with the enforced runtime baseline

## Testing
- .\.venv\Scripts\python.exe -m pytest