### PR TITLE
CORE-P41A - Define canonical trading core domain model

### DIFF
--- a/docs/architecture/trading_core_domain_model.md
+++ b/docs/architecture/trading_core_domain_model.md
@@ -1,0 +1,46 @@
+# Trading Core Domain Model
+
+Issue `#718` defines one canonical trading-core vocabulary for `Trade`, `Position`, `Order`, and `ExecutionEvent`.
+
+## Canonical Entities
+
+| Entity | Authority | Responsibility | Must not own |
+| --- | --- | --- | --- |
+| `Order` | Authoritative | The requested trading instruction and its bounded lifecycle state. | Position aggregation, trade lifecycle summaries |
+| `ExecutionEvent` | Authoritative | Immutable execution-side facts for one order lifecycle transition. | Aggregated position state, aggregated trade state |
+| `Position` | Derived | Deterministic aggregate exposure state built from execution events. | New execution facts, order intent |
+| `Trade` | Derived | Deterministic lifecycle summary assembled from orders and execution events. | Order submission intent, immutable execution facts |
+
+## Required vs Optional
+
+- `Order` requires deterministic identity and lifecycle fields: `order_id`, `strategy_id`, `symbol`, `sequence`, `side`, `order_type`, `time_in_force`, `status`, `quantity`, and `created_at`.
+- `Order` optional fields are present only when lifecycle state justifies them: `submitted_at`, `average_fill_price`, `last_execution_event_id`, `position_id`, and `trade_id`.
+- `ExecutionEvent` requires `event_id`, `order_id`, `strategy_id`, `symbol`, `side`, `event_type`, `occurred_at`, and `sequence`.
+- `ExecutionEvent` fill payload fields `execution_quantity`, `execution_price`, and `commission` are required only for fill events.
+- `Position` requires deterministic aggregate state: `position_id`, `strategy_id`, `symbol`, `direction`, `status`, `opened_at`, `quantity_opened`, `quantity_closed`, `net_quantity`, and `average_entry_price`.
+- `Position` optional fields are lifecycle-dependent: `closed_at`, `average_exit_price`, and `realized_pnl`.
+- `Trade` requires lifecycle identity and aggregate state: `trade_id`, `position_id`, `strategy_id`, `symbol`, `direction`, `status`, `opened_at`, `quantity_opened`, `quantity_closed`, and `average_entry_price`.
+- `Trade` optional fields are lifecycle-dependent: `closed_at`, `average_exit_price`, and `realized_pnl`.
+
+## Relationships
+
+- `ExecutionEvent.order_id -> Order.order_id`
+- `Order.position_id -> Position.position_id` when the order affects a position
+- `Trade.position_id -> Position.position_id`
+- `Trade.execution_event_ids -> ExecutionEvent.event_id`
+- `Position.execution_event_ids -> ExecutionEvent.event_id`
+- `Trade` and `Position` may both reference the same `Order` and `ExecutionEvent` identifiers, but only `Order` and `ExecutionEvent` are authoritative sources
+
+## Determinism Rules
+
+- Canonical serialization uses compact JSON with lexicographically sorted keys.
+- Decimal-valued trading-core fields serialize as strings to avoid float drift.
+- Identifier lists are normalized into deterministic lexicographic order.
+- Relationship validation rejects unknown references and mismatched entity links.
+
+## Lifecycle Interpretation
+
+1. `Order` captures intent.
+2. `ExecutionEvent` records immutable lifecycle facts for that order.
+3. `Position` derives current or closed aggregate exposure from those facts.
+4. `Trade` derives the lifecycle summary tied to the position and linked execution events.

--- a/src/cilly_trading/engine/order_execution_model.py
+++ b/src/cilly_trading/engine/order_execution_model.py
@@ -1,8 +1,4 @@
-"""Deterministic market order execution model for backtesting.
-
-This module defines deterministic market order filling, slippage, commission,
-and position transition behavior.
-"""
+"""Deterministic market-order execution model for backtesting."""
 
 from __future__ import annotations
 
@@ -14,71 +10,12 @@ from typing import Any, Literal, Mapping, Sequence
 from risk.contracts import RiskDecision
 
 from cilly_trading.engine.risk import enforce_approved_risk_decision
-
-
-@dataclass(frozen=True)
-class Order:
-    """Represents an order submitted to the deterministic executor.
-
-    Args:
-        id: Stable order identifier.
-        side: Order side (``"BUY"`` or ``"SELL"``).
-        quantity: Requested quantity.
-        created_snapshot_key: Snapshot key where the order was created.
-        sequence: Monotonic sequence number for deterministic tie-breaking.
-    """
-
-    id: str
-    side: Literal["BUY", "SELL"]
-    quantity: Decimal
-    created_snapshot_key: str
-    sequence: int
-
-
-@dataclass(frozen=True)
-class Fill:
-    """Represents a deterministic full fill for an order.
-
-    Args:
-        order_id: Filled order identifier.
-        fill_price: Deterministic execution price including slippage.
-        quantity: Filled quantity.
-        commission: Deterministic commission amount.
-    """
-
-    order_id: str
-    fill_price: Decimal
-    quantity: Decimal
-    commission: Decimal
-
-
-@dataclass(frozen=True)
-class Position:
-    """Represents deterministic position state.
-
-    Args:
-        quantity: Current position quantity.
-        avg_price: Weighted average entry price for remaining quantity.
-    """
-
-    quantity: Decimal
-    avg_price: Decimal
+from cilly_trading.models import ExecutionEvent, Order, Position, compute_execution_event_id
 
 
 @dataclass(frozen=True)
 class DeterministicExecutionConfig:
-    """Configuration for deterministic order execution.
-
-    Args:
-        slippage_bps: Fixed slippage in basis points.
-        commission_per_order: Fixed deterministic commission per order.
-        price_scale: Decimal scale for prices.
-        money_scale: Decimal scale for commission amounts.
-        quantity_scale: Decimal scale for quantity tracking.
-        fill_timing: Fill timing mode. ``"next_snapshot"`` fills an order only
-            after its creation snapshot. ``"same_snapshot"`` allows filling on
-            creation snapshot.
-    """
+    """Configuration for deterministic order execution."""
 
     slippage_bps: int
     commission_per_order: Decimal
@@ -105,7 +42,7 @@ def _execute_order(
     position: Position,
     config: DeterministicExecutionConfig,
     risk_decision: RiskDecision | None,
-) -> tuple[list[Fill], Position]:
+) -> tuple[list[ExecutionEvent], Position]:
     _enforce_orchestrator_caller()
     model = _DeterministicExecutionModel()
     return model._execute(
@@ -128,83 +65,137 @@ class _DeterministicExecutionModel:
         position: Position,
         config: DeterministicExecutionConfig,
         risk_decision: RiskDecision | None,
-    ) -> tuple[list[Fill], Position]:
-        """Executes ready orders for a snapshot in deterministic order.
-
-        Args:
-            orders: Orders that may be filled at this snapshot.
-            snapshot: Market snapshot providing ``open`` or ``price``.
-            position: Existing position state.
-            config: Deterministic execution settings.
-            risk_decision: Mandatory explicit pre-execution risk decision.
-
-        Returns:
-            A tuple containing ordered fills and updated position.
-
-        Raises:
-            ValueError: If a required price is missing, a quantity is invalid,
-                or an order attempts to sell more than current position.
-        """
-
+    ) -> tuple[list[ExecutionEvent], Position]:
         enforce_approved_risk_decision(risk_decision)
 
         snapshot_key = self._snapshot_key(snapshot)
         base_price = self._extract_fill_price(snapshot, config)
-        current = Position(
-            quantity=self._q(position.quantity, config.quantity_scale),
-            avg_price=self._q(position.avg_price, config.price_scale),
-        )
+        current = position
         ordered_orders = sorted(
             orders,
-            key=lambda order: (order.created_snapshot_key, order.sequence, order.id),
+            key=lambda order: (order.created_at, order.sequence, order.order_id),
         )
 
-        fills: list[Fill] = []
+        execution_events: list[ExecutionEvent] = []
         for order in ordered_orders:
             quantity = self._q(order.quantity, config.quantity_scale)
             if quantity <= Decimal("0"):
-                raise ValueError(f"Order quantity must be positive: {order.id}")
+                raise ValueError(f"Order quantity must be positive: {order.order_id}")
             if not self._is_ready(order=order, snapshot_key=snapshot_key, config=config):
                 continue
 
-            fill_price = self._apply_slippage(price=base_price, side=order.side, config=config)
+            execution_price = self._apply_slippage(price=base_price, side=order.side, config=config)
             commission = self._q(config.commission_per_order, config.money_scale)
-            fills.append(
-                Fill(
-                    order_id=order.id,
-                    fill_price=fill_price,
-                    quantity=quantity,
-                    commission=commission,
-                )
+            event = ExecutionEvent(
+                event_id=compute_execution_event_id(
+                    order_id=order.order_id,
+                    event_type="filled",
+                    occurred_at=snapshot_key,
+                    sequence=len(execution_events) + 1,
+                ),
+                order_id=order.order_id,
+                strategy_id=order.strategy_id,
+                symbol=order.symbol,
+                side=order.side,
+                event_type="filled",
+                occurred_at=snapshot_key,
+                sequence=len(execution_events) + 1,
+                execution_quantity=quantity,
+                execution_price=execution_price,
+                commission=commission,
+                position_id=order.position_id or current.position_id,
+                trade_id=order.trade_id,
             )
-            current = self._apply_fill(position=current, side=order.side, quantity=quantity, fill_price=fill_price, config=config)
+            execution_events.append(event)
+            current = self._apply_fill(
+                position=current,
+                order=order,
+                event=event,
+                config=config,
+            )
 
-        return fills, current
+        return execution_events, current
 
     def _apply_fill(
         self,
         *,
         position: Position,
-        side: Literal["BUY", "SELL"],
-        quantity: Decimal,
-        fill_price: Decimal,
+        order: Order,
+        event: ExecutionEvent,
         config: DeterministicExecutionConfig,
     ) -> Position:
-        if side == "BUY":
-            new_qty = self._q(position.quantity + quantity, config.quantity_scale)
-            if new_qty == Decimal("0"):
-                return Position(quantity=Decimal("0"), avg_price=Decimal("0"))
-            weighted = (position.avg_price * position.quantity) + (fill_price * quantity)
-            avg_price = self._q(weighted / new_qty, config.price_scale)
-            return Position(quantity=new_qty, avg_price=avg_price)
+        quantity = event.execution_quantity
+        execution_price = event.execution_price
+        if quantity is None or execution_price is None:
+            raise ValueError("fill events must define execution_quantity and execution_price")
 
-        if quantity > position.quantity:
+        order_ids = self._merge_ids(position.order_ids, order.order_id)
+        event_ids = self._merge_ids(position.execution_event_ids, event.event_id)
+        trade_ids = self._merge_ids(position.trade_ids, order.trade_id)
+
+        if order.side == "BUY":
+            quantity_opened = self._q(position.quantity_opened + quantity, config.quantity_scale)
+            net_quantity = self._q(position.net_quantity + quantity, config.quantity_scale)
+            if quantity_opened == Decimal("0"):
+                average_entry_price = Decimal("0")
+            else:
+                weighted = (
+                    position.average_entry_price * position.quantity_opened
+                ) + (execution_price * quantity)
+                average_entry_price = self._q(weighted / quantity_opened, config.price_scale)
+
+            return Position.model_validate(
+                {
+                    **position.model_dump(mode="python"),
+                    "opened_at": position.opened_at if position.status != "flat" else event.occurred_at,
+                    "status": "open",
+                    "closed_at": None,
+                    "quantity_opened": quantity_opened,
+                    "net_quantity": net_quantity,
+                    "average_entry_price": average_entry_price,
+                    "order_ids": order_ids,
+                    "execution_event_ids": event_ids,
+                    "trade_ids": trade_ids,
+                }
+            )
+
+        if quantity > position.net_quantity:
             raise ValueError("SELL quantity exceeds current position quantity")
 
-        remaining = self._q(position.quantity - quantity, config.quantity_scale)
-        if remaining == Decimal("0"):
-            return Position(quantity=Decimal("0"), avg_price=Decimal("0"))
-        return Position(quantity=remaining, avg_price=self._q(position.avg_price, config.price_scale))
+        quantity_closed = self._q(position.quantity_closed + quantity, config.quantity_scale)
+        net_quantity = self._q(position.net_quantity - quantity, config.quantity_scale)
+        previous_exit_notional = (
+            position.average_exit_price * position.quantity_closed
+            if position.average_exit_price is not None
+            else Decimal("0")
+        )
+        average_exit_price = self._q(
+            (previous_exit_notional + (execution_price * quantity)) / quantity_closed,
+            config.price_scale,
+        )
+        realized_pnl = self._q(
+            (position.realized_pnl or Decimal("0"))
+            + ((execution_price - position.average_entry_price) * quantity),
+            config.money_scale,
+        )
+
+        status = "closed" if net_quantity == Decimal("0") else "open"
+        closed_at = event.occurred_at if status == "closed" else None
+
+        return Position.model_validate(
+            {
+                **position.model_dump(mode="python"),
+                "status": status,
+                "closed_at": closed_at,
+                "quantity_closed": quantity_closed,
+                "net_quantity": net_quantity,
+                "average_exit_price": average_exit_price,
+                "realized_pnl": realized_pnl,
+                "order_ids": order_ids,
+                "execution_event_ids": event_ids,
+                "trade_ids": trade_ids,
+            }
+        )
 
     def _is_ready(
         self,
@@ -214,8 +205,8 @@ class _DeterministicExecutionModel:
         config: DeterministicExecutionConfig,
     ) -> bool:
         if config.fill_timing == "same_snapshot":
-            return order.created_snapshot_key <= snapshot_key
-        return order.created_snapshot_key < snapshot_key
+            return order.created_at <= snapshot_key
+        return order.created_at < snapshot_key
 
     def _extract_fill_price(self, snapshot: Mapping[str, Any], config: DeterministicExecutionConfig) -> Decimal:
         if snapshot.get("open") is not None:
@@ -248,10 +239,16 @@ class _DeterministicExecutionModel:
     def _q(self, value: Decimal, scale: Decimal) -> Decimal:
         return value.quantize(scale, rounding=ROUND_HALF_UP)
 
+    def _merge_ids(self, current_ids: Sequence[str], candidate: str | None) -> list[str]:
+        values = set(current_ids)
+        if candidate is not None:
+            values.add(candidate)
+        return sorted(values)
+
 
 __all__ = [
     "DeterministicExecutionConfig",
-    "Fill",
+    "ExecutionEvent",
     "Order",
     "Position",
 ]

--- a/src/cilly_trading/engine/pipeline/orchestrator.py
+++ b/src/cilly_trading/engine/pipeline/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Literal, Mapping, Sequence
 
 from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
@@ -10,7 +11,7 @@ from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
 from cilly_trading.engine.logging import emit_structured_engine_log
 from cilly_trading.engine.order_execution_model import (
     DeterministicExecutionConfig,
-    Fill,
+    ExecutionEvent,
     Order,
     Position,
     _execute_order,
@@ -25,7 +26,7 @@ class PipelineResult:
     """Result payload for orchestrated pipeline execution."""
 
     status: Literal["executed", "rejected"]
-    fills: list[Fill]
+    fills: list[ExecutionEvent]
     position: Position
     risk_decision: RiskDecision
 
@@ -46,15 +47,25 @@ def run_pipeline(
 
     state = lifecycle_store.get_state(risk_request.strategy_id)
     risk_decision = risk_gate.evaluate(risk_request)
-    orders = _extract_orders(signal)
+    normalized_position = _extract_position(
+        position,
+        strategy_id=risk_request.strategy_id,
+        symbol=risk_request.symbol,
+    )
+    orders = _extract_orders(
+        signal,
+        strategy_id=risk_request.strategy_id,
+        symbol=risk_request.symbol,
+        position_id=normalized_position.position_id,
+    )
     snapshot = _extract_snapshot(signal)
     emit_structured_engine_log(
         "order_submission.attempt",
-        payload={
-            "request_id": risk_request.request_id,
-            "strategy_id": risk_request.strategy_id,
-            "symbol": risk_request.symbol,
-            "order_count": len(orders),
+            payload={
+                "request_id": risk_request.request_id,
+                "strategy_id": risk_request.strategy_id,
+                "symbol": risk_request.symbol,
+                "order_count": len(orders),
             "snapshot_key": _extract_snapshot_key(snapshot),
             "lifecycle_state": state.value,
             "risk_decision": risk_decision.decision,
@@ -85,14 +96,14 @@ def run_pipeline(
         return PipelineResult(
             status="rejected",
             fills=[],
-            position=position,
+            position=normalized_position,
             risk_decision=risk_decision,
         )
 
     fills, updated_position = _execute_order(
         orders=orders,
         snapshot=snapshot,
-        position=position,
+        position=normalized_position,
         config=execution_config,
         risk_decision=risk_decision,
     )
@@ -115,11 +126,70 @@ def run_pipeline(
     )
 
 
-def _extract_orders(signal: Mapping[str, object]) -> Sequence[Order]:
+def _extract_orders(
+    signal: Mapping[str, object],
+    *,
+    strategy_id: str,
+    symbol: str,
+    position_id: str,
+) -> Sequence[Order]:
     orders = signal.get("orders")
     if not isinstance(orders, Sequence):
         raise ValueError("Signal must define 'orders' as a sequence")
-    return orders  # type: ignore[return-value]
+    normalized_orders: list[Order] = []
+    for order in orders:
+        if isinstance(order, Order):
+            normalized_orders.append(order)
+            continue
+        if isinstance(order, Mapping):
+            normalized_orders.append(Order.model_validate(order))
+            continue
+        if all(hasattr(order, field) for field in ("id", "side", "quantity", "created_snapshot_key", "sequence")):
+            normalized_orders.append(
+                Order(
+                    order_id=str(order.id),
+                    strategy_id=str(strategy_id),
+                    symbol=str(symbol),
+                    sequence=int(order.sequence),
+                    side=str(order.side),
+                    order_type="market",
+                    time_in_force="day",
+                    status="created",
+                    quantity=Decimal(str(order.quantity)),
+                    created_at=str(order.created_snapshot_key),
+                    position_id=position_id,
+                )
+            )
+            continue
+        normalized_orders.append(Order.model_validate(order))
+    return normalized_orders
+
+
+def _extract_position(position: object, *, strategy_id: str, symbol: str) -> Position:
+    if isinstance(position, Position):
+        return position
+    if isinstance(position, Mapping):
+        return Position.model_validate(position)
+    if all(hasattr(position, field) for field in ("quantity", "avg_price")):
+        quantity = Decimal(str(position.quantity))
+        avg_price = Decimal(str(position.avg_price))
+        status = "flat" if quantity == Decimal("0") else "open"
+        return Position(
+            position_id="runtime-position",
+            strategy_id=strategy_id,
+            symbol=symbol,
+            direction="long",
+            status=status,
+            opened_at="legacy-position",
+            quantity_opened=quantity,
+            quantity_closed=Decimal("0"),
+            net_quantity=quantity,
+            average_entry_price=avg_price,
+            order_ids=[],
+            execution_event_ids=[],
+            trade_ids=[],
+        )
+    return Position.model_validate(position)
 
 
 def _extract_snapshot(signal: Mapping[str, object]) -> Mapping[str, object]:

--- a/src/cilly_trading/models.py
+++ b/src/cilly_trading/models.py
@@ -1,14 +1,15 @@
 """
-Zentrale Datenmodelle für die Cilly Trading Engine.
+Central data models for the Cilly Trading Engine.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+from decimal import Decimal
 from typing import Any, Dict, List, Literal, Mapping, Optional, TypedDict, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 Stage = Literal["setup", "entry_confirmed"]
@@ -22,6 +23,68 @@ ReasonType = Literal[
     "STATE_TRANSITION",
 ]
 DataType = Literal["INDICATOR_VALUE", "PRICE_VALUE", "BAR_VALUE", "STATE_VALUE"]
+
+CoreDirection = Literal["long"]
+OrderSide = Literal["BUY", "SELL"]
+OrderType = Literal["market"]
+TimeInForce = Literal["day", "gtc"]
+OrderStatus = Literal["created", "submitted", "partially_filled", "filled", "cancelled", "rejected"]
+PositionStatus = Literal["flat", "open", "closed"]
+TradeStatus = Literal["open", "closed"]
+ExecutionEventType = Literal["created", "submitted", "partially_filled", "filled", "cancelled", "rejected"]
+
+
+TRADING_CORE_MODEL_VERSION = "1.0.0"
+
+TRADING_CORE_ENTITIES: Dict[str, Dict[str, str]] = {
+    "Order": {
+        "authority": "authoritative",
+        "responsibility": "A trading instruction and its bounded lifecycle state.",
+    },
+    "ExecutionEvent": {
+        "authority": "authoritative",
+        "responsibility": "An immutable execution-side lifecycle fact linked to exactly one order.",
+    },
+    "Position": {
+        "authority": "derived",
+        "responsibility": "Deterministic aggregate exposure state derived from execution events.",
+    },
+    "Trade": {
+        "authority": "derived",
+        "responsibility": "Deterministic lifecycle summary assembled from orders and execution events.",
+    },
+}
+
+TRADING_CORE_RELATIONSHIPS: tuple[dict[str, str], ...] = (
+    {
+        "from_entity": "Order",
+        "to_entity": "ExecutionEvent",
+        "cardinality": "1:n",
+        "link_field": "order_id",
+        "description": "ExecutionEvent.order_id references Order.order_id.",
+    },
+    {
+        "from_entity": "Position",
+        "to_entity": "Order",
+        "cardinality": "1:n",
+        "link_field": "position_id",
+        "description": "Order.position_id references Position.position_id when the order affects the position.",
+    },
+    {
+        "from_entity": "Trade",
+        "to_entity": "Position",
+        "cardinality": "n:1",
+        "link_field": "position_id",
+        "description": "Trade.position_id references the derived position the trade belongs to.",
+    },
+    {
+        "from_entity": "Trade",
+        "to_entity": "ExecutionEvent",
+        "cardinality": "1:n",
+        "link_field": "execution_event_ids",
+        "description": "Trade.execution_event_ids records the execution events that formed the trade lifecycle.",
+    },
+)
 
 
 class EntryZone(TypedDict):
@@ -56,9 +119,8 @@ class SignalReason(TypedDict):
 
 
 class Signal(TypedDict, total=False):
-    """
-    Einheitliches Signalmodell gemäß MVP-Spezifikation.
-    """
+    """Unified signal model for the existing MVP surface."""
+
     signal_id: str
     analysis_run_id: str
     ingestion_run_id: str
@@ -66,26 +128,25 @@ class Signal(TypedDict, total=False):
     strategy: str
     direction: Direction
     score: float
-    timestamp: str      # ISO-String
-    stage: Stage        # "setup" | "entry_confirmed"
+    timestamp: str
+    stage: Stage
     entry_zone: Optional[EntryZone]
     confirmation_rule: str
-    timeframe: str      # z. B. "D1"
+    timeframe: str
     market_type: MarketType
     data_source: DataSource
     reasons: Optional[List[SignalReason]]
 
 
-class Trade(TypedDict, total=False):
-    """
-    Minimales Trade-Modell für Papertrading und spätere Backtests.
-    """
-    id: int              # wird von DB vergeben
+class PersistedTradePayload(TypedDict, total=False):
+    """Legacy persisted trade payload used by current paper-trading surfaces."""
+
+    id: int
     symbol: str
     strategy: str
     stage: Stage
     entry_price: Optional[float]
-    entry_date: Optional[str]   # ISO-String
+    entry_date: Optional[str]
     exit_price: Optional[float]
     exit_date: Optional[str]
     reason_entry: str
@@ -109,14 +170,50 @@ def _normalize_assets(value: Any) -> list[str]:
     return sorted(normalized)
 
 
+def _normalize_decimal(value: Decimal) -> str:
+    normalized = format(value.normalize(), "f")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    if normalized in {"", "-0"}:
+        return "0"
+    return normalized
+
+
+def _normalize_identifier_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple)):
+        raise TypeError("identifier collections must be a list or tuple")
+
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise TypeError("identifier collections must contain strings")
+        identifier = item.strip()
+        if not identifier:
+            raise ValueError("identifier collections must not contain empty strings")
+        normalized.append(identifier)
+
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("identifier collections must not contain duplicates")
+
+    return sorted(normalized)
+
+
 def _normalize_canonical_value(value: Any, *, key: Optional[str] = None) -> Any:
     if isinstance(value, float):
         raise TypeError("floats are not supported in canonical_json")
 
+    if isinstance(value, Decimal):
+        return _normalize_decimal(value)
+
     if value is None or isinstance(value, (bool, int, str)):
         return value
 
-    if isinstance(value, dict):
+    if isinstance(value, TradingCoreBase):
+        return value.to_canonical_payload()
+
+    if isinstance(value, Mapping):
         normalized_dict: Dict[str, Any] = {}
         for raw_key, raw_value in value.items():
             if not isinstance(raw_key, str):
@@ -133,14 +230,8 @@ def _normalize_canonical_value(value: Any, *, key: Optional[str] = None) -> Any:
 
 
 def canonical_json(obj: Any) -> str:
-    """Create a deterministic JSON representation of the provided object.
+    """Create a deterministic JSON representation of the provided object."""
 
-    Args:
-        obj: Object to serialize into deterministic JSON.
-
-    Returns:
-        Canonical JSON string.
-    """
     normalized = _normalize_canonical_value(obj)
     return json.dumps(
         normalized,
@@ -152,15 +243,224 @@ def canonical_json(obj: Any) -> str:
 
 
 def sha256_hex(text: str) -> str:
-    """Return a SHA-256 hex digest for the provided text.
+    """Return a SHA-256 hex digest for the provided text."""
 
-    Args:
-        text: String to hash.
-
-    Returns:
-        SHA-256 hex digest.
-    """
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class TradingCoreBase(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    def to_canonical_payload(self) -> dict[str, Any]:
+        payload = self.model_dump(mode="python")
+        return {
+            key: _normalize_canonical_value(value, key=key)
+            for key, value in payload.items()
+        }
+
+    def to_canonical_json(self) -> str:
+        return canonical_json(self.to_canonical_payload())
+
+
+class CanonicalOrder(TradingCoreBase):
+    order_id: str = Field(min_length=1)
+    strategy_id: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    sequence: int = Field(ge=1)
+    side: OrderSide
+    order_type: OrderType
+    time_in_force: TimeInForce
+    status: OrderStatus
+    quantity: Decimal = Field(gt=Decimal("0"))
+    filled_quantity: Decimal = Field(default=Decimal("0"), ge=Decimal("0"))
+    created_at: str = Field(min_length=1)
+    submitted_at: Optional[str] = None
+    average_fill_price: Optional[Decimal] = Field(default=None, gt=Decimal("0"))
+    last_execution_event_id: Optional[str] = Field(default=None, min_length=1)
+    position_id: Optional[str] = Field(default=None, min_length=1)
+    trade_id: Optional[str] = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_lifecycle(self) -> "CanonicalOrder":
+        if self.filled_quantity > self.quantity:
+            raise ValueError("filled_quantity must not exceed quantity")
+
+        if self.status in {"partially_filled", "filled"}:
+            if self.average_fill_price is None:
+                raise ValueError("average_fill_price is required for filled orders")
+            if self.last_execution_event_id is None:
+                raise ValueError("last_execution_event_id is required for filled orders")
+        elif self.filled_quantity != Decimal("0"):
+            raise ValueError("filled_quantity must be zero unless status is partially_filled or filled")
+
+        if self.status == "filled" and self.filled_quantity != self.quantity:
+            raise ValueError("filled orders must have filled_quantity equal to quantity")
+
+        if self.status == "partially_filled" and self.filled_quantity >= self.quantity:
+            raise ValueError("partially_filled orders must have filled_quantity less than quantity")
+
+        return self
+
+
+class CanonicalExecutionEvent(TradingCoreBase):
+    event_id: str = Field(min_length=1)
+    order_id: str = Field(min_length=1)
+    strategy_id: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    side: OrderSide
+    event_type: ExecutionEventType
+    occurred_at: str = Field(min_length=1)
+    sequence: int = Field(ge=1)
+    execution_quantity: Optional[Decimal] = Field(default=None, gt=Decimal("0"))
+    execution_price: Optional[Decimal] = Field(default=None, gt=Decimal("0"))
+    commission: Optional[Decimal] = Field(default=None, ge=Decimal("0"))
+    position_id: Optional[str] = Field(default=None, min_length=1)
+    trade_id: Optional[str] = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_event_shape(self) -> "CanonicalExecutionEvent":
+        requires_fill_payload = self.event_type in {"partially_filled", "filled"}
+        if requires_fill_payload:
+            if self.execution_quantity is None:
+                raise ValueError("execution_quantity is required for fill events")
+            if self.execution_price is None:
+                raise ValueError("execution_price is required for fill events")
+            if self.commission is None:
+                raise ValueError("commission is required for fill events")
+        elif any(
+            value is not None
+            for value in (self.execution_quantity, self.execution_price, self.commission)
+        ):
+            raise ValueError("non-fill events must not define execution payload fields")
+
+        return self
+
+
+class CanonicalPosition(TradingCoreBase):
+    position_id: str = Field(min_length=1)
+    strategy_id: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    direction: CoreDirection
+    status: PositionStatus
+    opened_at: str = Field(min_length=1)
+    closed_at: Optional[str] = None
+    quantity_opened: Decimal = Field(ge=Decimal("0"))
+    quantity_closed: Decimal = Field(default=Decimal("0"), ge=Decimal("0"))
+    net_quantity: Decimal
+    average_entry_price: Decimal = Field(ge=Decimal("0"))
+    average_exit_price: Optional[Decimal] = Field(default=None, gt=Decimal("0"))
+    realized_pnl: Optional[Decimal] = None
+    order_ids: List[str] = Field(default_factory=list)
+    execution_event_ids: List[str] = Field(default_factory=list)
+    trade_ids: List[str] = Field(default_factory=list)
+
+    @field_validator("order_ids", "execution_event_ids", "trade_ids", mode="before")
+    @classmethod
+    def _normalize_id_fields(cls, value: Any) -> list[str]:
+        return _normalize_identifier_list(value)
+
+    @model_validator(mode="after")
+    def _validate_position_state(self) -> "CanonicalPosition":
+        expected_net = self.quantity_opened - self.quantity_closed
+        if self.net_quantity != expected_net:
+            raise ValueError("net_quantity must equal quantity_opened minus quantity_closed")
+        if self.quantity_closed > self.quantity_opened:
+            raise ValueError("quantity_closed must not exceed quantity_opened")
+
+        if self.status == "flat":
+            if any(
+                value != Decimal("0")
+                for value in (
+                    self.quantity_opened,
+                    self.quantity_closed,
+                    self.net_quantity,
+                    self.average_entry_price,
+                )
+            ):
+                raise ValueError("flat positions must have zero quantities and zero average_entry_price")
+            if self.closed_at is not None:
+                raise ValueError("flat positions must not define closed_at")
+        elif self.status == "open":
+            if self.net_quantity <= Decimal("0"):
+                raise ValueError("open positions must have positive net_quantity")
+            if self.closed_at is not None:
+                raise ValueError("open positions must not define closed_at")
+        elif self.status == "closed":
+            if self.net_quantity != Decimal("0"):
+                raise ValueError("closed positions must have zero net_quantity")
+            if self.closed_at is None:
+                raise ValueError("closed positions must define closed_at")
+            if self.realized_pnl is None:
+                raise ValueError("closed positions must define realized_pnl")
+            if self.quantity_opened != self.quantity_closed:
+                raise ValueError("closed positions must have quantity_closed equal to quantity_opened")
+
+        if self.quantity_closed > Decimal("0") and self.average_exit_price is None:
+            raise ValueError("average_exit_price is required when quantity_closed is positive")
+
+        return self
+
+
+class CanonicalTrade(TradingCoreBase):
+    trade_id: str = Field(min_length=1)
+    position_id: str = Field(min_length=1)
+    strategy_id: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    direction: CoreDirection
+    status: TradeStatus
+    opened_at: str = Field(min_length=1)
+    closed_at: Optional[str] = None
+    quantity_opened: Decimal = Field(gt=Decimal("0"))
+    quantity_closed: Decimal = Field(default=Decimal("0"), ge=Decimal("0"))
+    average_entry_price: Decimal = Field(gt=Decimal("0"))
+    average_exit_price: Optional[Decimal] = Field(default=None, gt=Decimal("0"))
+    realized_pnl: Optional[Decimal] = None
+    opening_order_ids: List[str] = Field(default_factory=list)
+    closing_order_ids: List[str] = Field(default_factory=list)
+    execution_event_ids: List[str] = Field(default_factory=list)
+
+    @field_validator("opening_order_ids", "closing_order_ids", "execution_event_ids", mode="before")
+    @classmethod
+    def _normalize_id_lists(cls, value: Any) -> list[str]:
+        return _normalize_identifier_list(value)
+
+    @model_validator(mode="after")
+    def _validate_trade_state(self) -> "CanonicalTrade":
+        if self.quantity_closed > self.quantity_opened:
+            raise ValueError("quantity_closed must not exceed quantity_opened")
+
+        if self.status == "open":
+            if self.quantity_closed >= self.quantity_opened:
+                raise ValueError("open trades must retain positive remaining quantity")
+            if self.closed_at is not None:
+                raise ValueError("open trades must not define closed_at")
+        elif self.status == "closed":
+            if self.quantity_closed != self.quantity_opened:
+                raise ValueError("closed trades must have quantity_closed equal to quantity_opened")
+            if self.closed_at is None:
+                raise ValueError("closed trades must define closed_at")
+            if self.average_exit_price is None:
+                raise ValueError("closed trades must define average_exit_price")
+            if self.realized_pnl is None:
+                raise ValueError("closed trades must define realized_pnl")
+
+        if self.quantity_closed > Decimal("0") and self.average_exit_price is None:
+            raise ValueError("average_exit_price is required when quantity_closed is positive")
+
+        return self
+
+
+Order = CanonicalOrder
+Position = CanonicalPosition
+ExecutionEvent = CanonicalExecutionEvent
+Trade = CanonicalTrade
+
+TRADING_CORE_MODEL_TYPES: Dict[str, type[TradingCoreBase]] = {
+    "order": Order,
+    "position": Position,
+    "execution_event": ExecutionEvent,
+    "trade": Trade,
+}
 
 
 def _signal_identity_payload(signal: Mapping[str, Any]) -> Dict[str, Any]:
@@ -182,14 +482,8 @@ def _signal_identity_payload(signal: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def compute_signal_id(signal: Mapping[str, Any]) -> str:
-    """Compute a deterministic signal ID.
+    """Compute a deterministic signal ID."""
 
-    Args:
-        signal: Signal payload used to compute the ID.
-
-    Returns:
-        Deterministic signal ID.
-    """
     return sha256_hex(canonical_json(_signal_identity_payload(signal)))
 
 
@@ -224,6 +518,79 @@ def compute_signal_reason_id(
     )
     digest = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
     return f"sr_{digest}"
+
+
+def compute_execution_event_id(
+    *,
+    order_id: str,
+    event_type: ExecutionEventType,
+    occurred_at: str,
+    sequence: int,
+) -> str:
+    payload = {
+        "order_id": order_id,
+        "event_type": event_type,
+        "occurred_at": occurred_at,
+        "sequence": sequence,
+    }
+    return f"evt_{sha256_hex(canonical_json(payload))}"
+
+
+def validate_trading_core_entity(entity_name: str, payload: Mapping[str, Any]) -> TradingCoreBase:
+    model_type = TRADING_CORE_MODEL_TYPES.get(entity_name)
+    if model_type is None:
+        raise ValueError(f"unsupported trading core entity: {entity_name}")
+    return model_type.model_validate(payload)
+
+
+def serialize_trading_core_entity(entity: TradingCoreBase) -> str:
+    return entity.to_canonical_json()
+
+
+def validate_trading_core_relationships(
+    *,
+    trade: CanonicalTrade,
+    position: CanonicalPosition,
+    orders: List[CanonicalOrder],
+    execution_events: List[CanonicalExecutionEvent],
+) -> None:
+    order_ids = {order.order_id for order in orders}
+    event_ids = {event.event_id for event in execution_events}
+
+    if trade.position_id != position.position_id:
+        raise ValueError("trade.position_id must match position.position_id")
+
+    if not set(trade.opening_order_ids).issubset(order_ids):
+        raise ValueError("trade opening_order_ids must reference known orders")
+
+    if not set(trade.closing_order_ids).issubset(order_ids):
+        raise ValueError("trade closing_order_ids must reference known orders")
+
+    if not set(trade.execution_event_ids).issubset(event_ids):
+        raise ValueError("trade execution_event_ids must reference known execution events")
+
+    if not set(position.order_ids).issubset(order_ids):
+        raise ValueError("position order_ids must reference known orders")
+
+    if not set(position.execution_event_ids).issubset(event_ids):
+        raise ValueError("position execution_event_ids must reference known execution events")
+
+    if trade.trade_id not in position.trade_ids:
+        raise ValueError("position.trade_ids must include trade.trade_id")
+
+    for order in orders:
+        if order.position_id is not None and order.position_id != position.position_id:
+            raise ValueError("order.position_id must match position.position_id")
+        if order.trade_id is not None and order.trade_id != trade.trade_id:
+            raise ValueError("order.trade_id must match trade.trade_id")
+
+    for event in execution_events:
+        if event.order_id not in order_ids:
+            raise ValueError("execution_event.order_id must reference a known order")
+        if event.position_id is not None and event.position_id != position.position_id:
+            raise ValueError("execution_event.position_id must match position.position_id")
+        if event.trade_id is not None and event.trade_id != trade.trade_id:
+            raise ValueError("execution_event.trade_id must match trade.trade_id")
 
 
 class EntryZoneDTO(BaseModel):

--- a/tests/cilly_trading/engine/test_order_execution_model.py
+++ b/tests/cilly_trading/engine/test_order_execution_model.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Literal
 
-from cilly_trading.engine.pipeline.orchestrator import run_pipeline
+from cilly_trading.engine.pipeline.orchestrator import (
+    DeterministicExecutionConfig,
+    Order,
+    Position,
+    run_pipeline,
+)
 from cilly_trading.engine.strategy_lifecycle.model import StrategyLifecycleState
 from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
 
@@ -16,31 +19,6 @@ class _ProductionLifecycleStore:
 
     def set_state(self, strategy_id: str, new_state: StrategyLifecycleState) -> None:
         return None
-
-
-@dataclass(frozen=True)
-class Order:
-    id: str
-    side: Literal["BUY", "SELL"]
-    quantity: Decimal
-    created_snapshot_key: str
-    sequence: int
-
-
-@dataclass(frozen=True)
-class Position:
-    quantity: Decimal
-    avg_price: Decimal
-
-
-@dataclass(frozen=True)
-class DeterministicExecutionConfig:
-    slippage_bps: int
-    commission_per_order: Decimal
-    price_scale: Decimal = Decimal("0.00000001")
-    money_scale: Decimal = Decimal("0.01")
-    quantity_scale: Decimal = Decimal("0.00000001")
-    fill_timing: Literal["next_snapshot", "same_snapshot"] = "next_snapshot"
 
 
 class _StaticDecisionRiskGate(RiskGate):
@@ -80,6 +58,70 @@ def _risk_request() -> RiskEvaluationRequest:
     )
 
 
+def _order(
+    *,
+    order_id: str,
+    side: str,
+    quantity: str,
+    created_at: str,
+    sequence: int,
+    position_id: str = "pos-1",
+    trade_id: str = "trade-1",
+) -> Order:
+    return Order(
+        order_id=order_id,
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        sequence=sequence,
+        side=side,
+        order_type="market",
+        time_in_force="day",
+        status="created",
+        quantity=Decimal(quantity),
+        created_at=created_at,
+        position_id=position_id,
+        trade_id=trade_id,
+    )
+
+
+def _position(
+    *,
+    status: str = "flat",
+    opened_at: str = "2024-01-01T00:00:00Z",
+    closed_at: str | None = None,
+    quantity_opened: str = "0",
+    quantity_closed: str = "0",
+    net_quantity: str = "0",
+    average_entry_price: str = "0",
+    average_exit_price: str | None = None,
+    realized_pnl: str | None = None,
+    order_ids: list[str] | None = None,
+    execution_event_ids: list[str] | None = None,
+    trade_ids: list[str] | None = None,
+) -> Position:
+    payload = {
+        "position_id": "pos-1",
+        "strategy_id": "strategy-a",
+        "symbol": "AAPL",
+        "direction": "long",
+        "status": status,
+        "opened_at": opened_at,
+        "closed_at": closed_at,
+        "quantity_opened": Decimal(quantity_opened),
+        "quantity_closed": Decimal(quantity_closed),
+        "net_quantity": Decimal(net_quantity),
+        "average_entry_price": Decimal(average_entry_price),
+        "order_ids": order_ids or [],
+        "execution_event_ids": execution_event_ids or [],
+        "trade_ids": trade_ids or [],
+    }
+    if average_exit_price is not None:
+        payload["average_exit_price"] = Decimal(average_exit_price)
+    if realized_pnl is not None:
+        payload["realized_pnl"] = Decimal(realized_pnl)
+    return Position.model_validate(payload)
+
+
 def _run(
     *,
     orders: list[Order],
@@ -101,11 +143,11 @@ def _run(
 def test_order_fill_determinism_repeated_runs_identical() -> None:
     config = _config()
     snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
-    position = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
+    position = _position()
 
     orders = [
-        Order(id="ord-2", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=2),
-        Order(id="ord-1", side="BUY", quantity=Decimal("2"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1),
+        _order(order_id="ord-2", side="BUY", quantity="1", created_at="2024-01-01T00:00:00Z", sequence=2),
+        _order(order_id="ord-1", side="BUY", quantity="2", created_at="2024-01-01T00:00:00Z", sequence=1),
     ]
 
     result_a = _run(orders=orders, snapshot=snapshot, position=position, config=config)
@@ -113,22 +155,22 @@ def test_order_fill_determinism_repeated_runs_identical() -> None:
 
     assert result_a.fills == result_b.fills
     assert result_a.position == result_b.position
-    assert [fill.order_id for fill in result_a.fills] == ["ord-1", "ord-2"]
+    assert [event.order_id for event in result_a.fills] == ["ord-1", "ord-2"]
 
 
 def test_commission_model_is_fixed_and_repeatable() -> None:
     config = _config()
     snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "50"}
-    position = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
+    position = _position()
     orders = [
-        Order(id="buy-a", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1),
-        Order(id="buy-b", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=2),
+        _order(order_id="buy-a", side="BUY", quantity="1", created_at="2024-01-01T00:00:00Z", sequence=1),
+        _order(order_id="buy-b", side="BUY", quantity="1", created_at="2024-01-01T00:00:00Z", sequence=2),
     ]
 
     result_1 = _run(orders=orders, snapshot=snapshot, position=position, config=config)
     result_2 = _run(orders=orders, snapshot=snapshot, position=position, config=config)
 
-    assert [fill.commission for fill in result_1.fills] == [Decimal("1.25"), Decimal("1.25")]
+    assert [event.commission for event in result_1.fills] == [Decimal("1.25"), Decimal("1.25")]
     assert result_1.fills == result_2.fills
 
 
@@ -136,49 +178,37 @@ def test_position_lifecycle_buy_increase_sell_reduce_close() -> None:
     config = _config()
 
     buy_snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
-    first_buy = Order(
-        id="buy-1",
-        side="BUY",
-        quantity=Decimal("2"),
-        created_snapshot_key="2024-01-01T00:00:00Z",
-        sequence=1,
-    )
-    second_buy = Order(
-        id="buy-2",
-        side="BUY",
-        quantity=Decimal("2"),
-        created_snapshot_key="2024-01-01T00:00:00Z",
-        sequence=2,
-    )
-
     buy_result = _run(
-        orders=[first_buy, second_buy],
+        orders=[
+            _order(order_id="buy-1", side="BUY", quantity="2", created_at="2024-01-01T00:00:00Z", sequence=1),
+            _order(order_id="buy-2", side="BUY", quantity="2", created_at="2024-01-01T00:00:00Z", sequence=2),
+        ],
         snapshot=buy_snapshot,
-        position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
+        position=_position(),
         config=config,
     )
 
     assert len(buy_result.fills) == 2
-    assert buy_result.position.quantity == Decimal("4.00000000")
-    assert buy_result.position.avg_price == Decimal("100.10000000")
+    assert buy_result.position.status == "open"
+    assert buy_result.position.net_quantity == Decimal("4.00000000")
+    assert buy_result.position.average_entry_price == Decimal("100.10000000")
 
     sell_snapshot = {"timestamp": "2024-01-03T00:00:00Z", "open": "110"}
-    reduce_and_close = [
-        Order(id="sell-1", side="SELL", quantity=Decimal("1"), created_snapshot_key="2024-01-02T00:00:00Z", sequence=3),
-        Order(id="sell-2", side="SELL", quantity=Decimal("3"), created_snapshot_key="2024-01-02T00:00:00Z", sequence=4),
-    ]
-
     sell_result = _run(
-        orders=reduce_and_close,
+        orders=[
+            _order(order_id="sell-1", side="SELL", quantity="1", created_at="2024-01-02T00:00:00Z", sequence=3),
+            _order(order_id="sell-2", side="SELL", quantity="3", created_at="2024-01-02T00:00:00Z", sequence=4),
+        ],
         snapshot=sell_snapshot,
         position=buy_result.position,
         config=config,
     )
 
     assert len(sell_result.fills) == 2
-    assert sell_result.fills[0].fill_price == Decimal("109.89000000")
-    assert sell_result.position.quantity == Decimal("0")
-    assert sell_result.position.avg_price == Decimal("0")
+    assert sell_result.fills[0].execution_price == Decimal("109.89000000")
+    assert sell_result.position.status == "closed"
+    assert sell_result.position.net_quantity == Decimal("0")
+    assert sell_result.position.average_exit_price == Decimal("109.89000000")
 
 
 def test_slippage_applies_by_side_direction() -> None:
@@ -186,61 +216,64 @@ def test_slippage_applies_by_side_direction() -> None:
     snapshot = {"timestamp": "2024-01-02T00:00:00Z", "open": "100"}
 
     buy_result = _run(
-        orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
+        orders=[_order(order_id="buy", side="BUY", quantity="1", created_at="2024-01-01T00:00:00Z", sequence=1)],
         snapshot=snapshot,
-        position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
+        position=_position(),
         config=config,
     )
 
     sell_result = _run(
-        orders=[Order(id="sell", side="SELL", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
+        orders=[_order(order_id="sell", side="SELL", quantity="1", created_at="2024-01-01T00:00:00Z", sequence=1)],
         snapshot=snapshot,
-        position=Position(quantity=Decimal("1"), avg_price=Decimal("99")),
+        position=_position(
+            status="open",
+            quantity_opened="1",
+            net_quantity="1",
+            average_entry_price="99",
+            trade_ids=["trade-1"],
+        ),
         config=config,
     )
 
-    assert buy_result.fills[0].fill_price == Decimal("100.10000000")
-    assert sell_result.fills[0].fill_price == Decimal("99.90000000")
+    assert buy_result.fills[0].execution_price == Decimal("100.10000000")
+    assert sell_result.fills[0].execution_price == Decimal("99.90000000")
 
 
 def test_next_snapshot_fill_timing_enforced() -> None:
     config = _config(fill_timing="next_snapshot")
-
-    order = Order(
-        id="next-fill",
+    order = _order(
+        order_id="next-fill",
         side="BUY",
-        quantity=Decimal("1"),
-        created_snapshot_key="2024-01-02T00:00:00Z",
+        quantity="1",
+        created_at="2024-01-02T00:00:00Z",
         sequence=1,
     )
-    start = Position(quantity=Decimal("0"), avg_price=Decimal("0"))
 
     result_t = _run(
         orders=[order],
         snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "10"},
-        position=start,
+        position=_position(),
         config=config,
     )
 
     result_t1 = _run(
         orders=[order],
         snapshot={"timestamp": "2024-01-03T00:00:00Z", "open": "11"},
-        position=start,
+        position=_position(),
         config=config,
     )
 
     assert result_t.fills == []
-    assert result_t.position.quantity == Decimal("0")
-    assert result_t.position.avg_price == Decimal("0")
+    assert result_t.position.net_quantity == Decimal("0")
     assert len(result_t1.fills) == 1
-    assert result_t1.position.quantity == Decimal("1.00000000")
+    assert result_t1.position.net_quantity == Decimal("1.00000000")
 
 
 def test_execution_rejected_risk_decision_fails_closed() -> None:
     result = _run(
-        orders=[Order(id="buy", side="BUY", quantity=Decimal("1"), created_snapshot_key="2024-01-01T00:00:00Z", sequence=1)],
+        orders=[_order(order_id="buy", side="BUY", quantity="1", created_at="2024-01-01T00:00:00Z", sequence=1)],
         snapshot={"timestamp": "2024-01-02T00:00:00Z", "open": "100"},
-        position=Position(quantity=Decimal("0"), avg_price=Decimal("0")),
+        position=_position(),
         config=_config(),
         decision="REJECTED",
     )

--- a/tests/test_trading_core_models.py
+++ b/tests/test_trading_core_models.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from cilly_trading.models import (
+    ExecutionEvent,
+    Order,
+    Position,
+    Trade,
+    TRADING_CORE_ENTITIES,
+    TRADING_CORE_RELATIONSHIPS,
+    compute_execution_event_id,
+    serialize_trading_core_entity,
+    validate_trading_core_entity,
+    validate_trading_core_relationships,
+)
+
+
+def _order_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "order_id": "ord-1",
+        "strategy_id": "strategy-a",
+        "symbol": "AAPL",
+        "sequence": 1,
+        "side": "BUY",
+        "order_type": "market",
+        "time_in_force": "day",
+        "status": "created",
+        "quantity": Decimal("2"),
+        "filled_quantity": Decimal("0"),
+        "created_at": "2024-01-01T00:00:00Z",
+        "position_id": "pos-1",
+        "trade_id": "trade-1",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _event_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "event_id": compute_execution_event_id(
+            order_id="ord-1",
+            event_type="filled",
+            occurred_at="2024-01-02T00:00:00Z",
+            sequence=1,
+        ),
+        "order_id": "ord-1",
+        "strategy_id": "strategy-a",
+        "symbol": "AAPL",
+        "side": "BUY",
+        "event_type": "filled",
+        "occurred_at": "2024-01-02T00:00:00Z",
+        "sequence": 1,
+        "execution_quantity": Decimal("2"),
+        "execution_price": Decimal("100.10"),
+        "commission": Decimal("1.25"),
+        "position_id": "pos-1",
+        "trade_id": "trade-1",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _position_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "position_id": "pos-1",
+        "strategy_id": "strategy-a",
+        "symbol": "AAPL",
+        "direction": "long",
+        "status": "open",
+        "opened_at": "2024-01-02T00:00:00Z",
+        "quantity_opened": Decimal("2"),
+        "quantity_closed": Decimal("0"),
+        "net_quantity": Decimal("2"),
+        "average_entry_price": Decimal("100.10"),
+        "order_ids": ["ord-1"],
+        "execution_event_ids": ["evt-b", "evt-a"],
+        "trade_ids": ["trade-1"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _trade_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "trade_id": "trade-1",
+        "position_id": "pos-1",
+        "strategy_id": "strategy-a",
+        "symbol": "AAPL",
+        "direction": "long",
+        "status": "open",
+        "opened_at": "2024-01-02T00:00:00Z",
+        "quantity_opened": Decimal("2"),
+        "quantity_closed": Decimal("0"),
+        "average_entry_price": Decimal("100.10"),
+        "opening_order_ids": ["ord-1"],
+        "closing_order_ids": [],
+        "execution_event_ids": ["evt-b", "evt-a"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_trading_core_entity_responsibilities_are_explicit() -> None:
+    assert TRADING_CORE_ENTITIES["Order"]["authority"] == "authoritative"
+    assert TRADING_CORE_ENTITIES["ExecutionEvent"]["authority"] == "authoritative"
+    assert TRADING_CORE_ENTITIES["Position"]["authority"] == "derived"
+    assert TRADING_CORE_ENTITIES["Trade"]["authority"] == "derived"
+    assert any(
+        relationship["from_entity"] == "Trade" and relationship["to_entity"] == "ExecutionEvent"
+        for relationship in TRADING_CORE_RELATIONSHIPS
+    )
+
+
+def test_representative_payloads_validate_and_relationships_hold() -> None:
+    order = Order.model_validate(
+        _order_payload(
+            status="filled",
+            filled_quantity=Decimal("2"),
+            average_fill_price=Decimal("100.10"),
+            last_execution_event_id="evt-1",
+        )
+    )
+    event = ExecutionEvent.model_validate(_event_payload())
+    position = Position.model_validate(
+        _position_payload(execution_event_ids=[event.event_id], order_ids=[order.order_id])
+    )
+    trade = Trade.model_validate(
+        _trade_payload(execution_event_ids=[event.event_id], opening_order_ids=[order.order_id])
+    )
+
+    validate_trading_core_relationships(
+        trade=trade,
+        position=position,
+        orders=[order],
+        execution_events=[event],
+    )
+
+
+def test_trading_core_serialization_is_deterministic() -> None:
+    trade_a = validate_trading_core_entity("trade", _trade_payload())
+    trade_b = validate_trading_core_entity(
+        "trade",
+        _trade_payload(execution_event_ids=["evt-a", "evt-b"]),
+    )
+
+    assert serialize_trading_core_entity(trade_a) == serialize_trading_core_entity(trade_b)
+
+
+def test_negative_order_validation_rejects_invalid_fill_state() -> None:
+    with pytest.raises(ValidationError):
+        Order.model_validate(
+            _order_payload(
+                status="filled",
+                filled_quantity=Decimal("1"),
+                average_fill_price=Decimal("100.10"),
+                last_execution_event_id="evt-1",
+            )
+        )
+
+
+def test_negative_execution_event_validation_rejects_missing_fill_fields() -> None:
+    with pytest.raises(ValidationError):
+        ExecutionEvent.model_validate(_event_payload(execution_price=None))
+
+
+def test_negative_position_validation_rejects_incorrect_net_quantity() -> None:
+    with pytest.raises(ValidationError):
+        Position.model_validate(_position_payload(net_quantity=Decimal("3")))
+
+
+def test_negative_trade_validation_rejects_closed_trade_without_exit_fields() -> None:
+    with pytest.raises(ValidationError):
+        Trade.model_validate(
+            _trade_payload(
+                status="closed",
+                quantity_closed=Decimal("2"),
+                closed_at=None,
+                average_exit_price=None,
+                realized_pnl=None,
+            )
+        )
+
+
+def test_relationship_validation_rejects_unknown_execution_event_reference() -> None:
+    order = Order.model_validate(
+        _order_payload(
+            status="filled",
+            filled_quantity=Decimal("2"),
+            average_fill_price=Decimal("100.10"),
+            last_execution_event_id="evt-1",
+        )
+    )
+    event = ExecutionEvent.model_validate(_event_payload())
+    position = Position.model_validate(_position_payload(order_ids=[order.order_id], execution_event_ids=[event.event_id]))
+    trade = Trade.model_validate(_trade_payload(opening_order_ids=[order.order_id], execution_event_ids=["evt-missing"]))
+
+    with pytest.raises(ValueError):
+        validate_trading_core_relationships(
+            trade=trade,
+            position=position,
+            orders=[order],
+            execution_events=[event],
+        )


### PR DESCRIPTION
Closes #718

## Summary
- define canonical trading-core entities for `Trade`, `Position`, `Order`, and `ExecutionEvent`
- make authoritative vs derived responsibilities explicit and document entity relationships
- add deterministic serialization, validation, negative validation, and lifecycle tests
- align the execution pipeline to the canonical `Order` / `Position` / `ExecutionEvent` vocabulary while preserving legacy test compatibility

## Testing
- `python -m pytest`
