### PR TITLE
CORE-P41A: Define deterministic trading lifecycle state machine

### DIFF
--- a/docs/architecture/trading_core_domain_model.md
+++ b/docs/architecture/trading_core_domain_model.md
@@ -44,3 +44,10 @@ Issue `#718` defines one canonical trading-core vocabulary for `Trade`, `Positio
 2. `ExecutionEvent` records immutable lifecycle facts for that order.
 3. `Position` derives current or closed aggregate exposure from those facts.
 4. `Trade` derives the lifecycle summary tied to the position and linked execution events.
+
+## Lifecycle State Machine
+
+Deterministic lifecycle states, transition rules, transition-order checks, and transition invariants for `Order`, `Trade`, and `Position` are defined once in:
+
+- `docs/architecture/trading_lifecycle_state_machine.md`
+- `src/cilly_trading/trading_lifecycle.py`

--- a/docs/architecture/trading_lifecycle_state_machine.md
+++ b/docs/architecture/trading_lifecycle_state_machine.md
@@ -1,0 +1,114 @@
+# Trading Lifecycle State Machine
+
+Issue `#719` defines one deterministic lifecycle model for `Order`, `Trade`, and `Position`.
+
+## Scope
+
+- This state machine governs lifecycle state transitions only.
+- Broker-specific behavior, strategy logic, UI workflow, and notifications are out of scope.
+- Lifecycle validation is centralized in `src/cilly_trading/trading_lifecycle.py`.
+
+## Canonical States
+
+### Order
+
+- `created`
+- `submitted`
+- `partially_filled`
+- `filled` (terminal)
+- `cancelled` (terminal)
+- `rejected` (terminal)
+
+### Trade
+
+- `open`
+- `closed` (terminal)
+
+### Position
+
+- `flat`
+- `open`
+- `closed` (terminal)
+
+## Allowed Transitions
+
+### Order
+
+- `created -> submitted`
+- `created -> cancelled`
+- `created -> rejected`
+- `submitted -> partially_filled`
+- `submitted -> filled`
+- `submitted -> cancelled`
+- `submitted -> rejected`
+- `partially_filled -> filled`
+
+All other `Order` transitions are forbidden.
+
+### Trade
+
+- `open -> closed`
+
+All other `Trade` transitions are forbidden.
+
+### Position
+
+- `flat -> open`
+- `open -> closed`
+
+All other `Position` transitions are forbidden.
+
+## Transition Invariants
+
+### Order Invariants
+
+- `filled_quantity` is never negative and never greater than `quantity`.
+- Non-fill states (`created`, `submitted`, `cancelled`, `rejected`) require `filled_quantity == 0`.
+- `partially_filled` requires `0 < filled_quantity < quantity`.
+- `filled` requires `filled_quantity == quantity`.
+- Across transitions:
+  - `quantity` is immutable.
+  - `filled_quantity` is monotonic non-decreasing.
+
+### Trade Invariants
+
+- `quantity_closed` never exceeds `quantity_opened`.
+- `open` requires `quantity_closed < quantity_opened`.
+- `closed` requires `quantity_closed == quantity_opened`.
+- Across transitions:
+  - `quantity_opened` is immutable.
+  - `quantity_closed` is monotonic non-decreasing.
+
+### Position Invariants
+
+- `net_quantity == quantity_opened - quantity_closed`.
+- `quantity_closed` never exceeds `quantity_opened`.
+- `flat` requires all quantities to be zero.
+- `open` requires `net_quantity > 0`.
+- `closed` requires `net_quantity == 0` and `quantity_opened == quantity_closed`.
+- Across transitions:
+  - `quantity_opened` is immutable.
+  - `quantity_closed` is monotonic non-decreasing.
+
+## Validation Guards
+
+Reusable guards are exposed from `src/cilly_trading/trading_lifecycle.py`:
+
+- Transition guards:
+  - `validate_order_transition`
+  - `validate_trade_transition`
+  - `validate_position_transition`
+- Transition-order guards:
+  - `validate_order_transition_sequence`
+  - `validate_trade_transition_sequence`
+  - `validate_position_transition_sequence`
+- State invariant guards:
+  - `validate_order_state_invariants`
+  - `validate_trade_state_invariants`
+  - `validate_position_state_invariants`
+- Transition invariant guards:
+  - `validate_order_transition_invariants`
+  - `validate_trade_transition_invariants`
+  - `validate_position_transition_invariants`
+
+This is the canonical lifecycle model and must be reused instead of creating parallel transition logic.

--- a/src/cilly_trading/models.py
+++ b/src/cilly_trading/models.py
@@ -11,6 +11,15 @@ from typing import Any, Dict, List, Literal, Mapping, Optional, TypedDict, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from cilly_trading.trading_lifecycle import (
+    OrderLifecycleState,
+    PositionLifecycleState,
+    TradeLifecycleState,
+    validate_order_state_invariants,
+    validate_position_state_invariants,
+    validate_trade_state_invariants,
+)
+
 
 Stage = Literal["setup", "entry_confirmed"]
 MarketType = Literal["stock", "crypto"]
@@ -282,22 +291,21 @@ class CanonicalOrder(TradingCoreBase):
 
     @model_validator(mode="after")
     def _validate_lifecycle(self) -> "CanonicalOrder":
-        if self.filled_quantity > self.quantity:
-            raise ValueError("filled_quantity must not exceed quantity")
+        order_status = OrderLifecycleState(self.status)
+        validate_order_state_invariants(
+            status=order_status,
+            quantity=self.quantity,
+            filled_quantity=self.filled_quantity,
+        )
 
-        if self.status in {"partially_filled", "filled"}:
+        if order_status in {
+            OrderLifecycleState.PARTIALLY_FILLED,
+            OrderLifecycleState.FILLED,
+        }:
             if self.average_fill_price is None:
                 raise ValueError("average_fill_price is required for filled orders")
             if self.last_execution_event_id is None:
                 raise ValueError("last_execution_event_id is required for filled orders")
-        elif self.filled_quantity != Decimal("0"):
-            raise ValueError("filled_quantity must be zero unless status is partially_filled or filled")
-
-        if self.status == "filled" and self.filled_quantity != self.quantity:
-            raise ValueError("filled orders must have filled_quantity equal to quantity")
-
-        if self.status == "partially_filled" and self.filled_quantity >= self.quantity:
-            raise ValueError("partially_filled orders must have filled_quantity less than quantity")
 
         return self
 
@@ -361,13 +369,15 @@ class CanonicalPosition(TradingCoreBase):
 
     @model_validator(mode="after")
     def _validate_position_state(self) -> "CanonicalPosition":
-        expected_net = self.quantity_opened - self.quantity_closed
-        if self.net_quantity != expected_net:
-            raise ValueError("net_quantity must equal quantity_opened minus quantity_closed")
-        if self.quantity_closed > self.quantity_opened:
-            raise ValueError("quantity_closed must not exceed quantity_opened")
+        position_status = PositionLifecycleState(self.status)
+        validate_position_state_invariants(
+            status=position_status,
+            quantity_opened=self.quantity_opened,
+            quantity_closed=self.quantity_closed,
+            net_quantity=self.net_quantity,
+        )
 
-        if self.status == "flat":
+        if position_status == PositionLifecycleState.FLAT:
             if any(
                 value != Decimal("0")
                 for value in (
@@ -380,12 +390,12 @@ class CanonicalPosition(TradingCoreBase):
                 raise ValueError("flat positions must have zero quantities and zero average_entry_price")
             if self.closed_at is not None:
                 raise ValueError("flat positions must not define closed_at")
-        elif self.status == "open":
+        elif position_status == PositionLifecycleState.OPEN:
             if self.net_quantity <= Decimal("0"):
                 raise ValueError("open positions must have positive net_quantity")
             if self.closed_at is not None:
                 raise ValueError("open positions must not define closed_at")
-        elif self.status == "closed":
+        elif position_status == PositionLifecycleState.CLOSED:
             if self.net_quantity != Decimal("0"):
                 raise ValueError("closed positions must have zero net_quantity")
             if self.closed_at is None:
@@ -426,15 +436,19 @@ class CanonicalTrade(TradingCoreBase):
 
     @model_validator(mode="after")
     def _validate_trade_state(self) -> "CanonicalTrade":
-        if self.quantity_closed > self.quantity_opened:
-            raise ValueError("quantity_closed must not exceed quantity_opened")
+        trade_status = TradeLifecycleState(self.status)
+        validate_trade_state_invariants(
+            status=trade_status,
+            quantity_opened=self.quantity_opened,
+            quantity_closed=self.quantity_closed,
+        )
 
-        if self.status == "open":
+        if trade_status == TradeLifecycleState.OPEN:
             if self.quantity_closed >= self.quantity_opened:
                 raise ValueError("open trades must retain positive remaining quantity")
             if self.closed_at is not None:
                 raise ValueError("open trades must not define closed_at")
-        elif self.status == "closed":
+        elif trade_status == TradeLifecycleState.CLOSED:
             if self.quantity_closed != self.quantity_opened:
                 raise ValueError("closed trades must have quantity_closed equal to quantity_opened")
             if self.closed_at is None:

--- a/src/cilly_trading/trading_lifecycle.py
+++ b/src/cilly_trading/trading_lifecycle.py
@@ -1,0 +1,376 @@
+"""Deterministic lifecycle state machine for trading-core entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import Enum
+from types import MappingProxyType
+from typing import Callable, Mapping, Sequence
+
+
+class OrderLifecycleState(str, Enum):
+    CREATED = "created"
+    SUBMITTED = "submitted"
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    CANCELLED = "cancelled"
+    REJECTED = "rejected"
+
+
+class TradeLifecycleState(str, Enum):
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+class PositionLifecycleState(str, Enum):
+    FLAT = "flat"
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+class TradingLifecycleTransitionError(ValueError):
+    """Raised when a lifecycle transition is not explicitly allowed."""
+
+
+class TradingLifecycleInvariantError(ValueError):
+    """Raised when lifecycle invariants are violated."""
+
+
+_ORDER_ALLOWED_TRANSITIONS_MUTABLE: dict[OrderLifecycleState, frozenset[OrderLifecycleState]] = {
+    OrderLifecycleState.CREATED: frozenset(
+        {
+            OrderLifecycleState.SUBMITTED,
+            OrderLifecycleState.CANCELLED,
+            OrderLifecycleState.REJECTED,
+        }
+    ),
+    OrderLifecycleState.SUBMITTED: frozenset(
+        {
+            OrderLifecycleState.PARTIALLY_FILLED,
+            OrderLifecycleState.FILLED,
+            OrderLifecycleState.CANCELLED,
+            OrderLifecycleState.REJECTED,
+        }
+    ),
+    OrderLifecycleState.PARTIALLY_FILLED: frozenset({OrderLifecycleState.FILLED}),
+    OrderLifecycleState.FILLED: frozenset(),
+    OrderLifecycleState.CANCELLED: frozenset(),
+    OrderLifecycleState.REJECTED: frozenset(),
+}
+
+_TRADE_ALLOWED_TRANSITIONS_MUTABLE: dict[TradeLifecycleState, frozenset[TradeLifecycleState]] = {
+    TradeLifecycleState.OPEN: frozenset({TradeLifecycleState.CLOSED}),
+    TradeLifecycleState.CLOSED: frozenset(),
+}
+
+_POSITION_ALLOWED_TRANSITIONS_MUTABLE: dict[PositionLifecycleState, frozenset[PositionLifecycleState]] = {
+    PositionLifecycleState.FLAT: frozenset({PositionLifecycleState.OPEN}),
+    PositionLifecycleState.OPEN: frozenset({PositionLifecycleState.CLOSED}),
+    PositionLifecycleState.CLOSED: frozenset(),
+}
+
+ORDER_ALLOWED_TRANSITIONS = MappingProxyType(_ORDER_ALLOWED_TRANSITIONS_MUTABLE)
+TRADE_ALLOWED_TRANSITIONS = MappingProxyType(_TRADE_ALLOWED_TRANSITIONS_MUTABLE)
+POSITION_ALLOWED_TRANSITIONS = MappingProxyType(_POSITION_ALLOWED_TRANSITIONS_MUTABLE)
+
+ORDER_TERMINAL_STATES: frozenset[OrderLifecycleState] = frozenset(
+    {
+        OrderLifecycleState.FILLED,
+        OrderLifecycleState.CANCELLED,
+        OrderLifecycleState.REJECTED,
+    }
+)
+TRADE_TERMINAL_STATES: frozenset[TradeLifecycleState] = frozenset({TradeLifecycleState.CLOSED})
+POSITION_TERMINAL_STATES: frozenset[PositionLifecycleState] = frozenset({PositionLifecycleState.CLOSED})
+
+
+def _validate_transition(
+    *,
+    entity_name: str,
+    current_state: Enum,
+    target_state: Enum,
+    allowed_transitions: Mapping[Enum, frozenset[Enum]],
+    terminal_states: frozenset[Enum],
+) -> None:
+    if current_state == target_state:
+        raise TradingLifecycleTransitionError(
+            f"Illegal {entity_name} lifecycle transition: {current_state.value} -> {target_state.value}"
+        )
+
+    allowed_targets = allowed_transitions[current_state]
+    if target_state in allowed_targets:
+        return
+
+    if current_state in terminal_states:
+        raise TradingLifecycleTransitionError(
+            f"Illegal {entity_name} lifecycle transition: {current_state.value} is terminal"
+        )
+
+    raise TradingLifecycleTransitionError(
+        f"Illegal {entity_name} lifecycle transition: {current_state.value} -> {target_state.value}"
+    )
+
+
+def _validate_transition_sequence(
+    *,
+    states: Sequence[Enum],
+    validate_step: Callable[[Enum, Enum], None],
+) -> None:
+    if len(states) < 2:
+        return
+    for index in range(1, len(states)):
+        validate_step(states[index - 1], states[index])
+
+
+def get_allowed_order_transitions(state: OrderLifecycleState) -> frozenset[OrderLifecycleState]:
+    return ORDER_ALLOWED_TRANSITIONS[state]
+
+
+def get_allowed_trade_transitions(state: TradeLifecycleState) -> frozenset[TradeLifecycleState]:
+    return TRADE_ALLOWED_TRANSITIONS[state]
+
+
+def get_allowed_position_transitions(state: PositionLifecycleState) -> frozenset[PositionLifecycleState]:
+    return POSITION_ALLOWED_TRANSITIONS[state]
+
+
+def validate_order_transition(current_state: OrderLifecycleState, target_state: OrderLifecycleState) -> None:
+    _validate_transition(
+        entity_name="Order",
+        current_state=current_state,
+        target_state=target_state,
+        allowed_transitions=ORDER_ALLOWED_TRANSITIONS,
+        terminal_states=ORDER_TERMINAL_STATES,
+    )
+
+
+def validate_trade_transition(current_state: TradeLifecycleState, target_state: TradeLifecycleState) -> None:
+    _validate_transition(
+        entity_name="Trade",
+        current_state=current_state,
+        target_state=target_state,
+        allowed_transitions=TRADE_ALLOWED_TRANSITIONS,
+        terminal_states=TRADE_TERMINAL_STATES,
+    )
+
+
+def validate_position_transition(
+    current_state: PositionLifecycleState,
+    target_state: PositionLifecycleState,
+) -> None:
+    _validate_transition(
+        entity_name="Position",
+        current_state=current_state,
+        target_state=target_state,
+        allowed_transitions=POSITION_ALLOWED_TRANSITIONS,
+        terminal_states=POSITION_TERMINAL_STATES,
+    )
+
+
+def validate_order_transition_sequence(states: Sequence[OrderLifecycleState]) -> None:
+    _validate_transition_sequence(
+        states=states,
+        validate_step=lambda current, target: validate_order_transition(
+            current_state=current,  # type: ignore[arg-type]
+            target_state=target,  # type: ignore[arg-type]
+        ),
+    )
+
+
+def validate_trade_transition_sequence(states: Sequence[TradeLifecycleState]) -> None:
+    _validate_transition_sequence(
+        states=states,
+        validate_step=lambda current, target: validate_trade_transition(
+            current_state=current,  # type: ignore[arg-type]
+            target_state=target,  # type: ignore[arg-type]
+        ),
+    )
+
+
+def validate_position_transition_sequence(states: Sequence[PositionLifecycleState]) -> None:
+    _validate_transition_sequence(
+        states=states,
+        validate_step=lambda current, target: validate_position_transition(
+            current_state=current,  # type: ignore[arg-type]
+            target_state=target,  # type: ignore[arg-type]
+        ),
+    )
+
+
+def validate_order_state_invariants(
+    *,
+    status: OrderLifecycleState,
+    quantity: Decimal,
+    filled_quantity: Decimal,
+) -> None:
+    if filled_quantity > quantity:
+        raise TradingLifecycleInvariantError("Order invariant violation: filled_quantity must not exceed quantity")
+
+    if status in {
+        OrderLifecycleState.CREATED,
+        OrderLifecycleState.SUBMITTED,
+        OrderLifecycleState.CANCELLED,
+        OrderLifecycleState.REJECTED,
+    }:
+        if filled_quantity != Decimal("0"):
+            raise TradingLifecycleInvariantError(
+                "Order invariant violation: non-fill states must have filled_quantity equal to zero"
+            )
+        return
+
+    if status == OrderLifecycleState.PARTIALLY_FILLED:
+        if filled_quantity <= Decimal("0"):
+            raise TradingLifecycleInvariantError(
+                "Order invariant violation: partially_filled requires positive filled_quantity"
+            )
+        if filled_quantity >= quantity:
+            raise TradingLifecycleInvariantError(
+                "Order invariant violation: partially_filled requires filled_quantity less than quantity"
+            )
+        return
+
+    if status == OrderLifecycleState.FILLED and filled_quantity != quantity:
+        raise TradingLifecycleInvariantError(
+            "Order invariant violation: filled state requires filled_quantity equal to quantity"
+        )
+
+
+def validate_trade_state_invariants(
+    *,
+    status: TradeLifecycleState,
+    quantity_opened: Decimal,
+    quantity_closed: Decimal,
+) -> None:
+    if quantity_closed > quantity_opened:
+        raise TradingLifecycleInvariantError("Trade invariant violation: quantity_closed must not exceed quantity_opened")
+
+    if status == TradeLifecycleState.OPEN and quantity_closed >= quantity_opened:
+        raise TradingLifecycleInvariantError(
+            "Trade invariant violation: open state requires quantity_closed less than quantity_opened"
+        )
+
+    if status == TradeLifecycleState.CLOSED and quantity_closed != quantity_opened:
+        raise TradingLifecycleInvariantError(
+            "Trade invariant violation: closed state requires quantity_closed equal to quantity_opened"
+        )
+
+
+def validate_position_state_invariants(
+    *,
+    status: PositionLifecycleState,
+    quantity_opened: Decimal,
+    quantity_closed: Decimal,
+    net_quantity: Decimal,
+) -> None:
+    if quantity_closed > quantity_opened:
+        raise TradingLifecycleInvariantError(
+            "Position invariant violation: quantity_closed must not exceed quantity_opened"
+        )
+    if net_quantity != quantity_opened - quantity_closed:
+        raise TradingLifecycleInvariantError(
+            "Position invariant violation: net_quantity must equal quantity_opened minus quantity_closed"
+        )
+
+    if status == PositionLifecycleState.FLAT:
+        if any(value != Decimal("0") for value in (quantity_opened, quantity_closed, net_quantity)):
+            raise TradingLifecycleInvariantError(
+                "Position invariant violation: flat state requires all quantities to be zero"
+            )
+        return
+
+    if status == PositionLifecycleState.OPEN and net_quantity <= Decimal("0"):
+        raise TradingLifecycleInvariantError("Position invariant violation: open state requires positive net_quantity")
+
+    if status == PositionLifecycleState.CLOSED:
+        if net_quantity != Decimal("0"):
+            raise TradingLifecycleInvariantError(
+                "Position invariant violation: closed state requires net_quantity equal to zero"
+            )
+        if quantity_opened != quantity_closed:
+            raise TradingLifecycleInvariantError(
+                "Position invariant violation: closed state requires quantity_closed equal to quantity_opened"
+            )
+
+
+@dataclass(frozen=True)
+class OrderLifecycleSnapshot:
+    status: OrderLifecycleState
+    quantity: Decimal
+    filled_quantity: Decimal
+
+
+@dataclass(frozen=True)
+class TradeLifecycleSnapshot:
+    status: TradeLifecycleState
+    quantity_opened: Decimal
+    quantity_closed: Decimal
+
+
+@dataclass(frozen=True)
+class PositionLifecycleSnapshot:
+    status: PositionLifecycleState
+    quantity_opened: Decimal
+    quantity_closed: Decimal
+    net_quantity: Decimal
+
+
+def validate_order_transition_invariants(
+    *,
+    current: OrderLifecycleSnapshot,
+    target: OrderLifecycleSnapshot,
+) -> None:
+    validate_order_transition(current_state=current.status, target_state=target.status)
+    if target.quantity != current.quantity:
+        raise TradingLifecycleInvariantError("Order transition invariant violation: quantity must be immutable")
+    if target.filled_quantity < current.filled_quantity:
+        raise TradingLifecycleInvariantError(
+            "Order transition invariant violation: filled_quantity must be monotonic non-decreasing"
+        )
+    validate_order_state_invariants(
+        status=target.status,
+        quantity=target.quantity,
+        filled_quantity=target.filled_quantity,
+    )
+
+
+def validate_trade_transition_invariants(
+    *,
+    current: TradeLifecycleSnapshot,
+    target: TradeLifecycleSnapshot,
+) -> None:
+    validate_trade_transition(current_state=current.status, target_state=target.status)
+    if target.quantity_opened != current.quantity_opened:
+        raise TradingLifecycleInvariantError("Trade transition invariant violation: quantity_opened must be immutable")
+    if target.quantity_closed < current.quantity_closed:
+        raise TradingLifecycleInvariantError(
+            "Trade transition invariant violation: quantity_closed must be monotonic non-decreasing"
+        )
+    validate_trade_state_invariants(
+        status=target.status,
+        quantity_opened=target.quantity_opened,
+        quantity_closed=target.quantity_closed,
+    )
+
+
+def validate_position_transition_invariants(
+    *,
+    current: PositionLifecycleSnapshot,
+    target: PositionLifecycleSnapshot,
+) -> None:
+    validate_position_transition(current_state=current.status, target_state=target.status)
+    if target.quantity_opened != current.quantity_opened:
+        raise TradingLifecycleInvariantError(
+            "Position transition invariant violation: quantity_opened must be immutable"
+        )
+    if target.quantity_closed < current.quantity_closed:
+        raise TradingLifecycleInvariantError(
+            "Position transition invariant violation: quantity_closed must be monotonic non-decreasing"
+        )
+    validate_position_state_invariants(
+        status=target.status,
+        quantity_opened=target.quantity_opened,
+        quantity_closed=target.quantity_closed,
+        net_quantity=target.net_quantity,
+    )
+

--- a/tests/test_trading_lifecycle_state_machine.py
+++ b/tests/test_trading_lifecycle_state_machine.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import itertools
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from cilly_trading.models import Order, Position, Trade
+from cilly_trading.trading_lifecycle import (
+    ORDER_ALLOWED_TRANSITIONS,
+    POSITION_ALLOWED_TRANSITIONS,
+    TRADE_ALLOWED_TRANSITIONS,
+    OrderLifecycleSnapshot,
+    OrderLifecycleState,
+    PositionLifecycleSnapshot,
+    PositionLifecycleState,
+    TradeLifecycleSnapshot,
+    TradeLifecycleState,
+    TradingLifecycleInvariantError,
+    TradingLifecycleTransitionError,
+    get_allowed_order_transitions,
+    get_allowed_position_transitions,
+    get_allowed_trade_transitions,
+    validate_order_transition,
+    validate_order_transition_invariants,
+    validate_order_transition_sequence,
+    validate_position_transition,
+    validate_position_transition_invariants,
+    validate_position_transition_sequence,
+    validate_trade_transition,
+    validate_trade_transition_invariants,
+    validate_trade_transition_sequence,
+)
+
+
+VALID_ORDER_TRANSITIONS = {
+    (OrderLifecycleState.CREATED, OrderLifecycleState.SUBMITTED),
+    (OrderLifecycleState.CREATED, OrderLifecycleState.CANCELLED),
+    (OrderLifecycleState.CREATED, OrderLifecycleState.REJECTED),
+    (OrderLifecycleState.SUBMITTED, OrderLifecycleState.PARTIALLY_FILLED),
+    (OrderLifecycleState.SUBMITTED, OrderLifecycleState.FILLED),
+    (OrderLifecycleState.SUBMITTED, OrderLifecycleState.CANCELLED),
+    (OrderLifecycleState.SUBMITTED, OrderLifecycleState.REJECTED),
+    (OrderLifecycleState.PARTIALLY_FILLED, OrderLifecycleState.FILLED),
+}
+
+VALID_TRADE_TRANSITIONS = {
+    (TradeLifecycleState.OPEN, TradeLifecycleState.CLOSED),
+}
+
+VALID_POSITION_TRANSITIONS = {
+    (PositionLifecycleState.FLAT, PositionLifecycleState.OPEN),
+    (PositionLifecycleState.OPEN, PositionLifecycleState.CLOSED),
+}
+
+
+@pytest.mark.parametrize(("current", "target"), sorted(VALID_ORDER_TRANSITIONS, key=lambda t: (t[0].value, t[1].value)))
+def test_valid_order_transitions_succeed(current: OrderLifecycleState, target: OrderLifecycleState) -> None:
+    validate_order_transition(current_state=current, target_state=target)
+
+
+@pytest.mark.parametrize(("current", "target"), sorted(VALID_TRADE_TRANSITIONS, key=lambda t: (t[0].value, t[1].value)))
+def test_valid_trade_transitions_succeed(current: TradeLifecycleState, target: TradeLifecycleState) -> None:
+    validate_trade_transition(current_state=current, target_state=target)
+
+
+@pytest.mark.parametrize(
+    ("current", "target"),
+    sorted(VALID_POSITION_TRANSITIONS, key=lambda t: (t[0].value, t[1].value)),
+)
+def test_valid_position_transitions_succeed(current: PositionLifecycleState, target: PositionLifecycleState) -> None:
+    validate_position_transition(current_state=current, target_state=target)
+
+
+def test_invalid_order_transitions_fail_deterministically() -> None:
+    all_pairs = set(itertools.product(OrderLifecycleState, repeat=2))
+    invalid_pairs = sorted(all_pairs - VALID_ORDER_TRANSITIONS, key=lambda t: (t[0].value, t[1].value))
+
+    for current, target in invalid_pairs:
+        with pytest.raises(TradingLifecycleTransitionError) as error:
+            validate_order_transition(current_state=current, target_state=target)
+
+        if current == target:
+            assert str(error.value) == f"Illegal Order lifecycle transition: {current.value} -> {target.value}"
+        elif current in {OrderLifecycleState.FILLED, OrderLifecycleState.CANCELLED, OrderLifecycleState.REJECTED}:
+            assert str(error.value) == f"Illegal Order lifecycle transition: {current.value} is terminal"
+        else:
+            assert str(error.value) == f"Illegal Order lifecycle transition: {current.value} -> {target.value}"
+
+
+def test_invalid_trade_transitions_fail_deterministically() -> None:
+    with pytest.raises(TradingLifecycleTransitionError, match="Illegal Trade lifecycle transition: closed is terminal"):
+        validate_trade_transition(
+            current_state=TradeLifecycleState.CLOSED,
+            target_state=TradeLifecycleState.OPEN,
+        )
+
+
+def test_invalid_position_transitions_fail_deterministically() -> None:
+    with pytest.raises(TradingLifecycleTransitionError, match="Illegal Position lifecycle transition: flat -> closed"):
+        validate_position_transition(
+            current_state=PositionLifecycleState.FLAT,
+            target_state=PositionLifecycleState.CLOSED,
+        )
+
+
+def test_transition_order_sequences_are_validated() -> None:
+    validate_order_transition_sequence(
+        [OrderLifecycleState.CREATED, OrderLifecycleState.SUBMITTED, OrderLifecycleState.PARTIALLY_FILLED, OrderLifecycleState.FILLED]
+    )
+    validate_trade_transition_sequence([TradeLifecycleState.OPEN, TradeLifecycleState.CLOSED])
+    validate_position_transition_sequence([PositionLifecycleState.FLAT, PositionLifecycleState.OPEN, PositionLifecycleState.CLOSED])
+
+    with pytest.raises(TradingLifecycleTransitionError, match="Illegal Order lifecycle transition: created -> filled"):
+        validate_order_transition_sequence([OrderLifecycleState.CREATED, OrderLifecycleState.FILLED])
+
+    with pytest.raises(TradingLifecycleTransitionError, match="Illegal Position lifecycle transition: open -> flat"):
+        validate_position_transition_sequence([PositionLifecycleState.OPEN, PositionLifecycleState.FLAT])
+
+
+def test_transition_invariants_enforce_monotonic_progression() -> None:
+    validate_order_transition_invariants(
+        current=OrderLifecycleSnapshot(
+            status=OrderLifecycleState.SUBMITTED,
+            quantity=Decimal("2"),
+            filled_quantity=Decimal("0"),
+        ),
+        target=OrderLifecycleSnapshot(
+            status=OrderLifecycleState.PARTIALLY_FILLED,
+            quantity=Decimal("2"),
+            filled_quantity=Decimal("1"),
+        ),
+    )
+
+    with pytest.raises(TradingLifecycleInvariantError, match="filled_quantity must be monotonic non-decreasing"):
+        validate_order_transition_invariants(
+            current=OrderLifecycleSnapshot(
+                status=OrderLifecycleState.PARTIALLY_FILLED,
+                quantity=Decimal("2"),
+                filled_quantity=Decimal("1"),
+            ),
+            target=OrderLifecycleSnapshot(
+                status=OrderLifecycleState.FILLED,
+                quantity=Decimal("2"),
+                filled_quantity=Decimal("0.5"),
+            ),
+        )
+
+    validate_trade_transition_invariants(
+        current=TradeLifecycleSnapshot(
+            status=TradeLifecycleState.OPEN,
+            quantity_opened=Decimal("3"),
+            quantity_closed=Decimal("1"),
+        ),
+        target=TradeLifecycleSnapshot(
+            status=TradeLifecycleState.CLOSED,
+            quantity_opened=Decimal("3"),
+            quantity_closed=Decimal("3"),
+        ),
+    )
+
+    with pytest.raises(TradingLifecycleInvariantError, match="quantity_opened must be immutable"):
+        validate_position_transition_invariants(
+            current=PositionLifecycleSnapshot(
+                status=PositionLifecycleState.OPEN,
+                quantity_opened=Decimal("3"),
+                quantity_closed=Decimal("1"),
+                net_quantity=Decimal("2"),
+            ),
+            target=PositionLifecycleSnapshot(
+                status=PositionLifecycleState.CLOSED,
+                quantity_opened=Decimal("4"),
+                quantity_closed=Decimal("4"),
+                net_quantity=Decimal("0"),
+            ),
+        )
+
+
+def test_transition_matrices_are_explicit_and_immutable() -> None:
+    assert get_allowed_order_transitions(OrderLifecycleState.CREATED) == frozenset(
+        {
+            OrderLifecycleState.SUBMITTED,
+            OrderLifecycleState.CANCELLED,
+            OrderLifecycleState.REJECTED,
+        }
+    )
+    assert get_allowed_trade_transitions(TradeLifecycleState.OPEN) == frozenset({TradeLifecycleState.CLOSED})
+    assert get_allowed_position_transitions(PositionLifecycleState.OPEN) == frozenset({PositionLifecycleState.CLOSED})
+
+    with pytest.raises(TypeError):
+        ORDER_ALLOWED_TRANSITIONS[OrderLifecycleState.CREATED] = frozenset()  # type: ignore[index]
+
+    with pytest.raises(TypeError):
+        TRADE_ALLOWED_TRANSITIONS[TradeLifecycleState.OPEN] = frozenset()  # type: ignore[index]
+
+    with pytest.raises(TypeError):
+        POSITION_ALLOWED_TRANSITIONS[PositionLifecycleState.FLAT] = frozenset()  # type: ignore[index]
+
+
+def test_regression_model_validation_uses_canonical_lifecycle_invariants() -> None:
+    Order.model_validate(
+        {
+            "order_id": "ord-1",
+            "strategy_id": "s1",
+            "symbol": "AAPL",
+            "sequence": 1,
+            "side": "BUY",
+            "order_type": "market",
+            "time_in_force": "day",
+            "status": "partially_filled",
+            "quantity": Decimal("2"),
+            "filled_quantity": Decimal("1"),
+            "created_at": "2024-01-01T00:00:00Z",
+            "average_fill_price": Decimal("100.1"),
+            "last_execution_event_id": "evt-1",
+        }
+    )
+
+    with pytest.raises(ValidationError):
+        Order.model_validate(
+            {
+                "order_id": "ord-1",
+                "strategy_id": "s1",
+                "symbol": "AAPL",
+                "sequence": 1,
+                "side": "BUY",
+                "order_type": "market",
+                "time_in_force": "day",
+                "status": "submitted",
+                "quantity": Decimal("2"),
+                "filled_quantity": Decimal("1"),
+                "created_at": "2024-01-01T00:00:00Z",
+            }
+        )
+
+    with pytest.raises(ValidationError):
+        Position.model_validate(
+            {
+                "position_id": "pos-1",
+                "strategy_id": "s1",
+                "symbol": "AAPL",
+                "direction": "long",
+                "status": "flat",
+                "opened_at": "2024-01-01T00:00:00Z",
+                "quantity_opened": Decimal("1"),
+                "quantity_closed": Decimal("0"),
+                "net_quantity": Decimal("1"),
+                "average_entry_price": Decimal("100"),
+            }
+        )
+
+    with pytest.raises(ValidationError):
+        Trade.model_validate(
+            {
+                "trade_id": "tr-1",
+                "position_id": "pos-1",
+                "strategy_id": "s1",
+                "symbol": "AAPL",
+                "direction": "long",
+                "status": "open",
+                "opened_at": "2024-01-01T00:00:00Z",
+                "quantity_opened": Decimal("2"),
+                "quantity_closed": Decimal("2"),
+                "average_entry_price": Decimal("100"),
+            }
+        )


### PR DESCRIPTION
Closes #719

## Summary
- Added a single canonical deterministic lifecycle module for Order, Trade, and Position.
- Defined explicit states, allowed transitions, terminal states, and deterministic transition error semantics.
- Added reusable invariant guards for state and transition validation.
- Rewired trading core model validation to reuse lifecycle invariant guards.
- Added lifecycle documentation and linked the core domain model doc to the canonical lifecycle source.
- Added tests for valid transitions, invalid transitions, transition order, transition invariants, and regression behavior.

## Validation
- Ran full repository test suite:
  - `.\.venv\Scripts\python.exe -m pytest`
  - Result: `626 passed, 4 warnings`
