### PR TITLE
STRAT-P42C: Define controlled strategy onboarding contract (#733)

### DIFF
--- a/docs/architecture/strategy/onboarding_contract.md
+++ b/docs/architecture/strategy/onboarding_contract.md
@@ -1,0 +1,63 @@
+﻿# Strategy Onboarding Contract
+
+## Goal
+
+Define one controlled onboarding contract for adding strategies so expansion remains consistent, testable, and comparable.
+
+## Contract Scope
+
+This contract is enforced at strategy registration time in `src/cilly_trading/strategies/validation.py` and applied through `src/cilly_trading/strategies/registry.py`.
+
+Any new strategy must register through `register_strategy(...)` with metadata that satisfies this contract.
+
+## Required Metadata
+
+Every strategy registration must provide all fields below:
+
+- `pack_id` (string)
+- `version` (SemVer string: `MAJOR.MINOR.PATCH`)
+- `deterministic_hash` (string)
+- `dependencies` (sorted, unique list of strings)
+- `comparison_group` (string matching `^[a-z0-9][a-z0-9_-]*$`)
+- `documentation` (object)
+- `test_coverage` (object)
+
+Unknown metadata fields are rejected to keep onboarding bounded.
+
+## Required Documentation Metadata
+
+`documentation` must include:
+
+- `architecture`: path to `docs/architecture/*.md`
+- `operations`: path to `docs/operations/*.md`
+
+Both paths are required and must be non-empty strings.
+
+## Required Test Coverage Metadata
+
+`test_coverage` must include:
+
+- `contract`: path to onboarding/contract tests under `tests/*.py`
+- `registry`: path to registry/metadata tests under `tests/*.py`
+- `negative`: path to negative validation tests under `tests/*.py`
+
+All three paths are required, must be distinct, and must point to `tests/*.py`.
+
+## Registry Alignment
+
+The registry stores validated metadata in each `RegisteredStrategy` entry and exposes deterministic metadata through:
+
+- `get_registered_strategies()`
+- `get_registered_strategy_metadata()`
+
+This enables consistent downstream comparison and governance logic without ad hoc conventions.
+
+## Onboarding Checklist
+
+When adding a new strategy:
+
+1. Implement the strategy class.
+2. Add a `register_strategy(...)` entry in the registry with full contract metadata.
+3. Add/extend contract tests (`contract`, `registry`, `negative`) and reference them in metadata.
+4. Add or update architecture/operations docs and reference them in metadata.
+5. Run full `pytest` and keep suite green.

--- a/docs/architecture/strategy/registry.md
+++ b/docs/architecture/strategy/registry.md
@@ -1,9 +1,9 @@
-# Strategy Registry
+﻿# Strategy Registry
 
 ## Overview
 
-The engine uses a **central strategy registry** as the single source of truth for strategy loading.
-All strategies are registered explicitly via code and then loaded through registry APIs.
+The engine uses a central strategy registry as the single source of truth for strategy loading and onboarding metadata.
+All strategies are registered explicitly via code and loaded through registry APIs.
 
 Location: `src/cilly_trading/strategies/registry.py`.
 
@@ -11,8 +11,9 @@ Location: `src/cilly_trading/strategies/registry.py`.
 
 Use the explicit API:
 
-- `register_strategy(strategy_key, factory)`
+- `register_strategy(strategy_key, factory, metadata)`
 - `get_registered_strategies()`
+- `get_registered_strategy_metadata()`
 - `create_strategy(strategy_key)`
 - `create_registered_strategies()`
 
@@ -22,13 +23,14 @@ Built-in strategies are initialized by `initialize_default_registry()`.
 
 Deterministic ordering is guaranteed by returning registrations sorted by stable strategy key in `get_registered_strategies()`.
 
+## Metadata persistence rule
+
+Validated onboarding metadata is stored per registry entry and returned deterministically for comparison-oriented consumers.
+Metadata is validated before registry mutation; invalid onboarding definitions never enter the registry.
+
 ## Duplicate registration rule
 
-If the same strategy key is registered twice, the registry raises:
-
-- `DuplicateStrategyRegistrationError`
-
-Error message format:
+If the same strategy key is registered twice, validation raises `StrategyValidationError` with message format:
 
 - `strategy already registered: <KEY>`
 

--- a/docs/architecture/strategy/validation.md
+++ b/docs/architecture/strategy/validation.md
@@ -1,36 +1,69 @@
-# Strategy Registry Validation
+﻿# Strategy Registry Validation
 
 ## Purpose
 
-Strategy registry validation enforces deterministic and schema-safe strategy registrations before any registry write occurs.
+Strategy registry validation enforces deterministic, schema-safe onboarding before any strategy registration is written.
 
-## Fail-fast Behavior
+## Fail-fast behavior
 
-`register_strategy(...)` validates key, metadata, factory signature, and factory output before mutating the registry.
-If validation fails, registration is rejected and registry state remains unchanged.
+`register_strategy(...)` validates key, metadata, factory signature, and factory output before mutating registry state.
+If validation fails, registration is rejected and the registry remains unchanged.
 
-## What Is Validated
+## Controlled onboarding metadata
+
+Required metadata fields:
+
+- `pack_id`
+- `version`
+- `deterministic_hash`
+- `dependencies`
+- `comparison_group`
+- `documentation`
+- `test_coverage`
+
+Validation rules:
+
+- Required metadata fields must exist.
+- Unsupported metadata fields are rejected.
+- Required string fields must be non-empty.
+- `version` must follow SemVer (`MAJOR.MINOR.PATCH`).
+- `dependencies` must be sorted, unique, and contain non-empty strings.
+- `comparison_group` must match `^[a-z0-9][a-z0-9_-]*$`.
+
+## Documentation expectations
+
+`documentation` must include:
+
+- `architecture`: path under `docs/architecture/*.md`
+- `operations`: path under `docs/operations/*.md`
+
+## Test expectations
+
+`test_coverage` must include:
+
+- `contract`: path under `tests/*.py`
+- `registry`: path under `tests/*.py`
+- `negative`: path under `tests/*.py`
+
+All three test paths must be distinct.
+
+## Factory and key validation
 
 - Strategy key must be a non-empty string and is normalized to uppercase.
-- Metadata must be a dictionary.
-- Required metadata fields must exist: `pack_id`, `version`, `deterministic_hash`, `dependencies`.
-- Required field types are enforced.
-- Required string fields must not be empty.
-- `version` must follow SemVer (`MAJOR.MINOR.PATCH`).
-- `dependencies` must be deterministic (sorted, non-duplicated, non-empty string entries).
 - Factory must be callable.
 - Factory must accept no arguments (`no args`, `no *args`, `no **kwargs`).
 - Factory must return a strategy-compatible object with stable `name` and callable `generate_signals`.
-- Duplicate registration keys are rejected before any write.
+- Duplicate keys are rejected before any write.
 
-## Error Semantics
+## Error semantics
 
-Validation failures raise `StrategyValidationError` with deterministic, explicit error messages.
-Duplicate registration also raises `StrategyValidationError` with message format:
-`strategy already registered: <KEY>`.
+Validation failures raise `StrategyValidationError` with explicit deterministic messages.
+Duplicate registration uses:
 
-## Out of Scope
+- `strategy already registered: <KEY>`
 
-- Performance metrics
-- Ranking logic
-- Backtesting integration
+## Out of scope
+
+- performance benchmarking
+- ranking logic
+- backtesting integration redesign

--- a/src/cilly_trading/strategies/onboarding_contract.py
+++ b/src/cilly_trading/strategies/onboarding_contract.py
@@ -1,0 +1,42 @@
+"""Controlled onboarding contract for strategy registrations.
+
+This module defines the reusable contract that every strategy registration must
+follow. The contract is intentionally strict so that strategy expansion stays
+bounded and comparable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StrategyOnboardingContract:
+    """Normative onboarding contract for strategy metadata."""
+
+    required_metadata_fields: tuple[str, ...]
+    required_documentation_fields: tuple[str, ...]
+    required_test_coverage_fields: tuple[str, ...]
+
+
+STRATEGY_ONBOARDING_CONTRACT = StrategyOnboardingContract(
+    required_metadata_fields=(
+        "pack_id",
+        "version",
+        "deterministic_hash",
+        "dependencies",
+        "comparison_group",
+        "documentation",
+        "test_coverage",
+    ),
+    required_documentation_fields=(
+        "architecture",
+        "operations",
+    ),
+    required_test_coverage_fields=(
+        "contract",
+        "registry",
+        "negative",
+    ),
+)
+

--- a/src/cilly_trading/strategies/registry.py
+++ b/src/cilly_trading/strategies/registry.py
@@ -1,4 +1,4 @@
-"""Deterministic central strategy registry.
+﻿"""Deterministic central strategy registry.
 
 This module is the only supported strategy loading mechanism. Strategies are
 registered explicitly via :func:`register_strategy` and resolved via
@@ -17,13 +17,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from cilly_trading.engine.core import BaseStrategy
 from cilly_trading.strategies.validation import validate_before_registration, validate_strategy_key
-
-
-class DuplicateStrategyRegistrationError(ValueError):
-    """Raised when a strategy key is registered more than once."""
 
 
 class StrategyNotRegisteredError(KeyError):
@@ -40,13 +37,15 @@ class RegisteredStrategy:
     Attributes:
         key: Stable strategy key (uppercase).
         factory: Zero-argument factory creating a strategy instance.
+        metadata: Validated strategy onboarding metadata.
     """
 
     key: str
     factory: StrategyFactory
+    metadata: dict[str, Any]
 
 
-_REGISTRY: dict[str, StrategyFactory] = {}
+_REGISTRY: dict[str, RegisteredStrategy] = {}
 
 
 def _normalize_key(strategy_key: str) -> str:
@@ -68,14 +67,18 @@ def register_strategy(
         ValueError: If key/factory/metadata are invalid.
     """
 
-    normalized_key, _ = validate_before_registration(
+    normalized_key, validated_metadata = validate_before_registration(
         strategy_key,
         factory,
         metadata,
         registry_keys=set(_REGISTRY.keys()),
     )
 
-    _REGISTRY[normalized_key] = factory
+    _REGISTRY[normalized_key] = RegisteredStrategy(
+        key=normalized_key,
+        factory=factory,
+        metadata=validated_metadata,
+    )
 
 
 def get_registered_strategies() -> list[RegisteredStrategy]:
@@ -87,9 +90,7 @@ def get_registered_strategies() -> list[RegisteredStrategy]:
         List of registered strategies sorted by key.
     """
 
-    return [
-        RegisteredStrategy(key=key, factory=_REGISTRY[key]) for key in sorted(_REGISTRY.keys())
-    ]
+    return [_REGISTRY[key] for key in sorted(_REGISTRY.keys())]
 
 
 def create_strategy(strategy_key: str) -> BaseStrategy:
@@ -97,10 +98,10 @@ def create_strategy(strategy_key: str) -> BaseStrategy:
 
     initialize_default_registry()
     normalized_key = _normalize_key(strategy_key)
-    factory = _REGISTRY.get(normalized_key)
-    if factory is None:
+    entry = _REGISTRY.get(normalized_key)
+    if entry is None:
         raise StrategyNotRegisteredError(f"strategy not registered: {normalized_key}")
-    return factory()
+    return entry.factory()
 
 
 def create_registered_strategies() -> list[BaseStrategy]:
@@ -108,6 +109,13 @@ def create_registered_strategies() -> list[BaseStrategy]:
 
     initialize_default_registry()
     return [entry.factory() for entry in get_registered_strategies()]
+
+
+def get_registered_strategy_metadata() -> dict[str, dict[str, Any]]:
+    """Return deterministic registry metadata keyed by strategy key."""
+
+    initialize_default_registry()
+    return {entry.key: entry.metadata for entry in get_registered_strategies()}
 
 
 def reset_registry() -> None:
@@ -137,6 +145,16 @@ def initialize_default_registry() -> None:
             "version": "1.0.0",
             "deterministic_hash": "reference-pack-v1-hash",
             "dependencies": [],
+            "comparison_group": "reference-control",
+            "documentation": {
+                "architecture": "docs/architecture/strategy/onboarding_contract.md",
+                "operations": "docs/operations/analyst-workflow.md",
+            },
+            "test_coverage": {
+                "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+                "registry": "tests/strategies/test_strategy_registry.py",
+                "negative": "tests/strategies/test_strategy_validation.py",
+            },
         },
     )
     register_strategy(
@@ -147,6 +165,16 @@ def initialize_default_registry() -> None:
             "version": "1.0.0",
             "deterministic_hash": "rsi2-default-pack-hash",
             "dependencies": [],
+            "comparison_group": "mean-reversion",
+            "documentation": {
+                "architecture": "docs/architecture/strategy/onboarding_contract.md",
+                "operations": "docs/operations/analyst-workflow.md",
+            },
+            "test_coverage": {
+                "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+                "registry": "tests/strategies/test_strategy_registry.py",
+                "negative": "tests/strategies/test_strategy_validation.py",
+            },
         },
     )
     register_strategy(
@@ -157,6 +185,16 @@ def initialize_default_registry() -> None:
             "version": "1.0.0",
             "deterministic_hash": "turtle-default-pack-hash",
             "dependencies": [],
+            "comparison_group": "trend-following",
+            "documentation": {
+                "architecture": "docs/architecture/strategy/onboarding_contract.md",
+                "operations": "docs/operations/analyst-workflow.md",
+            },
+            "test_coverage": {
+                "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+                "registry": "tests/strategies/test_strategy_registry.py",
+                "negative": "tests/strategies/test_strategy_validation.py",
+            },
         },
     )
 

--- a/src/cilly_trading/strategies/validation.py
+++ b/src/cilly_trading/strategies/validation.py
@@ -1,4 +1,4 @@
-"""Validation utilities for strategy registry inputs."""
+﻿"""Validation utilities for strategy registry inputs."""
 
 from __future__ import annotations
 
@@ -7,12 +7,18 @@ import re
 from collections.abc import Callable
 from typing import Any
 
+from cilly_trading.strategies.onboarding_contract import STRATEGY_ONBOARDING_CONTRACT
+
 _SEMVER_PATTERN = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
-_REQUIRED_METADATA_FIELDS: dict[str, type] = {
+_COMPARISON_GROUP_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_BASE_METADATA_FIELD_TYPES: dict[str, type] = {
     "pack_id": str,
     "version": str,
     "deterministic_hash": str,
     "dependencies": list,
+    "comparison_group": str,
+    "documentation": dict,
+    "test_coverage": dict,
 }
 
 
@@ -34,13 +40,25 @@ def validate_strategy_metadata(metadata: dict) -> dict[str, Any]:
     if not isinstance(metadata, dict):
         raise StrategyValidationError("metadata must be a dict")
 
-    missing_fields = [field for field in _REQUIRED_METADATA_FIELDS if field not in metadata]
+    missing_fields = [
+        field
+        for field in STRATEGY_ONBOARDING_CONTRACT.required_metadata_fields
+        if field not in metadata
+    ]
     if missing_fields:
         raise StrategyValidationError(
             f"metadata missing required fields: {', '.join(sorted(missing_fields))}"
         )
 
-    for field, expected_type in _REQUIRED_METADATA_FIELDS.items():
+    unsupported_fields = sorted(
+        set(metadata.keys()).difference(STRATEGY_ONBOARDING_CONTRACT.required_metadata_fields)
+    )
+    if unsupported_fields:
+        raise StrategyValidationError(
+            f"metadata contains unsupported fields: {', '.join(unsupported_fields)}"
+        )
+
+    for field, expected_type in _BASE_METADATA_FIELD_TYPES.items():
         value = metadata[field]
         if not isinstance(value, expected_type):
             raise StrategyValidationError(
@@ -49,7 +67,12 @@ def validate_strategy_metadata(metadata: dict) -> dict[str, Any]:
         if expected_type is str and not value.strip():
             raise StrategyValidationError(f"metadata field '{field}' must not be empty")
 
-    if not _SEMVER_PATTERN.fullmatch(metadata["version"]):
+    pack_id = metadata["pack_id"].strip()
+    version = metadata["version"].strip()
+    deterministic_hash = metadata["deterministic_hash"].strip()
+    comparison_group = metadata["comparison_group"].strip()
+
+    if not _SEMVER_PATTERN.fullmatch(version):
         raise StrategyValidationError("metadata field 'version' must be valid semver")
 
     dependencies = metadata["dependencies"]
@@ -62,7 +85,119 @@ def validate_strategy_metadata(metadata: dict) -> dict[str, Any]:
     if len(set(dependencies)) != len(dependencies):
         raise StrategyValidationError("metadata field 'dependencies' must not contain duplicates")
 
-    return metadata
+    if not _COMPARISON_GROUP_PATTERN.fullmatch(comparison_group):
+        raise StrategyValidationError(
+            "metadata field 'comparison_group' must match ^[a-z0-9][a-z0-9_-]*$"
+        )
+
+    documentation = _validate_documentation_metadata(metadata["documentation"])
+    test_coverage = _validate_test_coverage_metadata(metadata["test_coverage"])
+
+    return {
+        "pack_id": pack_id,
+        "version": version,
+        "deterministic_hash": deterministic_hash,
+        "dependencies": [dep.strip() for dep in dependencies],
+        "comparison_group": comparison_group,
+        "documentation": documentation,
+        "test_coverage": test_coverage,
+    }
+
+
+def _normalize_contract_path(path: str) -> str:
+    return path.strip().replace("\\", "/")
+
+
+def _validate_documentation_metadata(value: dict[str, Any]) -> dict[str, str]:
+    missing_fields = [
+        field
+        for field in STRATEGY_ONBOARDING_CONTRACT.required_documentation_fields
+        if field not in value
+    ]
+    if missing_fields:
+        raise StrategyValidationError(
+            "metadata field 'documentation' missing required fields: "
+            + ", ".join(sorted(missing_fields))
+        )
+
+    unsupported_fields = sorted(
+        set(value.keys()).difference(STRATEGY_ONBOARDING_CONTRACT.required_documentation_fields)
+    )
+    if unsupported_fields:
+        raise StrategyValidationError(
+            "metadata field 'documentation' contains unsupported fields: "
+            + ", ".join(unsupported_fields)
+        )
+
+    architecture_path = value["architecture"]
+    operations_path = value["operations"]
+
+    if not isinstance(architecture_path, str) or not architecture_path.strip():
+        raise StrategyValidationError(
+            "metadata field 'documentation.architecture' must be a non-empty string"
+        )
+    if not isinstance(operations_path, str) or not operations_path.strip():
+        raise StrategyValidationError(
+            "metadata field 'documentation.operations' must be a non-empty string"
+        )
+
+    architecture_path = _normalize_contract_path(architecture_path)
+    operations_path = _normalize_contract_path(operations_path)
+
+    if not architecture_path.startswith("docs/architecture/") or not architecture_path.endswith(".md"):
+        raise StrategyValidationError(
+            "metadata field 'documentation.architecture' must point to docs/architecture/*.md"
+        )
+    if not operations_path.startswith("docs/operations/") or not operations_path.endswith(".md"):
+        raise StrategyValidationError(
+            "metadata field 'documentation.operations' must point to docs/operations/*.md"
+        )
+
+    return {
+        "architecture": architecture_path,
+        "operations": operations_path,
+    }
+
+
+def _validate_test_coverage_metadata(value: dict[str, Any]) -> dict[str, str]:
+    missing_fields = [
+        field
+        for field in STRATEGY_ONBOARDING_CONTRACT.required_test_coverage_fields
+        if field not in value
+    ]
+    if missing_fields:
+        raise StrategyValidationError(
+            "metadata field 'test_coverage' missing required fields: "
+            + ", ".join(sorted(missing_fields))
+        )
+
+    unsupported_fields = sorted(
+        set(value.keys()).difference(STRATEGY_ONBOARDING_CONTRACT.required_test_coverage_fields)
+    )
+    if unsupported_fields:
+        raise StrategyValidationError(
+            "metadata field 'test_coverage' contains unsupported fields: "
+            + ", ".join(unsupported_fields)
+        )
+
+    normalized_refs: dict[str, str] = {}
+    for field in STRATEGY_ONBOARDING_CONTRACT.required_test_coverage_fields:
+        raw_value = value[field]
+        if not isinstance(raw_value, str) or not raw_value.strip():
+            raise StrategyValidationError(
+                f"metadata field 'test_coverage.{field}' must be a non-empty string"
+            )
+        normalized_value = _normalize_contract_path(raw_value)
+        if not normalized_value.startswith("tests/") or not normalized_value.endswith(".py"):
+            raise StrategyValidationError(
+                f"metadata field 'test_coverage.{field}' must point to tests/*.py"
+            )
+        normalized_refs[field] = normalized_value
+
+    if len(set(normalized_refs.values())) != len(normalized_refs):
+        raise StrategyValidationError("metadata field 'test_coverage' must contain distinct test paths")
+
+    return normalized_refs
 
 
 def _validate_factory_signature(factory: Callable[..., Any]) -> None:
@@ -96,7 +231,6 @@ def validate_strategy_factory(factory: Callable[..., Any]) -> None:
     instance = factory()
     if not _is_base_strategy_instance(instance):
         raise StrategyValidationError("factory must return an instance of BaseStrategy")
-
 
 
 def validate_before_registration(

--- a/tests/backtest_test_strategies.py
+++ b/tests/backtest_test_strategies.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import time
 from typing import Any, Mapping
 
-from cilly_trading.strategies.registry import DuplicateStrategyRegistrationError, register_strategy
+from cilly_trading.strategies.registry import register_strategy
+from cilly_trading.strategies.validation import StrategyValidationError
 
 
 class DeterminismViolationStrategy:
@@ -37,7 +38,17 @@ try:
             "version": "1.0.0",
             "deterministic_hash": "test-time-violation",
             "dependencies": [],
+            "comparison_group": "test-only",
+            "documentation": {
+                "architecture": "docs/architecture/strategy/onboarding_contract.md",
+                "operations": "docs/operations/analyst-workflow.md",
+            },
+            "test_coverage": {
+                "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+                "registry": "tests/strategies/test_strategy_registry.py",
+                "negative": "tests/strategies/test_strategy_validation.py",
+            },
         },
     )
-except DuplicateStrategyRegistrationError:
+except StrategyValidationError:
     pass

--- a/tests/strategies/test_strategy_onboarding_contract.py
+++ b/tests/strategies/test_strategy_onboarding_contract.py
@@ -1,0 +1,91 @@
+﻿from __future__ import annotations
+
+import re
+
+import pytest
+
+from cilly_trading.strategies.onboarding_contract import STRATEGY_ONBOARDING_CONTRACT
+from cilly_trading.strategies.validation import StrategyValidationError, validate_strategy_metadata
+
+
+def _valid_metadata() -> dict:
+    return {
+        "pack_id": "pack-alpha",
+        "version": "1.2.3",
+        "deterministic_hash": "abc123",
+        "dependencies": [],
+        "comparison_group": "mean-reversion",
+        "documentation": {
+            "architecture": "docs/architecture/strategy/onboarding_contract.md",
+            "operations": "docs/operations/analyst-workflow.md",
+        },
+        "test_coverage": {
+            "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+            "registry": "tests/strategies/test_strategy_registry.py",
+            "negative": "tests/strategies/test_strategy_validation.py",
+        },
+    }
+
+
+def test_onboarding_contract_defines_controlled_required_fields() -> None:
+    assert STRATEGY_ONBOARDING_CONTRACT.required_metadata_fields == (
+        "pack_id",
+        "version",
+        "deterministic_hash",
+        "dependencies",
+        "comparison_group",
+        "documentation",
+        "test_coverage",
+    )
+    assert STRATEGY_ONBOARDING_CONTRACT.required_documentation_fields == (
+        "architecture",
+        "operations",
+    )
+    assert STRATEGY_ONBOARDING_CONTRACT.required_test_coverage_fields == (
+        "contract",
+        "registry",
+        "negative",
+    )
+
+
+def test_validate_strategy_metadata_accepts_complete_onboarding_contract() -> None:
+    validated = validate_strategy_metadata(_valid_metadata())
+
+    assert validated["comparison_group"] == "mean-reversion"
+    assert validated["documentation"]["architecture"] == "docs/architecture/strategy/onboarding_contract.md"
+    assert validated["test_coverage"]["negative"] == "tests/strategies/test_strategy_validation.py"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        (
+            "documentation",
+            {"architecture": "docs/architecture/strategy/onboarding_contract.md"},
+            "metadata field 'documentation' missing required fields: operations",
+        ),
+        (
+            "test_coverage",
+            {
+                "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+                "registry": "tests/strategies/test_strategy_registry.py",
+            },
+            "metadata field 'test_coverage' missing required fields: negative",
+        ),
+        (
+            "comparison_group",
+            "MeanReversion",
+            "metadata field 'comparison_group' must match ^[a-z0-9][a-z0-9_-]*$",
+        ),
+    ],
+)
+def test_validate_strategy_metadata_rejects_incomplete_contract_definitions(
+    field: str,
+    value: object,
+    error: str,
+) -> None:
+    payload = _valid_metadata()
+    payload[field] = value
+
+    with pytest.raises(StrategyValidationError, match=re.escape(error)):
+        validate_strategy_metadata(payload)

--- a/tests/strategies/test_strategy_registry.py
+++ b/tests/strategies/test_strategy_registry.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import pytest
 
@@ -6,6 +6,7 @@ from cilly_trading.strategies.registry import (
     create_registered_strategies,
     create_strategy,
     get_registered_strategies,
+    get_registered_strategy_metadata,
     initialize_default_registry,
     register_strategy,
     reset_registry,
@@ -28,12 +29,22 @@ class _StrategyB:
         return []
 
 
-def _metadata(pack_id: str) -> dict:
+def _metadata(pack_id: str, comparison_group: str = "test-group") -> dict:
     return {
         "pack_id": pack_id,
         "version": "1.0.0",
         "deterministic_hash": f"{pack_id}-hash",
         "dependencies": [],
+        "comparison_group": comparison_group,
+        "documentation": {
+            "architecture": "docs/architecture/strategy/onboarding_contract.md",
+            "operations": "docs/operations/analyst-workflow.md",
+        },
+        "test_coverage": {
+            "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+            "registry": "tests/strategies/test_strategy_registry.py",
+            "negative": "tests/strategies/test_strategy_validation.py",
+        },
     }
 
 
@@ -66,6 +77,20 @@ def test_registered_strategies_are_returned_in_stable_sorted_order() -> None:
     keys = [entry.key for entry in get_registered_strategies()]
 
     assert keys == ["BETA", "ZETA"]
+
+
+def test_registry_returns_strategy_metadata_for_comparison_alignment() -> None:
+    register_strategy("alpha", _StrategyA, metadata=_metadata("pack-a", comparison_group="control"))
+
+    entries = get_registered_strategies()
+    assert entries[0].metadata["comparison_group"] == "control"
+
+    metadata_by_key = get_registered_strategy_metadata()
+    assert list(metadata_by_key.keys()) == ["ALPHA"]
+    assert metadata_by_key["ALPHA"]["pack_id"] == "pack-a"
+    assert metadata_by_key["ALPHA"]["test_coverage"]["registry"] == (
+        "tests/strategies/test_strategy_registry.py"
+    )
 
 
 def test_smoke_run_is_deterministic_and_uses_registry_only() -> None:

--- a/tests/strategies/test_strategy_validation.py
+++ b/tests/strategies/test_strategy_validation.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import pytest
 
@@ -28,6 +28,16 @@ def _metadata(**overrides):
         "version": "1.2.3",
         "deterministic_hash": "abc123",
         "dependencies": [],
+        "comparison_group": "validation-group",
+        "documentation": {
+            "architecture": "docs/architecture/strategy/onboarding_contract.md",
+            "operations": "docs/operations/analyst-workflow.md",
+        },
+        "test_coverage": {
+            "contract": "tests/strategies/test_strategy_onboarding_contract.py",
+            "registry": "tests/strategies/test_strategy_registry.py",
+            "negative": "tests/strategies/test_strategy_validation.py",
+        },
     }
     payload.update(overrides)
     return payload
@@ -40,12 +50,16 @@ def setup_function() -> None:
 def test_missing_metadata_fields_raises_strategy_validation_error() -> None:
     with pytest.raises(
         StrategyValidationError,
-        match="metadata missing required fields: deterministic_hash",
+        match="metadata missing required fields:",
     ):
         register_strategy(
             "alpha",
             _ValidStrategy,
-            metadata={"pack_id": "pack-alpha", "version": "1.2.3", "dependencies": []},
+            metadata={
+                "pack_id": "pack-alpha",
+                "version": "1.2.3",
+                "dependencies": [],
+            },
         )
 
 
@@ -55,6 +69,41 @@ def test_invalid_semver_raises_strategy_validation_error() -> None:
         match="metadata field 'version' must be valid semver",
     ):
         register_strategy("alpha", _ValidStrategy, metadata=_metadata(version="1.2"))
+
+
+def test_invalid_documentation_paths_raise_strategy_validation_error() -> None:
+    with pytest.raises(
+        StrategyValidationError,
+        match=r"metadata field 'documentation\.architecture' must point to docs/architecture/\*\.md",
+    ):
+        register_strategy(
+            "alpha",
+            _ValidStrategy,
+            metadata=_metadata(
+                documentation={
+                    "architecture": "docs/phases/phase-1.md",
+                    "operations": "docs/operations/analyst-workflow.md",
+                }
+            ),
+        )
+
+
+def test_invalid_test_coverage_paths_raise_strategy_validation_error() -> None:
+    with pytest.raises(
+        StrategyValidationError,
+        match=r"metadata field 'test_coverage\.contract' must point to tests/\*\.py",
+    ):
+        register_strategy(
+            "alpha",
+            _ValidStrategy,
+            metadata=_metadata(
+                test_coverage={
+                    "contract": "src/cilly_trading/strategies/registry.py",
+                    "registry": "tests/strategies/test_strategy_registry.py",
+                    "negative": "tests/strategies/test_strategy_validation.py",
+                }
+            ),
+        )
 
 
 def test_non_callable_factory_raises_strategy_validation_error() -> None:


### PR DESCRIPTION
Closes #733

## What changed
- Introduced controlled onboarding contract for strategy registration
- Enforced metadata, documentation, and test coverage requirements
- Persisted validated metadata in registry
- Unified duplicate registration behavior (StrategyValidationError only)
- Added contract + validation + registry tests
- Updated architecture documentation

## Validation
- python -m pytest tests/test_backtest_cli.py -q
- python -m pytest tests/strategies -q
- python -m pytest

Result: 677 passed, 4 warnings