### PR TITLE
CORE-P41A: Align execution persistence with canonical trading core (#720)

### DIFF
--- a/docs/architecture/trading_core_execution_persistence_boundary.md
+++ b/docs/architecture/trading_core_execution_persistence_boundary.md
@@ -1,0 +1,57 @@
+# Trading Core Execution Persistence Boundary
+
+Issue `#720` aligns execution persistence with the canonical trading core model.
+
+## Canonical Persistence Contract
+
+Execution persistence is bounded to canonical entities:
+
+- `Order` (authoritative intent and lifecycle state)
+- `ExecutionEvent` (authoritative immutable execution fact)
+- `Trade` (derived lifecycle summary)
+
+The persistence interface is `CanonicalExecutionRepository` in:
+
+- `src/cilly_trading/repositories/__init__.py`
+
+SQLite implementation:
+
+- `src/cilly_trading/repositories/execution_core_sqlite.py`
+
+## Repository Access Pattern
+
+Canonical writes are explicit by entity:
+
+1. `save_order(order)`
+2. `save_execution_events(events)`
+3. `save_trade(trade)`
+
+Canonical reads are explicit by entity:
+
+1. `get_order(order_id)` / `list_orders(...)`
+2. `list_execution_events(...)`
+3. `get_trade(trade_id)` / `list_trades(...)`
+
+This keeps replay and audit reads independent from paper-trading legacy payload storage.
+
+## Deterministic Ordering
+
+Deterministic read ordering is fixed by SQL order-by clauses:
+
+- Orders: `created_at`, `sequence`, `order_id`
+- Execution events: `occurred_at`, `sequence`, `event_id`
+- Trades: `opened_at`, `trade_id`
+
+All timestamps are normalized for lexical UTC ordering (`Z` treated as `+00:00`).
+
+## Auditability and Replay
+
+- `ExecutionEvent` rows are append-only by `event_id`.
+- Re-inserting an existing `event_id` with a different payload raises `conflicting_execution_event_payload`.
+- Canonical payloads are persisted as canonical JSON and validated on read, preserving deterministic round-trip behavior.
+
+## No Conflicting Model Boundary
+
+Legacy `TradeRepository` now explicitly uses `PersistedTradePayload` for paper-trading snapshots.
+Canonical execution persistence uses `Order`/`ExecutionEvent`/`Trade` only through `CanonicalExecutionRepository`.
+This removes type-level ambiguity between legacy and canonical persistence boundaries.

--- a/src/cilly_trading/repositories/__init__.py
+++ b/src/cilly_trading/repositories/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Optional, Protocol
 
-from cilly_trading.models import Signal, Trade
+from cilly_trading.models import ExecutionEvent, Order, PersistedTradePayload, Signal, Trade
 
 
 class SignalRepository(Protocol):
@@ -35,19 +35,79 @@ class SignalRepository(Protocol):
 
 class TradeRepository(Protocol):
     """
-    Abstraktes Interface fuer das Speichern und Laden von Trades.
+    Legacy-Interface fuer das Speichern und Laden von Paper-Trading-Trade-Payloads.
     """
 
-    def save_trade(self, trade: Trade) -> int:
+    def save_trade(self, trade: PersistedTradePayload) -> int:
         """
         Speichert einen Trade und gibt die neue Trade-ID zurueck.
         """
         ...
 
-    def list_trades(self, limit: int = 100) -> List[Trade]:
+    def list_trades(self, limit: int = 100) -> List[PersistedTradePayload]:
         """
         Liefert die letzten `limit` Trades, absteigend nach id.
         """
+        ...
+
+
+class CanonicalExecutionRepository(Protocol):
+    """Persistence boundary for canonical Order/ExecutionEvent/Trade entities."""
+
+    def save_order(self, order: Order) -> None:
+        """Persist or replace a canonical order by identity."""
+        ...
+
+    def get_order(self, order_id: str) -> Optional[Order]:
+        """Load a canonical order by ID."""
+        ...
+
+    def list_orders(
+        self,
+        *,
+        strategy_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[Order]:
+        """List canonical orders in deterministic order."""
+        ...
+
+    def save_execution_events(self, events: List[ExecutionEvent]) -> None:
+        """Append immutable canonical execution events."""
+        ...
+
+    def list_execution_events(
+        self,
+        *,
+        strategy_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+        order_id: Optional[str] = None,
+        trade_id: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[ExecutionEvent]:
+        """List canonical execution events in deterministic replay order."""
+        ...
+
+    def save_trade(self, trade: Trade) -> None:
+        """Persist or replace a canonical derived trade by identity."""
+        ...
+
+    def get_trade(self, trade_id: str) -> Optional[Trade]:
+        """Load a canonical trade by ID."""
+        ...
+
+    def list_trades(
+        self,
+        *,
+        strategy_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+        position_id: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[Trade]:
+        """List canonical trades in deterministic order."""
         ...
 
 
@@ -87,6 +147,7 @@ class WatchlistRepository(Protocol):
 __all__ = [
     "SignalRepository",
     "TradeRepository",
+    "CanonicalExecutionRepository",
     "Watchlist",
     "WatchlistRepository",
 ]

--- a/src/cilly_trading/repositories/execution_core_sqlite.py
+++ b/src/cilly_trading/repositories/execution_core_sqlite.py
@@ -1,0 +1,417 @@
+"""SQLite repository for canonical trading-core execution persistence."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from cilly_trading.db import DEFAULT_DB_PATH, init_db
+from cilly_trading.models import ExecutionEvent, Order, Trade
+from cilly_trading.repositories import CanonicalExecutionRepository
+
+
+class SqliteCanonicalExecutionRepository(CanonicalExecutionRepository):
+    """Deterministic persistence for canonical orders, execution events, and trades."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path or DEFAULT_DB_PATH)
+        init_db(self._db_path)
+        self._ensure_tables()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_tables(self) -> None:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS core_orders (
+                order_id TEXT PRIMARY KEY,
+                strategy_id TEXT NOT NULL,
+                symbol TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                payload_json TEXT NOT NULL
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_core_orders_deterministic
+            ON core_orders(strategy_id, symbol, created_at, sequence, order_id);
+            """
+        )
+
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS core_execution_events (
+                event_id TEXT PRIMARY KEY,
+                order_id TEXT NOT NULL,
+                strategy_id TEXT NOT NULL,
+                symbol TEXT NOT NULL,
+                trade_id TEXT NULL,
+                occurred_at TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                payload_json TEXT NOT NULL
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_core_execution_events_deterministic
+            ON core_execution_events(
+                strategy_id,
+                symbol,
+                order_id,
+                trade_id,
+                occurred_at,
+                sequence,
+                event_id
+            );
+            """
+        )
+
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS core_trades (
+                trade_id TEXT PRIMARY KEY,
+                position_id TEXT NOT NULL,
+                strategy_id TEXT NOT NULL,
+                symbol TEXT NOT NULL,
+                opened_at TEXT NOT NULL,
+                payload_json TEXT NOT NULL
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_core_trades_deterministic
+            ON core_trades(strategy_id, symbol, position_id, opened_at, trade_id);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def save_order(self, order: Order) -> None:
+        normalized_order = Order.model_validate(order)
+        payload_json = normalized_order.to_canonical_json()
+
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO core_orders (
+                order_id,
+                strategy_id,
+                symbol,
+                created_at,
+                sequence,
+                payload_json
+            )
+            VALUES (
+                :order_id,
+                :strategy_id,
+                :symbol,
+                :created_at,
+                :sequence,
+                :payload_json
+            )
+            ON CONFLICT(order_id) DO UPDATE SET
+                strategy_id = excluded.strategy_id,
+                symbol = excluded.symbol,
+                created_at = excluded.created_at,
+                sequence = excluded.sequence,
+                payload_json = excluded.payload_json;
+            """,
+            {
+                "order_id": normalized_order.order_id,
+                "strategy_id": normalized_order.strategy_id,
+                "symbol": normalized_order.symbol,
+                "created_at": normalized_order.created_at,
+                "sequence": normalized_order.sequence,
+                "payload_json": payload_json,
+            },
+        )
+        conn.commit()
+        conn.close()
+
+    def get_order(self, order_id: str) -> Optional[Order]:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT payload_json
+            FROM core_orders
+            WHERE order_id = ?;
+            """,
+            (order_id,),
+        )
+        row = cur.fetchone()
+        conn.close()
+        if row is None:
+            return None
+        return Order.model_validate_json(row["payload_json"])
+
+    def list_orders(
+        self,
+        *,
+        strategy_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Order]:
+        where_parts: list[str] = []
+        params: list[object] = []
+
+        if strategy_id is not None:
+            where_parts.append("strategy_id = ?")
+            params.append(strategy_id)
+        if symbol is not None:
+            where_parts.append("symbol = ?")
+            params.append(symbol)
+
+        where_sql = ""
+        if where_parts:
+            where_sql = "WHERE " + " AND ".join(where_parts)
+
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            f"""
+            SELECT payload_json
+            FROM core_orders
+            {where_sql}
+            ORDER BY
+                REPLACE(created_at, 'Z', '+00:00') ASC,
+                sequence ASC,
+                order_id ASC
+            LIMIT ?
+            OFFSET ?;
+            """,
+            [*params, limit, offset],
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [Order.model_validate_json(row["payload_json"]) for row in rows]
+
+    def save_execution_events(self, events: list[ExecutionEvent]) -> None:
+        if not events:
+            return
+
+        normalized_events = [ExecutionEvent.model_validate(event) for event in events]
+
+        conn = self._get_connection()
+        cur = conn.cursor()
+        for event in normalized_events:
+            payload_json = event.to_canonical_json()
+            cur.execute(
+                """
+                INSERT OR IGNORE INTO core_execution_events (
+                    event_id,
+                    order_id,
+                    strategy_id,
+                    symbol,
+                    trade_id,
+                    occurred_at,
+                    sequence,
+                    payload_json
+                )
+                VALUES (
+                    :event_id,
+                    :order_id,
+                    :strategy_id,
+                    :symbol,
+                    :trade_id,
+                    :occurred_at,
+                    :sequence,
+                    :payload_json
+                );
+                """,
+                {
+                    "event_id": event.event_id,
+                    "order_id": event.order_id,
+                    "strategy_id": event.strategy_id,
+                    "symbol": event.symbol,
+                    "trade_id": event.trade_id,
+                    "occurred_at": event.occurred_at,
+                    "sequence": event.sequence,
+                    "payload_json": payload_json,
+                },
+            )
+            if cur.rowcount == 0:
+                cur.execute(
+                    """
+                    SELECT payload_json
+                    FROM core_execution_events
+                    WHERE event_id = ?;
+                    """,
+                    (event.event_id,),
+                )
+                existing = cur.fetchone()
+                if existing is None or existing["payload_json"] != payload_json:
+                    conn.close()
+                    raise ValueError(
+                        f"conflicting_execution_event_payload: {event.event_id}"
+                    )
+        conn.commit()
+        conn.close()
+
+    def list_execution_events(
+        self,
+        *,
+        strategy_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+        order_id: Optional[str] = None,
+        trade_id: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[ExecutionEvent]:
+        where_parts: list[str] = []
+        params: list[object] = []
+
+        if strategy_id is not None:
+            where_parts.append("strategy_id = ?")
+            params.append(strategy_id)
+        if symbol is not None:
+            where_parts.append("symbol = ?")
+            params.append(symbol)
+        if order_id is not None:
+            where_parts.append("order_id = ?")
+            params.append(order_id)
+        if trade_id is not None:
+            where_parts.append("trade_id = ?")
+            params.append(trade_id)
+
+        where_sql = ""
+        if where_parts:
+            where_sql = "WHERE " + " AND ".join(where_parts)
+
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            f"""
+            SELECT payload_json
+            FROM core_execution_events
+            {where_sql}
+            ORDER BY
+                REPLACE(occurred_at, 'Z', '+00:00') ASC,
+                sequence ASC,
+                event_id ASC
+            LIMIT ?
+            OFFSET ?;
+            """,
+            [*params, limit, offset],
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [ExecutionEvent.model_validate_json(row["payload_json"]) for row in rows]
+
+    def save_trade(self, trade: Trade) -> None:
+        normalized_trade = Trade.model_validate(trade)
+        payload_json = normalized_trade.to_canonical_json()
+
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO core_trades (
+                trade_id,
+                position_id,
+                strategy_id,
+                symbol,
+                opened_at,
+                payload_json
+            )
+            VALUES (
+                :trade_id,
+                :position_id,
+                :strategy_id,
+                :symbol,
+                :opened_at,
+                :payload_json
+            )
+            ON CONFLICT(trade_id) DO UPDATE SET
+                position_id = excluded.position_id,
+                strategy_id = excluded.strategy_id,
+                symbol = excluded.symbol,
+                opened_at = excluded.opened_at,
+                payload_json = excluded.payload_json;
+            """,
+            {
+                "trade_id": normalized_trade.trade_id,
+                "position_id": normalized_trade.position_id,
+                "strategy_id": normalized_trade.strategy_id,
+                "symbol": normalized_trade.symbol,
+                "opened_at": normalized_trade.opened_at,
+                "payload_json": payload_json,
+            },
+        )
+        conn.commit()
+        conn.close()
+
+    def get_trade(self, trade_id: str) -> Optional[Trade]:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT payload_json
+            FROM core_trades
+            WHERE trade_id = ?;
+            """,
+            (trade_id,),
+        )
+        row = cur.fetchone()
+        conn.close()
+        if row is None:
+            return None
+        return Trade.model_validate_json(row["payload_json"])
+
+    def list_trades(
+        self,
+        *,
+        strategy_id: Optional[str] = None,
+        symbol: Optional[str] = None,
+        position_id: Optional[str] = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Trade]:
+        where_parts: list[str] = []
+        params: list[object] = []
+
+        if strategy_id is not None:
+            where_parts.append("strategy_id = ?")
+            params.append(strategy_id)
+        if symbol is not None:
+            where_parts.append("symbol = ?")
+            params.append(symbol)
+        if position_id is not None:
+            where_parts.append("position_id = ?")
+            params.append(position_id)
+
+        where_sql = ""
+        if where_parts:
+            where_sql = "WHERE " + " AND ".join(where_parts)
+
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            f"""
+            SELECT payload_json
+            FROM core_trades
+            {where_sql}
+            ORDER BY
+                REPLACE(opened_at, 'Z', '+00:00') ASC,
+                trade_id ASC
+            LIMIT ?
+            OFFSET ?;
+            """,
+            [*params, limit, offset],
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [Trade.model_validate_json(row["payload_json"]) for row in rows]
+

--- a/src/cilly_trading/repositories/trades_sqlite.py
+++ b/src/cilly_trading/repositories/trades_sqlite.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from cilly_trading.db import init_db, DEFAULT_DB_PATH  # type: ignore
-from cilly_trading.models import Trade
+from cilly_trading.models import PersistedTradePayload
 from cilly_trading.repositories import TradeRepository
 
 
@@ -30,7 +30,7 @@ class SqliteTradeRepository(TradeRepository):
         conn.row_factory = sqlite3.Row
         return conn
 
-    def save_trade(self, trade: Trade) -> int:
+    def save_trade(self, trade: PersistedTradePayload) -> int:
         conn = self._get_connection()
         cur = conn.cursor()
 
@@ -90,7 +90,7 @@ class SqliteTradeRepository(TradeRepository):
 
         return int(trade_id)
 
-    def list_trades(self, limit: int = 100) -> List[Trade]:
+    def list_trades(self, limit: int = 100) -> List[PersistedTradePayload]:
         conn = self._get_connection()
         cur = conn.cursor()
 
@@ -121,9 +121,9 @@ class SqliteTradeRepository(TradeRepository):
         rows = cur.fetchall()
         conn.close()
 
-        result: List[Trade] = []
+        result: List[PersistedTradePayload] = []
         for row in rows:
-            trade: Trade = {
+            trade: PersistedTradePayload = {
                 "id": row["id"],
                 "symbol": row["symbol"],
                 "strategy": row["strategy"],

--- a/tests/test_execution_core_repository_sqlite.py
+++ b/tests/test_execution_core_repository_sqlite.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from cilly_trading.models import (
+    ExecutionEvent,
+    Order,
+    Position,
+    Trade,
+    compute_execution_event_id,
+    validate_trading_core_relationships,
+)
+from cilly_trading.repositories.execution_core_sqlite import (
+    SqliteCanonicalExecutionRepository,
+)
+
+
+def _repo(tmp_path: Path) -> SqliteCanonicalExecutionRepository:
+    return SqliteCanonicalExecutionRepository(db_path=tmp_path / "core-execution.db")
+
+
+def _order(order_id: str, *, sequence: int = 1, created_at: str = "2025-01-01T09:00:00Z") -> Order:
+    return Order.model_validate(
+        {
+            "order_id": order_id,
+            "strategy_id": "strategy-a",
+            "symbol": "AAPL",
+            "sequence": sequence,
+            "side": "BUY",
+            "order_type": "market",
+            "time_in_force": "day",
+            "status": "filled",
+            "quantity": Decimal("1"),
+            "filled_quantity": Decimal("1"),
+            "created_at": created_at,
+            "average_fill_price": Decimal("100.00"),
+            "last_execution_event_id": "evt-placeholder",
+            "position_id": "pos-1",
+            "trade_id": "trade-1",
+        }
+    )
+
+
+def _event(
+    event_id: str,
+    order_id: str,
+    *,
+    sequence: int,
+    occurred_at: str,
+) -> ExecutionEvent:
+    return ExecutionEvent.model_validate(
+        {
+            "event_id": event_id,
+            "order_id": order_id,
+            "strategy_id": "strategy-a",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "event_type": "filled",
+            "occurred_at": occurred_at,
+            "sequence": sequence,
+            "execution_quantity": Decimal("1"),
+            "execution_price": Decimal("100.00"),
+            "commission": Decimal("1.00"),
+            "position_id": "pos-1",
+            "trade_id": "trade-1",
+        }
+    )
+
+
+def _trade(*, execution_event_ids: list[str]) -> Trade:
+    return Trade.model_validate(
+        {
+            "trade_id": "trade-1",
+            "position_id": "pos-1",
+            "strategy_id": "strategy-a",
+            "symbol": "AAPL",
+            "direction": "long",
+            "status": "closed",
+            "opened_at": "2025-01-01T09:00:00Z",
+            "closed_at": "2025-01-02T09:00:00Z",
+            "quantity_opened": Decimal("1"),
+            "quantity_closed": Decimal("1"),
+            "average_entry_price": Decimal("100.00"),
+            "average_exit_price": Decimal("101.00"),
+            "realized_pnl": Decimal("1.00"),
+            "opening_order_ids": ["ord-1"],
+            "closing_order_ids": [],
+            "execution_event_ids": execution_event_ids,
+        }
+    )
+
+
+def _position(*, order_ids: list[str], execution_event_ids: list[str]) -> Position:
+    return Position.model_validate(
+        {
+            "position_id": "pos-1",
+            "strategy_id": "strategy-a",
+            "symbol": "AAPL",
+            "direction": "long",
+            "status": "closed",
+            "opened_at": "2025-01-01T09:00:00Z",
+            "closed_at": "2025-01-02T09:00:00Z",
+            "quantity_opened": Decimal("1"),
+            "quantity_closed": Decimal("1"),
+            "net_quantity": Decimal("0"),
+            "average_entry_price": Decimal("100.00"),
+            "average_exit_price": Decimal("101.00"),
+            "realized_pnl": Decimal("1.00"),
+            "order_ids": order_ids,
+            "execution_event_ids": execution_event_ids,
+            "trade_ids": ["trade-1"],
+        }
+    )
+
+
+def test_create_and_read_round_trip_is_consistent(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    order = _order("ord-1")
+    event = _event(
+        compute_execution_event_id(
+            order_id="ord-1",
+            event_type="filled",
+            occurred_at="2025-01-01T09:01:00Z",
+            sequence=1,
+        ),
+        "ord-1",
+        sequence=1,
+        occurred_at="2025-01-01T09:01:00Z",
+    )
+    order = Order.model_validate({**order.model_dump(mode="python"), "last_execution_event_id": event.event_id})
+    trade = _trade(execution_event_ids=[event.event_id])
+
+    repo.save_order(order)
+    repo.save_execution_events([event])
+    repo.save_trade(trade)
+
+    stored_order = repo.get_order(order.order_id)
+    stored_trade = repo.get_trade(trade.trade_id)
+    stored_events = repo.list_execution_events(order_id=order.order_id)
+
+    assert stored_order is not None
+    assert stored_trade is not None
+    assert stored_events == [event]
+    assert stored_order.to_canonical_json() == order.to_canonical_json()
+    assert stored_trade.to_canonical_json() == trade.to_canonical_json()
+
+
+def test_execution_event_ordering_is_deterministic(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    e2 = _event("evt-2", "ord-1", sequence=2, occurred_at="2025-01-01T09:02:00Z")
+    e1 = _event("evt-1", "ord-1", sequence=1, occurred_at="2025-01-01T09:01:00Z")
+    e1b = _event("evt-1b", "ord-1", sequence=1, occurred_at="2025-01-01T09:01:00Z")
+
+    repo.save_execution_events([e2, e1b, e1])
+
+    first_read = repo.list_execution_events(order_id="ord-1")
+    second_read = repo.list_execution_events(order_id="ord-1")
+
+    assert first_read == second_read
+    assert [event.event_id for event in first_read] == ["evt-1", "evt-1b", "evt-2"]
+
+
+def test_replay_reads_support_relationship_validation(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    order = _order("ord-1")
+    event = _event("evt-1", "ord-1", sequence=1, occurred_at="2025-01-01T09:01:00Z")
+    order = Order.model_validate({**order.model_dump(mode="python"), "last_execution_event_id": event.event_id})
+    trade = _trade(execution_event_ids=[event.event_id])
+
+    repo.save_order(order)
+    repo.save_execution_events([event])
+    repo.save_trade(trade)
+
+    replay_orders = repo.list_orders(strategy_id="strategy-a", symbol="AAPL")
+    replay_events = repo.list_execution_events(strategy_id="strategy-a", symbol="AAPL")
+    replay_trade = repo.get_trade("trade-1")
+    replay_position = _position(
+        order_ids=[order.order_id],
+        execution_event_ids=[event.event_id],
+    )
+
+    assert replay_trade is not None
+    validate_trading_core_relationships(
+        trade=replay_trade,
+        position=replay_position,
+        orders=replay_orders,
+        execution_events=replay_events,
+    )
+
+
+def test_negative_conflicting_execution_event_payload_is_rejected(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    event = _event("evt-1", "ord-1", sequence=1, occurred_at="2025-01-01T09:01:00Z")
+    conflicting = _event("evt-1", "ord-1", sequence=1, occurred_at="2025-01-01T09:01:00Z")
+    conflicting = ExecutionEvent.model_validate(
+        {**conflicting.model_dump(mode="python"), "execution_price": Decimal("101.00")}
+    )
+
+    repo.save_execution_events([event])
+    with pytest.raises(ValueError, match="conflicting_execution_event_payload"):
+        repo.save_execution_events([conflicting])
+
+
+def test_negative_invalid_order_is_rejected_before_write(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    with pytest.raises(ValidationError):
+        repo.save_order(  # type: ignore[arg-type]
+            {
+                "order_id": "ord-invalid",
+                "strategy_id": "strategy-a",
+                "symbol": "AAPL",
+                "sequence": 1,
+                "side": "BUY",
+                "order_type": "market",
+                "time_in_force": "day",
+                "status": "filled",
+                "quantity": Decimal("1"),
+                "filled_quantity": Decimal("1"),
+                "created_at": "2025-01-01T09:00:00Z",
+                "average_fill_price": Decimal("100.00"),
+                # missing last_execution_event_id on a filled order
+                "position_id": "pos-1",
+                "trade_id": "trade-1",
+            }
+        )


### PR DESCRIPTION
Closes #720

## Summary

This PR aligns execution persistence with the canonical trading core model for deterministic, replayable history.

### What changed

- Added canonical persistence boundary for `Order`, `ExecutionEvent`, and `Trade`
- Added `CanonicalExecutionRepository` protocol
- Added `SqliteCanonicalExecutionRepository` implementation
- Added deterministic ordering for canonical reads
- Added conflict protection for immutable execution events
- Clarified the legacy-vs-canonical boundary for `TradeRepository`
- Added create/read, ordering, replay, negative, and round-trip repository tests
- Added architecture documentation for the execution persistence boundary

## Validation

- `.\.venv\Scripts\python.exe -m pytest`
- Result: `631 passed, 4 warnings`
