### PR TITLE
Phase 24: Paper Inspection API (canonical state) + docs fix (#757)

### DIFF
--- a/docs/api/paper_inspection.md
+++ b/docs/api/paper_inspection.md
@@ -12,6 +12,17 @@ All endpoints require `X-Cilly-Role: read_only` (or a higher role).
 
 No mutation endpoints are introduced by this surface.
 
+## Authoritative State Ownership
+
+Paper inspection state is authoritative only when derived from Trading Core entities:
+
+- Orders: canonical `Order` entities (`core_orders`)
+- Execution lifecycle facts: canonical `ExecutionEvent` entities (`core_execution_events`)
+- Trades: canonical `Trade` entities (`core_trades`)
+- Positions: derived canonical `Position` entities assembled from canonical trades/orders/execution events
+
+No `/paper/*` runtime endpoint uses legacy `trades` table payloads as the source of truth.
+
 ## Paper Account State
 
 `GET /paper/account` returns one explicit bounded state payload (all monetary fields use 4-decimal precision):
@@ -29,10 +40,21 @@ No mutation endpoints are introduced by this surface.
 
 Starting cash defaults to `100000` and can be overridden via `CILLY_PAPER_ACCOUNT_STARTING_CASH` (must be numeric and non-negative).
 
+`GET /paper/account` is derived from canonical Trading Core state:
+
+- `realized_pnl`: sum of canonical `Trade.realized_pnl` (null treated as `0`)
+- `unrealized_pnl`: sum of canonical `Trade.unrealized_pnl` (null treated as `0`)
+- `open_trades` / `closed_trades`: canonical `Trade.status`
+- `open_positions`: derived canonical `Position.status`
+- `cash`: `starting_cash + realized_pnl`
+- `equity`: `cash + unrealized_pnl`
+- `total_pnl`: `realized_pnl + unrealized_pnl`
+- `as_of`: max non-null timestamp across canonical trade open/close timestamps
+
 ## Trading Core Alignment
 
-- `GET /paper/trades` returns canonical `Trade` entities.
-- `GET /paper/positions` returns canonical `Position` entities derived from paper trades.
+- `GET /paper/trades` returns canonical `Trade` entities from Trading Core persistence.
+- `GET /paper/positions` returns canonical `Position` entities derived from canonical Trading Core entities.
 - Position/trade lifecycle state semantics follow the same canonical model constraints as Trading Core.
 
 ## Deterministic Ordering
@@ -65,5 +87,3 @@ Starting cash defaults to `100000` and can be overridden via `CILLY_PAPER_ACCOUN
   "total": 0
 }
 ```
-
-The JSON example block above is intentionally closed to keep the document valid for markdown renderers.

--- a/docs/operations/paper-trading.md
+++ b/docs/operations/paper-trading.md
@@ -26,6 +26,14 @@ The repository contains a deterministic engine-level paper-trading simulator. It
 - Paper order states use the canonical Trading Core order status values.
 - Transition legality and invariant checks are validated through the shared lifecycle guardrails.
 - Fill/cancel lifecycle events use canonical execution event shapes and deterministic event identity.
+- Paper inspection/account state is derived from canonical Trading Core entities (`Order`, `ExecutionEvent`, `Trade`) and derived canonical `Position` state, without legacy paper-trade payloads as authoritative truth.
+
+## Runtime State Flow (Authoritative)
+1. Paper order lifecycle simulator produces canonical order and execution-event transitions.
+2. Canonical entities are persisted through the Trading Core repository boundary.
+3. Canonical trades are read from Trading Core persistence for paper inspection.
+4. Canonical positions are deterministically derived from canonical trade/order/event relations.
+5. Paper account totals (`cash`, `equity`, `pnl`) are derived from canonical trade and position state.
 
 ## Explicit Boundaries
 - No live trading is implemented.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -68,7 +68,6 @@ from cilly_trading.engine.runtime_state import get_system_state_payload
 from cilly_trading.models import (
     ExecutionEvent,
     Order,
-    PersistedTradePayload,
     Position,
     SignalReadItemDTO,
     SignalReadResponseDTO,
@@ -77,7 +76,6 @@ from cilly_trading.models import (
 from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
 from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
-from cilly_trading.repositories.trades_sqlite import SqliteTradeRepository
 from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
 from cilly_trading.strategies.registry import (
     StrategyNotRegisteredError,
@@ -854,7 +852,6 @@ ANALYSIS_DB_PATH: Optional[str] = None
 signal_repo = SqliteSignalRepository()
 order_event_repo = SqliteOrderEventRepository(db_path=DEFAULT_DB_PATH)
 canonical_execution_repo = SqliteCanonicalExecutionRepository(db_path=DEFAULT_DB_PATH)
-paper_trade_repo = SqliteTradeRepository(db_path=DEFAULT_DB_PATH)
 analysis_run_repo = SqliteAnalysisRunRepository(db_path=DEFAULT_DB_PATH)
 watchlist_repo = SqliteWatchlistRepository(db_path=DEFAULT_DB_PATH)
 
@@ -1371,19 +1368,48 @@ def read_portfolio_positions(
 def read_paper_account(
     _: str = Depends(_require_role("read_only")),
 ) -> PaperAccountReadResponse:
-    snapshot = _load_paper_inspection_snapshot()
+    paper_trades = canonical_execution_repo.list_trades(
+        limit=1_000_000,
+        offset=0,
+    )
+    paper_positions = _build_trading_core_positions(
+        strategy_id=None,
+        symbol=None,
+        position_id=None,
+    )
+
+    starting_cash = _resolve_paper_starting_cash()
+    realized_pnl = _sum_decimals([trade.realized_pnl or Decimal("0") for trade in paper_trades])
+    unrealized_pnl = _sum_decimals([trade.unrealized_pnl or Decimal("0") for trade in paper_trades])
+    total_pnl = realized_pnl + unrealized_pnl
+    cash = starting_cash + realized_pnl
+    equity = cash + unrealized_pnl
+    open_positions = sum(1 for position in paper_positions if position.status == "open")
+    open_trades = sum(1 for trade in paper_trades if trade.status == "open")
+    closed_trades = sum(1 for trade in paper_trades if trade.status == "closed")
+
+    as_of_candidates = [
+        value
+        for value in [
+            *[trade.closed_at for trade in paper_trades],
+            *[trade.opened_at for trade in paper_trades],
+        ]
+        if value is not None
+    ]
+    as_of = max(as_of_candidates) if as_of_candidates else None
+
     return PaperAccountReadResponse(
         account=PaperAccountStateResponse(
-            starting_cash=snapshot.account.starting_cash,
-            cash=snapshot.account.cash,
-            equity=snapshot.account.equity,
-            realized_pnl=snapshot.account.realized_pnl,
-            unrealized_pnl=snapshot.account.unrealized_pnl,
-            total_pnl=snapshot.account.total_pnl,
-            open_positions=snapshot.account.open_positions,
-            open_trades=snapshot.account.open_trades,
-            closed_trades=snapshot.account.closed_trades,
-            as_of=snapshot.account.as_of,
+            starting_cash=starting_cash,
+            cash=cash,
+            equity=equity,
+            realized_pnl=realized_pnl,
+            unrealized_pnl=unrealized_pnl,
+            total_pnl=total_pnl,
+            open_positions=open_positions,
+            open_trades=open_trades,
+            closed_trades=closed_trades,
+            as_of=as_of,
         )
     )
 
@@ -1406,16 +1432,23 @@ def read_paper_trades(
         limit=limit,
         offset=offset,
     )
-    snapshot = _load_paper_inspection_snapshot()
-    all_items = list(snapshot.trades)
-    if params.strategy_id is not None:
-        all_items = [item for item in all_items if item.strategy_id == params.strategy_id]
-    if params.symbol is not None:
-        all_items = [item for item in all_items if item.symbol == params.symbol]
-    if params.position_id is not None:
-        all_items = [item for item in all_items if item.position_id == params.position_id]
-    if params.trade_id is not None:
-        all_items = [item for item in all_items if item.trade_id == params.trade_id]
+    if params.trade_id:
+        trade = canonical_execution_repo.get_trade(params.trade_id)
+        all_items = [] if trade is None else [trade]
+        if params.strategy_id is not None:
+            all_items = [item for item in all_items if item.strategy_id == params.strategy_id]
+        if params.symbol is not None:
+            all_items = [item for item in all_items if item.symbol == params.symbol]
+        if params.position_id is not None:
+            all_items = [item for item in all_items if item.position_id == params.position_id]
+    else:
+        all_items = canonical_execution_repo.list_trades(
+            strategy_id=params.strategy_id,
+            symbol=params.symbol,
+            position_id=params.position_id,
+            limit=1_000_000,
+            offset=0,
+        )
 
     page, total = _paginate_items(all_items, limit=params.limit, offset=params.offset)
     return PaperTradesReadResponse(
@@ -1442,14 +1475,11 @@ def read_paper_positions(
         limit=limit,
         offset=offset,
     )
-    snapshot = _load_paper_inspection_snapshot()
-    all_items = list(snapshot.positions)
-    if params.strategy_id is not None:
-        all_items = [item for item in all_items if item.strategy_id == params.strategy_id]
-    if params.symbol is not None:
-        all_items = [item for item in all_items if item.symbol == params.symbol]
-    if params.position_id is not None:
-        all_items = [item for item in all_items if item.position_id == params.position_id]
+    all_items = _build_trading_core_positions(
+        strategy_id=params.strategy_id,
+        symbol=params.symbol,
+        position_id=params.position_id,
+    )
 
     page, total = _paginate_items(all_items, limit=params.limit, offset=params.offset)
     return PaperPositionsReadResponse(
@@ -1619,16 +1649,6 @@ def _resolve_paper_starting_cash() -> Decimal:
     if value < Decimal("0"):
         raise HTTPException(status_code=500, detail="paper_account_starting_cash_invalid")
     return value
-
-
-def _load_paper_inspection_snapshot():
-    persisted: list[PersistedTradePayload] = paper_trade_repo.list_trades(limit=1_000_000)
-    ordered_persisted = list(reversed(persisted))
-    from cilly_trading.engine.paper_inspection import build_paper_inspection_snapshot
-    return build_paper_inspection_snapshot(
-        ordered_persisted,
-        starting_cash=_resolve_paper_starting_cash(),
-    )
 
 
 def _sum_decimals(values: list[Decimal]) -> Decimal:

--- a/tests/test_api_paper_inspection_read.py
+++ b/tests/test_api_paper_inspection_read.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from cilly_trading.models import ExecutionEvent, Order, Trade
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
+from tests.utils.json_schema_validator import validate_json_schema
+
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
+
+def _repo(tmp_path: Path) -> SqliteCanonicalExecutionRepository:
+    return SqliteCanonicalExecutionRepository(db_path=tmp_path / "paper-inspection.db")
+
+
+def _order(
+    order_id: str,
+    *,
+    sequence: int,
+    created_at: str,
+    position_id: str,
+    trade_id: str,
+) -> Order:
+    return Order.model_validate(
+        {
+            "order_id": order_id,
+            "strategy_id": "paper-strategy",
+            "symbol": "AAPL",
+            "sequence": sequence,
+            "side": "BUY",
+            "order_type": "market",
+            "time_in_force": "day",
+            "status": "filled",
+            "quantity": Decimal("1"),
+            "filled_quantity": Decimal("1"),
+            "created_at": created_at,
+            "submitted_at": created_at,
+            "average_fill_price": Decimal("100"),
+            "last_execution_event_id": f"evt-{sequence}",
+            "position_id": position_id,
+            "trade_id": trade_id,
+        }
+    )
+
+
+def _event(
+    event_id: str,
+    order_id: str,
+    *,
+    occurred_at: str,
+    sequence: int,
+    position_id: str,
+    trade_id: str,
+) -> ExecutionEvent:
+    return ExecutionEvent.model_validate(
+        {
+            "event_id": event_id,
+            "order_id": order_id,
+            "strategy_id": "paper-strategy",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "event_type": "filled",
+            "occurred_at": occurred_at,
+            "sequence": sequence,
+            "execution_quantity": Decimal("1"),
+            "execution_price": Decimal("100"),
+            "commission": Decimal("0"),
+            "position_id": position_id,
+            "trade_id": trade_id,
+        }
+    )
+
+
+def _trade(
+    trade_id: str,
+    *,
+    position_id: str,
+    status: str,
+    opened_at: str,
+    closed_at: str | None,
+    realized_pnl: str | None,
+    unrealized_pnl: str | None,
+    order_id: str,
+    event_id: str,
+) -> Trade:
+    return Trade.model_validate(
+        {
+            "trade_id": trade_id,
+            "position_id": position_id,
+            "strategy_id": "paper-strategy",
+            "symbol": "AAPL",
+            "direction": "long",
+            "status": status,
+            "opened_at": opened_at,
+            "closed_at": closed_at,
+            "quantity_opened": Decimal("1"),
+            "quantity_closed": Decimal("1") if status == "closed" else Decimal("0"),
+            "average_entry_price": Decimal("100"),
+            "average_exit_price": Decimal("101") if status == "closed" else None,
+            "realized_pnl": Decimal(realized_pnl) if realized_pnl is not None else None,
+            "unrealized_pnl": Decimal(unrealized_pnl) if unrealized_pnl is not None else None,
+            "opening_order_ids": [order_id],
+            "closing_order_ids": [order_id] if status == "closed" else [],
+            "execution_event_ids": [event_id],
+        }
+    )
+
+
+def _seed_core_data(repo: SqliteCanonicalExecutionRepository) -> None:
+    repo.save_order(
+        _order(
+            "ord-1",
+            sequence=1,
+            created_at="2025-01-01T09:00:00Z",
+            position_id="pos-1",
+            trade_id="trade-1",
+        )
+    )
+    repo.save_order(
+        _order(
+            "ord-2",
+            sequence=2,
+            created_at="2025-01-01T09:02:00Z",
+            position_id="pos-2",
+            trade_id="trade-2",
+        )
+    )
+    repo.save_execution_events(
+        [
+            _event(
+                "evt-1",
+                "ord-1",
+                occurred_at="2025-01-01T09:01:00Z",
+                sequence=1,
+                position_id="pos-1",
+                trade_id="trade-1",
+            ),
+            _event(
+                "evt-2",
+                "ord-2",
+                occurred_at="2025-01-01T09:03:00Z",
+                sequence=2,
+                position_id="pos-2",
+                trade_id="trade-2",
+            ),
+        ]
+    )
+    repo.save_trade(
+        _trade(
+            "trade-1",
+            position_id="pos-1",
+            status="closed",
+            opened_at="2025-01-01T09:00:00Z",
+            closed_at="2025-01-01T09:10:00Z",
+            realized_pnl="1.5",
+            unrealized_pnl=None,
+            order_id="ord-1",
+            event_id="evt-1",
+        )
+    )
+    repo.save_trade(
+        _trade(
+            "trade-2",
+            position_id="pos-2",
+            status="open",
+            opened_at="2025-01-01T09:02:00Z",
+            closed_at=None,
+            realized_pnl=None,
+            unrealized_pnl="2.25",
+            order_id="ord-2",
+            event_id="evt-2",
+        )
+    )
+
+
+def _test_client(monkeypatch, repo: SqliteCanonicalExecutionRepository) -> TestClient:
+    monkeypatch.setattr(api_main, "canonical_execution_repo", repo)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
+    return TestClient(api_main.app)
+
+
+def test_paper_endpoints_are_exposed_and_schema_valid(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    _seed_core_data(repo)
+
+    with _test_client(monkeypatch, repo) as client:
+        trades = client.get("/paper/trades", headers=READ_ONLY_HEADERS)
+        positions = client.get("/paper/positions", headers=READ_ONLY_HEADERS)
+        account = client.get("/paper/account", headers=READ_ONLY_HEADERS)
+        openapi = client.get("/openapi.json").json()
+
+    assert trades.status_code == 200
+    assert positions.status_code == 200
+    assert account.status_code == 200
+    assert "/paper/trades" in openapi["paths"]
+    assert "/paper/positions" in openapi["paths"]
+    assert "/paper/account" in openapi["paths"]
+
+    assert validate_json_schema(trades.json(), api_main.PaperTradesReadResponse.model_json_schema()) == []
+    assert validate_json_schema(positions.json(), api_main.PaperPositionsReadResponse.model_json_schema()) == []
+    assert validate_json_schema(account.json(), api_main.PaperAccountReadResponse.model_json_schema()) == []
+
+
+def test_paper_views_match_trading_core_authoritative_state(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    _seed_core_data(repo)
+
+    with _test_client(monkeypatch, repo) as client:
+        paper_trades = client.get("/paper/trades", headers=READ_ONLY_HEADERS).json()
+        core_trades = client.get("/trading-core/trades", headers=READ_ONLY_HEADERS).json()
+        paper_positions = client.get("/paper/positions", headers=READ_ONLY_HEADERS).json()
+        core_positions = client.get("/trading-core/positions", headers=READ_ONLY_HEADERS).json()
+
+    assert paper_trades == core_trades
+    assert paper_positions == core_positions
+
+
+def test_paper_account_is_derived_from_canonical_trades(tmp_path: Path, monkeypatch) -> None:
+    repo = _repo(tmp_path)
+    _seed_core_data(repo)
+    monkeypatch.setenv("CILLY_PAPER_ACCOUNT_STARTING_CASH", "100000")
+
+    with _test_client(monkeypatch, repo) as client:
+        first = client.get("/paper/account", headers=READ_ONLY_HEADERS)
+        second = client.get("/paper/account", headers=READ_ONLY_HEADERS)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert first.json() == {
+        "account": {
+            "starting_cash": "100000",
+            "cash": "100001.5",
+            "equity": "100003.75",
+            "realized_pnl": "1.5",
+            "unrealized_pnl": "2.25",
+            "total_pnl": "3.75",
+            "open_positions": 1,
+            "open_trades": 1,
+            "closed_trades": 1,
+            "as_of": "2025-01-01T09:10:00Z",
+        }
+    }


### PR DESCRIPTION
closes #757

## Goal
Introduce canonical /paper/* inspection endpoints aligned with Trading Core state.

## Scope
- /paper/account
- /paper/trades
- /paper/positions
- Canonical state derivation (Trade/Position)
- Documentation alignment

## Validation
- Targeted tests: PASS
- Full test suite: PASS (692 tests)

## Notes
- Read-only inspection only
- No mutation endpoints
- Fix: closed JSON code block in docs/api/paper_inspection.md

## Readiness
- Engineering: READY
- Trader Validation: PARTIAL
- Operational: LIMITED