### PR TITLE
CORE-P41A: Align read-only API with trading core inspection model

### DIFF
--- a/docs/api/trading_core_inspection.md
+++ b/docs/api/trading_core_inspection.md
@@ -1,0 +1,57 @@
+# Trading Core Inspection API
+
+This document defines the read-only trading core inspection surface aligned with the canonical model (`Order`, `ExecutionEvent`, `Trade`, `Position`).
+
+## Read-Only Endpoints
+
+All endpoints require `X-Cilly-Role: read_only` (or higher role).
+
+- `GET /trading-core/orders`
+- `GET /trading-core/execution-events`
+- `GET /trading-core/trades`
+- `GET /trading-core/positions`
+
+No mutation endpoints are introduced by this surface.
+
+## Canonical Alignment
+
+- Response payload entities map directly to canonical models in `src/cilly_trading/models.py`.
+- Decimal-valued canonical fields are serialized as strings.
+- Deterministic ordering is guaranteed by canonical repository ordering and stable in-memory ordering for derived positions.
+
+## Query Parameters
+
+### `GET /trading-core/orders`
+
+- Optional filters: `strategy_id`, `symbol`, `order_id`
+- Pagination: `limit` (`1..500`), `offset` (`>=0`)
+
+### `GET /trading-core/execution-events`
+
+- Optional filters: `strategy_id`, `symbol`, `order_id`, `trade_id`
+- Pagination: `limit` (`1..500`), `offset` (`>=0`)
+
+### `GET /trading-core/trades`
+
+- Optional filters: `strategy_id`, `symbol`, `position_id`, `trade_id`
+- Pagination: `limit` (`1..500`), `offset` (`>=0`)
+
+### `GET /trading-core/positions`
+
+- Optional filters: `strategy_id`, `symbol`, `position_id`
+- Pagination: `limit` (`1..500`), `offset` (`>=0`)
+
+## Response Shape
+
+Each endpoint returns a paginated payload in this structure:
+
+```json
+{
+  "items": [],
+  "limit": 50,
+  "offset": 0,
+  "total": 0
+}
+```
+
+The `items` array contains canonical entity payloads for the requested endpoint.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Use this order:
 
 ## API Usage
 - [API usage](operations/api/usage.md)
+- [Trading core inspection API](api/trading_core_inspection.md)
 - [Phase 39 runtime chart data contract](operations/api/runtime_chart_data_contract.md)
 - Legacy compatibility alias: `docs/api/runtime_chart_data_contract.md`
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -17,6 +17,7 @@ import logging
 import os
 import json
 import uuid
+from decimal import Decimal
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
@@ -64,8 +65,16 @@ from cilly_trading.engine.portfolio import (
 )
 from cilly_trading.engine.runtime_introspection import get_runtime_introspection_payload
 from cilly_trading.engine.runtime_state import get_system_state_payload
-from cilly_trading.models import SignalReadItemDTO, SignalReadResponseDTO
+from cilly_trading.models import (
+    ExecutionEvent,
+    Order,
+    Position,
+    SignalReadItemDTO,
+    SignalReadResponseDTO,
+    Trade,
+)
 from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
 from cilly_trading.strategies.registry import (
@@ -378,6 +387,84 @@ class ExecutionOrdersReadResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     items: List[ExecutionOrderEventItemResponse]
+    limit: int
+    offset: int
+    total: int
+
+
+class TradingCoreOrdersReadQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    strategy_id: Optional[str] = Field(default=None)
+    symbol: Optional[str] = Field(default=None)
+    order_id: Optional[str] = Field(default=None)
+    limit: int = Field(default=50, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+
+class TradingCoreExecutionEventsReadQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    strategy_id: Optional[str] = Field(default=None)
+    symbol: Optional[str] = Field(default=None)
+    order_id: Optional[str] = Field(default=None)
+    trade_id: Optional[str] = Field(default=None)
+    limit: int = Field(default=50, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+
+class TradingCoreTradesReadQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    strategy_id: Optional[str] = Field(default=None)
+    symbol: Optional[str] = Field(default=None)
+    position_id: Optional[str] = Field(default=None)
+    trade_id: Optional[str] = Field(default=None)
+    limit: int = Field(default=50, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+
+class TradingCorePositionsReadQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    strategy_id: Optional[str] = Field(default=None)
+    symbol: Optional[str] = Field(default=None)
+    position_id: Optional[str] = Field(default=None)
+    limit: int = Field(default=50, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+
+class TradingCoreOrdersReadResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[Order]
+    limit: int
+    offset: int
+    total: int
+
+
+class TradingCoreExecutionEventsReadResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[ExecutionEvent]
+    limit: int
+    offset: int
+    total: int
+
+
+class TradingCoreTradesReadResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[Trade]
+    limit: int
+    offset: int
+    total: int
+
+
+class TradingCorePositionsReadResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[Position]
     limit: int
     offset: int
     total: int
@@ -704,6 +791,7 @@ ANALYSIS_DB_PATH: Optional[str] = None
 
 signal_repo = SqliteSignalRepository()
 order_event_repo = SqliteOrderEventRepository(db_path=DEFAULT_DB_PATH)
+canonical_execution_repo = SqliteCanonicalExecutionRepository(db_path=DEFAULT_DB_PATH)
 analysis_run_repo = SqliteAnalysisRunRepository(db_path=DEFAULT_DB_PATH)
 watchlist_repo = SqliteWatchlistRepository(db_path=DEFAULT_DB_PATH)
 
@@ -1288,6 +1376,227 @@ def _get_execution_orders_query(
     )
 
 
+def _get_trading_core_orders_query(
+    strategy_id: Optional[str] = Query(default=None),
+    symbol: Optional[str] = Query(default=None),
+    order_id: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> TradingCoreOrdersReadQuery:
+    return TradingCoreOrdersReadQuery(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        order_id=order_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _get_trading_core_execution_events_query(
+    strategy_id: Optional[str] = Query(default=None),
+    symbol: Optional[str] = Query(default=None),
+    order_id: Optional[str] = Query(default=None),
+    trade_id: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> TradingCoreExecutionEventsReadQuery:
+    return TradingCoreExecutionEventsReadQuery(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        order_id=order_id,
+        trade_id=trade_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _get_trading_core_trades_query(
+    strategy_id: Optional[str] = Query(default=None),
+    symbol: Optional[str] = Query(default=None),
+    position_id: Optional[str] = Query(default=None),
+    trade_id: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> TradingCoreTradesReadQuery:
+    return TradingCoreTradesReadQuery(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        position_id=position_id,
+        trade_id=trade_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _get_trading_core_positions_query(
+    strategy_id: Optional[str] = Query(default=None),
+    symbol: Optional[str] = Query(default=None),
+    position_id: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> TradingCorePositionsReadQuery:
+    return TradingCorePositionsReadQuery(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        position_id=position_id,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def _paginate_items(items: list[Any], *, limit: int, offset: int) -> tuple[list[Any], int]:
+    total = len(items)
+    return items[offset : offset + limit], total
+
+
+def _sum_decimals(values: list[Decimal]) -> Decimal:
+    return sum(values, Decimal("0"))
+
+
+def _weighted_average(*, values: list[tuple[Decimal, Decimal]]) -> Optional[Decimal]:
+    total_weight = _sum_decimals([weight for _, weight in values])
+    if total_weight <= Decimal("0"):
+        return None
+    weighted_sum = _sum_decimals([value * weight for value, weight in values])
+    return weighted_sum / total_weight
+
+
+def _build_trading_core_positions(
+    *,
+    strategy_id: Optional[str] = None,
+    symbol: Optional[str] = None,
+    position_id: Optional[str] = None,
+) -> list[Position]:
+    trades = canonical_execution_repo.list_trades(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        position_id=position_id,
+        limit=1_000_000,
+        offset=0,
+    )
+    if not trades:
+        return []
+
+    orders = canonical_execution_repo.list_orders(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        limit=1_000_000,
+        offset=0,
+    )
+    events = canonical_execution_repo.list_execution_events(
+        strategy_id=strategy_id,
+        symbol=symbol,
+        limit=1_000_000,
+        offset=0,
+    )
+
+    target_position_ids = {trade.position_id for trade in trades}
+    orders_by_position: dict[str, list[Order]] = {}
+    events_by_position: dict[str, list[ExecutionEvent]] = {}
+    trades_by_position: dict[str, list[Trade]] = {}
+
+    for trade in trades:
+        trades_by_position.setdefault(trade.position_id, []).append(trade)
+    for order in orders:
+        if order.position_id is None or order.position_id not in target_position_ids:
+            continue
+        orders_by_position.setdefault(order.position_id, []).append(order)
+    for event in events:
+        if event.position_id is None or event.position_id not in target_position_ids:
+            continue
+        events_by_position.setdefault(event.position_id, []).append(event)
+
+    positions: list[Position] = []
+    for current_position_id in sorted(target_position_ids):
+        position_trades = trades_by_position.get(current_position_id, [])
+        if not position_trades:
+            continue
+
+        position_orders = orders_by_position.get(current_position_id, [])
+        position_events = events_by_position.get(current_position_id, [])
+
+        strategy_ids = {trade.strategy_id for trade in position_trades}
+        symbols = {trade.symbol for trade in position_trades}
+        directions = {trade.direction for trade in position_trades}
+        if len(strategy_ids) != 1 or len(symbols) != 1 or len(directions) != 1:
+            raise HTTPException(status_code=500, detail="trading_core_position_inconsistent")
+
+        quantity_opened = _sum_decimals([trade.quantity_opened for trade in position_trades])
+        quantity_closed = _sum_decimals([trade.quantity_closed for trade in position_trades])
+        net_quantity = quantity_opened - quantity_closed
+
+        opened_at = min(trade.opened_at for trade in position_trades)
+        closed_at_candidates = [trade.closed_at for trade in position_trades if trade.closed_at is not None]
+
+        if quantity_opened == Decimal("0") and quantity_closed == Decimal("0"):
+            status: Literal["flat", "open", "closed"] = "flat"
+        elif net_quantity == Decimal("0"):
+            status = "closed"
+        else:
+            status = "open"
+
+        average_entry_price = _weighted_average(
+            values=[(trade.average_entry_price, trade.quantity_opened) for trade in position_trades]
+        ) or Decimal("0")
+
+        average_exit_price = _weighted_average(
+            values=[
+                (trade.average_exit_price, trade.quantity_closed)
+                for trade in position_trades
+                if trade.average_exit_price is not None and trade.quantity_closed > Decimal("0")
+            ]
+        )
+
+        realized_pnl_values = [trade.realized_pnl for trade in position_trades if trade.realized_pnl is not None]
+        realized_pnl = _sum_decimals(realized_pnl_values) if realized_pnl_values else None
+
+        order_ids = sorted(
+            set(
+                [order.order_id for order in position_orders]
+                + [order_id for trade in position_trades for order_id in trade.opening_order_ids]
+                + [order_id for trade in position_trades for order_id in trade.closing_order_ids]
+            )
+        )
+        execution_event_ids = sorted(
+            set(
+                [event.event_id for event in position_events]
+                + [event_id for trade in position_trades for event_id in trade.execution_event_ids]
+            )
+        )
+        trade_ids = sorted([trade.trade_id for trade in position_trades])
+
+        positions.append(
+            Position.model_validate(
+                {
+                    "position_id": current_position_id,
+                    "strategy_id": next(iter(strategy_ids)),
+                    "symbol": next(iter(symbols)),
+                    "direction": next(iter(directions)),
+                    "status": status,
+                    "opened_at": opened_at,
+                    "closed_at": max(closed_at_candidates) if status == "closed" and closed_at_candidates else None,
+                    "quantity_opened": quantity_opened,
+                    "quantity_closed": quantity_closed,
+                    "net_quantity": net_quantity,
+                    "average_entry_price": average_entry_price,
+                    "average_exit_price": average_exit_price,
+                    "realized_pnl": realized_pnl if status == "closed" else None,
+                    "order_ids": order_ids,
+                    "execution_event_ids": execution_event_ids,
+                    "trade_ids": trade_ids,
+                }
+            )
+        )
+
+    return sorted(
+        positions,
+        key=lambda item: (
+            item.opened_at,
+            item.position_id,
+        ),
+    )
+
+
 def _get_screener_results_query(
     strategy: str = Query(...),
     timeframe: str = Query(...),
@@ -1692,6 +2001,111 @@ def read_execution_orders(
     response_items = [ExecutionOrderEventItemResponse(**item) for item in items]
     return ExecutionOrdersReadResponse(
         items=response_items,
+        limit=params.limit,
+        offset=params.offset,
+        total=total,
+    )
+
+
+@app.get("/trading-core/orders", response_model=TradingCoreOrdersReadResponse)
+def read_trading_core_orders(
+    params: TradingCoreOrdersReadQuery = Depends(_get_trading_core_orders_query),
+    _: str = Depends(_require_role("read_only")),
+) -> TradingCoreOrdersReadResponse:
+    if params.order_id:
+        order = canonical_execution_repo.get_order(params.order_id)
+        all_items = [] if order is None else [order]
+        if params.strategy_id is not None:
+            all_items = [item for item in all_items if item.strategy_id == params.strategy_id]
+        if params.symbol is not None:
+            all_items = [item for item in all_items if item.symbol == params.symbol]
+    else:
+        all_items = canonical_execution_repo.list_orders(
+            strategy_id=params.strategy_id,
+            symbol=params.symbol,
+            limit=1_000_000,
+            offset=0,
+        )
+
+    page, total = _paginate_items(all_items, limit=params.limit, offset=params.offset)
+    return TradingCoreOrdersReadResponse(
+        items=page,
+        limit=params.limit,
+        offset=params.offset,
+        total=total,
+    )
+
+
+@app.get(
+    "/trading-core/execution-events",
+    response_model=TradingCoreExecutionEventsReadResponse,
+)
+def read_trading_core_execution_events(
+    params: TradingCoreExecutionEventsReadQuery = Depends(_get_trading_core_execution_events_query),
+    _: str = Depends(_require_role("read_only")),
+) -> TradingCoreExecutionEventsReadResponse:
+    all_items = canonical_execution_repo.list_execution_events(
+        strategy_id=params.strategy_id,
+        symbol=params.symbol,
+        order_id=params.order_id,
+        trade_id=params.trade_id,
+        limit=1_000_000,
+        offset=0,
+    )
+    page, total = _paginate_items(all_items, limit=params.limit, offset=params.offset)
+    return TradingCoreExecutionEventsReadResponse(
+        items=page,
+        limit=params.limit,
+        offset=params.offset,
+        total=total,
+    )
+
+
+@app.get("/trading-core/trades", response_model=TradingCoreTradesReadResponse)
+def read_trading_core_trades(
+    params: TradingCoreTradesReadQuery = Depends(_get_trading_core_trades_query),
+    _: str = Depends(_require_role("read_only")),
+) -> TradingCoreTradesReadResponse:
+    if params.trade_id:
+        trade = canonical_execution_repo.get_trade(params.trade_id)
+        all_items = [] if trade is None else [trade]
+        if params.strategy_id is not None:
+            all_items = [item for item in all_items if item.strategy_id == params.strategy_id]
+        if params.symbol is not None:
+            all_items = [item for item in all_items if item.symbol == params.symbol]
+        if params.position_id is not None:
+            all_items = [item for item in all_items if item.position_id == params.position_id]
+    else:
+        all_items = canonical_execution_repo.list_trades(
+            strategy_id=params.strategy_id,
+            symbol=params.symbol,
+            position_id=params.position_id,
+            limit=1_000_000,
+            offset=0,
+        )
+
+    page, total = _paginate_items(all_items, limit=params.limit, offset=params.offset)
+    return TradingCoreTradesReadResponse(
+        items=page,
+        limit=params.limit,
+        offset=params.offset,
+        total=total,
+    )
+
+
+@app.get("/trading-core/positions", response_model=TradingCorePositionsReadResponse)
+def read_trading_core_positions(
+    params: TradingCorePositionsReadQuery = Depends(_get_trading_core_positions_query),
+    _: str = Depends(_require_role("read_only")),
+) -> TradingCorePositionsReadResponse:
+    all_items = _build_trading_core_positions(
+        strategy_id=params.strategy_id,
+        symbol=params.symbol,
+        position_id=params.position_id,
+    )
+    page, total = _paginate_items(all_items, limit=params.limit, offset=params.offset)
+    return TradingCorePositionsReadResponse(
+        items=page,
         limit=params.limit,
         offset=params.offset,
         total=total,

--- a/tests/test_api_trading_core_inspection_read.py
+++ b/tests/test_api_trading_core_inspection_read.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from cilly_trading.models import ExecutionEvent, Order, Trade
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
+from tests.utils.json_schema_validator import validate_json_schema
+
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
+
+def _repo(tmp_path: Path) -> SqliteCanonicalExecutionRepository:
+    return SqliteCanonicalExecutionRepository(db_path=tmp_path / "core-inspection.db")
+
+
+def _order(
+    order_id: str,
+    *,
+    strategy_id: str = "strategy-a",
+    symbol: str = "AAPL",
+    sequence: int = 1,
+    created_at: str = "2025-01-01T09:00:00Z",
+    position_id: str | None = None,
+    trade_id: str | None = None,
+) -> Order:
+    return Order.model_validate(
+        {
+            "order_id": order_id,
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "sequence": sequence,
+            "side": "BUY",
+            "order_type": "market",
+            "time_in_force": "day",
+            "status": "created",
+            "quantity": Decimal("1"),
+            "filled_quantity": Decimal("0"),
+            "created_at": created_at,
+            "position_id": position_id,
+            "trade_id": trade_id,
+        }
+    )
+
+
+def _event(
+    event_id: str,
+    order_id: str,
+    *,
+    strategy_id: str = "strategy-a",
+    symbol: str = "AAPL",
+    occurred_at: str = "2025-01-01T09:01:00Z",
+    sequence: int = 1,
+    position_id: str | None = None,
+    trade_id: str | None = None,
+) -> ExecutionEvent:
+    return ExecutionEvent.model_validate(
+        {
+            "event_id": event_id,
+            "order_id": order_id,
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "side": "BUY",
+            "event_type": "filled",
+            "occurred_at": occurred_at,
+            "sequence": sequence,
+            "execution_quantity": Decimal("1"),
+            "execution_price": Decimal("100"),
+            "commission": Decimal("1"),
+            "position_id": position_id,
+            "trade_id": trade_id,
+        }
+    )
+
+
+def _trade(
+    trade_id: str,
+    *,
+    position_id: str,
+    strategy_id: str = "strategy-a",
+    symbol: str = "AAPL",
+    status: str = "open",
+    opened_at: str = "2025-01-01T09:00:00Z",
+    closed_at: str | None = None,
+    quantity_opened: str = "1",
+    quantity_closed: str = "0",
+    average_entry_price: str = "100",
+    average_exit_price: str | None = None,
+    realized_pnl: str | None = None,
+    opening_order_ids: list[str] | None = None,
+    closing_order_ids: list[str] | None = None,
+    execution_event_ids: list[str] | None = None,
+) -> Trade:
+    payload: dict[str, object] = {
+        "trade_id": trade_id,
+        "position_id": position_id,
+        "strategy_id": strategy_id,
+        "symbol": symbol,
+        "direction": "long",
+        "status": status,
+        "opened_at": opened_at,
+        "closed_at": closed_at,
+        "quantity_opened": Decimal(quantity_opened),
+        "quantity_closed": Decimal(quantity_closed),
+        "average_entry_price": Decimal(average_entry_price),
+        "average_exit_price": Decimal(average_exit_price) if average_exit_price is not None else None,
+        "realized_pnl": Decimal(realized_pnl) if realized_pnl is not None else None,
+        "opening_order_ids": opening_order_ids or [],
+        "closing_order_ids": closing_order_ids or [],
+        "execution_event_ids": execution_event_ids or [],
+    }
+    return Trade.model_validate(payload)
+
+
+def _test_client(monkeypatch, repo: SqliteCanonicalExecutionRepository) -> TestClient:
+    monkeypatch.setattr(api_main, "canonical_execution_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
+    return TestClient(api_main.app)
+
+
+def _seed_core_data(repo: SqliteCanonicalExecutionRepository) -> None:
+    repo.save_order(
+        _order(
+            "ord-2",
+            sequence=2,
+            created_at="2025-01-01T09:02:00Z",
+            position_id="pos-2",
+            trade_id="trade-2",
+        )
+    )
+    repo.save_order(
+        _order(
+            "ord-1",
+            sequence=1,
+            created_at="2025-01-01T09:01:00Z",
+            position_id="pos-1",
+            trade_id="trade-1",
+        )
+    )
+    repo.save_order(
+        _order(
+            "ord-1b",
+            sequence=1,
+            created_at="2025-01-01T09:01:00Z",
+            position_id="pos-1",
+            trade_id="trade-1b",
+        )
+    )
+
+    repo.save_execution_events(
+        [
+            _event(
+                "evt-2",
+                "ord-2",
+                occurred_at="2025-01-01T09:02:00Z",
+                sequence=2,
+                position_id="pos-2",
+                trade_id="trade-2",
+            ),
+            _event(
+                "evt-1b",
+                "ord-1",
+                occurred_at="2025-01-01T09:01:00Z",
+                sequence=1,
+                position_id="pos-1",
+                trade_id="trade-1b",
+            ),
+            _event(
+                "evt-1",
+                "ord-1",
+                occurred_at="2025-01-01T09:01:00Z",
+                sequence=1,
+                position_id="pos-1",
+                trade_id="trade-1",
+            ),
+        ]
+    )
+
+    repo.save_trade(
+        _trade(
+            "trade-2",
+            position_id="pos-2",
+            status="closed",
+            opened_at="2025-01-01T09:02:00Z",
+            closed_at="2025-01-01T09:10:00Z",
+            quantity_opened="1",
+            quantity_closed="1",
+            average_entry_price="110",
+            average_exit_price="111",
+            realized_pnl="1",
+            opening_order_ids=["ord-2"],
+            execution_event_ids=["evt-2"],
+        )
+    )
+    repo.save_trade(
+        _trade(
+            "trade-1",
+            position_id="pos-1",
+            status="closed",
+            opened_at="2025-01-01T09:00:00Z",
+            closed_at="2025-01-01T09:03:00Z",
+            quantity_opened="1",
+            quantity_closed="1",
+            average_entry_price="100",
+            average_exit_price="101",
+            realized_pnl="1",
+            opening_order_ids=["ord-1"],
+            execution_event_ids=["evt-1"],
+        )
+    )
+    repo.save_trade(
+        _trade(
+            "trade-1b",
+            position_id="pos-1",
+            status="open",
+            opened_at="2025-01-01T09:01:30Z",
+            quantity_opened="2",
+            quantity_closed="0",
+            average_entry_price="102",
+            opening_order_ids=["ord-1b"],
+            execution_event_ids=["evt-1b"],
+        )
+    )
+
+
+def test_trading_core_inspection_endpoints_exposed_read_only(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    _seed_core_data(repo)
+    with _test_client(monkeypatch, repo) as client:
+        orders = client.get("/trading-core/orders", headers=READ_ONLY_HEADERS)
+        events = client.get("/trading-core/execution-events", headers=READ_ONLY_HEADERS)
+        trades = client.get("/trading-core/trades", headers=READ_ONLY_HEADERS)
+        positions = client.get("/trading-core/positions", headers=READ_ONLY_HEADERS)
+        openapi = client.get("/openapi.json").json()
+
+    assert orders.status_code == 200
+    assert events.status_code == 200
+    assert trades.status_code == 200
+    assert positions.status_code == 200
+    assert "/trading-core/orders" in openapi["paths"]
+    assert "/trading-core/execution-events" in openapi["paths"]
+    assert "/trading-core/trades" in openapi["paths"]
+    assert "/trading-core/positions" in openapi["paths"]
+
+
+def test_trading_core_ordering_is_deterministic(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    _seed_core_data(repo)
+
+    with _test_client(monkeypatch, repo) as client:
+        first = client.get("/trading-core/orders", headers=READ_ONLY_HEADERS)
+        second = client.get("/trading-core/orders", headers=READ_ONLY_HEADERS)
+        events = client.get("/trading-core/execution-events", headers=READ_ONLY_HEADERS).json()
+        trades = client.get("/trading-core/trades", headers=READ_ONLY_HEADERS).json()
+        positions = client.get("/trading-core/positions", headers=READ_ONLY_HEADERS).json()
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+
+    assert [item["order_id"] for item in first.json()["items"]] == ["ord-1", "ord-1b", "ord-2"]
+    assert [item["event_id"] for item in events["items"]] == ["evt-1", "evt-1b", "evt-2"]
+    assert [item["trade_id"] for item in trades["items"]] == ["trade-1", "trade-1b", "trade-2"]
+    assert [item["position_id"] for item in positions["items"]] == ["pos-1", "pos-2"]
+
+
+def test_trading_core_response_schemas_validate(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    _seed_core_data(repo)
+
+    with _test_client(monkeypatch, repo) as client:
+        orders = client.get("/trading-core/orders", headers=READ_ONLY_HEADERS).json()
+        events = client.get("/trading-core/execution-events", headers=READ_ONLY_HEADERS).json()
+        trades = client.get("/trading-core/trades", headers=READ_ONLY_HEADERS).json()
+        positions = client.get("/trading-core/positions", headers=READ_ONLY_HEADERS).json()
+
+    assert validate_json_schema(orders, api_main.TradingCoreOrdersReadResponse.model_json_schema()) == []
+    assert (
+        validate_json_schema(
+            events,
+            api_main.TradingCoreExecutionEventsReadResponse.model_json_schema(),
+        )
+        == []
+    )
+    assert validate_json_schema(trades, api_main.TradingCoreTradesReadResponse.model_json_schema()) == []
+    assert (
+        validate_json_schema(
+            positions,
+            api_main.TradingCorePositionsReadResponse.model_json_schema(),
+        )
+        == []
+    )
+
+
+def test_trading_core_empty_and_error_cases(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    with _test_client(monkeypatch, repo) as client:
+        assert client.get("/trading-core/orders", headers=READ_ONLY_HEADERS).json() == {
+            "items": [],
+            "limit": 50,
+            "offset": 0,
+            "total": 0,
+        }
+        assert client.get("/trading-core/execution-events", headers=READ_ONLY_HEADERS).json() == {
+            "items": [],
+            "limit": 50,
+            "offset": 0,
+            "total": 0,
+        }
+        assert client.get("/trading-core/trades", headers=READ_ONLY_HEADERS).json() == {
+            "items": [],
+            "limit": 50,
+            "offset": 0,
+            "total": 0,
+        }
+        assert client.get("/trading-core/positions", headers=READ_ONLY_HEADERS).json() == {
+            "items": [],
+            "limit": 50,
+            "offset": 0,
+            "total": 0,
+        }
+
+        unauthorized = client.get("/trading-core/orders")
+        invalid_limit = client.get(
+            "/trading-core/orders",
+            headers=READ_ONLY_HEADERS,
+            params={"limit": 0},
+        )
+        unknown_trade = client.get(
+            "/trading-core/trades",
+            headers=READ_ONLY_HEADERS,
+            params={"trade_id": "does-not-exist"},
+        )
+
+    assert unauthorized.status_code == 401
+    assert unauthorized.json() == {"detail": "unauthorized"}
+    assert invalid_limit.status_code == 422
+    assert unknown_trade.status_code == 200
+    assert unknown_trade.json()["items"] == []
+    assert unknown_trade.json()["total"] == 0


### PR DESCRIPTION
﻿Closes #721

## Summary
- Added read-only trading core inspection endpoints:
  - `GET /trading-core/orders`
  - `GET /trading-core/execution-events`
  - `GET /trading-core/trades`
  - `GET /trading-core/positions`
- Aligned response payloads to canonical trading core entities from `src/cilly_trading/models.py`.
- Kept API scope strictly read-only with no new mutation surfaces.

## Determinism
- Orders, execution events, and trades use deterministic canonical repository ordering.
- Positions are deterministically derived and ordered by `(opened_at, position_id)`.

## Tests
- Added FastAPI coverage for:
  - endpoint exposure
  - deterministic ordering
  - schema validation
  - empty and error cases
- Full suite result:
  - `635 passed, 4 warnings`

## Docs
- Added `docs/api/trading_core_inspection.md`
- Added index entry in `docs/index.md`

## Governance
- Review decision: `APPROVED`
- Classification: `technically good, but traderically weak`
