### PR TITLE
BT-P42B: Define backtest execution contract and reproducible run configuration

### DIFF
--- a/docs/architecture/backtest_execution_contract.md
+++ b/docs/architecture/backtest_execution_contract.md
@@ -1,0 +1,76 @@
+# Backtest Execution Contract (BT-P42B)
+
+## Goal
+
+Define one explicit contract for deterministic backtest execution so runs are reproducible and operational assumptions are visible in the artifact.
+
+## Contract Boundary
+
+The backtest contract is bounded to:
+
+- run configuration validation
+- signal-to-order translation
+- deterministic order execution assumptions
+- reproducibility metadata written into the run artifact
+
+Out of scope:
+
+- portfolio optimization
+- paper-trading runtime
+- broker integrations
+- UI workflows
+
+## Run Configuration Model
+
+Backtests use `BacktestRunContract` with explicit sections:
+
+- `contract_version`: currently `1.0.0`
+- `signal_translation`:
+  - `signal_collection_field`
+  - `signal_id_field`
+  - `action_field`
+  - `quantity_field`
+  - `symbol_field`
+  - `action_to_side`
+- `execution_assumptions`:
+  - `fill_model` = `deterministic_market`
+  - `fill_timing` = `next_snapshot` or `same_snapshot`
+  - `price_source` = `open_then_price`
+  - `slippage_bps` (integer, `>= 0`)
+  - `commission_per_order` (decimal, `>= 0`)
+  - `partial_fills_allowed` = `false`
+- `reproducibility_metadata`:
+  - `run_id`
+  - `strategy_name`
+  - `strategy_params`
+  - `engine_name`
+  - `engine_version`
+
+## Signal -> Order -> Fill Semantics
+
+Signal translation is deterministic:
+
+1. Snapshots are sorted by `timestamp` / `snapshot_key`, then by `id`.
+2. Signals in each snapshot are sorted by `signal_id`, then `symbol`.
+3. Each translated order is market-only and receives a deterministic `order_id`.
+
+Execution assumptions are explicit and testable:
+
+- no partial fills
+- fill price source is `open`, then fallback `price`
+- side-aware slippage:
+  - BUY: `price * (1 + bps/10000)`
+  - SELL: `price * (1 - bps/10000)`
+- fixed commission per filled order
+- deterministic decimal quantization
+
+## Reproducibility
+
+For identical snapshots and identical run contract:
+
+- translated orders are identical
+- fills and resulting positions are identical
+- `backtest-result.json` bytes and hash remain identical
+
+The run artifact now surfaces both the explicit `run_config` contract and realized `orders` / `fills` / `positions`.
+

--- a/src/cilly_trading/engine/backtest_execution_contract.py
+++ b/src/cilly_trading/engine/backtest_execution_contract.py
@@ -1,0 +1,383 @@
+"""Backtest execution contract and deterministic run configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Dict, List, Literal, Mapping, Sequence
+
+from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
+
+from cilly_trading.engine.pipeline.orchestrator import (
+    DeterministicExecutionConfig,
+    ExecutionEvent,
+    Order,
+    Position,
+    run_pipeline,
+)
+from cilly_trading.engine.strategy_lifecycle.model import StrategyLifecycleState
+
+SUPPORTED_RUN_CONTRACT_VERSION = "1.0.0"
+DEFAULT_ACTION_TO_SIDE: dict[str, Literal["BUY", "SELL"]] = {"BUY": "BUY", "SELL": "SELL"}
+
+
+@dataclass(frozen=True)
+class BacktestSignalTranslationConfig:
+    """Explicit rules for translating signals into simulated market orders."""
+
+    signal_collection_field: str = "signals"
+    signal_id_field: str = "signal_id"
+    action_field: str = "action"
+    quantity_field: str = "quantity"
+    symbol_field: str = "symbol"
+    action_to_side: Mapping[str, Literal["BUY", "SELL"]] = field(
+        default_factory=lambda: dict(DEFAULT_ACTION_TO_SIDE)
+    )
+
+    def __post_init__(self) -> None:
+        for value in (
+            self.signal_collection_field,
+            self.signal_id_field,
+            self.action_field,
+            self.quantity_field,
+            self.symbol_field,
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError("Signal translation field names must be non-empty strings")
+
+        normalized: dict[str, Literal["BUY", "SELL"]] = {}
+        for action, side in self.action_to_side.items():
+            normalized_action = str(action).strip().upper()
+            if side not in {"BUY", "SELL"}:
+                raise ValueError("Signal action mappings must resolve to BUY or SELL")
+            if not normalized_action:
+                raise ValueError("Signal action mapping keys must be non-empty")
+            normalized[normalized_action] = side
+
+        if not normalized:
+            raise ValueError("Signal action mapping must not be empty")
+
+        object.__setattr__(self, "action_to_side", normalized)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "signal_collection_field": self.signal_collection_field,
+            "signal_id_field": self.signal_id_field,
+            "action_field": self.action_field,
+            "quantity_field": self.quantity_field,
+            "symbol_field": self.symbol_field,
+            "action_to_side": dict(sorted(self.action_to_side.items())),
+        }
+
+
+@dataclass(frozen=True)
+class BacktestExecutionAssumptions:
+    """Explicit deterministic assumptions for backtest order execution."""
+
+    fill_model: Literal["deterministic_market"] = "deterministic_market"
+    fill_timing: Literal["next_snapshot", "same_snapshot"] = "next_snapshot"
+    price_source: Literal["open_then_price"] = "open_then_price"
+    slippage_bps: int = 0
+    commission_per_order: Decimal = Decimal("0")
+    partial_fills_allowed: bool = False
+
+    def __post_init__(self) -> None:
+        if self.slippage_bps < 0:
+            raise ValueError("Execution assumption slippage_bps must be >= 0")
+        if self.commission_per_order < Decimal("0"):
+            raise ValueError("Execution assumption commission_per_order must be >= 0")
+        if self.partial_fills_allowed:
+            raise ValueError("Execution assumption partial_fills_allowed must be false")
+
+    def to_execution_config(self) -> DeterministicExecutionConfig:
+        return DeterministicExecutionConfig(
+            slippage_bps=self.slippage_bps,
+            commission_per_order=self.commission_per_order,
+            fill_timing=self.fill_timing,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "fill_model": self.fill_model,
+            "fill_timing": self.fill_timing,
+            "price_source": self.price_source,
+            "slippage_bps": self.slippage_bps,
+            "commission_per_order": str(self.commission_per_order),
+            "partial_fills_allowed": self.partial_fills_allowed,
+        }
+
+
+@dataclass(frozen=True)
+class BacktestRunContract:
+    """Backtest run contract with explicit reproducibility metadata."""
+
+    contract_version: str = SUPPORTED_RUN_CONTRACT_VERSION
+    signal_translation: BacktestSignalTranslationConfig = field(
+        default_factory=BacktestSignalTranslationConfig
+    )
+    execution_assumptions: BacktestExecutionAssumptions = field(
+        default_factory=BacktestExecutionAssumptions
+    )
+
+    def __post_init__(self) -> None:
+        if self.contract_version != SUPPORTED_RUN_CONTRACT_VERSION:
+            raise ValueError(
+                f"Unsupported backtest contract_version: {self.contract_version}"
+            )
+
+    def to_payload(
+        self,
+        *,
+        run_id: str,
+        strategy_name: str,
+        strategy_params: Mapping[str, Any],
+        engine_name: str,
+        engine_version: str | None,
+    ) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "signal_translation": self.signal_translation.to_payload(),
+            "execution_assumptions": self.execution_assumptions.to_payload(),
+            "reproducibility_metadata": {
+                "run_id": run_id,
+                "strategy_name": strategy_name,
+                "strategy_params": dict(strategy_params),
+                "engine_name": engine_name,
+                "engine_version": engine_version,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class BacktestExecutionFlowResult:
+    """Deterministic simulated flow result for a run contract."""
+
+    orders: List[Order]
+    fills: List[ExecutionEvent]
+    positions: List[Position]
+
+
+def resolve_snapshot_key(snapshot: Mapping[str, Any]) -> str:
+    """Resolve deterministic snapshot key used for sequencing and fills."""
+
+    if snapshot.get("timestamp") is not None:
+        return str(snapshot["timestamp"])
+    if snapshot.get("snapshot_key") is not None:
+        return str(snapshot["snapshot_key"])
+    if snapshot.get("id") is not None:
+        return str(snapshot["id"])
+    raise ValueError("Snapshot must contain one of: timestamp, snapshot_key, id")
+
+
+def sort_snapshots(snapshots: Sequence[Mapping[str, Any]]) -> List[dict[str, Any]]:
+    """Sort snapshots deterministically by key and id."""
+
+    sortable: list[tuple[tuple[str, str], dict[str, Any]]] = []
+    for snapshot in snapshots:
+        normalized = dict(snapshot)
+        sortable.append(
+            (
+                (resolve_snapshot_key(normalized), str(normalized.get("id", ""))),
+                normalized,
+            )
+        )
+    sortable.sort(key=lambda item: item[0])
+    return [item[1] for item in sortable]
+
+
+def translate_signals_to_orders(
+    *,
+    ordered_snapshots: Sequence[Mapping[str, Any]],
+    run_id: str,
+    strategy_name: str,
+    signal_translation: BacktestSignalTranslationConfig,
+) -> List[Order]:
+    """Translate snapshot signals into deterministic market orders."""
+
+    orders: list[Order] = []
+    sequence = 1
+    for snapshot in ordered_snapshots:
+        snapshot_key = resolve_snapshot_key(snapshot)
+        raw_signals = snapshot.get(signal_translation.signal_collection_field, [])
+        if raw_signals in (None, []):
+            continue
+        if not isinstance(raw_signals, Sequence) or isinstance(raw_signals, (str, bytes)):
+            raise ValueError("Snapshot signals must be a sequence")
+
+        normalized_signals = sorted(
+            (signal for signal in raw_signals),
+            key=lambda signal: (
+                str(signal.get(signal_translation.signal_id_field, "")),
+                str(signal.get(signal_translation.symbol_field, "")),
+            ),
+        )
+        for signal in normalized_signals:
+            if not isinstance(signal, Mapping):
+                raise ValueError("Each signal must be a mapping")
+            signal_id = signal.get(signal_translation.signal_id_field)
+            if not isinstance(signal_id, str) or not signal_id.strip():
+                raise ValueError("Signal must define a non-empty signal_id")
+            raw_action = signal.get(signal_translation.action_field)
+            if not isinstance(raw_action, str):
+                raise ValueError("Signal must define an action string")
+            action = raw_action.strip().upper()
+            side = signal_translation.action_to_side.get(action)
+            if side is None:
+                raise ValueError(f"Unsupported signal action: {action}")
+
+            symbol_value = signal.get(signal_translation.symbol_field, snapshot.get("symbol"))
+            if not isinstance(symbol_value, str) or not symbol_value.strip():
+                raise ValueError("Signal must define a non-empty symbol")
+            symbol = symbol_value.strip().upper()
+
+            quantity_value = signal.get(signal_translation.quantity_field)
+            try:
+                quantity = Decimal(str(quantity_value))
+            except Exception as exc:  # pragma: no cover - defensive parsing
+                raise ValueError("Signal quantity must be decimal-compatible") from exc
+            if quantity <= Decimal("0"):
+                raise ValueError("Signal quantity must be > 0")
+
+            order = Order(
+                order_id=f"{run_id}:{signal_id}:{sequence}",
+                strategy_id=strategy_name,
+                symbol=symbol,
+                sequence=sequence,
+                side=side,
+                order_type="market",
+                time_in_force="day",
+                status="created",
+                quantity=quantity,
+                created_at=snapshot_key,
+                position_id=f"{run_id}:{symbol}:position",
+                trade_id=f"{run_id}:{symbol}:trade",
+            )
+            orders.append(order)
+            sequence += 1
+
+    return orders
+
+
+def simulate_execution_flow(
+    *,
+    snapshots: Sequence[Mapping[str, Any]],
+    run_id: str,
+    strategy_name: str,
+    run_contract: BacktestRunContract,
+) -> BacktestExecutionFlowResult:
+    """Run deterministic signal->order->fill->position backtest flow."""
+
+    ordered_snapshots = sort_snapshots(snapshots)
+    orders = translate_signals_to_orders(
+        ordered_snapshots=ordered_snapshots,
+        run_id=run_id,
+        strategy_name=strategy_name,
+        signal_translation=run_contract.signal_translation,
+    )
+    execution_config = run_contract.execution_assumptions.to_execution_config()
+    lifecycle_store = _ProductionLifecycleStore()
+    risk_gate = _ApprovedRiskGate()
+
+    symbol_positions: dict[str, Position] = {}
+    symbol_pending_orders: dict[str, list[Order]] = {}
+    for order in orders:
+        symbol_pending_orders.setdefault(order.symbol, []).append(order)
+        symbol_positions.setdefault(order.symbol, _initial_position(run_id, strategy_name, order.symbol))
+
+    fills: list[ExecutionEvent] = []
+    for snapshot in ordered_snapshots:
+        snapshot_symbol = snapshot.get("symbol")
+        candidate_symbols: list[str]
+        if isinstance(snapshot_symbol, str) and snapshot_symbol.strip():
+            candidate_symbols = [snapshot_symbol.strip().upper()]
+        else:
+            candidate_symbols = sorted(symbol_pending_orders.keys())
+
+        for symbol in candidate_symbols:
+            pending_orders = symbol_pending_orders.get(symbol, [])
+            if not pending_orders:
+                continue
+
+            current_position = symbol_positions[symbol]
+            pipeline_result = run_pipeline(
+                {"orders": pending_orders, "snapshot": snapshot},
+                risk_gate=risk_gate,
+                lifecycle_store=lifecycle_store,
+                risk_request=_risk_request(run_id=run_id, strategy_name=strategy_name, symbol=symbol),
+                position=current_position,
+                execution_config=execution_config,
+            )
+            snapshot_fills = pipeline_result.fills
+            if not snapshot_fills:
+                continue
+
+            symbol_positions[symbol] = pipeline_result.position
+            filled_order_ids = {fill.order_id for fill in snapshot_fills}
+            symbol_pending_orders[symbol] = [
+                order for order in pending_orders if order.order_id not in filled_order_ids
+            ]
+            fills.extend(snapshot_fills)
+
+    positions = [symbol_positions[symbol] for symbol in sorted(symbol_positions.keys())]
+    return BacktestExecutionFlowResult(orders=orders, fills=fills, positions=positions)
+
+
+def _initial_position(run_id: str, strategy_name: str, symbol: str) -> Position:
+    return Position(
+        position_id=f"{run_id}:{symbol}:position",
+        strategy_id=strategy_name,
+        symbol=symbol,
+        direction="long",
+        status="flat",
+        opened_at="backtest-start",
+        quantity_opened=Decimal("0"),
+        quantity_closed=Decimal("0"),
+        net_quantity=Decimal("0"),
+        average_entry_price=Decimal("0"),
+        order_ids=[],
+        execution_event_ids=[],
+        trade_ids=[],
+    )
+
+
+def _risk_request(*, run_id: str, strategy_name: str, symbol: str) -> RiskEvaluationRequest:
+    return RiskEvaluationRequest(
+        request_id=f"{run_id}:{strategy_name}:{symbol}:risk",
+        strategy_id=strategy_name,
+        symbol=symbol,
+        notional_usd=0.0,
+        metadata={"source": "backtest_execution_contract"},
+    )
+
+
+class _ApprovedRiskGate(RiskGate):
+    def evaluate(self, request: RiskEvaluationRequest) -> RiskDecision:
+        return RiskDecision(
+            decision="APPROVED",
+            score=0.0,
+            max_allowed=0.0,
+            reason="deterministic_backtest",
+            timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc),
+            rule_version="deterministic-backtest-v1",
+        )
+
+
+class _ProductionLifecycleStore:
+    def get_state(self, strategy_id: str) -> StrategyLifecycleState:
+        return StrategyLifecycleState.PRODUCTION
+
+    def set_state(self, strategy_id: str, new_state: StrategyLifecycleState) -> None:
+        return None
+
+
+def serialize_orders(orders: Sequence[Order]) -> list[dict[str, Any]]:
+    return [order.model_dump(mode="json") for order in orders]
+
+
+def serialize_fills(fills: Sequence[ExecutionEvent]) -> list[dict[str, Any]]:
+    return [fill.model_dump(mode="json") for fill in fills]
+
+
+def serialize_positions(positions: Sequence[Position]) -> list[dict[str, Any]]:
+    return [position.model_dump(mode="json") for position in positions]

--- a/src/cilly_trading/engine/backtest_runner.py
+++ b/src/cilly_trading/engine/backtest_runner.py
@@ -6,6 +6,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Protocol, Sequence, Tuple
 
+from cilly_trading.engine.backtest_execution_contract import (
+    BacktestRunContract,
+    serialize_fills,
+    serialize_orders,
+    serialize_positions,
+    simulate_execution_flow,
+)
 from cilly_trading.engine.journal.execution_journal import (
     build_execution_journal_artifact,
     write_execution_journal_artifact,
@@ -48,6 +55,7 @@ class BacktestRunnerConfig:
     strategy_params: Mapping[str, Any] = field(default_factory=dict)
     engine_name: str = "cilly_trading_engine"
     engine_version: str | None = None
+    run_contract: BacktestRunContract = field(default_factory=BacktestRunContract)
 
 
 class BacktestRunner:
@@ -211,6 +219,12 @@ class BacktestRunner:
         invocation_log: List[str],
         config: BacktestRunnerConfig,
     ) -> Dict[str, Any]:
+        flow_result = simulate_execution_flow(
+            snapshots=processed_snapshots,
+            run_id=config.run_id,
+            strategy_name=config.strategy_name,
+            run_contract=config.run_contract,
+        )
         if not processed_snapshots:
             snapshot_mode = "timestamp"
             start = None
@@ -248,11 +262,18 @@ class BacktestRunner:
                 "version": None,
                 "params": dict(config.strategy_params),
             },
+            "run_config": config.run_contract.to_payload(
+                run_id=config.run_id,
+                strategy_name=config.strategy_name,
+                strategy_params=config.strategy_params,
+                engine_name=config.engine_name,
+                engine_version=config.engine_version,
+            ),
             "invocation_log": invocation_log,
             "processed_snapshots": processed_snapshots,
-            "orders": [],
-            "fills": [],
-            "positions": [],
+            "orders": serialize_orders(flow_result.orders),
+            "fills": serialize_fills(flow_result.fills),
+            "positions": serialize_positions(flow_result.positions),
         }
 
     def _snapshot_boundaries(

--- a/tests/cilly_trading/engine/test_backtest_execution_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_execution_contract.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.engine.backtest_execution_contract import (
+    BacktestExecutionAssumptions,
+    BacktestRunContract,
+    BacktestSignalTranslationConfig,
+    serialize_fills,
+    serialize_orders,
+    serialize_positions,
+    simulate_execution_flow,
+)
+from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerConfig
+
+
+def _sample_flow_snapshots() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "100",
+            "signals": [
+                {"signal_id": "sig-buy", "action": "BUY", "quantity": "2", "symbol": "AAPL"},
+            ],
+        },
+        {
+            "id": "s2",
+            "timestamp": "2024-01-02T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "110",
+            "signals": [
+                {"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"},
+            ],
+        },
+        {
+            "id": "s3",
+            "timestamp": "2024-01-03T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "111",
+        },
+    ]
+
+
+def test_contract_validation_rejects_invalid_execution_assumptions() -> None:
+    with pytest.raises(ValueError, match="slippage_bps"):
+        BacktestExecutionAssumptions(slippage_bps=-1)
+    with pytest.raises(ValueError, match="commission_per_order"):
+        BacktestExecutionAssumptions(commission_per_order=Decimal("-0.01"))
+    with pytest.raises(ValueError, match="partial_fills_allowed"):
+        BacktestExecutionAssumptions(partial_fills_allowed=True)
+
+
+def test_contract_validation_rejects_invalid_contract_version() -> None:
+    with pytest.raises(ValueError, match="Unsupported backtest contract_version"):
+        BacktestRunContract(contract_version="2.0.0")
+
+
+def test_representative_backtest_flow_next_snapshot() -> None:
+    result = simulate_execution_flow(
+        snapshots=_sample_flow_snapshots(),
+        run_id="run-1",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(
+            execution_assumptions=BacktestExecutionAssumptions(
+                slippage_bps=10,
+                commission_per_order=Decimal("1.25"),
+                fill_timing="next_snapshot",
+            )
+        ),
+    )
+
+    assert len(result.orders) == 2
+    assert len(result.fills) == 2
+    assert result.fills[0].order_id.endswith(":sig-buy:1")
+    assert result.fills[0].occurred_at == "2024-01-02T00:00:00Z"
+    assert result.fills[1].order_id.endswith(":sig-sell:2")
+    assert result.fills[1].occurred_at == "2024-01-03T00:00:00Z"
+    assert result.positions[0].status == "open"
+    assert result.positions[0].net_quantity == Decimal("1.00000000")
+
+
+def test_representative_backtest_flow_same_snapshot() -> None:
+    result = simulate_execution_flow(
+        snapshots=_sample_flow_snapshots(),
+        run_id="run-2",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(
+            execution_assumptions=BacktestExecutionAssumptions(
+                slippage_bps=0,
+                commission_per_order=Decimal("0"),
+                fill_timing="same_snapshot",
+            )
+        ),
+    )
+
+    assert len(result.fills) == 2
+    assert result.fills[0].occurred_at == "2024-01-01T00:00:00Z"
+    assert result.fills[1].occurred_at == "2024-01-02T00:00:00Z"
+
+
+def test_reproducibility_flow_serialization_is_deterministic() -> None:
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=3,
+            commission_per_order=Decimal("0.55"),
+        )
+    )
+    result_a = simulate_execution_flow(
+        snapshots=_sample_flow_snapshots(),
+        run_id="run-repro",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+    result_b = simulate_execution_flow(
+        snapshots=_sample_flow_snapshots(),
+        run_id="run-repro",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    assert serialize_orders(result_a.orders) == serialize_orders(result_b.orders)
+    assert serialize_fills(result_a.fills) == serialize_fills(result_b.fills)
+    assert serialize_positions(result_a.positions) == serialize_positions(result_b.positions)
+
+
+def test_negative_configuration_invalid_signal_mapping_fails() -> None:
+    with pytest.raises(ValueError, match="Signal action mapping must not be empty"):
+        BacktestSignalTranslationConfig(action_to_side={})
+
+
+def test_negative_configuration_invalid_signal_payload_fails(tmp_path: Path) -> None:
+    class _NoopStrategy:
+        def on_run_start(self, config):  # type: ignore[no-untyped-def]
+            return None
+
+        def on_snapshot(self, snapshot, config):  # type: ignore[no-untyped-def]
+            return None
+
+        def on_run_end(self, config):  # type: ignore[no-untyped-def]
+            return None
+
+    snapshots_path = tmp_path / "snapshots.json"
+    snapshots_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "s1",
+                    "timestamp": "2024-01-01T00:00:00Z",
+                    "symbol": "AAPL",
+                    "open": "100",
+                    "signals": [{"signal_id": "sig-1", "action": "BUY", "quantity": "0"}],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    snapshots = json.loads(snapshots_path.read_text(encoding="utf-8"))
+
+    runner = BacktestRunner()
+    with pytest.raises(ValueError, match="Signal quantity must be > 0"):
+        runner.run(
+            snapshots=snapshots,
+            strategy_factory=lambda: _NoopStrategy(),
+            config=BacktestRunnerConfig(output_dir=tmp_path / "out"),
+        )

--- a/tests/cilly_trading/engine/test_backtest_runner.py
+++ b/tests/cilly_trading/engine/test_backtest_runner.py
@@ -6,6 +6,10 @@ from typing import Any, Dict, List, Mapping
 
 import pytest
 
+from cilly_trading.engine.backtest_execution_contract import (
+    BacktestExecutionAssumptions,
+    BacktestRunContract,
+)
 from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerConfig
 from cilly_trading.engine.journal.execution_journal import EXECUTION_JOURNAL_SCHEMA
 from tests.utils.json_schema_validator import validate_json_schema
@@ -204,3 +208,71 @@ def test_backtest_runner_persists_execution_journal_artifacts(tmp_path: Path) ->
     assert phases[0] == ("run", "started")
     assert phases[-1] == ("run", "completed")
     assert any(phase == ("snapshot", "processed") for phase in phases)
+
+
+def test_backtest_runner_artifact_contains_explicit_run_contract(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    result = runner.run(
+        snapshots=[
+            {"id": "s1", "timestamp": "2024-01-01T00:00:00Z", "symbol": "AAPL", "open": "100"},
+            {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "101"},
+        ],
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(
+            output_dir=tmp_path / "run-config",
+            run_id="contract-run",
+            strategy_name="REFERENCE",
+            strategy_params={"alpha": "1"},
+            run_contract=BacktestRunContract(
+                execution_assumptions=BacktestExecutionAssumptions(
+                    slippage_bps=7,
+                    commission_per_order=7,
+                )
+            ),
+        ),
+    )
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    run_config = payload["run_config"]
+    assert run_config["contract_version"] == "1.0.0"
+    assert run_config["execution_assumptions"]["slippage_bps"] == 7
+    assert run_config["execution_assumptions"]["commission_per_order"] == "7"
+    assert run_config["reproducibility_metadata"]["run_id"] == "contract-run"
+    assert run_config["reproducibility_metadata"]["strategy_name"] == "REFERENCE"
+
+
+def test_backtest_runner_emits_deterministic_orders_fills_positions(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    result = runner.run(
+        snapshots=[
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {
+                "id": "s2",
+                "timestamp": "2024-01-02T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "110",
+            },
+        ],
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=tmp_path / "flow", run_id="flow-run"),
+    )
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    assert len(payload["orders"]) == 1
+    assert len(payload["fills"]) == 1
+    assert len(payload["positions"]) == 1
+    assert payload["fills"][0]["occurred_at"] == "2024-01-02T00:00:00Z"


### PR DESCRIPTION
Closes #727

## Summary
Implements an explicit, bounded backtest execution contract with reproducible run configuration and deterministic signal->order->fill behavior.

## What changed
- Added BacktestRunContract model
- Added deterministic execution flow
- Added run_config + orders + fills + positions to artifact
- Added tests for validation, flow, reproducibility, negative cases
- Added architecture documentation

## Test evidence
- python -m pytest
- Result: 646 passed, 4 warnings

---

## Codex A Review

Decision: APPROVED

Active Issue  
#727 — Backtest execution contract and reproducible run configuration

Top Findings  
1. Scope remains bounded to deterministic backtest execution governance and artifact reproducibility without drift into live-trading or unrelated runtime expansion.  
2. Review-package requirements are satisfied: changed/new files, full file contents, and full test evidence were provided.  
3. Classification: technically good, but traderically weak — the implementation improves technical backtest governance, but trader validation and backtest realism are still not proven by this issue alone.

Acceptance Criteria Check  
- AC1: satisfied — an explicit, versioned BacktestRunContract is implemented and surfaced in the artifact.  
- AC2: satisfied — deterministic signal→order→fill→position behavior is implemented and covered by targeted tests.  
- AC3: satisfied — full repository test evidence is green: 646 passed, 4 warnings.

Approval Note  
- Implementation is inside issue scope.  
- Acceptance Criteria are satisfied.  
- Test evidence is sufficient.  
- PR may proceed.