### PR TITLE
LAB-P42: Add validation discipline and anti-overfit experiment guardrails

### DIFF
--- a/docs/phases/phase-42-experiment-search-framework.md
+++ b/docs/phases/phase-42-experiment-search-framework.md
@@ -19,6 +19,35 @@ Bounded constraints:
 - Only supported objective metrics are accepted.
 - Snapshot inputs must be explicit and non-empty.
 
+## Validation Discipline
+
+Validation is explicit and enforced during optimization:
+
+- Split mode: chronological holdout (`development` first, `validation` tail).
+- Config bounds:
+  - `validation_split_ratio` must be between `0.1` and `0.5`.
+  - `min_development_snapshots` must be >= `1`.
+  - `min_validation_snapshots` must be >= `1`.
+- Runtime enforcement:
+  - The run fails if the split cannot satisfy both minimum segment sizes.
+  - Every trial is evaluated on both segments.
+  - Trial selection uses development objective ranking only.
+
+## Anti-Overfit Guardrails
+
+Guardrails are bounded and enforced in selection:
+
+- Guardrail config:
+  - `max_validation_degradation_fraction` in `[0.0, 1.0]`.
+  - `require_guardrail_pass_for_selection` boolean.
+- Per-trial computed values:
+  - `validation_degradation`
+  - `validation_degradation_fraction`
+  - `passed`
+- Enforcement:
+  - If `require_guardrail_pass_for_selection=true`, only guardrail-passing trials are eligible for final selection.
+  - If no trial passes, the run fails with an explicit error.
+
 ## Reproducibility Model
 
 Each run is deterministic from explicit inputs:
@@ -45,6 +74,11 @@ Given identical config and snapshot inputs, produced artifact bytes and SHA256 a
 - `objective_direction`
 - `max_trials`
 - `snapshot_selector`
+- `validation_split_ratio`
+- `min_development_snapshots`
+- `min_validation_snapshots`
+- `max_validation_degradation_fraction`
+- `require_guardrail_pass_for_selection`
 
 Runtime input:
 
@@ -60,30 +94,44 @@ Search artifact files:
 
 Artifact payload sections:
 
-- `experiment` (explicit configuration)
-- `run_metadata` (hashes, run id, trial count)
-- `search_results` (objective definition, best trial, trial rows)
+- `experiment` (explicit configuration, validation discipline, guardrails)
+- `run_metadata` (hashes, run id, trial count, split counts)
+- `search_results` (objective definition, selection policy, trial rows)
 - `reports` (aligned reusable report structures)
 
-Within each `search_results.trials[*].comparison_artifact` entry:
+Within each `search_results.trials[*]`:
 
-- `relpath` points to `trials/<trial_id>/strategy-comparison.json`
+- `development` segment metrics/artifact linkage
+- `validation` segment metrics/artifact linkage
+- `guardrails` status
+- legacy trial summary fields retained for development segment compatibility
+
+Within each segment comparison-artifact entry:
+
+- `relpath` points to `trials/<trial_id>/<segment>/strategy-comparison.json`
 - `sha256` is the SHA256 of the exact file bytes at that `relpath`
 
-## Reusable Report Alignment
+## Comparison and Reporting Conventions
 
-The framework emits report-aligned structures in `reports`:
+The framework now emits explicit development/validation distinctions in report payloads:
 
-- `strategy_comparison` artifact-shaped payload
-- `performance_report` artifact-shaped payload
+- `reports.strategy_comparison.strategies[*].development`
+- `reports.strategy_comparison.strategies[*].validation`
+- `reports.performance_report.selected_trial_validation`
 
-This allows future research runs to use consistent report conventions instead of ad hoc output schemas.
+Selection metadata is always explicit:
+
+- `search_results.selection.policy`
+- `search_results.selection.best_development_trial_id`
+- `search_results.selection.selected_trial_id`
+- `search_results.selection.guardrail_passed_trial_count`
 
 ## Tests
 
-Added representative test coverage in `tests/strategies/test_experiment_search.py`:
+Representative coverage in `tests/strategies/test_experiment_search.py` includes:
 
-- configuration validation test
-- representative search-run test
-- reproducibility test
-- negative execution test
+- validation workflow tests (segment split and dual-segment trial outputs)
+- negative tests for invalid setup (invalid ratio, insufficient split size)
+- negative tests for guardrail enforcement (no eligible trial)
+- representative report/output tests (development vs validation report shape)
+- reproducibility test for identical inputs

--- a/src/cilly_trading/strategies/experiment_search.py
+++ b/src/cilly_trading/strategies/experiment_search.py
@@ -10,7 +10,7 @@ from typing import Any, Mapping, Sequence
 from cilly_trading.metrics.artifact import canonical_json_bytes
 from cilly_trading.strategies.evaluation_harness import run_strategy_comparison
 
-FRAMEWORK_VERSION = "1"
+FRAMEWORK_VERSION = "2"
 SEARCH_ARTIFACT_FILENAME = "parameter-search-result.json"
 SEARCH_HASH_FILENAME = "parameter-search-result.sha256"
 SUPPORTED_OBJECTIVE_METRICS = {
@@ -21,6 +21,10 @@ SUPPORTED_OBJECTIVE_METRICS = {
     "win_rate",
     "profit_factor",
 }
+
+_MIN_VALIDATION_SPLIT_RATIO = 0.1
+_MAX_VALIDATION_SPLIT_RATIO = 0.5
+_EPSILON = 1e-12
 
 
 class StrategyLabConfigError(ValueError):
@@ -43,6 +47,11 @@ class ParameterSearchExperimentConfig:
     objective_direction: str = "max"
     max_trials: int = 32
     snapshot_selector: Mapping[str, Any] = field(default_factory=dict)
+    validation_split_ratio: float = 0.3
+    min_development_snapshots: int = 10
+    min_validation_snapshots: int = 5
+    max_validation_degradation_fraction: float = 0.35
+    require_guardrail_pass_for_selection: bool = True
 
     def __post_init__(self) -> None:
         if not isinstance(self.experiment_id, str) or not self.experiment_id.strip():
@@ -74,6 +83,29 @@ class ParameterSearchExperimentConfig:
         if not isinstance(self.snapshot_selector, Mapping):
             raise StrategyLabConfigError("snapshot_selector must be a mapping")
 
+        if not isinstance(self.validation_split_ratio, (int, float)):
+            raise StrategyLabConfigError("validation_split_ratio must be numeric")
+        if not _MIN_VALIDATION_SPLIT_RATIO <= float(self.validation_split_ratio) <= _MAX_VALIDATION_SPLIT_RATIO:
+            raise StrategyLabConfigError(
+                "validation_split_ratio must be between "
+                f"{_MIN_VALIDATION_SPLIT_RATIO} and {_MAX_VALIDATION_SPLIT_RATIO}"
+            )
+
+        if not isinstance(self.min_development_snapshots, int) or self.min_development_snapshots < 1:
+            raise StrategyLabConfigError("min_development_snapshots must be a positive integer")
+        if not isinstance(self.min_validation_snapshots, int) or self.min_validation_snapshots < 1:
+            raise StrategyLabConfigError("min_validation_snapshots must be a positive integer")
+
+        if not isinstance(self.max_validation_degradation_fraction, (int, float)):
+            raise StrategyLabConfigError("max_validation_degradation_fraction must be numeric")
+        if not 0.0 <= float(self.max_validation_degradation_fraction) <= 1.0:
+            raise StrategyLabConfigError(
+                "max_validation_degradation_fraction must be between 0.0 and 1.0"
+            )
+
+        if not isinstance(self.require_guardrail_pass_for_selection, bool):
+            raise StrategyLabConfigError("require_guardrail_pass_for_selection must be a boolean")
+
     def to_payload(self) -> dict[str, Any]:
         return {
             "framework_version": FRAMEWORK_VERSION,
@@ -90,6 +122,16 @@ class ParameterSearchExperimentConfig:
             },
             "max_trials": self.max_trials,
             "snapshot_selector": dict(self.snapshot_selector),
+            "validation_discipline": {
+                "split_mode": "chronological_holdout",
+                "validation_split_ratio": float(self.validation_split_ratio),
+                "min_development_snapshots": self.min_development_snapshots,
+                "min_validation_snapshots": self.min_validation_snapshots,
+            },
+            "anti_overfit_guardrails": {
+                "max_validation_degradation_fraction": float(self.max_validation_degradation_fraction),
+                "require_guardrail_pass_for_selection": self.require_guardrail_pass_for_selection,
+            },
         }
 
 
@@ -111,6 +153,11 @@ def run_parameter_search_experiment(
     """Run a bounded deterministic parameter search and persist canonical artifacts."""
 
     ordered_snapshots = _normalize_snapshots(snapshots)
+    development_snapshots, validation_snapshots = _split_snapshots_for_validation(
+        snapshots=ordered_snapshots,
+        config=config,
+    )
+
     trial_params = _normalize_parameter_space(config.parameter_space)
     if not trial_params:
         raise StrategyLabRunError("parameter_space must expand to at least one trial")
@@ -123,56 +170,69 @@ def run_parameter_search_experiment(
     trial_rows: list[dict[str, Any]] = []
     for index, params in enumerate(trial_params, start=1):
         trial_id = f"trial-{index:03d}"
-        trial_output_dir = output_dir / "trials" / trial_id
         trial_run_id = f"{run_id}:{trial_id}"
-        comparison_artifact_relpath = Path("trials") / trial_id / "strategy-comparison.json"
-        comparison_artifact_path = output_dir / comparison_artifact_relpath
 
-        comparison = run_strategy_comparison(
-            snapshots=ordered_snapshots,
-            strategy_names=[config.strategy_name],
-            output_dir=trial_output_dir,
+        development_result = _run_trial_segment(
+            config=config,
+            output_dir=output_dir,
             run_id=trial_run_id,
-            strategy_configs={config.strategy_name: params},
+            trial_id=trial_id,
+            segment_name="development",
+            snapshots=development_snapshots,
+            params=params,
         )
-        strategy_row = comparison.payload["strategies"][0]
-        if not isinstance(strategy_row, Mapping):
-            raise StrategyLabRunError("strategy comparison output is malformed")
+        validation_result = _run_trial_segment(
+            config=config,
+            output_dir=output_dir,
+            run_id=trial_run_id,
+            trial_id=trial_id,
+            segment_name="validation",
+            snapshots=validation_snapshots,
+            params=params,
+        )
 
-        metrics = strategy_row.get("metrics")
-        if not isinstance(metrics, Mapping):
-            raise StrategyLabRunError("strategy comparison metrics are missing")
-        objective_value = metrics.get(config.objective_metric)
-        if not isinstance(objective_value, (int, float)):
-            raise StrategyLabRunError(
-                f"objective metric '{config.objective_metric}' is missing or non-numeric"
-            )
-
-        backtest = strategy_row.get("backtest")
-        if not isinstance(backtest, Mapping):
-            raise StrategyLabRunError("strategy comparison backtest payload is missing")
-
-        baseline_summary_raw = strategy_row.get("metrics_baseline_summary")
-        baseline_summary = baseline_summary_raw if isinstance(baseline_summary_raw, Mapping) else {}
-        comparison_artifact_sha = hashlib.sha256(comparison_artifact_path.read_bytes()).hexdigest()
+        development_objective = float(development_result["objective_value"])
+        validation_objective = float(validation_result["objective_value"])
+        degradation = _validation_degradation(
+            development_objective=development_objective,
+            validation_objective=validation_objective,
+            objective_direction=config.objective_direction,
+        )
+        degradation_fraction = degradation / max(abs(development_objective), _EPSILON)
+        guardrail_passed = degradation_fraction <= float(config.max_validation_degradation_fraction)
 
         trial_rows.append(
             {
                 "trial_id": trial_id,
                 "run_id": trial_run_id,
                 "parameters": params,
-                "objective_value": float(objective_value),
-                "metrics": dict(metrics),
-                "metrics_baseline_summary": dict(baseline_summary),
-                "comparison_artifact": {
-                    "relpath": str(comparison_artifact_relpath.as_posix()),
-                    "sha256": comparison_artifact_sha,
+                "objective_value": development_objective,
+                "metrics": dict(development_result["metrics"]),
+                "metrics_baseline_summary": dict(development_result["metrics_baseline_summary"]),
+                "comparison_artifact": dict(development_result["comparison_artifact"]),
+                "development": dict(development_result),
+                "validation": dict(validation_result),
+                "guardrails": {
+                    "validation_degradation": degradation,
+                    "validation_degradation_fraction": degradation_fraction,
+                    "max_validation_degradation_fraction": float(config.max_validation_degradation_fraction),
+                    "passed": guardrail_passed,
                 },
             }
         )
 
-    best_trial = _select_best_trial(
+    best_development_trial = _select_best_trial(
         trial_rows=trial_rows,
+        objective_direction=config.objective_direction,
+    )
+
+    guardrail_passed_trials = [row for row in trial_rows if _guardrail_passed(row)]
+    if config.require_guardrail_pass_for_selection and not guardrail_passed_trials:
+        raise StrategyLabRunError("no trial satisfies the configured validation guardrails")
+
+    candidate_rows = guardrail_passed_trials if config.require_guardrail_pass_for_selection else trial_rows
+    selected_trial = _select_best_trial(
+        trial_rows=candidate_rows,
         objective_direction=config.objective_direction,
     )
 
@@ -185,16 +245,26 @@ def run_parameter_search_experiment(
             "config_sha256": config_sha,
             "snapshots_sha256": snapshots_sha,
             "trial_count": len(trial_rows),
+            "snapshot_count": len(ordered_snapshots),
+            "development_snapshot_count": len(development_snapshots),
+            "validation_snapshot_count": len(validation_snapshots),
         },
         "search_results": {
             "objective": {
                 "metric": config.objective_metric,
                 "direction": config.objective_direction,
             },
-            "best_trial_id": best_trial["trial_id"],
+            "best_trial_id": selected_trial["trial_id"],
+            "selection": {
+                "policy": "best_development_trial_with_validation_guardrail",
+                "best_development_trial_id": best_development_trial["trial_id"],
+                "selected_trial_id": selected_trial["trial_id"],
+                "guardrail_required": config.require_guardrail_pass_for_selection,
+                "guardrail_passed_trial_count": len(guardrail_passed_trials),
+            },
             "trials": trial_rows,
         },
-        "reports": _build_reusable_reports(config, trial_rows, best_trial),
+        "reports": _build_reusable_reports(config, trial_rows, selected_trial),
     }
 
     artifact_path, artifact_sha = write_parameter_search_artifact(payload=payload, output_dir=output_dir)
@@ -222,51 +292,115 @@ def write_parameter_search_artifact(
     return artifact_path, artifact_sha
 
 
+def _run_trial_segment(
+    *,
+    config: ParameterSearchExperimentConfig,
+    output_dir: Path,
+    run_id: str,
+    trial_id: str,
+    segment_name: str,
+    snapshots: Sequence[Mapping[str, Any]],
+    params: Mapping[str, Any],
+) -> dict[str, Any]:
+    trial_output_dir = output_dir / "trials" / trial_id / segment_name
+    segment_run_id = f"{run_id}:{segment_name}"
+    comparison_artifact_relpath = Path("trials") / trial_id / segment_name / "strategy-comparison.json"
+    comparison_artifact_path = output_dir / comparison_artifact_relpath
+
+    comparison = run_strategy_comparison(
+        snapshots=snapshots,
+        strategy_names=[config.strategy_name],
+        output_dir=trial_output_dir,
+        run_id=segment_run_id,
+        strategy_configs={config.strategy_name: params},
+    )
+    strategy_row = comparison.payload["strategies"][0]
+    if not isinstance(strategy_row, Mapping):
+        raise StrategyLabRunError("strategy comparison output is malformed")
+
+    metrics_raw = strategy_row.get("metrics")
+    metrics = metrics_raw if isinstance(metrics_raw, Mapping) else None
+    if metrics is None:
+        raise StrategyLabRunError("strategy comparison metrics are missing")
+
+    objective_value = metrics.get(config.objective_metric)
+    if not isinstance(objective_value, (int, float)):
+        raise StrategyLabRunError(
+            f"objective metric '{config.objective_metric}' is missing or non-numeric"
+        )
+
+    backtest = strategy_row.get("backtest")
+    if not isinstance(backtest, Mapping):
+        raise StrategyLabRunError("strategy comparison backtest payload is missing")
+
+    baseline_summary_raw = strategy_row.get("metrics_baseline_summary")
+    baseline_summary = baseline_summary_raw if isinstance(baseline_summary_raw, Mapping) else {}
+    comparison_artifact_sha = hashlib.sha256(comparison_artifact_path.read_bytes()).hexdigest()
+
+    return {
+        "objective_value": float(objective_value),
+        "metrics": dict(metrics),
+        "metrics_baseline_summary": dict(baseline_summary),
+        "comparison_artifact": {
+            "relpath": str(comparison_artifact_relpath.as_posix()),
+            "sha256": comparison_artifact_sha,
+        },
+        "snapshot_count": len(snapshots),
+    }
+
+
+def _split_snapshots_for_validation(
+    *,
+    snapshots: Sequence[Mapping[str, Any]],
+    config: ParameterSearchExperimentConfig,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    total_count = len(snapshots)
+    ratio_based_count = int(total_count * float(config.validation_split_ratio))
+    validation_count = max(config.min_validation_snapshots, ratio_based_count)
+
+    development_count = total_count - validation_count
+    if development_count < config.min_development_snapshots:
+        raise StrategyLabRunError(
+            "validation split requires at least "
+            f"{config.min_development_snapshots + config.min_validation_snapshots} snapshots "
+            f"(received {total_count})"
+        )
+
+    if validation_count < 1 or development_count < 1:
+        raise StrategyLabRunError("validation split produced an empty development or validation partition")
+
+    development = [dict(snapshot) for snapshot in snapshots[:development_count]]
+    validation = [dict(snapshot) for snapshot in snapshots[development_count:]]
+    return development, validation
+
+
 def _build_reusable_reports(
     config: ParameterSearchExperimentConfig,
     trial_rows: Sequence[Mapping[str, Any]],
     best_trial: Mapping[str, Any],
 ) -> dict[str, Any]:
-    ranking_rows = sorted(
-        trial_rows,
-        key=lambda row: (-float(row["objective_value"]), str(row["trial_id"])),
-    )
-    if config.objective_direction == "min":
-        ranking_rows = sorted(
-            trial_rows,
-            key=lambda row: (float(row["objective_value"]), str(row["trial_id"])),
-        )
+    ranking_rows = _sorted_trial_rows(trial_rows=trial_rows, objective_direction=config.objective_direction)
 
     strategy_comparison: list[dict[str, Any]] = []
     for row in ranking_rows:
-        baseline_raw = row.get("metrics_baseline_summary")
-        baseline = baseline_raw if isinstance(baseline_raw, Mapping) else {}
-        starting_equity = baseline.get("starting_equity")
-        ending_equity = baseline.get("ending_equity_cost_aware")
-        fill_count = baseline.get("fill_count")
+        development_segment = _segment_summary(row, "development")
+        validation_segment = _segment_summary(row, "validation")
 
-        total_pnl = None
-        if isinstance(starting_equity, (int, float)) and isinstance(ending_equity, (int, float)):
-            total_pnl = float(ending_equity) - float(starting_equity)
-
-        average_pnl = None
-        if total_pnl is not None and isinstance(fill_count, int) and fill_count > 0:
-            average_pnl = total_pnl / float(fill_count)
-
-        metrics_raw = row.get("metrics")
-        metrics = metrics_raw if isinstance(metrics_raw, Mapping) else {}
         strategy_comparison.append(
             {
                 "strategy_id": f"{config.strategy_name.strip().upper()}:{row['trial_id']}",
-                "trade_count": fill_count if isinstance(fill_count, int) else 0,
-                "total_pnl": total_pnl,
-                "average_pnl": average_pnl,
-                "win_rate": metrics.get("win_rate"),
+                "trade_count": development_segment["trade_count"],
+                "total_pnl": development_segment["total_pnl"],
+                "average_pnl": development_segment["average_pnl"],
+                "win_rate": development_segment["win_rate"],
+                "development": development_segment,
+                "validation": validation_segment,
+                "guardrails": dict(row.get("guardrails") or {}),
             }
         )
 
-    best_metrics_raw = best_trial.get("metrics")
-    best_metrics = best_metrics_raw if isinstance(best_metrics_raw, Mapping) else {}
+    selected_development = _segment_metrics(best_trial, "development")
+    selected_validation = _segment_metrics(best_trial, "validation")
     return {
         "strategy_comparison": {
             "artifact": "strategy_comparison",
@@ -276,6 +410,7 @@ def _build_reusable_reports(
                 "strategy": config.strategy_name.strip().upper(),
                 "objective_metric": config.objective_metric,
                 "objective_direction": config.objective_direction,
+                "selection_rule": "best_development_trial_with_validation_guardrail",
             },
             "strategies": list(strategy_comparison),
         },
@@ -294,15 +429,104 @@ def _build_reusable_reports(
             },
             "strategy_comparison": list(strategy_comparison),
             "key_metrics_overview": {
-                "overall_win_rate": best_metrics.get("win_rate"),
+                "overall_win_rate": selected_development.get("win_rate"),
                 "average_pnl_per_trade": None,
                 "average_holding_time_seconds": None,
                 "best_strategy_id": f"{config.strategy_name.strip().upper()}:{best_trial['trial_id']}",
                 "worst_strategy_id": strategy_comparison[-1]["strategy_id"] if strategy_comparison else None,
                 "risk_adjusted_metrics": None,
             },
+            "selected_trial_validation": {
+                "objective_value": selected_validation.get("objective_value"),
+                "win_rate": selected_validation.get("win_rate"),
+            },
         },
     }
+
+
+def _segment_summary(row: Mapping[str, Any], segment_name: str) -> dict[str, Any]:
+    metrics = _segment_metrics(row, segment_name)
+    baseline = _segment_baseline(row, segment_name)
+    total_pnl = _segment_total_pnl(baseline)
+    fill_count = baseline.get("fill_count")
+
+    average_pnl = None
+    if total_pnl is not None and isinstance(fill_count, int) and fill_count > 0:
+        average_pnl = total_pnl / float(fill_count)
+
+    return {
+        "objective_value": metrics.get("objective_value"),
+        "trade_count": fill_count if isinstance(fill_count, int) else 0,
+        "total_pnl": total_pnl,
+        "average_pnl": average_pnl,
+        "win_rate": metrics.get("win_rate"),
+    }
+
+
+def _segment_metrics(row: Mapping[str, Any], segment_name: str) -> Mapping[str, Any]:
+    segment = row.get(segment_name)
+    if not isinstance(segment, Mapping):
+        return {}
+    metrics = segment.get("metrics")
+    if not isinstance(metrics, Mapping):
+        return {"objective_value": segment.get("objective_value")}
+
+    values = dict(metrics)
+    values["objective_value"] = segment.get("objective_value")
+    return values
+
+
+def _segment_baseline(row: Mapping[str, Any], segment_name: str) -> Mapping[str, Any]:
+    segment = row.get(segment_name)
+    if not isinstance(segment, Mapping):
+        return {}
+    baseline = segment.get("metrics_baseline_summary")
+    if isinstance(baseline, Mapping):
+        return baseline
+    return {}
+
+
+def _segment_total_pnl(baseline: Mapping[str, Any]) -> float | None:
+    starting_equity = baseline.get("starting_equity")
+    ending_equity = baseline.get("ending_equity_cost_aware")
+
+    if isinstance(starting_equity, (int, float)) and isinstance(ending_equity, (int, float)):
+        return float(ending_equity) - float(starting_equity)
+    return None
+
+
+def _validation_degradation(
+    *,
+    development_objective: float,
+    validation_objective: float,
+    objective_direction: str,
+) -> float:
+    if objective_direction == "max":
+        return max(0.0, development_objective - validation_objective)
+    return max(0.0, validation_objective - development_objective)
+
+
+def _guardrail_passed(row: Mapping[str, Any]) -> bool:
+    guardrails = row.get("guardrails")
+    if not isinstance(guardrails, Mapping):
+        return False
+    return bool(guardrails.get("passed"))
+
+
+def _sorted_trial_rows(
+    *,
+    trial_rows: Sequence[Mapping[str, Any]],
+    objective_direction: str,
+) -> list[Mapping[str, Any]]:
+    if objective_direction == "max":
+        return sorted(
+            trial_rows,
+            key=lambda row: (-float(row["objective_value"]), str(row["trial_id"])),
+        )
+    return sorted(
+        trial_rows,
+        key=lambda row: (float(row["objective_value"]), str(row["trial_id"])),
+    )
 
 
 def _select_best_trial(
@@ -310,15 +534,7 @@ def _select_best_trial(
     trial_rows: Sequence[Mapping[str, Any]],
     objective_direction: str,
 ) -> Mapping[str, Any]:
-    if objective_direction == "max":
-        return sorted(
-            trial_rows,
-            key=lambda row: (-float(row["objective_value"]), str(row["trial_id"])),
-        )[0]
-    return sorted(
-        trial_rows,
-        key=lambda row: (float(row["objective_value"]), str(row["trial_id"])),
-    )[0]
+    return _sorted_trial_rows(trial_rows=trial_rows, objective_direction=objective_direction)[0]
 
 
 def _normalize_parameter_space(parameter_space: Mapping[str, Sequence[Any]]) -> list[dict[str, Any]]:

--- a/tests/strategies/test_experiment_search.py
+++ b/tests/strategies/test_experiment_search.py
@@ -16,11 +16,11 @@ from cilly_trading.strategies.experiment_search import (
 
 def _search_snapshots() -> list[dict[str, object]]:
     snapshots: list[dict[str, object]] = []
-    for day in range(1, 31):
+    for day in range(1, 41):
         timestamp = f"2024-01-{day:02d}T00:00:00Z"
-        if day <= 20:
+        if day <= 25:
             close = 100
-        elif day <= 25:
+        elif day <= 35:
             close = 104
         else:
             close = 130
@@ -55,7 +55,20 @@ def test_parameter_search_config_validation_rejects_oversized_grid() -> None:
         )
 
 
-def test_parameter_search_representative_run_outputs_expected_shape(tmp_path: Path) -> None:
+def test_parameter_search_config_validation_rejects_invalid_validation_ratio() -> None:
+    with pytest.raises(StrategyLabConfigError, match="validation_split_ratio"):
+        ParameterSearchExperimentConfig(
+            experiment_id="lab-p42-bad-validation-ratio",
+            strategy_name="TURTLE",
+            dataset_ref="snapshot-set-a",
+            parameter_space={"breakout_lookback": [20]},
+            validation_split_ratio=0.8,
+        )
+
+
+def test_parameter_search_validation_workflow_outputs_development_and_validation_segments(
+    tmp_path: Path,
+) -> None:
     config = ParameterSearchExperimentConfig(
         experiment_id="lab-p42",
         strategy_name="TURTLE",
@@ -68,6 +81,10 @@ def test_parameter_search_representative_run_outputs_expected_shape(tmp_path: Pa
         objective_direction="max",
         max_trials=4,
         snapshot_selector={"symbol": "AAPL", "timeframe": "D1"},
+        validation_split_ratio=0.3,
+        min_development_snapshots=20,
+        min_validation_snapshots=8,
+        max_validation_degradation_fraction=1.0,
     )
 
     result = run_parameter_search_experiment(
@@ -83,22 +100,65 @@ def test_parameter_search_representative_run_outputs_expected_shape(tmp_path: Pa
     assert payload["artifact"] == "parameter_search_experiment"
     assert payload["experiment"]["strategy_name"] == "TURTLE"
     assert payload["run_metadata"]["trial_count"] == 2
+    assert payload["run_metadata"]["development_snapshot_count"] == 28
+    assert payload["run_metadata"]["validation_snapshot_count"] == 12
 
     trials = payload["search_results"]["trials"]
     assert len(trials) == 2
     assert trials[0]["trial_id"] == "trial-001"
-    assert "objective_value" in trials[0]
-    for trial in trials:
-        comparison_artifact = trial["comparison_artifact"]
-        relpath = comparison_artifact["relpath"]
-        artifact_path = tmp_path / "search" / relpath
-        assert artifact_path.exists()
-        actual_sha = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
-        assert actual_sha == comparison_artifact["sha256"]
 
-    reports = payload["reports"]
-    assert reports["strategy_comparison"]["artifact"] == "strategy_comparison"
-    assert reports["performance_report"]["artifact"] == "performance_report"
+    for trial in trials:
+        assert "development" in trial
+        assert "validation" in trial
+        assert "guardrails" in trial
+        assert isinstance(trial["guardrails"]["passed"], bool)
+
+        for segment_name in ("development", "validation"):
+            segment = trial[segment_name]
+            assert "objective_value" in segment
+            comparison_artifact = segment["comparison_artifact"]
+            relpath = comparison_artifact["relpath"]
+            artifact_path = tmp_path / "search" / relpath
+            assert artifact_path.exists()
+            actual_sha = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+            assert actual_sha == comparison_artifact["sha256"]
+
+    selection = payload["search_results"]["selection"]
+    assert selection["policy"] == "best_development_trial_with_validation_guardrail"
+    assert selection["selected_trial_id"] == payload["search_results"]["best_trial_id"]
+
+
+def test_parameter_search_reports_distinguish_development_and_validation(tmp_path: Path) -> None:
+    config = ParameterSearchExperimentConfig(
+        experiment_id="lab-p42-reports",
+        strategy_name="TURTLE",
+        dataset_ref="snapshot-set-reports",
+        parameter_space={
+            "breakout_lookback": [20, 22],
+            "min_score": [30.0],
+        },
+        max_trials=4,
+        max_validation_degradation_fraction=1.0,
+    )
+
+    result = run_parameter_search_experiment(
+        config=config,
+        snapshots=_search_snapshots(),
+        output_dir=tmp_path / "reports-run",
+    )
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    strategy_rows = payload["reports"]["strategy_comparison"]["strategies"]
+    assert len(strategy_rows) == 2
+
+    for row in strategy_rows:
+        assert "development" in row
+        assert "validation" in row
+        assert "objective_value" in row["development"]
+        assert "objective_value" in row["validation"]
+
+    selected_validation = payload["reports"]["performance_report"]["selected_trial_validation"]
+    assert "objective_value" in selected_validation
 
 
 def test_parameter_search_run_is_reproducible_for_same_inputs(tmp_path: Path) -> None:
@@ -111,6 +171,7 @@ def test_parameter_search_run_is_reproducible_for_same_inputs(tmp_path: Path) ->
             "min_score": [30.0],
         },
         max_trials=4,
+        max_validation_degradation_fraction=1.0,
     )
 
     run_a = run_parameter_search_experiment(
@@ -139,3 +200,76 @@ def test_parameter_search_negative_invalid_snapshots_fail() -> None:
 
     with pytest.raises(StrategyLabRunError, match="at least one"):
         run_parameter_search_experiment(config=config, snapshots=[], output_dir=Path("unused"))
+
+
+def test_parameter_search_negative_guardrail_failure_blocks_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeComparisonResult:
+        def __init__(self, objective_value: float) -> None:
+            self.payload = {
+                "strategies": [
+                    {
+                        "metrics": {"total_return": objective_value, "win_rate": 0.5},
+                        "metrics_baseline_summary": {
+                            "starting_equity": 1000.0,
+                            "ending_equity_cost_aware": 1000.0 + objective_value,
+                            "fill_count": 1,
+                        },
+                        "backtest": {"run_id": "fake"},
+                    }
+                ]
+            }
+
+    call_state = {"count": 0}
+
+    def _fake_run_strategy_comparison(**kwargs: object) -> _FakeComparisonResult:
+        output_dir = kwargs["output_dir"]
+        assert isinstance(output_dir, Path)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "strategy-comparison.json").write_text("{}", encoding="utf-8")
+
+        call_state["count"] += 1
+        if call_state["count"] % 2 == 1:
+            return _FakeComparisonResult(objective_value=1.0)  # development
+        return _FakeComparisonResult(objective_value=0.0)  # validation
+
+    monkeypatch.setattr(
+        "cilly_trading.strategies.experiment_search.run_strategy_comparison",
+        _fake_run_strategy_comparison,
+    )
+
+    config = ParameterSearchExperimentConfig(
+        experiment_id="lab-p42-negative-guardrail",
+        strategy_name="TURTLE",
+        dataset_ref="snapshot-set-negative-guardrail",
+        parameter_space={"breakout_lookback": [20], "min_score": [30.0]},
+        max_trials=2,
+        max_validation_degradation_fraction=0.0,
+    )
+
+    with pytest.raises(StrategyLabRunError, match="validation guardrails"):
+        run_parameter_search_experiment(
+            config=config,
+            snapshots=_search_snapshots(),
+            output_dir=tmp_path / "guardrail-fail",
+        )
+
+
+def test_parameter_search_negative_split_requires_enough_snapshots() -> None:
+    config = ParameterSearchExperimentConfig(
+        experiment_id="lab-p42-negative-split",
+        strategy_name="TURTLE",
+        dataset_ref="snapshot-set-negative-split",
+        parameter_space={"breakout_lookback": [20]},
+        min_development_snapshots=30,
+        min_validation_snapshots=20,
+    )
+
+    with pytest.raises(StrategyLabRunError, match="requires at least"):
+        run_parameter_search_experiment(
+            config=config,
+            snapshots=_search_snapshots(),
+            output_dir=Path("unused"),
+        )


### PR DESCRIPTION
Closes #736

## What changed
- Enforced explicit chronological development/validation split in parameter search
- Added bounded validation config constraints and runtime split validation
- Added bounded anti-overfit guardrails with enforced trial selection gating
- Extended search artifacts and reports to distinguish development vs validation behavior
- Added representative tests for validation workflow, invalid setup negatives, guardrail failures, and report/output conventions
- Updated phase-42 documentation to match implemented behavior

## Why
Prevents curve-fitting by enforcing validation-aware selection and explicit experiment discipline.

## Validation
- python -m pytest