### PR TITLE
BT-P42B: Add bounded transaction cost/slippage baseline and deterministic metrics outputs

### DIFF
--- a/docs/testing/backtesting/metrics.md
+++ b/docs/testing/backtesting/metrics.md
@@ -18,6 +18,17 @@ The evaluation input consists of three artifacts:
 - `equity_curve`: ordered equity observations with timestamped equity values.
 - `trades`: closed-trade records with realized `pnl` and trade identifiers.
 
+For issue `#728`, backtest artifacts now include deterministic baseline artifacts directly:
+
+- `summary` (cost-aware baseline): `start_equity`, `end_equity`.
+- `equity_curve` (cost-aware baseline): canonical timestamp/equity series.
+- `trades`: currently an empty deterministic list for the baseline phase.
+- `metrics_baseline`: deterministic comparison object with:
+  - `assumptions` (explicit cost/slippage assumptions from run config),
+  - `summary` (starting/ending equity, total commission, total slippage cost, total transaction cost, fill count),
+  - `equity_curve.cost_free` and `equity_curve.cost_aware`,
+  - `metrics.cost_free`, `metrics.cost_aware`, and `metrics.deltas`.
+
 ## Canonical Ordering Rules
 
 The evaluator SHALL operate on canonicalized sequences:
@@ -220,3 +231,22 @@ Reproducibility validation requirements:
 - SHA-256 hash equality across all 3 produced artifacts is required.
 - Raw byte-equality across all 3 produced artifacts is required.
 - These checks are covered by CI and SHALL be enforced in continuous validation.
+
+# 7. Cost/Slippage Baseline Rules
+
+The deterministic baseline in this phase uses bounded assumptions:
+
+- `slippage_bps` range: `[0, 250]`.
+- `commission_per_order` range: `[0, 25]`.
+
+Cost model:
+
+- Slippage is side-aware and adverse (`BUY` increases fill price, `SELL` decreases fill price).
+- Commission is fixed per filled order.
+- Total transaction cost is `total_commission + total_slippage_cost`.
+
+Cost-aware vs cost-free comparison:
+
+- `cost_free` uses reference snapshot fill price (`open` or fallback `price`) and zero costs.
+- `cost_aware` uses executed fill price plus commission.
+- For identical fills with non-zero assumptions, `ending_equity_cost_aware` SHALL be less than `ending_equity_cost_free`.

--- a/src/cilly_trading/engine/backtest_execution_contract.py
+++ b/src/cilly_trading/engine/backtest_execution_contract.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Literal, Mapping, Sequence
 
 from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
 
+from cilly_trading.metrics import compute_backtest_metrics
 from cilly_trading.engine.pipeline.orchestrator import (
     DeterministicExecutionConfig,
     ExecutionEvent,
@@ -19,7 +20,11 @@ from cilly_trading.engine.pipeline.orchestrator import (
 from cilly_trading.engine.strategy_lifecycle.model import StrategyLifecycleState
 
 SUPPORTED_RUN_CONTRACT_VERSION = "1.0.0"
+BASELINE_VERSION = "1.0.0"
 DEFAULT_ACTION_TO_SIDE: dict[str, Literal["BUY", "SELL"]] = {"BUY": "BUY", "SELL": "SELL"}
+MAX_SLIPPAGE_BPS = 250
+MAX_COMMISSION_PER_ORDER = Decimal("25")
+DEFAULT_STARTING_EQUITY = Decimal("100000")
 
 
 @dataclass(frozen=True)
@@ -85,8 +90,14 @@ class BacktestExecutionAssumptions:
     def __post_init__(self) -> None:
         if self.slippage_bps < 0:
             raise ValueError("Execution assumption slippage_bps must be >= 0")
+        if self.slippage_bps > MAX_SLIPPAGE_BPS:
+            raise ValueError(f"Execution assumption slippage_bps must be <= {MAX_SLIPPAGE_BPS}")
         if self.commission_per_order < Decimal("0"):
             raise ValueError("Execution assumption commission_per_order must be >= 0")
+        if self.commission_per_order > MAX_COMMISSION_PER_ORDER:
+            raise ValueError(
+                f"Execution assumption commission_per_order must be <= {MAX_COMMISSION_PER_ORDER}"
+            )
         if self.partial_fills_allowed:
             raise ValueError("Execution assumption partial_fills_allowed must be false")
 
@@ -381,3 +392,195 @@ def serialize_fills(fills: Sequence[ExecutionEvent]) -> list[dict[str, Any]]:
 
 def serialize_positions(positions: Sequence[Position]) -> list[dict[str, Any]]:
     return [position.model_dump(mode="json") for position in positions]
+
+
+def build_cost_slippage_metrics_baseline(
+    *,
+    ordered_snapshots: Sequence[Mapping[str, Any]],
+    fills: Sequence[ExecutionEvent],
+    execution_assumptions: BacktestExecutionAssumptions,
+) -> dict[str, Any]:
+    """Build deterministic cost-aware vs cost-free baseline outputs."""
+
+    snapshot_rows = [dict(snapshot) for snapshot in ordered_snapshots]
+    if not snapshot_rows:
+        return {
+            "baseline_version": BASELINE_VERSION,
+            "assumptions": execution_assumptions.to_payload(),
+            "summary": {
+                "starting_equity": float(DEFAULT_STARTING_EQUITY),
+                "ending_equity_cost_free": float(DEFAULT_STARTING_EQUITY),
+                "ending_equity_cost_aware": float(DEFAULT_STARTING_EQUITY),
+                "total_transaction_cost": 0.0,
+                "total_commission": 0.0,
+                "total_slippage_cost": 0.0,
+                "fill_count": 0,
+            },
+            "equity_curve": {
+                "cost_free": [],
+                "cost_aware": [],
+            },
+            "metrics": {
+                "cost_free": compute_backtest_metrics(
+                    summary={
+                        "start_equity": float(DEFAULT_STARTING_EQUITY),
+                        "end_equity": float(DEFAULT_STARTING_EQUITY),
+                    },
+                    equity_curve=[],
+                    trades=[],
+                ),
+                "cost_aware": compute_backtest_metrics(
+                    summary={
+                        "start_equity": float(DEFAULT_STARTING_EQUITY),
+                        "end_equity": float(DEFAULT_STARTING_EQUITY),
+                    },
+                    equity_curve=[],
+                    trades=[],
+                ),
+                "deltas": {},
+            },
+            "trades": [],
+        }
+
+    fills_by_snapshot: dict[str, list[ExecutionEvent]] = {}
+    for fill in fills:
+        fills_by_snapshot.setdefault(fill.occurred_at, []).append(fill)
+    for key in fills_by_snapshot:
+        fills_by_snapshot[key] = sorted(
+            fills_by_snapshot[key],
+            key=lambda event: (event.sequence, event.order_id, event.event_id),
+        )
+
+    cash_cost_free = DEFAULT_STARTING_EQUITY
+    cash_cost_aware = DEFAULT_STARTING_EQUITY
+    net_quantity = Decimal("0")
+    total_commission = Decimal("0")
+    total_slippage_cost = Decimal("0")
+
+    cost_free_curve: list[dict[str, Any]] = []
+    cost_aware_curve: list[dict[str, Any]] = []
+
+    for index, snapshot in enumerate(snapshot_rows):
+        snapshot_key = resolve_snapshot_key(snapshot)
+        reference_price = _snapshot_fill_reference_price(snapshot)
+        snapshot_fills = fills_by_snapshot.get(snapshot_key, [])
+        if snapshot_fills and reference_price is None:
+            raise ValueError("Snapshot must contain either 'open' or 'price'")
+
+        for fill in snapshot_fills:
+            if fill.execution_quantity is None or fill.execution_price is None:
+                continue
+            quantity = fill.execution_quantity
+            execution_price = fill.execution_price
+            commission = fill.commission if fill.commission is not None else Decimal("0")
+
+            reference_notional = reference_price * quantity
+            execution_notional = execution_price * quantity
+
+            total_commission += commission
+            total_slippage_cost += abs(execution_price - reference_price) * quantity
+
+            if fill.side == "BUY":
+                cash_cost_free -= reference_notional
+                cash_cost_aware -= execution_notional + commission
+                net_quantity += quantity
+            else:
+                cash_cost_free += reference_notional
+                cash_cost_aware += execution_notional - commission
+                net_quantity -= quantity
+
+        if reference_price is None:
+            if net_quantity != Decimal("0"):
+                raise ValueError("Snapshot must contain either 'open' or 'price' when position is open")
+            mark_to_market_notional = Decimal("0")
+        else:
+            mark_to_market_notional = net_quantity * reference_price
+        equity_cost_free = cash_cost_free + mark_to_market_notional
+        equity_cost_aware = cash_cost_aware + mark_to_market_notional
+
+        point_timestamp = snapshot.get("timestamp", index)
+        cost_free_curve.append(
+            {
+                "timestamp": point_timestamp,
+                "equity": _round_money(equity_cost_free),
+            }
+        )
+        cost_aware_curve.append(
+            {
+                "timestamp": point_timestamp,
+                "equity": _round_money(equity_cost_aware),
+            }
+        )
+
+    start_equity = _round_money(DEFAULT_STARTING_EQUITY)
+    end_equity_cost_free = cost_free_curve[-1]["equity"]
+    end_equity_cost_aware = cost_aware_curve[-1]["equity"]
+
+    summary_cost_free = {
+        "start_equity": start_equity,
+        "end_equity": end_equity_cost_free,
+    }
+    summary_cost_aware = {
+        "start_equity": start_equity,
+        "end_equity": end_equity_cost_aware,
+    }
+
+    metrics_cost_free = compute_backtest_metrics(
+        summary=summary_cost_free,
+        equity_curve=cost_free_curve,
+        trades=[],
+    )
+    metrics_cost_aware = compute_backtest_metrics(
+        summary=summary_cost_aware,
+        equity_curve=cost_aware_curve,
+        trades=[],
+    )
+
+    deltas: dict[str, float | None] = {}
+    for key, value in metrics_cost_aware.items():
+        cost_free_value = metrics_cost_free.get(key)
+        if isinstance(value, (int, float)) and isinstance(cost_free_value, (int, float)):
+            deltas[key] = _round_metric(float(value) - float(cost_free_value))
+        else:
+            deltas[key] = None
+
+    total_transaction_cost = total_commission + total_slippage_cost
+    return {
+        "baseline_version": BASELINE_VERSION,
+        "assumptions": execution_assumptions.to_payload(),
+        "summary": {
+            "starting_equity": start_equity,
+            "ending_equity_cost_free": end_equity_cost_free,
+            "ending_equity_cost_aware": end_equity_cost_aware,
+            "total_transaction_cost": _round_money(total_transaction_cost),
+            "total_commission": _round_money(total_commission),
+            "total_slippage_cost": _round_money(total_slippage_cost),
+            "fill_count": len(fills),
+        },
+        "equity_curve": {
+            "cost_free": cost_free_curve,
+            "cost_aware": cost_aware_curve,
+        },
+        "metrics": {
+            "cost_free": metrics_cost_free,
+            "cost_aware": metrics_cost_aware,
+            "deltas": deltas,
+        },
+        "trades": [],
+    }
+
+
+def _snapshot_fill_reference_price(snapshot: Mapping[str, Any]) -> Decimal | None:
+    if snapshot.get("open") is not None:
+        return Decimal(str(snapshot["open"]))
+    if snapshot.get("price") is not None:
+        return Decimal(str(snapshot["price"]))
+    return None
+
+
+def _round_money(value: Decimal) -> float:
+    return float(value.quantize(Decimal("0.01")))
+
+
+def _round_metric(value: float) -> float:
+    return float(Decimal(str(value)).quantize(Decimal("0.000000000001")))

--- a/src/cilly_trading/engine/backtest_runner.py
+++ b/src/cilly_trading/engine/backtest_runner.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Mapping, Protocol, Sequence, Tuple
 
 from cilly_trading.engine.backtest_execution_contract import (
     BacktestRunContract,
+    build_cost_slippage_metrics_baseline,
     serialize_fills,
     serialize_orders,
     serialize_positions,
@@ -219,12 +220,6 @@ class BacktestRunner:
         invocation_log: List[str],
         config: BacktestRunnerConfig,
     ) -> Dict[str, Any]:
-        flow_result = simulate_execution_flow(
-            snapshots=processed_snapshots,
-            run_id=config.run_id,
-            strategy_name=config.strategy_name,
-            run_contract=config.run_contract,
-        )
         if not processed_snapshots:
             snapshot_mode = "timestamp"
             start = None
@@ -239,6 +234,18 @@ class BacktestRunner:
             else:
                 raise ValueError("Snapshots must consistently define either 'timestamp' or 'snapshot_key'")
             start, end = self._snapshot_boundaries(processed_snapshots, snapshot_mode)
+
+        flow_result = simulate_execution_flow(
+            snapshots=processed_snapshots,
+            run_id=config.run_id,
+            strategy_name=config.strategy_name,
+            run_contract=config.run_contract,
+        )
+        metrics_baseline = build_cost_slippage_metrics_baseline(
+            ordered_snapshots=processed_snapshots,
+            fills=flow_result.fills,
+            execution_assumptions=config.run_contract.execution_assumptions,
+        )
 
         return {
             "artifact_version": "1",
@@ -274,6 +281,13 @@ class BacktestRunner:
             "orders": serialize_orders(flow_result.orders),
             "fills": serialize_fills(flow_result.fills),
             "positions": serialize_positions(flow_result.positions),
+            "summary": {
+                "start_equity": metrics_baseline["summary"]["starting_equity"],
+                "end_equity": metrics_baseline["summary"]["ending_equity_cost_aware"],
+            },
+            "equity_curve": metrics_baseline["equity_curve"]["cost_aware"],
+            "trades": metrics_baseline["trades"],
+            "metrics_baseline": metrics_baseline,
         }
 
     def _snapshot_boundaries(

--- a/tests/cilly_trading/engine/test_backtest_execution_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_execution_contract.py
@@ -10,9 +10,11 @@ from cilly_trading.engine.backtest_execution_contract import (
     BacktestExecutionAssumptions,
     BacktestRunContract,
     BacktestSignalTranslationConfig,
+    build_cost_slippage_metrics_baseline,
     serialize_fills,
     serialize_orders,
     serialize_positions,
+    sort_snapshots,
     simulate_execution_flow,
 )
 from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerConfig
@@ -50,8 +52,12 @@ def _sample_flow_snapshots() -> list[dict[str, object]]:
 def test_contract_validation_rejects_invalid_execution_assumptions() -> None:
     with pytest.raises(ValueError, match="slippage_bps"):
         BacktestExecutionAssumptions(slippage_bps=-1)
+    with pytest.raises(ValueError, match="slippage_bps"):
+        BacktestExecutionAssumptions(slippage_bps=251)
     with pytest.raises(ValueError, match="commission_per_order"):
         BacktestExecutionAssumptions(commission_per_order=Decimal("-0.01"))
+    with pytest.raises(ValueError, match="commission_per_order"):
+        BacktestExecutionAssumptions(commission_per_order=Decimal("25.01"))
     with pytest.raises(ValueError, match="partial_fills_allowed"):
         BacktestExecutionAssumptions(partial_fills_allowed=True)
 
@@ -127,6 +133,66 @@ def test_reproducibility_flow_serialization_is_deterministic() -> None:
     assert serialize_orders(result_a.orders) == serialize_orders(result_b.orders)
     assert serialize_fills(result_a.fills) == serialize_fills(result_b.fills)
     assert serialize_positions(result_a.positions) == serialize_positions(result_b.positions)
+
+
+def test_cost_slippage_baseline_reports_expected_cost_delta() -> None:
+    snapshots = sort_snapshots(_sample_flow_snapshots())
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=10,
+            commission_per_order=Decimal("1.00"),
+            fill_timing="next_snapshot",
+        )
+    )
+    flow = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="run-costs",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    baseline = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=flow.fills,
+        execution_assumptions=run_contract.execution_assumptions,
+    )
+
+    assert baseline["summary"]["total_commission"] == 2.0
+    assert baseline["summary"]["total_slippage_cost"] == 0.33
+    assert baseline["summary"]["total_transaction_cost"] == 2.33
+    assert baseline["summary"]["ending_equity_cost_aware"] == 99999.67
+    assert baseline["summary"]["ending_equity_cost_free"] == 100002.0
+    assert baseline["summary"]["fill_count"] == 2
+
+
+def test_cost_slippage_baseline_is_reproducible() -> None:
+    snapshots = sort_snapshots(_sample_flow_snapshots())
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=10,
+            commission_per_order=Decimal("1.00"),
+            fill_timing="next_snapshot",
+        )
+    )
+    flow = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="run-repro-baseline",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    first = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=flow.fills,
+        execution_assumptions=run_contract.execution_assumptions,
+    )
+    second = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=flow.fills,
+        execution_assumptions=run_contract.execution_assumptions,
+    )
+
+    assert first == second
 
 
 def test_negative_configuration_invalid_signal_mapping_fails() -> None:

--- a/tests/cilly_trading/engine/test_backtest_runner.py
+++ b/tests/cilly_trading/engine/test_backtest_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Dict, List, Mapping
 
@@ -276,3 +277,60 @@ def test_backtest_runner_emits_deterministic_orders_fills_positions(tmp_path: Pa
     assert len(payload["fills"]) == 1
     assert len(payload["positions"]) == 1
     assert payload["fills"][0]["occurred_at"] == "2024-01-02T00:00:00Z"
+    assert "summary" in payload
+    assert "equity_curve" in payload
+    assert "metrics_baseline" in payload
+    assert payload["summary"]["start_equity"] == 100000.0
+
+
+def test_backtest_runner_metrics_baseline_cost_aware_differs_from_cost_free(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    result = runner.run(
+        snapshots=[
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {
+                "id": "s2",
+                "timestamp": "2024-01-02T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "101",
+                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {
+                "id": "s3",
+                "timestamp": "2024-01-03T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "102",
+            },
+        ],
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(
+            output_dir=tmp_path / "baseline",
+            run_contract=BacktestRunContract(
+                execution_assumptions=BacktestExecutionAssumptions(
+                    slippage_bps=10,
+                    commission_per_order=Decimal("1"),
+                    fill_timing="next_snapshot",
+                )
+            ),
+        ),
+    )
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    baseline = payload["metrics_baseline"]
+
+    assert baseline["summary"]["total_transaction_cost"] > 0.0
+    assert (
+        baseline["summary"]["ending_equity_cost_aware"]
+        < baseline["summary"]["ending_equity_cost_free"]
+    )
+    assert baseline["metrics"]["cost_aware"]["total_return"] < baseline["metrics"]["cost_free"]["total_return"]

--- a/tests/test_cli_evaluate_metrics.py
+++ b/tests/test_cli_evaluate_metrics.py
@@ -89,3 +89,46 @@ def test_cli_evaluate_missing_artifact_exit_20(tmp_path: Path) -> None:
     )
 
     assert result.returncode == 20
+
+
+def test_cli_evaluate_accepts_backtest_artifact_with_baseline_outputs(tmp_path: Path) -> None:
+    snapshots_path = tmp_path / "snapshots.json"
+    snapshots_path.write_text(
+        json.dumps(
+            [
+                {"id": "s1", "timestamp": "2024-01-01T00:00:00Z", "price": 100},
+                {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "price": 101},
+                {"id": "s3", "timestamp": "2024-01-03T00:00:00Z", "price": 102},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    backtest_out = tmp_path / "bt-out"
+    backtest_result = _run_cli(
+        [
+            "backtest",
+            "--snapshots",
+            str(snapshots_path),
+            "--strategy",
+            "REFERENCE",
+            "--out",
+            str(backtest_out),
+        ]
+    )
+    assert backtest_result.returncode == 0
+
+    evaluate_out = tmp_path / "eval-out"
+    evaluate_result = _run_cli(
+        [
+            "evaluate",
+            "--artifact",
+            str(backtest_out / "backtest-result.json"),
+            "--out",
+            str(evaluate_out),
+        ]
+    )
+    assert evaluate_result.returncode == 0
+
+    metrics_payload = json.loads((evaluate_out / "metrics-result.json").read_text(encoding="utf-8"))
+    assert metrics_payload["total_return"] == 0.0


### PR DESCRIPTION
Closes #728

## What changed

- Added bounded execution assumptions in backtest contract:
  - slippage_bps ∈ [0, 250]
  - commission_per_order ∈ [0, 25]
- Added deterministic cost/slippage baseline:
  - metrics_baseline.assumptions
  - metrics_baseline.summary
  - metrics_baseline.equity_curve (cost_free / cost_aware)
  - metrics_baseline.metrics (cost_free / cost_aware / deltas)
- Extended artifact:
  - summary
  - equity_curve
  - trades
  - metrics_baseline
- Added tests:
  - bounded validation
  - reproducibility
  - cost-aware vs cost-free divergence
  - CLI evaluate compatibility
- Updated docs:
  - docs/testing/backtesting/metrics.md

## Acceptance Criteria mapping

- Explicit cost/slippage assumptions → satisfied  
- Deterministic metrics baseline → satisfied  
- Predictable cost-aware vs cost-free behavior → satisfied  
- Metrics covered + documented → satisfied  

## Test evidence

- python -m pytest  
- Result: 650 passed, 4 warnings  

---

## Codex A Review

Decision: APPROVED

Active Issue  
#728 — Bounded transaction cost/slippage baseline and deterministic metrics outputs

Top Findings  
1. Scope remains strictly within backtest realism and does not introduce scope drift.  
2. Review package is complete (files + evidence + tests).  
3. Classification: technically good, but traderically weak.

Acceptance Criteria Check  
- AC1: satisfied — bounded assumptions implemented and serialized  
- AC2: satisfied — deterministic baseline reproducible (650 passed)  
- AC3: satisfied — cost-aware vs cost-free separation verified  

Approval Note  
- Implementation is inside issue scope  
- Acceptance Criteria are satisfied  
- Test evidence is sufficient  
- PR may proceed  