### PR TITLE
SIM-P44A: paper inspection reconciliation coverage (#758)

### DIFF
--- a/docs/api/paper_inspection.md
+++ b/docs/api/paper_inspection.md
@@ -9,6 +9,7 @@ All endpoints require `X-Cilly-Role: read_only` (or a higher role).
 - `GET /paper/account`
 - `GET /paper/trades`
 - `GET /paper/positions`
+- `GET /paper/reconciliation`
 
 No mutation endpoints are introduced by this surface.
 
@@ -56,6 +57,20 @@ Starting cash defaults to `100000` and can be overridden via `CILLY_PAPER_ACCOUN
 - `GET /paper/trades` returns canonical `Trade` entities from Trading Core persistence.
 - `GET /paper/positions` returns canonical `Position` entities derived from canonical Trading Core entities.
 - Position/trade lifecycle state semantics follow the same canonical model constraints as Trading Core.
+- `GET /paper/reconciliation` reads canonical orders, execution events, trades, positions, and derived paper account state from the same runtime source and reports deterministic reconciliation mismatches.
+
+## End-to-End Inspection Path
+
+This is the minimum operator inspection path for paper trading from order intent to account state:
+
+1. Read order intent and final order state from `GET /trading-core/orders`.
+2. Read lifecycle transitions and fills from `GET /trading-core/execution-events` (`created` -> `submitted` -> fill states).
+3. Read resulting trade lifecycle from `GET /trading-core/trades`.
+4. Read derived position state from `GET /trading-core/positions`.
+5. Read paper-facing account state from `GET /paper/account`.
+6. Run `GET /paper/reconciliation` and require `ok: true` with `summary.mismatches: 0`.
+
+`GET /paper/reconciliation` fails closed for operational validation: any missing cross-reference or account equation mismatch is returned in `mismatch_items` with deterministic `code`, `entity_type`, and `entity_id` values.
 
 ## Deterministic Ordering
 
@@ -77,7 +92,7 @@ Starting cash defaults to `100000` and can be overridden via `CILLY_PAPER_ACCOUN
 
 ## Response Shape
 
-`GET /paper/trades` and `GET /paper/positions` use:
+### `GET /paper/trades` and `GET /paper/positions`
 
 ```json
 {
@@ -87,3 +102,42 @@ Starting cash defaults to `100000` and can be overridden via `CILLY_PAPER_ACCOUN
   "total": 0
 }
 ```
+
+### `GET /paper/reconciliation`
+
+```json
+{
+  "ok": true,
+  "summary": {
+    "orders": 0,
+    "execution_events": 0,
+    "trades": 0,
+    "positions": 0,
+    "open_trades": 0,
+    "closed_trades": 0,
+    "open_positions": 0,
+    "mismatches": 0
+  },
+  "account": {
+    "starting_cash": "100000",
+    "cash": "100000",
+    "equity": "100000",
+    "realized_pnl": "0",
+    "unrealized_pnl": "0",
+    "total_pnl": "0",
+    "open_positions": 0,
+    "open_trades": 0,
+    "closed_trades": 0,
+    "as_of": null
+  },
+  "mismatch_items": []
+}
+```
+
+## Deterministic Evidence
+
+- Integration coverage validates this path with deterministic lifecycle events in:
+  - `tests/test_api_paper_inspection_read.py::test_paper_reconciliation_matches_deterministic_lifecycle_outputs`
+  - `tests/test_api_paper_inspection_read.py::test_paper_reconciliation_detects_missing_execution_event_reference`
+- Reproducible focused test command: `.\.venv\Scripts\python -m pytest tests/test_api_paper_inspection_read.py -q`
+- Reproducible full-suite test command: `.\.venv\Scripts\python -m pytest`

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Use this order:
 ## API Usage
 - [API usage](operations/api/usage.md)
 - [Trading core inspection API](api/trading_core_inspection.md)
+- [Paper inspection and reconciliation API](api/paper_inspection.md)
 - [Phase 39 runtime chart data contract](operations/api/runtime_chart_data_contract.md)
 - Legacy compatibility alias: `docs/api/runtime_chart_data_contract.md`
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -530,6 +530,37 @@ class PaperPositionsReadResponse(BaseModel):
     total: int
 
 
+class PaperReconciliationMismatchResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    message: str
+    entity_type: Optional[str] = None
+    entity_id: Optional[str] = None
+
+
+class PaperReconciliationSummaryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    orders: int
+    execution_events: int
+    trades: int
+    positions: int
+    open_trades: int
+    closed_trades: int
+    open_positions: int
+    mismatches: int
+
+
+class PaperReconciliationReadResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ok: bool
+    summary: PaperReconciliationSummaryResponse
+    account: PaperAccountStateResponse
+    mismatch_items: List[PaperReconciliationMismatchResponse]
+
+
 class ScreenerResultsQuery(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1368,49 +1399,18 @@ def read_portfolio_positions(
 def read_paper_account(
     _: str = Depends(_require_role("read_only")),
 ) -> PaperAccountReadResponse:
-    paper_trades = canonical_execution_repo.list_trades(
-        limit=1_000_000,
-        offset=0,
-    )
-    paper_positions = _build_trading_core_positions(
-        strategy_id=None,
-        symbol=None,
-        position_id=None,
-    )
-
-    starting_cash = _resolve_paper_starting_cash()
-    realized_pnl = _sum_decimals([trade.realized_pnl or Decimal("0") for trade in paper_trades])
-    unrealized_pnl = _sum_decimals([trade.unrealized_pnl or Decimal("0") for trade in paper_trades])
-    total_pnl = realized_pnl + unrealized_pnl
-    cash = starting_cash + realized_pnl
-    equity = cash + unrealized_pnl
-    open_positions = sum(1 for position in paper_positions if position.status == "open")
-    open_trades = sum(1 for trade in paper_trades if trade.status == "open")
-    closed_trades = sum(1 for trade in paper_trades if trade.status == "closed")
-
-    as_of_candidates = [
-        value
-        for value in [
-            *[trade.closed_at for trade in paper_trades],
-            *[trade.opened_at for trade in paper_trades],
-        ]
-        if value is not None
-    ]
-    as_of = max(as_of_candidates) if as_of_candidates else None
-
     return PaperAccountReadResponse(
-        account=PaperAccountStateResponse(
-            starting_cash=starting_cash,
-            cash=cash,
-            equity=equity,
-            realized_pnl=realized_pnl,
-            unrealized_pnl=unrealized_pnl,
-            total_pnl=total_pnl,
-            open_positions=open_positions,
-            open_trades=open_trades,
-            closed_trades=closed_trades,
-            as_of=as_of,
-        )
+        account=_build_paper_account_state(
+            paper_trades=canonical_execution_repo.list_trades(
+                limit=1_000_000,
+                offset=0,
+            ),
+            paper_positions=_build_trading_core_positions(
+                strategy_id=None,
+                symbol=None,
+                position_id=None,
+            ),
+        ),
     )
 
 
@@ -1487,6 +1487,39 @@ def read_paper_positions(
         limit=params.limit,
         offset=params.offset,
         total=total,
+    )
+
+
+@app.get("/paper/reconciliation", response_model=PaperReconciliationReadResponse)
+def read_paper_reconciliation(
+    _: str = Depends(_require_role("read_only")),
+) -> PaperReconciliationReadResponse:
+    orders = canonical_execution_repo.list_orders(limit=1_000_000, offset=0)
+    execution_events = canonical_execution_repo.list_execution_events(limit=1_000_000, offset=0)
+    trades = canonical_execution_repo.list_trades(limit=1_000_000, offset=0)
+    positions = _build_trading_core_positions(strategy_id=None, symbol=None, position_id=None)
+    account = _build_paper_account_state(paper_trades=trades, paper_positions=positions)
+    mismatch_items = _build_paper_reconciliation_mismatches(
+        orders=orders,
+        execution_events=execution_events,
+        trades=trades,
+        positions=positions,
+        account=account,
+    )
+    return PaperReconciliationReadResponse(
+        ok=not mismatch_items,
+        summary=PaperReconciliationSummaryResponse(
+            orders=len(orders),
+            execution_events=len(execution_events),
+            trades=len(trades),
+            positions=len(positions),
+            open_trades=sum(1 for trade in trades if trade.status == "open"),
+            closed_trades=sum(1 for trade in trades if trade.status == "closed"),
+            open_positions=sum(1 for position in positions if position.status == "open"),
+            mismatches=len(mismatch_items),
+        ),
+        account=account,
+        mismatch_items=mismatch_items,
     )
 
 
@@ -1653,6 +1686,285 @@ def _resolve_paper_starting_cash() -> Decimal:
 
 def _sum_decimals(values: list[Decimal]) -> Decimal:
     return sum(values, Decimal("0"))
+
+
+def _build_paper_account_state(
+    *,
+    paper_trades: list[Trade],
+    paper_positions: list[Position],
+) -> PaperAccountStateResponse:
+    starting_cash = _resolve_paper_starting_cash()
+    realized_pnl = _sum_decimals([trade.realized_pnl or Decimal("0") for trade in paper_trades])
+    unrealized_pnl = _sum_decimals([trade.unrealized_pnl or Decimal("0") for trade in paper_trades])
+    total_pnl = realized_pnl + unrealized_pnl
+    cash = starting_cash + realized_pnl
+    equity = cash + unrealized_pnl
+    open_positions = sum(1 for position in paper_positions if position.status == "open")
+    open_trades = sum(1 for trade in paper_trades if trade.status == "open")
+    closed_trades = sum(1 for trade in paper_trades if trade.status == "closed")
+
+    as_of_candidates = [
+        value
+        for value in [
+            *[trade.closed_at for trade in paper_trades],
+            *[trade.opened_at for trade in paper_trades],
+        ]
+        if value is not None
+    ]
+    as_of = max(as_of_candidates) if as_of_candidates else None
+
+    return PaperAccountStateResponse(
+        starting_cash=starting_cash,
+        cash=cash,
+        equity=equity,
+        realized_pnl=realized_pnl,
+        unrealized_pnl=unrealized_pnl,
+        total_pnl=total_pnl,
+        open_positions=open_positions,
+        open_trades=open_trades,
+        closed_trades=closed_trades,
+        as_of=as_of,
+    )
+
+
+def _build_paper_reconciliation_mismatches(
+    *,
+    orders: list[Order],
+    execution_events: list[ExecutionEvent],
+    trades: list[Trade],
+    positions: list[Position],
+    account: PaperAccountStateResponse,
+) -> list[PaperReconciliationMismatchResponse]:
+    mismatches: list[PaperReconciliationMismatchResponse] = []
+    orders_by_id = {order.order_id: order for order in orders}
+    execution_events_by_id = {event.event_id: event for event in execution_events}
+    trades_by_id = {trade.trade_id: trade for trade in trades}
+    positions_by_id = {position.position_id: position for position in positions}
+
+    for event in execution_events:
+        if event.order_id not in orders_by_id:
+            mismatches.append(
+                PaperReconciliationMismatchResponse(
+                    code="execution_event_order_missing",
+                    message=f"execution event references unknown order_id={event.order_id}",
+                    entity_type="execution_event",
+                    entity_id=event.event_id,
+                )
+            )
+
+    for trade in trades:
+        if trade.position_id not in positions_by_id:
+            mismatches.append(
+                PaperReconciliationMismatchResponse(
+                    code="trade_position_missing",
+                    message=f"trade references unknown position_id={trade.position_id}",
+                    entity_type="trade",
+                    entity_id=trade.trade_id,
+                )
+            )
+
+        for order_id in [*trade.opening_order_ids, *trade.closing_order_ids]:
+            order = orders_by_id.get(order_id)
+            if order is None:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="trade_order_missing",
+                        message=f"trade references unknown order_id={order_id}",
+                        entity_type="trade",
+                        entity_id=trade.trade_id,
+                    )
+                )
+                continue
+            if order.trade_id is not None and order.trade_id != trade.trade_id:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="trade_order_trade_mismatch",
+                        message=f"order trade_id={order.trade_id} does not match trade_id={trade.trade_id}",
+                        entity_type="trade",
+                        entity_id=trade.trade_id,
+                    )
+                )
+
+        for event_id in trade.execution_event_ids:
+            event = execution_events_by_id.get(event_id)
+            if event is None:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="trade_execution_event_missing",
+                        message=f"trade references unknown execution_event_id={event_id}",
+                        entity_type="trade",
+                        entity_id=trade.trade_id,
+                    )
+                )
+                continue
+            if event.trade_id is not None and event.trade_id != trade.trade_id:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="trade_execution_event_trade_mismatch",
+                        message=f"execution event trade_id={event.trade_id} does not match trade_id={trade.trade_id}",
+                        entity_type="trade",
+                        entity_id=trade.trade_id,
+                    )
+                )
+
+    for position in positions:
+        for trade_id in position.trade_ids:
+            trade = trades_by_id.get(trade_id)
+            if trade is None:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="position_trade_missing",
+                        message=f"position references unknown trade_id={trade_id}",
+                        entity_type="position",
+                        entity_id=position.position_id,
+                    )
+                )
+                continue
+            if trade.position_id != position.position_id:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="position_trade_position_mismatch",
+                        message=f"trade position_id={trade.position_id} does not match position_id={position.position_id}",
+                        entity_type="position",
+                        entity_id=position.position_id,
+                    )
+                )
+
+        for order_id in position.order_ids:
+            order = orders_by_id.get(order_id)
+            if order is None:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="position_order_missing",
+                        message=f"position references unknown order_id={order_id}",
+                        entity_type="position",
+                        entity_id=position.position_id,
+                    )
+                )
+                continue
+            if order.position_id is not None and order.position_id != position.position_id:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="position_order_position_mismatch",
+                        message=f"order position_id={order.position_id} does not match position_id={position.position_id}",
+                        entity_type="position",
+                        entity_id=position.position_id,
+                    )
+                )
+
+        for event_id in position.execution_event_ids:
+            event = execution_events_by_id.get(event_id)
+            if event is None:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="position_execution_event_missing",
+                        message=f"position references unknown execution_event_id={event_id}",
+                        entity_type="position",
+                        entity_id=position.position_id,
+                    )
+                )
+                continue
+            if event.position_id is not None and event.position_id != position.position_id:
+                mismatches.append(
+                    PaperReconciliationMismatchResponse(
+                        code="position_execution_event_position_mismatch",
+                        message=f"execution event position_id={event.position_id} does not match position_id={position.position_id}",
+                        entity_type="position",
+                        entity_id=position.position_id,
+                    )
+                )
+
+    expected_open_trades = sum(1 for trade in trades if trade.status == "open")
+    expected_closed_trades = sum(1 for trade in trades if trade.status == "closed")
+    expected_open_positions = sum(1 for position in positions if position.status == "open")
+    expected_realized_pnl = _sum_decimals([trade.realized_pnl or Decimal("0") for trade in trades])
+    expected_unrealized_pnl = _sum_decimals([trade.unrealized_pnl or Decimal("0") for trade in trades])
+    expected_total_pnl = expected_realized_pnl + expected_unrealized_pnl
+    expected_cash = account.starting_cash + expected_realized_pnl
+    expected_equity = expected_cash + expected_unrealized_pnl
+
+    if account.open_trades != expected_open_trades:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_open_trades_mismatch",
+                message=f"open_trades={account.open_trades} expected={expected_open_trades}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+    if account.closed_trades != expected_closed_trades:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_closed_trades_mismatch",
+                message=f"closed_trades={account.closed_trades} expected={expected_closed_trades}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+    if account.open_positions != expected_open_positions:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_open_positions_mismatch",
+                message=f"open_positions={account.open_positions} expected={expected_open_positions}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+    if account.realized_pnl != expected_realized_pnl:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_realized_pnl_mismatch",
+                message=f"realized_pnl={account.realized_pnl} expected={expected_realized_pnl}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+    if account.unrealized_pnl != expected_unrealized_pnl:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_unrealized_pnl_mismatch",
+                message=f"unrealized_pnl={account.unrealized_pnl} expected={expected_unrealized_pnl}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+    if account.total_pnl != expected_total_pnl:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_total_pnl_mismatch",
+                message=f"total_pnl={account.total_pnl} expected={expected_total_pnl}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+    if account.cash != expected_cash:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_cash_mismatch",
+                message=f"cash={account.cash} expected={expected_cash}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+    if account.equity != expected_equity:
+        mismatches.append(
+            PaperReconciliationMismatchResponse(
+                code="paper_account_equity_mismatch",
+                message=f"equity={account.equity} expected={expected_equity}",
+                entity_type="paper_account",
+                entity_id="account",
+            )
+        )
+
+    return sorted(
+        mismatches,
+        key=lambda mismatch: (
+            mismatch.code,
+            mismatch.entity_type or "",
+            mismatch.entity_id or "",
+            mismatch.message,
+        ),
+    )
 
 
 def _weighted_average(*, values: list[tuple[Decimal, Decimal]]) -> Optional[Decimal]:

--- a/tests/test_api_paper_inspection_read.py
+++ b/tests/test_api_paper_inspection_read.py
@@ -6,6 +6,11 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 import api.main as api_main
+from cilly_trading.engine.paper_order_lifecycle import (
+    PaperOrderLifecycleRequest,
+    PaperOrderLifecycleSimulator,
+    PaperOrderStep,
+)
 from cilly_trading.models import ExecutionEvent, Order, Trade
 from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
 from tests.utils.json_schema_validator import validate_json_schema
@@ -184,6 +189,66 @@ def _test_client(monkeypatch, repo: SqliteCanonicalExecutionRepository) -> TestC
     return TestClient(api_main.app)
 
 
+def _seed_lifecycle_data(repo: SqliteCanonicalExecutionRepository) -> None:
+    simulator = PaperOrderLifecycleSimulator()
+    lifecycle = simulator.run(
+        request=PaperOrderLifecycleRequest(
+            order_id="ord-lifecycle-1",
+            strategy_id="paper-strategy",
+            symbol="AAPL",
+            side="BUY",
+            quantity=Decimal("2"),
+            created_at="2025-01-01T09:00:00Z",
+            submitted_at="2025-01-01T09:00:01Z",
+            sequence=1,
+            position_id="pos-lifecycle-1",
+            trade_id="trade-lifecycle-1",
+        ),
+        steps=[
+            PaperOrderStep(
+                occurred_at="2025-01-01T09:00:10Z",
+                action="fill",
+                quantity=Decimal("1"),
+                price=Decimal("100"),
+                commission=Decimal("0"),
+            ),
+            PaperOrderStep(
+                occurred_at="2025-01-01T09:00:20Z",
+                action="fill",
+                quantity=Decimal("1"),
+                price=Decimal("101"),
+                commission=Decimal("0"),
+            ),
+        ],
+    )
+
+    repo.save_order(lifecycle.final_order)
+    repo.save_execution_events(list(lifecycle.execution_events))
+    repo.save_trade(
+        Trade.model_validate(
+            {
+                "trade_id": "trade-lifecycle-1",
+                "position_id": "pos-lifecycle-1",
+                "strategy_id": "paper-strategy",
+                "symbol": "AAPL",
+                "direction": "long",
+                "status": "open",
+                "opened_at": "2025-01-01T09:00:00Z",
+                "closed_at": None,
+                "quantity_opened": Decimal("2"),
+                "quantity_closed": Decimal("0"),
+                "average_entry_price": Decimal("100.5"),
+                "average_exit_price": None,
+                "realized_pnl": None,
+                "unrealized_pnl": Decimal("2"),
+                "opening_order_ids": ["ord-lifecycle-1"],
+                "closing_order_ids": [],
+                "execution_event_ids": [event.event_id for event in lifecycle.execution_events],
+            }
+        )
+    )
+
+
 def test_paper_endpoints_are_exposed_and_schema_valid(tmp_path: Path, monkeypatch) -> None:
     repo = _repo(tmp_path)
     _seed_core_data(repo)
@@ -192,18 +257,28 @@ def test_paper_endpoints_are_exposed_and_schema_valid(tmp_path: Path, monkeypatc
         trades = client.get("/paper/trades", headers=READ_ONLY_HEADERS)
         positions = client.get("/paper/positions", headers=READ_ONLY_HEADERS)
         account = client.get("/paper/account", headers=READ_ONLY_HEADERS)
+        reconciliation = client.get("/paper/reconciliation", headers=READ_ONLY_HEADERS)
         openapi = client.get("/openapi.json").json()
 
     assert trades.status_code == 200
     assert positions.status_code == 200
     assert account.status_code == 200
+    assert reconciliation.status_code == 200
     assert "/paper/trades" in openapi["paths"]
     assert "/paper/positions" in openapi["paths"]
     assert "/paper/account" in openapi["paths"]
+    assert "/paper/reconciliation" in openapi["paths"]
 
     assert validate_json_schema(trades.json(), api_main.PaperTradesReadResponse.model_json_schema()) == []
     assert validate_json_schema(positions.json(), api_main.PaperPositionsReadResponse.model_json_schema()) == []
     assert validate_json_schema(account.json(), api_main.PaperAccountReadResponse.model_json_schema()) == []
+    assert (
+        validate_json_schema(
+            reconciliation.json(),
+            api_main.PaperReconciliationReadResponse.model_json_schema(),
+        )
+        == []
+    )
 
 
 def test_paper_views_match_trading_core_authoritative_state(tmp_path: Path, monkeypatch) -> None:
@@ -246,3 +321,109 @@ def test_paper_account_is_derived_from_canonical_trades(tmp_path: Path, monkeypa
             "as_of": "2025-01-01T09:10:00Z",
         }
     }
+
+
+def test_paper_reconciliation_matches_deterministic_lifecycle_outputs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _repo(tmp_path)
+    _seed_lifecycle_data(repo)
+    monkeypatch.setenv("CILLY_PAPER_ACCOUNT_STARTING_CASH", "100000")
+
+    with _test_client(monkeypatch, repo) as client:
+        first_reconciliation = client.get("/paper/reconciliation", headers=READ_ONLY_HEADERS)
+        second_reconciliation = client.get("/paper/reconciliation", headers=READ_ONLY_HEADERS)
+        core_orders = client.get("/trading-core/orders", headers=READ_ONLY_HEADERS).json()
+        core_events = client.get("/trading-core/execution-events", headers=READ_ONLY_HEADERS).json()
+        core_trades = client.get("/trading-core/trades", headers=READ_ONLY_HEADERS).json()
+        core_positions = client.get("/trading-core/positions", headers=READ_ONLY_HEADERS).json()
+        paper_trades = client.get("/paper/trades", headers=READ_ONLY_HEADERS).json()
+        paper_positions = client.get("/paper/positions", headers=READ_ONLY_HEADERS).json()
+        paper_account = client.get("/paper/account", headers=READ_ONLY_HEADERS).json()
+
+    assert first_reconciliation.status_code == 200
+    assert second_reconciliation.status_code == 200
+    assert first_reconciliation.json() == second_reconciliation.json()
+
+    reconciliation = first_reconciliation.json()
+    assert reconciliation["ok"] is True
+    assert reconciliation["summary"] == {
+        "orders": 1,
+        "execution_events": 4,
+        "trades": 1,
+        "positions": 1,
+        "open_trades": 1,
+        "closed_trades": 0,
+        "open_positions": 1,
+        "mismatches": 0,
+    }
+    assert reconciliation["mismatch_items"] == []
+    assert reconciliation["account"] == paper_account["account"]
+
+    assert [item["status"] for item in core_orders["items"]] == ["filled"]
+    assert [item["event_type"] for item in core_events["items"]] == [
+        "created",
+        "submitted",
+        "partially_filled",
+        "filled",
+    ]
+    assert [item["trade_id"] for item in core_trades["items"]] == ["trade-lifecycle-1"]
+    assert [item["position_id"] for item in core_positions["items"]] == ["pos-lifecycle-1"]
+    assert paper_trades == core_trades
+    assert paper_positions == core_positions
+    assert paper_account == {
+        "account": {
+            "starting_cash": "100000",
+            "cash": "100000",
+            "equity": "100002",
+            "realized_pnl": "0",
+            "unrealized_pnl": "2",
+            "total_pnl": "2",
+            "open_positions": 1,
+            "open_trades": 1,
+            "closed_trades": 0,
+            "as_of": "2025-01-01T09:00:00Z",
+        }
+    }
+
+
+def test_paper_reconciliation_detects_missing_execution_event_reference(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _repo(tmp_path)
+    _seed_core_data(repo)
+    repo.save_trade(
+        _trade(
+            "trade-2",
+            position_id="pos-2",
+            status="open",
+            opened_at="2025-01-01T09:02:00Z",
+            closed_at=None,
+            realized_pnl=None,
+            unrealized_pnl="2.25",
+            order_id="ord-2",
+            event_id="evt-missing",
+        )
+    )
+
+    with _test_client(monkeypatch, repo) as client:
+        response = client.get("/paper/reconciliation", headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["summary"]["mismatches"] == 2
+    assert payload["mismatch_items"] == [
+        {
+            "code": "position_execution_event_missing",
+            "message": "position references unknown execution_event_id=evt-missing",
+            "entity_type": "position",
+            "entity_id": "pos-2",
+        },
+        {
+            "code": "trade_execution_event_missing",
+            "message": "trade references unknown execution_event_id=evt-missing",
+            "entity_type": "trade",
+            "entity_id": "trade-2",
+        },
+    ]


### PR DESCRIPTION
## Goal
Add deterministic end-to-end reconciliation for paper-trading inspection.

## In Scope
- GET /paper/reconciliation (read-only)
- Deterministic reconciliation across:
  - orders
  - execution events
  - trades
  - positions
  - account state
- Mismatch detection with explicit codes
- API test coverage (happy path + failing path)
- Documentation of operator inspection workflow

## Out of Scope
- No live trading
- No mutation endpoints
- No UI / dashboard expansion
- No architecture changes

## Validation
- Targeted:
  .\.venv\Scripts\python -m pytest tests/test_api_paper_inspection_read.py -q
- Full suite:
  .\.venv\Scripts\python -m pytest

## Results
- 694 tests passed
- Deterministic reconciliation verified
- Mismatch detection reproducible

## Readiness Classification
- Engineering: READY
- Trader Validation: PARTIAL
- Operational: LIMITED (read-only inspection)

## Notes
- Improves operator-level validation of canonical Trading Core state
- Does not complete Phase 44 (paper trading productization)