### PR TITLE
PERSIST-P40X: make analysis-run reuse and signal identity deterministic

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1541,14 +1541,16 @@ def execute_watchlist(
         ],
     }
 
-    analysis_run_repo.save_run(
+    persisted_run = analysis_run_repo.save_run(
         analysis_run_id=computed_run_id,
         ingestion_run_id=req.ingestion_run_id,
         request_payload=run_request_payload,
         result_payload=response_payload,
     )
 
-    return WatchlistExecutionResponse(**response_payload)
+    if persisted_run is None:
+        return WatchlistExecutionResponse(**response_payload)
+    return WatchlistExecutionResponse(**persisted_run["result"])
 
 
 @app.get("/journal/artifacts", response_model=JournalArtifactListResponse)
@@ -1903,14 +1905,16 @@ def manual_analysis(
         "signals": filtered_signals,
     }
 
-    analysis_run_repo.save_run(
+    persisted_run = analysis_run_repo.save_run(
         analysis_run_id=computed_run_id,
         ingestion_run_id=req.ingestion_run_id,
         request_payload=run_request_payload,
         result_payload=response_payload,
     )
 
-    return ManualAnalysisResponse(**response_payload)
+    if persisted_run is None:
+        return ManualAnalysisResponse(**response_payload)
+    return ManualAnalysisResponse(**persisted_run["result"])
 
 
 @app.post("/screener/basic", response_model=ScreenerResponse)

--- a/src/cilly_trading/db/init_db.py
+++ b/src/cilly_trading/db/init_db.py
@@ -49,6 +49,7 @@ def init_db(db_path: Optional[Path] = None) -> None:
         """
         CREATE TABLE IF NOT EXISTS signals (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            signal_id TEXT,
             analysis_run_id TEXT,
             ingestion_run_id TEXT,
             symbol TEXT NOT NULL,
@@ -67,6 +68,10 @@ def init_db(db_path: Optional[Path] = None) -> None:
         );
         """
     )
+    cur.execute("PRAGMA table_info(signals);")
+    signal_columns = {row["name"] for row in cur.fetchall()}
+    if "signal_id" not in signal_columns:
+        cur.execute("ALTER TABLE signals ADD COLUMN signal_id TEXT;")
     cur.execute(
         """
         CREATE INDEX IF NOT EXISTS idx_signals_timestamp
@@ -89,6 +94,13 @@ def init_db(db_path: Optional[Path] = None) -> None:
         """
         CREATE INDEX IF NOT EXISTS idx_signals_symbol_strategy_timestamp
           ON signals(symbol, strategy, timestamp);
+        """
+    )
+    cur.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_signals_analysis_run_signal_id_unique
+          ON signals(analysis_run_id, signal_id)
+          WHERE analysis_run_id IS NOT NULL AND signal_id IS NOT NULL;
         """
     )
 

--- a/src/cilly_trading/models.py
+++ b/src/cilly_trading/models.py
@@ -59,6 +59,9 @@ class Signal(TypedDict, total=False):
     """
     Einheitliches Signalmodell gemäß MVP-Spezifikation.
     """
+    signal_id: str
+    analysis_run_id: str
+    ingestion_run_id: str
     symbol: str
     strategy: str
     direction: Direction

--- a/src/cilly_trading/repositories/analysis_runs_sqlite.py
+++ b/src/cilly_trading/repositories/analysis_runs_sqlite.py
@@ -27,9 +27,20 @@ class SqliteAnalysisRunRepository:
         init_db(self._db_path)
 
     def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path)
+        conn = sqlite3.connect(self._db_path, timeout=5.0)
         conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout = 5000;")
         return conn
+
+    @staticmethod
+    def _deserialize_run_row(row: sqlite3.Row) -> Dict[str, Any]:
+        return {
+            "analysis_run_id": row["analysis_run_id"],
+            "ingestion_run_id": row["ingestion_run_id"],
+            "request": json.loads(row["request_payload"]),
+            "result": json.loads(row["result_payload"]),
+            "created_at": row["created_at"],
+        }
 
     def ingestion_run_exists(self, ingestion_run_id: str) -> bool:
         conn = self._get_connection()
@@ -124,13 +135,7 @@ class SqliteAnalysisRunRepository:
         if row is None:
             return None
 
-        return {
-            "analysis_run_id": row["analysis_run_id"],
-            "ingestion_run_id": row["ingestion_run_id"],
-            "request": json.loads(row["request_payload"]),
-            "result": json.loads(row["result_payload"]),
-            "created_at": row["created_at"],
-        }
+        return self._deserialize_run_row(row)
 
     def save_run(
         self,
@@ -139,7 +144,7 @@ class SqliteAnalysisRunRepository:
         ingestion_run_id: str,
         request_payload: Dict[str, Any],
         result_payload: Dict[str, Any],
-    ) -> None:
+    ) -> Dict[str, Any]:
         """
         Speichert einen Analyse-Run mit Request- und Result-Payload.
 
@@ -174,12 +179,34 @@ class SqliteAnalysisRunRepository:
                 ),
             )
             conn.commit()
+            cur.execute(
+                """
+                SELECT
+                    analysis_run_id,
+                    ingestion_run_id,
+                    request_payload,
+                    result_payload,
+                    created_at
+                FROM analysis_runs
+                WHERE analysis_run_id = ?;
+                """,
+                (analysis_run_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise RuntimeError("persisted analysis run could not be reloaded")
+            return self._deserialize_run_row(row)
         except sqlite3.IntegrityError:
             conn.rollback()
             cur = conn.cursor()
             cur.execute(
                 """
-                SELECT ingestion_run_id, request_payload, result_payload
+                SELECT
+                    analysis_run_id,
+                    ingestion_run_id,
+                    request_payload,
+                    result_payload,
+                    created_at
                 FROM analysis_runs
                 WHERE analysis_run_id = ?;
                 """,
@@ -188,12 +215,8 @@ class SqliteAnalysisRunRepository:
             row = cur.fetchone()
             if row is None:
                 raise
-            if (
-                row["ingestion_run_id"] == ingestion_run_id
-                and row["request_payload"] == serialized_request
-                and row["result_payload"] == serialized_result
-            ):
-                return
+            if row["request_payload"] == serialized_request:
+                return self._deserialize_run_row(row)
             raise ValueError("analysis_run_id already exists with different persisted payload")
         finally:
             conn.close()
@@ -203,14 +226,14 @@ class SqliteAnalysisRunRepository:
         analysis_run: AnalysisRun,
         *,
         result_payload: Dict[str, Any],
-    ) -> None:
+    ) -> Dict[str, Any]:
         """Persist an analysis run using the existing schema.
 
         Args:
             analysis_run: AnalysisRun entity containing IDs and request payload.
             result_payload: Result payload to persist.
         """
-        self.save_run(
+        return self.save_run(
             analysis_run_id=analysis_run.analysis_run_id,
             ingestion_run_id=analysis_run.ingestion_run_id,
             request_payload=analysis_run.request_payload,

--- a/src/cilly_trading/repositories/signals_sqlite.py
+++ b/src/cilly_trading/repositories/signals_sqlite.py
@@ -34,8 +34,9 @@ class SqliteSignalRepository(SignalRepository):
         self._ensure_signal_columns()
 
     def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path)
+        conn = sqlite3.connect(self._db_path, timeout=5.0)
         conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout = 5000;")
         return conn
 
     def _ensure_signal_columns(self) -> None:
@@ -44,6 +45,8 @@ class SqliteSignalRepository(SignalRepository):
         cur.execute("PRAGMA table_info(signals);")
         columns = {row["name"] for row in cur.fetchall()}
         missing_columns = []
+        if "signal_id" not in columns:
+            missing_columns.append(("signal_id", "TEXT"))
         if "analysis_run_id" not in columns:
             missing_columns.append(("analysis_run_id", "TEXT"))
         if "ingestion_run_id" not in columns:
@@ -53,8 +56,14 @@ class SqliteSignalRepository(SignalRepository):
 
         for column_name, column_type in missing_columns:
             cur.execute(f"ALTER TABLE signals ADD COLUMN {column_name} {column_type};")
-        if missing_columns:
-            conn.commit()
+        cur.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_signals_analysis_run_signal_id_unique
+              ON signals(analysis_run_id, signal_id)
+              WHERE analysis_run_id IS NOT NULL AND signal_id IS NOT NULL;
+            """
+        )
+        conn.commit()
         conn.close()
 
     def _serialize_reasons(self, reasons: Optional[List[SignalReason]]) -> Optional[str]:
@@ -85,7 +94,8 @@ class SqliteSignalRepository(SignalRepository):
 
         cur.executemany(
             """
-            INSERT INTO signals (
+            INSERT OR IGNORE INTO signals (
+                signal_id,
                 analysis_run_id,
                 ingestion_run_id,
                 symbol,
@@ -103,6 +113,7 @@ class SqliteSignalRepository(SignalRepository):
                 reasons_json
             )
             VALUES (
+                :signal_id,
                 :analysis_run_id,
                 :ingestion_run_id,
                 :symbol,
@@ -122,6 +133,10 @@ class SqliteSignalRepository(SignalRepository):
             """,
             [
                 {
+                    "signal_id": (
+                        s.get("signal_id")
+                        or (compute_signal_id(s) if s.get("timestamp") else None)
+                    ),
                     "analysis_run_id": s.get("analysis_run_id"),
                     "ingestion_run_id": s.get("ingestion_run_id"),
                     "symbol": s["symbol"],
@@ -157,6 +172,7 @@ class SqliteSignalRepository(SignalRepository):
             """
             SELECT
                 id,
+                signal_id,
                 analysis_run_id,
                 ingestion_run_id,
                 symbol,
@@ -185,6 +201,7 @@ class SqliteSignalRepository(SignalRepository):
         result: List[Signal] = []
         for row in rows:
             signal: Signal = {
+                "signal_id": row["signal_id"],
                 "analysis_run_id": row["analysis_run_id"],
                 "ingestion_run_id": row["ingestion_run_id"],
                 "symbol": row["symbol"],
@@ -201,6 +218,8 @@ class SqliteSignalRepository(SignalRepository):
                 signal.pop("analysis_run_id")
             if signal["ingestion_run_id"] is None:
                 signal.pop("ingestion_run_id")
+            if signal["signal_id"] is None:
+                signal.pop("signal_id")
             reasons = self._deserialize_reasons(row["reasons_json"])
             if reasons is not None:
                 signal["reasons"] = reasons
@@ -272,6 +291,7 @@ class SqliteSignalRepository(SignalRepository):
         data_query = f"""
             SELECT
                 id,
+                signal_id,
                 analysis_run_id,
                 ingestion_run_id,
                 symbol,
@@ -300,6 +320,7 @@ class SqliteSignalRepository(SignalRepository):
         result: List[Signal] = []
         for row in rows:
             signal: Signal = {
+                "signal_id": row["signal_id"],
                 "analysis_run_id": row["analysis_run_id"],
                 "ingestion_run_id": row["ingestion_run_id"],
                 "symbol": row["symbol"],
@@ -316,6 +337,8 @@ class SqliteSignalRepository(SignalRepository):
                 signal.pop("analysis_run_id")
             if signal["ingestion_run_id"] is None:
                 signal.pop("ingestion_run_id")
+            if signal["signal_id"] is None:
+                signal.pop("signal_id")
             reasons = self._deserialize_reasons(row["reasons_json"])
             if reasons is not None:
                 signal["reasons"] = reasons

--- a/tests/test_api_manual_analysis_trigger.py
+++ b/tests/test_api_manual_analysis_trigger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 import sqlite3
 import uuid
@@ -451,6 +452,59 @@ def test_manual_analysis_requires_authenticated_role(tmp_path: Path, monkeypatch
     assert response.json() == {"detail": "unauthorized"}
 
 
+def test_manual_analysis_returns_persisted_result_when_duplicate_save_races(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    signal_repo = _make_signal_repo(tmp_path)
+    analysis_repo = _make_analysis_repo(tmp_path)
+    persisted_lookup = analysis_repo.get_run
+    queued_signals = [
+        [{"symbol": "AAPL", "strategy": "RSI2", "score": 1.0}],
+        [{"symbol": "AAPL", "strategy": "RSI2", "score": 2.0}],
+    ]
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_repo)
+    monkeypatch.setattr(api_main, "_require_ingestion_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(api_main, "_require_snapshot_ready", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(api_main, "create_strategy", lambda _name: object())
+    monkeypatch.setattr(
+        api_main,
+        "trigger_operator_analysis_run",
+        lambda **_kwargs: queued_signals.pop(0),
+    )
+
+    state = {"calls": 0}
+
+    def _stale_get_run(run_id: str) -> dict[str, object] | None:
+        state["calls"] += 1
+        if state["calls"] == 1:
+            return None
+        if state["calls"] == 2:
+            return None
+        return persisted_lookup(run_id)
+
+    monkeypatch.setattr(analysis_repo, "get_run", _stale_get_run)
+
+    client = TestClient(api_main.app)
+    payload = {
+        "ingestion_run_id": str(uuid.uuid4()),
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "market_type": "stock",
+        "lookback_days": 200,
+    }
+
+    first_response = client.post("/analysis/run", headers=OPERATOR_HEADERS, json=payload)
+    second_response = client.post("/analysis/run", headers=OPERATOR_HEADERS, json=payload)
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.json() == second_response.json()
+    assert first_response.json()["signals"] == [{"symbol": "AAPL", "strategy": "RSI2", "score": 1.0}]
+
+
 def test_analysis_run_repository_duplicate_save_is_idempotent(tmp_path: Path) -> None:
     repo = _make_analysis_repo(tmp_path)
     run_id = "run-001"
@@ -475,6 +529,64 @@ def test_analysis_run_repository_duplicate_save_is_idempotent(tmp_path: Path) ->
     assert saved["ingestion_run_id"] == "ingestion-001"
     assert saved["request"] == request_payload
     assert saved["result"] == result_payload
+
+
+def test_analysis_run_repository_duplicate_save_reuses_persisted_result_for_same_request(
+    tmp_path: Path,
+) -> None:
+    repo = _make_analysis_repo(tmp_path)
+    run_id = "run-001"
+    request_payload = {"symbol": "AAPL", "strategy": "RSI2"}
+    first_result = {"analysis_run_id": run_id, "signals": []}
+    second_result = {"analysis_run_id": run_id, "signals": [{"symbol": "AAPL"}]}
+
+    persisted_first = repo.save_run(
+        analysis_run_id=run_id,
+        ingestion_run_id="ingestion-001",
+        request_payload=request_payload,
+        result_payload=first_result,
+    )
+    persisted_second = repo.save_run(
+        analysis_run_id=run_id,
+        ingestion_run_id="ingestion-999",
+        request_payload=request_payload,
+        result_payload=second_result,
+    )
+
+    assert persisted_first["result"] == first_result
+    assert persisted_second["result"] == first_result
+    assert repo.get_run(run_id) == persisted_first
+
+
+def test_analysis_run_repository_duplicate_save_is_safe_under_concurrent_requests(
+    tmp_path: Path,
+) -> None:
+    repo = _make_analysis_repo(tmp_path)
+    run_id = "run-001"
+    request_payload = {"symbol": "AAPL", "strategy": "RSI2"}
+    result_payload = {"analysis_run_id": run_id, "signals": []}
+
+    def _save() -> dict[str, object]:
+        return repo.save_run(
+            analysis_run_id=run_id,
+            ingestion_run_id="ingestion-001",
+            request_payload=request_payload,
+            result_payload=result_payload,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        persisted = [future.result() for future in [executor.submit(_save), executor.submit(_save)]]
+
+    assert persisted[0]["result"] == result_payload
+    assert persisted[1]["result"] == result_payload
+
+    conn = sqlite3.connect(tmp_path / "analysis.db")
+    try:
+        row_count = conn.execute("SELECT COUNT(*) FROM analysis_runs WHERE analysis_run_id = ?;", (run_id,)).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert row_count == 1
 
 
 def test_analysis_run_repository_rejects_conflicting_duplicate_save(tmp_path: Path) -> None:

--- a/tests/test_reason_persistence_and_reconstruction.py
+++ b/tests/test_reason_persistence_and_reconstruction.py
@@ -98,10 +98,12 @@ def _signal_with_reasons():
 def test_persist_reasons_roundtrip(tmp_path: Path) -> None:
     repo = _make_repo(tmp_path)
     signal = _signal_with_reasons()
+    expected_signal_id = compute_signal_id(signal)
 
     repo.save_signals([signal])
 
     rows = repo.list_signals(limit=1)
+    assert rows[0]["signal_id"] == expected_signal_id
     assert rows[0]["analysis_run_id"] == signal["analysis_run_id"]
     assert rows[0]["ingestion_run_id"] == signal["ingestion_run_id"]
     assert rows[0]["reasons"] == signal["reasons"]

--- a/tests/test_signal_repository_sqlite.py
+++ b/tests/test_signal_repository_sqlite.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 
+from cilly_trading.models import compute_signal_id
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 
 
@@ -38,13 +40,15 @@ def test_save_signals_empty_list_is_noop(tmp_path: Path) -> None:
 
 def test_roundtrip_minimal_signal(tmp_path: Path) -> None:
     repo = _make_repo(tmp_path)
+    signal = _base_signal(symbol="MSFT")
 
-    repo.save_signals([_base_signal(symbol="MSFT")])
+    repo.save_signals([signal])
 
     rows = repo.list_signals(limit=10)
     assert len(rows) == 1
 
     s = rows[0]
+    assert s["signal_id"] == compute_signal_id(signal)
     assert s["symbol"] == "MSFT"
     assert s["strategy"] == "RSI2"
     assert s["direction"] == "long"
@@ -196,3 +200,33 @@ def test_read_screener_results_respects_bounds(tmp_path: Path) -> None:
 
     assert total == 4
     assert [item["symbol"] for item in items] == ["BBB", "CCC"]
+
+
+def test_save_signals_deduplicates_same_analysis_run_and_signal_id(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    signal = _base_signal(
+        analysis_run_id="analysis-run-1",
+        signal_id="signal-001",
+    )
+
+    repo.save_signals([signal])
+    repo.save_signals([signal])
+
+    rows = repo.list_signals(limit=10)
+    assert len(rows) == 1
+    assert rows[0]["signal_id"] == "signal-001"
+
+    conn = sqlite3.connect(tmp_path / "test_signals.db")
+    try:
+        row_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM signals
+            WHERE analysis_run_id = ? AND signal_id = ?;
+            """,
+            ("analysis-run-1", "signal-001"),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert row_count == 1


### PR DESCRIPTION
Closes #725

## Summary
- make analysis-run duplicate persistence deterministic for repeated/concurrent requests
- return the persisted analysis-run payload from API write paths so reuse is authoritative
- persist signal_id in SQLite and round-trip it through the signal repository
- bound duplicate same-run signal writes by (analysis_run_id, signal_id)
- add duplicate, concurrency, retry, and round-trip regression tests

## Testing
- .\.venv\Scripts\python -m pytest
