### PR TITLE
STRAT-P42C: Add comparable strategy evaluation harness

### DIFF
--- a/docs/testing/backtesting/README.md
+++ b/docs/testing/backtesting/README.md
@@ -6,6 +6,7 @@ Backtesting runs a strategy against historical snapshots and writes deterministi
 ## Usage
 ```bash
 python -m cilly_trading backtest --snapshots <PATH> --strategy <NAME> --out <DIR> [--run-id <STR>] [--strategy-module <PYMOD>]...
+python -m cilly_trading compare-strategies --snapshots <PATH> --strategy <NAME> --strategy <NAME> --out <DIR> [--run-id <STR>] [--benchmark-strategy <NAME>] [--strategy-config <JSON_PATH>] [--strategy-module <PYMOD>]...
 ```
 
 - `--snapshots`: Path to a JSON file containing snapshot data.
@@ -13,6 +14,11 @@ python -m cilly_trading backtest --snapshots <PATH> --strategy <NAME> --out <DIR
 - `--out`: Output directory for backtest artifacts.
 - `--run-id` (default deterministic): Optional run identifier; when omitted, a deterministic identifier is used.
 - `--strategy-module` (optional, repeatable, imports module(s) before strategy resolution): Optional module path to import before strategy lookup; may be provided multiple times.
+- `compare-strategies`: Runs the bounded comparable strategy evaluation harness for two or more strategies against the same snapshots.
+
+## Comparable Harness
+- Detailed contract and workflow: `docs/testing/backtesting/strategy_comparison_harness.md`
+- Output artifact: `strategy-comparison.json` + `strategy-comparison.sha256`
 
 ## Determinism Rules
 - Determinism guard is installed during backtest execution and uninstalled in a finally block.

--- a/docs/testing/backtesting/strategy_comparison_harness.md
+++ b/docs/testing/backtesting/strategy_comparison_harness.md
@@ -1,0 +1,102 @@
+# Comparable Strategy Evaluation Harness
+
+## Purpose
+
+`STRAT-P42C` adds one bounded, reusable workflow for evaluating multiple strategies with the same deterministic path.
+
+The harness is intentionally limited to comparability:
+
+- same snapshot input set for all strategies
+- same backtest engine path for all strategies
+- explicit, deterministic comparison artifact output
+
+Out of scope by design:
+
+- parameter search/optimization loops
+- notebook workflows
+- UI redesign/reporting expansion
+- broker or live-trading integration
+
+## Command
+
+```bash
+python -m cilly_trading compare-strategies \
+  --snapshots <PATH> \
+  --strategy <NAME> \
+  --strategy <NAME> \
+  --out <DIR> \
+  [--run-id <STR>] \
+  [--benchmark-strategy <NAME>] \
+  [--strategy-config <JSON_PATH>] \
+  [--strategy-module <PYMOD>]...
+```
+
+## Shared Evaluation Inputs
+
+`--snapshots` JSON must be an array of snapshot objects with:
+
+- `id` (non-empty string)
+- either `timestamp` (non-empty string) or `snapshot_key` (non-empty string)
+
+All evaluated strategies receive the same ordered snapshot stream.
+
+Optional per-strategy configs are provided via `--strategy-config` as:
+
+```json
+{
+  "RSI2": {"oversold_threshold": 12.0},
+  "TURTLE": {"breakout_lookback": 20}
+}
+```
+
+## Bounded Translation Rules
+
+Strategy output is translated into executable backtest signals with a fixed rule:
+
+- only `stage="entry_confirmed"` and `direction="long"` are executable
+- executable signal becomes one deterministic `BUY` order with `quantity="1"`
+- maximum one open position per strategy in the harness flow
+
+This keeps strategy comparison deterministic and bounded.
+
+## Output Contract
+
+The harness writes:
+
+- `strategy-comparison.json`
+- `strategy-comparison.sha256`
+- per-strategy backtest artifacts under `strategies/<strategy>/`
+
+`strategy-comparison.json` contains:
+
+- workflow metadata (benchmark, snapshot linkage, translation rules)
+- per-strategy bounded outputs:
+  - executable/candidate signal counts
+  - backtest artifact hash
+  - summary (`start_equity`, `end_equity`)
+  - metrics (`total_return`, `cagr`, `max_drawdown`, `sharpe_ratio`, `win_rate`, `profit_factor`)
+  - `metrics_baseline.summary` alignment fields from backtest output
+- deterministic ranking by `total_return`
+- metric deltas vs benchmark strategy
+
+## Alignment With Backtesting Outputs
+
+Per-strategy comparison rows are derived from each strategy's `backtest-result.json`:
+
+- `summary`
+- `metrics_baseline.summary`
+- metrics computed from `summary` + `equity_curve` + `trades`
+
+This guarantees the comparison harness stays aligned with existing backtesting artifacts.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success |
+| `2` | CLI usage / argument error |
+| `10` | Determinism violation |
+| `20` | Snapshot/config input invalid |
+| `30` | Strategy selection invalid |
+| `1` | Unexpected fallback error |
+

--- a/src/cilly_trading/__main__.py
+++ b/src/cilly_trading/__main__.py
@@ -25,6 +25,15 @@ def _build_parser() -> argparse.ArgumentParser:
     evaluate_parser.add_argument("--artifact", required=True)
     evaluate_parser.add_argument("--out", required=True)
 
+    compare_parser = subparsers.add_parser("compare-strategies")
+    compare_parser.add_argument("--snapshots", required=True)
+    compare_parser.add_argument("--strategy", action="append", required=True)
+    compare_parser.add_argument("--out", required=True)
+    compare_parser.add_argument("--run-id", default="deterministic")
+    compare_parser.add_argument("--benchmark-strategy", default=None)
+    compare_parser.add_argument("--strategy-module", action="append", default=None)
+    compare_parser.add_argument("--strategy-config", default=None)
+
     return parser
 
 
@@ -51,6 +60,20 @@ def main(argv: list[str] | None = None) -> int:
         return run_evaluate(
             artifact_path=Path(args.artifact),
             out_dir=Path(args.out),
+        )
+
+    if args.command == "compare-strategies":
+        from .cli.compare_strategies_cli import run_compare_strategies
+
+        strategy_config_path = Path(args.strategy_config) if args.strategy_config else None
+        return run_compare_strategies(
+            snapshots_path=Path(args.snapshots),
+            strategy_names=list(args.strategy),
+            out_dir=Path(args.out),
+            run_id=args.run_id,
+            benchmark_strategy=args.benchmark_strategy,
+            strategy_modules=args.strategy_module,
+            strategy_config_path=strategy_config_path,
         )
 
     parser.print_usage()

--- a/src/cilly_trading/cli/compare_strategies_cli.py
+++ b/src/cilly_trading/cli/compare_strategies_cli.py
@@ -1,0 +1,127 @@
+"""Comparable strategy evaluation CLI execution helpers."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+from cilly_trading.engine.determinism_guard import (
+    DeterminismViolationError,
+    install_guard,
+    uninstall_guard,
+)
+from cilly_trading.strategies.evaluation_harness import (
+    StrategyEvaluationInputError,
+    StrategyEvaluationSelectionError,
+    run_strategy_comparison,
+)
+
+
+class ComparisonConfigInputError(ValueError):
+    """Raised when comparison strategy configuration cannot be loaded."""
+
+
+def _load_snapshots(path: Path) -> list[dict[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise StrategyEvaluationInputError("Invalid snapshots input") from exc
+
+    if not isinstance(payload, list):
+        raise StrategyEvaluationInputError("Invalid snapshots input")
+
+    snapshots: list[dict[str, Any]] = []
+    for item in payload:
+        if not isinstance(item, Mapping):
+            raise StrategyEvaluationInputError("Invalid snapshots input")
+
+        snapshot_id = item.get("id")
+        if not isinstance(snapshot_id, str) or not snapshot_id.strip():
+            raise StrategyEvaluationInputError("Invalid snapshots input")
+
+        has_timestamp = isinstance(item.get("timestamp"), str) and bool(item["timestamp"].strip())
+        has_snapshot_key = isinstance(item.get("snapshot_key"), str) and bool(item["snapshot_key"].strip())
+        if not has_timestamp and not has_snapshot_key:
+            raise StrategyEvaluationInputError("Invalid snapshots input")
+
+        snapshots.append(dict(item))
+    return snapshots
+
+
+def _load_strategy_configs(path: Path | None) -> dict[str, dict[str, Any]]:
+    if path is None:
+        return {}
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ComparisonConfigInputError("Invalid strategy config input") from exc
+
+    if not isinstance(payload, Mapping):
+        raise ComparisonConfigInputError("Invalid strategy config input")
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for strategy_name, config in payload.items():
+        if not isinstance(strategy_name, str) or not strategy_name.strip():
+            raise ComparisonConfigInputError("Invalid strategy config input")
+        if not isinstance(config, Mapping):
+            raise ComparisonConfigInputError("Invalid strategy config input")
+        normalized[strategy_name.strip().upper()] = dict(config)
+    return normalized
+
+
+def run_compare_strategies(
+    *,
+    snapshots_path: Path,
+    strategy_names: list[str],
+    out_dir: Path,
+    run_id: str,
+    benchmark_strategy: str | None,
+    strategy_modules: list[str] | None = None,
+    strategy_config_path: Path | None = None,
+) -> int:
+    """Run deterministic comparable strategy evaluation command."""
+
+    install_guard()
+    try:
+        snapshots = _load_snapshots(snapshots_path)
+
+        if strategy_modules is not None:
+            for module_name in strategy_modules:
+                try:
+                    importlib.import_module(module_name)
+                except Exception as exc:
+                    raise StrategyEvaluationSelectionError("Unknown strategy") from exc
+
+        strategy_configs = _load_strategy_configs(strategy_config_path)
+        result = run_strategy_comparison(
+            snapshots=snapshots,
+            strategy_names=strategy_names,
+            output_dir=out_dir,
+            run_id=run_id,
+            benchmark_strategy=benchmark_strategy,
+            strategy_configs=strategy_configs,
+        )
+        print(f"WROTE {result.artifact_path}")
+        return 0
+    except DeterminismViolationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 10
+    except StrategyEvaluationInputError as exc:
+        print(str(exc), file=sys.stderr)
+        return 20
+    except ComparisonConfigInputError as exc:
+        print(str(exc), file=sys.stderr)
+        return 20
+    except StrategyEvaluationSelectionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 30
+    except Exception as exc:  # pragma: no cover - fallback protection
+        print(f"Unexpected error: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        uninstall_guard()
+

--- a/src/cilly_trading/strategies/evaluation_harness.py
+++ b/src/cilly_trading/strategies/evaluation_harness.py
@@ -1,0 +1,511 @@
+"""Deterministic comparable strategy evaluation harness."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_EVEN
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import pandas as pd
+
+from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerConfig
+from cilly_trading.metrics import canonical_json_bytes, compute_metrics
+from cilly_trading.strategies.registry import (
+    StrategyNotRegisteredError,
+    create_strategy,
+    get_registered_strategy_metadata,
+)
+
+_METRIC_KEYS = (
+    "total_return",
+    "cagr",
+    "max_drawdown",
+    "sharpe_ratio",
+    "win_rate",
+    "profit_factor",
+)
+_RUNNER_SNAPSHOT_BOUNDARY_ERROR = (
+    "Snapshots must consistently define either 'timestamp' or 'snapshot_key'"
+)
+_QUANT = Decimal("0.000000000001")
+COMPARISON_ARTIFACT_FILENAME = "strategy-comparison.json"
+COMPARISON_HASH_FILENAME = "strategy-comparison.sha256"
+
+
+class StrategyEvaluationInputError(ValueError):
+    """Raised when strategy evaluation inputs are invalid."""
+
+
+class StrategyEvaluationSelectionError(ValueError):
+    """Raised when strategy selection fails for strategy evaluation."""
+
+
+@dataclass(frozen=True)
+class StrategyComparisonResult:
+    """Result payload for deterministic strategy comparison."""
+
+    artifact_path: Path
+    artifact_sha256: str
+    payload: dict[str, Any]
+
+
+def run_strategy_comparison(
+    *,
+    snapshots: Sequence[Mapping[str, Any]],
+    strategy_names: Sequence[str],
+    output_dir: Path,
+    run_id: str,
+    benchmark_strategy: str | None = None,
+    strategy_configs: Mapping[str, Mapping[str, Any]] | None = None,
+) -> StrategyComparisonResult:
+    """Run deterministic strategy comparison workflow and write bounded outputs."""
+
+    normalized_strategy_names = _normalize_strategy_names(strategy_names)
+    if benchmark_strategy is None:
+        resolved_benchmark = normalized_strategy_names[0]
+    else:
+        resolved_benchmark = benchmark_strategy.strip().upper()
+        if resolved_benchmark not in normalized_strategy_names:
+            raise StrategyEvaluationInputError("Benchmark strategy must be included in strategy list")
+
+    strategy_config_map = _normalize_strategy_configs(strategy_configs)
+    ordered_snapshots = _sort_snapshots(snapshots)
+    snapshot_linkage = _snapshot_linkage(ordered_snapshots)
+    metadata_by_key = get_registered_strategy_metadata()
+    runner = BacktestRunner()
+
+    strategy_rows: list[dict[str, Any]] = []
+    for strategy_name in normalized_strategy_names:
+        try:
+            strategy = create_strategy(strategy_name)
+        except StrategyNotRegisteredError as exc:
+            raise StrategyEvaluationSelectionError("Unknown strategy") from exc
+
+        strategy_snapshot_rows, candidate_count, executable_count = _build_strategy_snapshots(
+            ordered_snapshots=ordered_snapshots,
+            strategy_name=strategy_name,
+            strategy=strategy,
+            strategy_config=strategy_config_map.get(strategy_name, {}),
+        )
+
+        strategy_output_dir = output_dir / "strategies" / strategy_name.lower()
+        strategy_run_id = f"{run_id}:{strategy_name.lower()}"
+        result = runner.run(
+            snapshots=strategy_snapshot_rows,
+            strategy_factory=_NoOpBacktestStrategy,
+            config=BacktestRunnerConfig(
+                output_dir=strategy_output_dir,
+                run_id=strategy_run_id,
+                strategy_name=strategy_name,
+                strategy_params=strategy_config_map.get(strategy_name, {}),
+            ),
+        )
+
+        artifact_payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+        metrics = compute_metrics(artifact_payload)
+        baseline = artifact_payload.get("metrics_baseline")
+        baseline_summary = baseline.get("summary") if isinstance(baseline, Mapping) else {}
+        summary = artifact_payload.get("summary")
+        summary_payload = summary if isinstance(summary, Mapping) else {}
+
+        strategy_rows.append(
+            {
+                "strategy_name": strategy_name,
+                "comparison_group": _comparison_group(metadata_by_key, strategy_name),
+                "signals": {
+                    "candidate_count": candidate_count,
+                    "executable_count": executable_count,
+                    "translation_rule": "entry_confirmed long -> BUY quantity=1 (single-open-position)",
+                },
+                "backtest": {
+                    "run_id": strategy_run_id,
+                    "artifact_relpath": f"strategies/{strategy_name.lower()}/backtest-result.json",
+                    "artifact_sha256": result.artifact_sha256,
+                    "invocation_log": result.invocation_log,
+                },
+                "summary": {
+                    "start_equity": summary_payload.get("start_equity"),
+                    "end_equity": summary_payload.get("end_equity"),
+                },
+                "metrics": {key: metrics.get(key) for key in _METRIC_KEYS},
+                "metrics_baseline_summary": {
+                    "starting_equity": baseline_summary.get("starting_equity"),
+                    "ending_equity_cost_free": baseline_summary.get("ending_equity_cost_free"),
+                    "ending_equity_cost_aware": baseline_summary.get("ending_equity_cost_aware"),
+                    "total_transaction_cost": baseline_summary.get("total_transaction_cost"),
+                    "total_commission": baseline_summary.get("total_commission"),
+                    "total_slippage_cost": baseline_summary.get("total_slippage_cost"),
+                    "fill_count": baseline_summary.get("fill_count"),
+                },
+            }
+        )
+
+    ranking = _build_ranking(strategy_rows)
+    deltas = _build_deltas(strategy_rows, resolved_benchmark)
+    payload: dict[str, Any] = {
+        "artifact": "strategy_comparison",
+        "artifact_version": "1",
+        "workflow": {
+            "name": "bounded_comparable_strategy_evaluation",
+            "benchmark_strategy": resolved_benchmark,
+            "snapshot_linkage": snapshot_linkage,
+            "strategy_order": normalized_strategy_names,
+            "signal_translation": {
+                "trigger_stage": "entry_confirmed",
+                "direction": "long",
+                "action": "BUY",
+                "quantity": "1",
+                "max_open_positions": 1,
+            },
+        },
+        "strategies": strategy_rows,
+        "ranking": ranking,
+        "deltas_vs_benchmark": deltas,
+    }
+
+    artifact_path, artifact_sha256 = write_strategy_comparison_artifact(
+        payload=payload,
+        output_dir=output_dir,
+    )
+    return StrategyComparisonResult(
+        artifact_path=artifact_path,
+        artifact_sha256=artifact_sha256,
+        payload=payload,
+    )
+
+
+def write_strategy_comparison_artifact(
+    *,
+    payload: Mapping[str, Any],
+    output_dir: Path,
+) -> tuple[Path, str]:
+    """Persist deterministic strategy comparison artifact and hash."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = output_dir / COMPARISON_ARTIFACT_FILENAME
+    canonical_bytes = canonical_json_bytes(payload)
+    artifact_path.write_bytes(canonical_bytes)
+
+    artifact_sha = hashlib.sha256(canonical_bytes).hexdigest()
+    (output_dir / COMPARISON_HASH_FILENAME).write_text(f"{artifact_sha}\n", encoding="utf-8")
+    return artifact_path, artifact_sha
+
+
+class _NoOpBacktestStrategy:
+    def on_run_start(self, config: Mapping[str, Any]) -> None:
+        del config
+
+    def on_snapshot(self, snapshot: Mapping[str, Any], config: Mapping[str, Any]) -> None:
+        del snapshot, config
+
+    def on_run_end(self, config: Mapping[str, Any]) -> None:
+        del config
+
+
+def _normalize_strategy_names(strategy_names: Sequence[str]) -> list[str]:
+    normalized: list[str] = []
+    for strategy_name in strategy_names:
+        if not isinstance(strategy_name, str) or not strategy_name.strip():
+            raise StrategyEvaluationInputError("Strategy names must be non-empty strings")
+        normalized_name = strategy_name.strip().upper()
+        if normalized_name in normalized:
+            raise StrategyEvaluationInputError("Strategy names must be unique")
+        normalized.append(normalized_name)
+
+    if not normalized:
+        raise StrategyEvaluationInputError("At least one strategy is required")
+    return normalized
+
+
+def _normalize_strategy_configs(
+    strategy_configs: Mapping[str, Mapping[str, Any]] | None,
+) -> dict[str, dict[str, Any]]:
+    if strategy_configs is None:
+        return {}
+    if not isinstance(strategy_configs, Mapping):
+        raise StrategyEvaluationInputError("Strategy configs must be a mapping")
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for raw_key, raw_value in strategy_configs.items():
+        if not isinstance(raw_key, str) or not raw_key.strip():
+            raise StrategyEvaluationInputError("Strategy config keys must be non-empty strings")
+        if not isinstance(raw_value, Mapping):
+            raise StrategyEvaluationInputError("Each strategy config must be an object")
+        normalized[raw_key.strip().upper()] = dict(raw_value)
+    return normalized
+
+
+def _sort_snapshots(snapshots: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    sortable: list[tuple[tuple[str, str], dict[str, Any]]] = []
+    for raw_snapshot in snapshots:
+        if not isinstance(raw_snapshot, Mapping):
+            raise StrategyEvaluationInputError("Snapshots must be objects")
+        snapshot = dict(raw_snapshot)
+        snapshot_id = snapshot.get("id")
+        if not isinstance(snapshot_id, str) or not snapshot_id.strip():
+            raise StrategyEvaluationInputError("Snapshots must define a non-empty id")
+        if "timestamp" in snapshot:
+            primary_key = str(snapshot.get("timestamp"))
+        elif "snapshot_key" in snapshot:
+            primary_key = str(snapshot.get("snapshot_key"))
+        else:
+            raise StrategyEvaluationInputError("Snapshots must define timestamp or snapshot_key")
+
+        sortable.append(((primary_key, str(snapshot_id)), snapshot))
+
+    sortable.sort(key=lambda item: item[0])
+    return [item[1] for item in sortable]
+
+
+def _snapshot_linkage(snapshots: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not snapshots:
+        return {
+            "mode": "timestamp",
+            "start": None,
+            "end": None,
+            "count": 0,
+        }
+
+    has_timestamp = [("timestamp" in snapshot) for snapshot in snapshots]
+    has_snapshot_key = [("snapshot_key" in snapshot) for snapshot in snapshots]
+    if all(has_timestamp):
+        mode = "timestamp"
+        boundary_field = "timestamp"
+    elif all(has_snapshot_key):
+        mode = "snapshot_key"
+        boundary_field = "snapshot_key"
+    else:
+        raise StrategyEvaluationInputError(_RUNNER_SNAPSHOT_BOUNDARY_ERROR)
+
+    start_value = snapshots[0].get(boundary_field)
+    end_value = snapshots[-1].get(boundary_field)
+    return {
+        "mode": mode,
+        "start": str(start_value) if start_value is not None else None,
+        "end": str(end_value) if end_value is not None else None,
+        "count": len(snapshots),
+    }
+
+
+def _build_strategy_snapshots(
+    *,
+    ordered_snapshots: Sequence[Mapping[str, Any]],
+    strategy_name: str,
+    strategy: Any,
+    strategy_config: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], int, int]:
+    snapshot_rows: list[dict[str, Any]] = []
+    candidate_count = 0
+    executable_count = 0
+    has_open_position = False
+
+    for index, snapshot in enumerate(ordered_snapshots):
+        history_frame = _history_frame(ordered_snapshots, index)
+        candidate_signals = _to_executable_signals(
+            strategy_name=strategy_name,
+            snapshot=snapshot,
+            strategy=strategy,
+            history_frame=history_frame,
+            strategy_config=strategy_config,
+        )
+        candidate_count += len(candidate_signals)
+
+        executable_signals: list[dict[str, str]] = []
+        if not has_open_position and candidate_signals:
+            executable_signals = [candidate_signals[0]]
+            has_open_position = True
+            executable_count += 1
+
+        row = dict(snapshot)
+        if executable_signals:
+            row["signals"] = executable_signals
+        snapshot_rows.append(row)
+
+    return snapshot_rows, candidate_count, executable_count
+
+
+def _history_frame(
+    ordered_snapshots: Sequence[Mapping[str, Any]],
+    index: int,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for snapshot in ordered_snapshots[: index + 1]:
+        row: dict[str, Any] = {}
+        for field in ("id", "timestamp", "symbol", "open", "high", "low", "close", "price", "volume"):
+            if field in snapshot:
+                row[field] = snapshot[field]
+
+        price = row.get("price")
+        close = row.get("close")
+        if close is None and price is not None:
+            row["close"] = price
+
+        normalized_close = row.get("close")
+        if normalized_close is not None:
+            row.setdefault("open", normalized_close)
+            row.setdefault("high", normalized_close)
+            row.setdefault("low", normalized_close)
+
+        rows.append(row)
+
+    frame = pd.DataFrame(rows)
+    for column in ("open", "high", "low", "close", "price", "volume"):
+        if column in frame.columns:
+            frame[column] = pd.to_numeric(frame[column], errors="coerce")
+
+    if "timestamp" in frame.columns:
+        timestamps = pd.to_datetime(frame["timestamp"], utc=True, errors="coerce")
+        if timestamps.notna().all():
+            frame = frame.copy()
+            frame.index = timestamps
+
+    return frame
+
+
+def _to_executable_signals(
+    *,
+    strategy_name: str,
+    snapshot: Mapping[str, Any],
+    strategy: Any,
+    history_frame: pd.DataFrame,
+    strategy_config: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    try:
+        generated = strategy.generate_signals(history_frame, dict(strategy_config))
+    except Exception as exc:
+        raise StrategyEvaluationInputError(
+            f"Strategy signal generation failed: {strategy_name}"
+        ) from exc
+
+    if generated is None:
+        return []
+    if not isinstance(generated, list):
+        raise StrategyEvaluationInputError(
+            f"Strategy signals must be a list: {strategy_name}"
+        )
+
+    snapshot_id = str(snapshot.get("id", "snapshot"))
+    executable_signals: list[dict[str, str]] = []
+    for index, signal in enumerate(generated, start=1):
+        if not isinstance(signal, Mapping):
+            continue
+
+        stage = str(signal.get("stage", "")).strip().lower()
+        direction = str(signal.get("direction", "long")).strip().lower()
+        if stage != "entry_confirmed" or direction != "long":
+            continue
+
+        symbol = _normalize_symbol(signal.get("symbol", snapshot.get("symbol")))
+        executable_signals.append(
+            {
+                "signal_id": f"{strategy_name}:{snapshot_id}:{index}",
+                "action": "BUY",
+                "quantity": "1",
+                "symbol": symbol,
+            }
+        )
+
+    executable_signals.sort(key=lambda signal: (signal["signal_id"], signal["symbol"]))
+    return executable_signals
+
+
+def _normalize_symbol(value: Any) -> str:
+    if not isinstance(value, str):
+        return "UNKNOWN"
+    normalized = value.strip().upper()
+    if not normalized:
+        return "UNKNOWN"
+    return normalized
+
+
+def _comparison_group(metadata_by_key: Mapping[str, Mapping[str, Any]], strategy_name: str) -> str | None:
+    strategy_metadata = metadata_by_key.get(strategy_name)
+    if not isinstance(strategy_metadata, Mapping):
+        return None
+    value = strategy_metadata.get("comparison_group")
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _build_ranking(strategy_rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    sorted_rows = sorted(
+        strategy_rows,
+        key=lambda row: (
+            _numeric_metric(row, "total_return") is None,
+            -_numeric_metric(row, "total_return")
+            if _numeric_metric(row, "total_return") is not None
+            else 0.0,
+            str(row.get("strategy_name")),
+        ),
+    )
+    ranking: list[dict[str, Any]] = []
+    for index, row in enumerate(sorted_rows, start=1):
+        ranking.append(
+            {
+                "rank": index,
+                "strategy_name": row.get("strategy_name"),
+                "total_return": _numeric_metric(row, "total_return"),
+            }
+        )
+    return ranking
+
+
+def _build_deltas(
+    strategy_rows: Sequence[Mapping[str, Any]],
+    benchmark_strategy: str,
+) -> list[dict[str, Any]]:
+    benchmark_metrics = None
+    for row in strategy_rows:
+        if row.get("strategy_name") == benchmark_strategy:
+            benchmark_metrics = row.get("metrics")
+            break
+
+    benchmark_mapping = benchmark_metrics if isinstance(benchmark_metrics, Mapping) else {}
+    deltas: list[dict[str, Any]] = []
+    for row in strategy_rows:
+        metrics = row.get("metrics")
+        metrics_map = metrics if isinstance(metrics, Mapping) else {}
+        delta_row: dict[str, Any] = {
+            "strategy_name": row.get("strategy_name"),
+        }
+        for key in _METRIC_KEYS:
+            strategy_value = metrics_map.get(key)
+            benchmark_value = benchmark_mapping.get(key)
+            delta_row[f"{key}_delta"] = _delta(strategy_value, benchmark_value)
+        deltas.append(delta_row)
+    return deltas
+
+
+def _numeric_metric(row: Mapping[str, Any], metric_key: str) -> float | None:
+    metrics = row.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return None
+    value = metrics.get(metric_key)
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _delta(strategy_value: Any, benchmark_value: Any) -> float | None:
+    if (
+        isinstance(strategy_value, bool)
+        or isinstance(benchmark_value, bool)
+        or strategy_value is None
+        or benchmark_value is None
+    ):
+        return None
+    if not isinstance(strategy_value, (int, float)) or not isinstance(benchmark_value, (int, float)):
+        return None
+
+    delta = Decimal(str(float(strategy_value) - float(benchmark_value)))
+    rounded = delta.quantize(_QUANT, rounding=ROUND_HALF_EVEN)
+    if rounded == Decimal("0"):
+        return 0.0
+    return float(rounded)
+

--- a/tests/test_cli_compare_strategies.py
+++ b/tests/test_cli_compare_strategies.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_cli(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    run_env = dict(os.environ)
+    if env is not None:
+        run_env.update(env)
+
+    project_paths = [str(Path.cwd()), str(Path.cwd() / "src")]
+    existing_pythonpath = run_env.get("PYTHONPATH")
+    if existing_pythonpath:
+        run_env["PYTHONPATH"] = os.pathsep.join(project_paths + [existing_pythonpath])
+    else:
+        run_env["PYTHONPATH"] = os.pathsep.join(project_paths)
+
+    return subprocess.run(
+        [sys.executable, "-m", "cilly_trading", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=run_env,
+    )
+
+
+def _comparison_snapshots() -> list[dict[str, object]]:
+    snapshots: list[dict[str, object]] = []
+    for day in range(1, 26):
+        timestamp = f"2024-01-{day:02d}T00:00:00Z"
+        if day <= 20:
+            close = 100
+        elif day == 21:
+            close = 105
+        elif day == 22:
+            close = 106
+        else:
+            close = 130
+
+        snapshots.append(
+            {
+                "id": f"s{day:02d}",
+                "timestamp": timestamp,
+                "symbol": "AAPL",
+                "open": close,
+                "high": close,
+                "low": close - 1,
+                "close": close,
+                "price": close,
+            }
+        )
+    return snapshots
+
+
+def test_cli_compare_strategies_happy_path(tmp_path: Path) -> None:
+    snapshots_path = tmp_path / "snapshots.json"
+    snapshots_path.write_text(json.dumps(_comparison_snapshots()), encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    result = _run_cli(
+        [
+            "compare-strategies",
+            "--snapshots",
+            str(snapshots_path),
+            "--strategy",
+            "REFERENCE",
+            "--strategy",
+            "TURTLE",
+            "--benchmark-strategy",
+            "REFERENCE",
+            "--out",
+            str(out_dir),
+        ]
+    )
+
+    assert result.returncode == 0
+    artifact_path = out_dir / "strategy-comparison.json"
+    assert artifact_path.exists()
+
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["workflow"]["benchmark_strategy"] == "REFERENCE"
+    assert [row["strategy_name"] for row in payload["ranking"]] == ["TURTLE", "REFERENCE"]
+

--- a/tests/test_strategy_evaluation_harness.py
+++ b/tests/test_strategy_evaluation_harness.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cilly_trading.strategies.evaluation_harness import run_strategy_comparison
+
+
+def _comparison_snapshots() -> list[dict[str, object]]:
+    snapshots: list[dict[str, object]] = []
+    for day in range(1, 26):
+        timestamp = f"2024-01-{day:02d}T00:00:00Z"
+        if day <= 20:
+            close = 100
+        elif day == 21:
+            close = 105
+        elif day == 22:
+            close = 106
+        else:
+            close = 130
+
+        snapshots.append(
+            {
+                "id": f"s{day:02d}",
+                "timestamp": timestamp,
+                "symbol": "AAPL",
+                "open": close,
+                "high": close,
+                "low": close - 1,
+                "close": close,
+                "price": close,
+            }
+        )
+    return snapshots
+
+
+def _strategy_map(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    rows = payload["strategies"]
+    assert isinstance(rows, list)
+    mapped: dict[str, dict[str, object]] = {}
+    for row in rows:
+        assert isinstance(row, dict)
+        mapped[str(row["strategy_name"])] = row
+    return mapped
+
+
+def test_strategy_comparison_flow_writes_bounded_output(tmp_path: Path) -> None:
+    run_dir = tmp_path / "comparison"
+    result = run_strategy_comparison(
+        snapshots=_comparison_snapshots(),
+        strategy_names=["REFERENCE", "TURTLE"],
+        output_dir=run_dir,
+        run_id="cmp-flow",
+    )
+
+    assert result.artifact_path.exists()
+    assert (run_dir / "strategy-comparison.sha256").exists()
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    assert payload["artifact"] == "strategy_comparison"
+    assert payload["workflow"]["name"] == "bounded_comparable_strategy_evaluation"
+    assert payload["workflow"]["strategy_order"] == ["REFERENCE", "TURTLE"]
+    assert payload["workflow"]["snapshot_linkage"]["count"] == 25
+
+    strategies = _strategy_map(payload)
+    reference = strategies["REFERENCE"]
+    turtle = strategies["TURTLE"]
+
+    assert reference["signals"]["executable_count"] == 0
+    assert turtle["signals"]["executable_count"] == 1
+    assert reference["metrics_baseline_summary"]["fill_count"] == 0
+    assert turtle["metrics_baseline_summary"]["fill_count"] == 1
+
+
+def test_strategy_comparison_is_reproducible_across_runs(tmp_path: Path) -> None:
+    snapshots = _comparison_snapshots()
+    result_a = run_strategy_comparison(
+        snapshots=snapshots,
+        strategy_names=["REFERENCE", "TURTLE"],
+        output_dir=tmp_path / "run-a",
+        run_id="cmp-repro",
+    )
+    result_b = run_strategy_comparison(
+        snapshots=snapshots,
+        strategy_names=["REFERENCE", "TURTLE"],
+        output_dir=tmp_path / "run-b",
+        run_id="cmp-repro",
+    )
+
+    assert result_a.artifact_path.read_bytes() == result_b.artifact_path.read_bytes()
+    assert result_a.artifact_sha256 == result_b.artifact_sha256
+
+
+def test_strategy_comparison_regression_reference_vs_turtle(tmp_path: Path) -> None:
+    result = run_strategy_comparison(
+        snapshots=_comparison_snapshots(),
+        strategy_names=["REFERENCE", "TURTLE"],
+        output_dir=tmp_path / "regression",
+        run_id="cmp-regression",
+        benchmark_strategy="REFERENCE",
+    )
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    strategies = _strategy_map(payload)
+
+    reference_total_return = strategies["REFERENCE"]["metrics"]["total_return"]
+    turtle_total_return = strategies["TURTLE"]["metrics"]["total_return"]
+    assert reference_total_return == 0.0
+    assert turtle_total_return == 0.00024
+
+    ranking = payload["ranking"]
+    assert ranking[0]["strategy_name"] == "TURTLE"
+    assert ranking[1]["strategy_name"] == "REFERENCE"
+
+    deltas = {row["strategy_name"]: row for row in payload["deltas_vs_benchmark"]}
+    assert deltas["REFERENCE"]["total_return_delta"] == 0.0
+    assert deltas["TURTLE"]["total_return_delta"] == 0.00024
+


### PR DESCRIPTION
Closes #734

## What changed
- Added reusable harness: \un_strategy_comparison(...)\
- Added CLI command: \compare-strategies\
- Added deterministic comparison artifact outputs:
  - \strategy-comparison.json\
  - \strategy-comparison.sha256\
- Added representative tests:
  - comparison-flow
  - reproducibility
  - regression across REFERENCE vs TURTLE
  - CLI happy-path
- Added harness documentation under backtesting docs

## Acceptance Criteria mapping
- Strategies can be evaluated through one comparable bounded workflow: implemented via \compare-strategies\ + reusable harness.
- Comparison outputs are explicit and reproducible: explicit contract fields + canonical JSON + SHA256.
- Harness reusable for later Strategy Lab work: isolated module API + CLI wrapper.
- Representative strategy comparisons are test-covered: new tests added and passing.
- Full pytest run remains green: \681 passed\.