### PR TITLE
RISK-P43A: close portfolio decision pipeline from signal prioritization to exposure approval (#759)

### DIFF
--- a/docs/architecture/risk/portfolio_framework.md
+++ b/docs/architecture/risk/portfolio_framework.md
@@ -219,3 +219,40 @@ This model is intentionally bounded and reusable:
 - no broker/live enforcement
 - no optimization/re-ranking logic
 - pure deterministic transformations suitable for later simulation and execution phases
+
+## 11. Canonical Portfolio Decision Pipeline (Issue #759)
+
+Issue #759 closes the portfolio decision path in one canonical pure-function sequence:
+
+- `src/cilly_trading/portfolio_framework/capital_allocation_policy.py`
+- `run_portfolio_decision_pipeline(...)`
+
+The covered path is:
+
+1. Ranked signal input is sorted with the existing deterministic prioritization rules.
+2. An explicit `PortfolioDecisionIntent` is created for each ranked signal.
+3. If no valid allocation intent can be formed, the signal ends with outcome `rejected`.
+4. If an allocation intent exists, a proposed portfolio state is built from that intent.
+5. The proposed state is evaluated through both:
+   - `assess_capital_allocation(...)`
+   - `assess_portfolio_guardrails(...)`
+6. Only if both checks approve does the signal end with outcome `approved` and mutate the working portfolio state.
+7. If allocation intent exists but either enforcement layer fails, the signal ends with outcome `constraint_hit`, the reasons remain inspectable, and the working portfolio state is unchanged.
+
+### 11.1 Outcome Semantics
+
+`PortfolioDecisionRecord` exposes one explicit final outcome per signal:
+
+- `approved`
+- `rejected`
+- `constraint_hit`
+
+The record also carries:
+
+- the ranked allocation intent
+- any proposed portfolio state used for exposure approval
+- the capital-allocation assessment
+- the portfolio-guardrail assessment
+- deterministic ordered outcome reasons
+
+This removes the ambiguous partial path where allocation and exposure enforcement could be reasoned about separately instead of through one inspectable decision sequence.

--- a/src/cilly_trading/portfolio_framework/__init__.py
+++ b/src/cilly_trading/portfolio_framework/__init__.py
@@ -4,6 +4,9 @@ from cilly_trading.portfolio_framework.capital_allocation_policy import (
     BoundedPositionSizingHook,
     CapitalAllocationAssessment,
     CapitalAllocationRules,
+    PortfolioDecisionIntent,
+    PortfolioDecisionRecord,
+    PortfolioDecisionResult,
     PrioritizedAllocationConfig,
     PrioritizedAllocationDecision,
     PrioritizedAllocationResult,
@@ -12,6 +15,7 @@ from cilly_trading.portfolio_framework.capital_allocation_policy import (
     StrategyAllocationRule,
     allocate_prioritized_signals,
     assess_capital_allocation,
+    run_portfolio_decision_pipeline,
 )
 from cilly_trading.portfolio_framework.contract import PortfolioPosition, PortfolioState
 from cilly_trading.portfolio_framework.exposure_aggregator import (
@@ -30,6 +34,9 @@ __all__ = [
     "BoundedPositionSizingHook",
     "CapitalAllocationAssessment",
     "CapitalAllocationRules",
+    "PortfolioDecisionIntent",
+    "PortfolioDecisionRecord",
+    "PortfolioDecisionResult",
     "PortfolioGuardrailAssessment",
     "PortfolioGuardrailLimits",
     "PrioritizedAllocationConfig",
@@ -48,4 +55,5 @@ __all__ = [
     "aggregate_portfolio_exposure",
     "allocate_prioritized_signals",
     "assess_capital_allocation",
+    "run_portfolio_decision_pipeline",
 ]

--- a/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
+++ b/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Literal
 
-from cilly_trading.portfolio_framework.contract import PortfolioState
+from cilly_trading.portfolio_framework.contract import PortfolioPosition, PortfolioState
 from cilly_trading.portfolio_framework.exposure_aggregator import aggregate_portfolio_exposure
+from cilly_trading.portfolio_framework.guardrails import (
+    PortfolioGuardrailAssessment,
+    PortfolioGuardrailLimits,
+    assess_portfolio_guardrails,
+)
 
 
 @dataclass(frozen=True)
@@ -104,6 +109,8 @@ class PrioritizedAllocationSignal:
     requested_notional: float
     signal_timestamp: str
     max_position_notional: float | None = None
+    mark_price: float = 1.0
+    side: Literal["long", "short"] = "long"
 
 
 @dataclass(frozen=True)
@@ -146,6 +153,51 @@ class PrioritizedAllocationResult:
     decisions: tuple[PrioritizedAllocationDecision, ...]
     accepted_signal_ids: tuple[str, ...]
     total_allocated_notional: float
+    remaining_capital_notional: float
+
+
+@dataclass(frozen=True)
+class PortfolioDecisionIntent:
+    """Inspectable allocation intent for one ranked signal."""
+
+    signal_id: str
+    strategy_id: str
+    symbol: str
+    priority_rank: int
+    tie_break_key: tuple[float, str, str, str, str]
+    requested_notional: float
+    bounded_requested_notional: float
+    allocated_notional: float
+    capital_before_signal: float
+    capital_after_signal: float
+    accepted: bool
+    rejection_reason: str | None
+
+
+@dataclass(frozen=True)
+class PortfolioDecisionRecord:
+    """Canonical decision record from ranked signal to final outcome."""
+
+    signal_id: str
+    strategy_id: str
+    symbol: str
+    intent: PortfolioDecisionIntent
+    outcome: Literal["approved", "rejected", "constraint_hit"]
+    outcome_reasons: tuple[str, ...]
+    proposed_state: PortfolioState | None
+    allocation_assessment: CapitalAllocationAssessment | None
+    guardrail_assessment: PortfolioGuardrailAssessment | None
+
+
+@dataclass(frozen=True)
+class PortfolioDecisionResult:
+    """Deterministic result for the canonical portfolio decision pipeline."""
+
+    decisions: tuple[PortfolioDecisionRecord, ...]
+    approved_signal_ids: tuple[str, ...]
+    rejected_signal_ids: tuple[str, ...]
+    constraint_hit_signal_ids: tuple[str, ...]
+    final_state: PortfolioState
     remaining_capital_notional: float
 
 
@@ -312,6 +364,198 @@ def allocate_prioritized_signals(
     )
 
 
+def run_portfolio_decision_pipeline(
+    *,
+    state: PortfolioState,
+    signals: tuple[PrioritizedAllocationSignal, ...],
+    allocation_config: PrioritizedAllocationConfig,
+    allocation_rules: CapitalAllocationRules,
+    guardrail_limits: PortfolioGuardrailLimits,
+    bounded_position_sizing_hook: BoundedPositionSizingHook | None = None,
+) -> PortfolioDecisionResult:
+    """Run the canonical ranked-signal to approval pipeline deterministically.
+
+    Sequence:
+    1) rank signal
+    2) build allocation intent
+    3) propose state mutation
+    4) enforce capital allocation assessment
+    5) enforce portfolio guardrails
+    6) emit explicit approved/rejected/constraint_hit outcome
+    """
+
+    ranked_signals = tuple(sorted(signals, key=_priority_sort_key))
+    remaining_capital = max(allocation_config.available_capital_notional, 0.0)
+    approved_positions = 0
+    working_state = state
+    decisions: list[PortfolioDecisionRecord] = []
+
+    for index, signal in enumerate(ranked_signals):
+        priority_rank = index + 1
+        tie_break_key = _priority_sort_key(signal)
+        bounded_requested_notional = _bounded_requested_notional(
+            signal=signal,
+            config=allocation_config,
+        )
+        capital_before_signal = remaining_capital
+        intent_rejection_reason = _allocation_rejection_reason(
+            remaining_capital=remaining_capital,
+            accepted_positions=approved_positions,
+            config=allocation_config,
+            bounded_requested_notional=bounded_requested_notional,
+        )
+
+        if intent_rejection_reason != "not_allocated":
+            intent = PortfolioDecisionIntent(
+                signal_id=signal.signal_id,
+                strategy_id=signal.strategy_id,
+                symbol=signal.symbol,
+                priority_rank=priority_rank,
+                tie_break_key=tie_break_key,
+                requested_notional=signal.requested_notional,
+                bounded_requested_notional=bounded_requested_notional,
+                allocated_notional=0.0,
+                capital_before_signal=capital_before_signal,
+                capital_after_signal=remaining_capital,
+                accepted=False,
+                rejection_reason=intent_rejection_reason,
+            )
+            decisions.append(
+                PortfolioDecisionRecord(
+                    signal_id=signal.signal_id,
+                    strategy_id=signal.strategy_id,
+                    symbol=signal.symbol,
+                    intent=intent,
+                    outcome="rejected",
+                    outcome_reasons=(intent_rejection_reason,),
+                    proposed_state=None,
+                    allocation_assessment=None,
+                    guardrail_assessment=None,
+                )
+            )
+            continue
+
+        proposed_notional = min(bounded_requested_notional, remaining_capital)
+        allocated_notional = _apply_bounded_position_sizing_hook(
+            signal=signal,
+            proposed_notional=proposed_notional,
+            bounded_position_sizing_hook=bounded_position_sizing_hook,
+        )
+        allocated_notional = min(max(allocated_notional, 0.0), proposed_notional)
+
+        if allocated_notional < allocation_config.min_allocation_notional:
+            intent = PortfolioDecisionIntent(
+                signal_id=signal.signal_id,
+                strategy_id=signal.strategy_id,
+                symbol=signal.symbol,
+                priority_rank=priority_rank,
+                tie_break_key=tie_break_key,
+                requested_notional=signal.requested_notional,
+                bounded_requested_notional=bounded_requested_notional,
+                allocated_notional=0.0,
+                capital_before_signal=capital_before_signal,
+                capital_after_signal=remaining_capital,
+                accepted=False,
+                rejection_reason="below_min_allocation_after_bounded_sizing",
+            )
+            decisions.append(
+                PortfolioDecisionRecord(
+                    signal_id=signal.signal_id,
+                    strategy_id=signal.strategy_id,
+                    symbol=signal.symbol,
+                    intent=intent,
+                    outcome="rejected",
+                    outcome_reasons=("below_min_allocation_after_bounded_sizing",),
+                    proposed_state=None,
+                    allocation_assessment=None,
+                    guardrail_assessment=None,
+                )
+            )
+            continue
+
+        proposed_state = _append_allocated_position(
+            state=working_state,
+            signal=signal,
+            allocated_notional=allocated_notional,
+        )
+        allocation_assessment = assess_capital_allocation(proposed_state, allocation_rules)
+        guardrail_assessment = assess_portfolio_guardrails(proposed_state, guardrail_limits)
+        constraint_reasons = allocation_assessment.reasons + guardrail_assessment.reasons
+
+        if constraint_reasons:
+            intent = PortfolioDecisionIntent(
+                signal_id=signal.signal_id,
+                strategy_id=signal.strategy_id,
+                symbol=signal.symbol,
+                priority_rank=priority_rank,
+                tie_break_key=tie_break_key,
+                requested_notional=signal.requested_notional,
+                bounded_requested_notional=bounded_requested_notional,
+                allocated_notional=allocated_notional,
+                capital_before_signal=capital_before_signal,
+                capital_after_signal=remaining_capital,
+                accepted=True,
+                rejection_reason=None,
+            )
+            decisions.append(
+                PortfolioDecisionRecord(
+                    signal_id=signal.signal_id,
+                    strategy_id=signal.strategy_id,
+                    symbol=signal.symbol,
+                    intent=intent,
+                    outcome="constraint_hit",
+                    outcome_reasons=constraint_reasons,
+                    proposed_state=proposed_state,
+                    allocation_assessment=allocation_assessment,
+                    guardrail_assessment=guardrail_assessment,
+                )
+            )
+            continue
+
+        remaining_capital -= allocated_notional
+        approved_positions += 1
+        working_state = proposed_state
+        intent = PortfolioDecisionIntent(
+            signal_id=signal.signal_id,
+            strategy_id=signal.strategy_id,
+            symbol=signal.symbol,
+            priority_rank=priority_rank,
+            tie_break_key=tie_break_key,
+            requested_notional=signal.requested_notional,
+            bounded_requested_notional=bounded_requested_notional,
+            allocated_notional=allocated_notional,
+            capital_before_signal=capital_before_signal,
+            capital_after_signal=remaining_capital,
+            accepted=True,
+            rejection_reason=None,
+        )
+        decisions.append(
+            PortfolioDecisionRecord(
+                signal_id=signal.signal_id,
+                strategy_id=signal.strategy_id,
+                symbol=signal.symbol,
+                intent=intent,
+                outcome="approved",
+                outcome_reasons=(),
+                proposed_state=proposed_state,
+                allocation_assessment=allocation_assessment,
+                guardrail_assessment=guardrail_assessment,
+            )
+        )
+
+    decision_rows = tuple(decisions)
+    return PortfolioDecisionResult(
+        decisions=decision_rows,
+        approved_signal_ids=tuple(item.signal_id for item in decision_rows if item.outcome == "approved"),
+        rejected_signal_ids=tuple(item.signal_id for item in decision_rows if item.outcome == "rejected"),
+        constraint_hit_signal_ids=tuple(
+            item.signal_id for item in decision_rows if item.outcome == "constraint_hit"
+        ),
+        final_state=working_state,
+        remaining_capital_notional=remaining_capital,
+    )
+
+
 def _assess_strategy(
     *,
     rule: StrategyAllocationRule,
@@ -452,3 +696,39 @@ def _safe_ratio(numerator: float, denominator: float) -> float:
     if denominator == 0.0:
         return 0.0
     return numerator / denominator
+
+
+def _append_allocated_position(
+    *,
+    state: PortfolioState,
+    signal: PrioritizedAllocationSignal,
+    allocated_notional: float,
+) -> PortfolioState:
+    signed_quantity = _signed_quantity_from_notional(
+        allocated_notional=allocated_notional,
+        mark_price=signal.mark_price,
+        side=signal.side,
+    )
+    return PortfolioState(
+        account_equity=state.account_equity,
+        positions=state.positions
+        + (
+            PortfolioPosition(
+                strategy_id=signal.strategy_id,
+                symbol=signal.symbol,
+                quantity=signed_quantity,
+                mark_price=signal.mark_price,
+            ),
+        ),
+    )
+
+
+def _signed_quantity_from_notional(
+    *,
+    allocated_notional: float,
+    mark_price: float,
+    side: Literal["long", "short"],
+) -> float:
+    safe_mark_price = max(mark_price, 1.0)
+    quantity = allocated_notional / safe_mark_price
+    return quantity if side == "long" else -quantity

--- a/tests/portfolio/test_portfolio_decision_pipeline.py
+++ b/tests/portfolio/test_portfolio_decision_pipeline.py
@@ -1,0 +1,196 @@
+"""Tests for the canonical portfolio decision pipeline (Issue #759)."""
+
+from __future__ import annotations
+
+from cilly_trading.portfolio_framework import (
+    CapitalAllocationRules,
+    PortfolioGuardrailLimits,
+    PortfolioPosition,
+    PortfolioState,
+    PrioritizedAllocationConfig,
+    PrioritizedAllocationSignal,
+    StrategyAllocationRule,
+    run_portfolio_decision_pipeline,
+)
+
+
+def _allocation_rules() -> CapitalAllocationRules:
+    return CapitalAllocationRules(
+        global_capital_cap_pct=0.60,
+        strategy_rules=(
+            StrategyAllocationRule(
+                strategy_id="alpha",
+                capital_cap_pct=0.60,
+                allocation_score=1.0,
+            ),
+            StrategyAllocationRule(
+                strategy_id="beta",
+                capital_cap_pct=0.60,
+                allocation_score=1.0,
+            ),
+        ),
+    )
+
+
+def _guardrail_limits() -> PortfolioGuardrailLimits:
+    return PortfolioGuardrailLimits(
+        max_gross_exposure_pct=0.60,
+        max_abs_net_exposure_pct=0.60,
+        max_offset_exposure_pct=0.20,
+        max_strategy_concentration_pct=1.0,
+        max_symbol_concentration_pct=1.0,
+        max_position_concentration_pct=1.0,
+    )
+
+
+def test_pipeline_approves_signal_and_persists_it_in_final_state() -> None:
+    result = run_portfolio_decision_pipeline(
+        state=PortfolioState(account_equity=1_000.0, positions=()),
+        signals=(
+            PrioritizedAllocationSignal(
+                signal_id="sig-1",
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                priority_score=90.0,
+                requested_notional=250.0,
+                signal_timestamp="2026-03-24T09:00:00Z",
+                mark_price=100.0,
+            ),
+        ),
+        allocation_config=PrioritizedAllocationConfig(
+            available_capital_notional=300.0,
+            max_positions=2,
+            default_position_cap_notional=300.0,
+            min_allocation_notional=50.0,
+        ),
+        allocation_rules=_allocation_rules(),
+        guardrail_limits=_guardrail_limits(),
+    )
+
+    assert result.approved_signal_ids == ("sig-1",)
+    assert result.rejected_signal_ids == ()
+    assert result.constraint_hit_signal_ids == ()
+    assert result.remaining_capital_notional == 50.0
+    assert len(result.final_state.positions) == 1
+    assert result.decisions[0].outcome == "approved"
+    assert result.decisions[0].allocation_assessment is not None
+    assert result.decisions[0].guardrail_assessment is not None
+    assert result.decisions[0].intent.capital_after_signal == 50.0
+
+
+def test_pipeline_rejects_signal_before_exposure_checks_when_intent_is_below_minimum() -> None:
+    result = run_portfolio_decision_pipeline(
+        state=PortfolioState(account_equity=1_000.0, positions=()),
+        signals=(
+            PrioritizedAllocationSignal(
+                signal_id="sig-small",
+                strategy_id="alpha",
+                symbol="ETHUSDT",
+                priority_score=90.0,
+                requested_notional=25.0,
+                signal_timestamp="2026-03-24T09:00:00Z",
+            ),
+        ),
+        allocation_config=PrioritizedAllocationConfig(
+            available_capital_notional=300.0,
+            max_positions=2,
+            default_position_cap_notional=300.0,
+            min_allocation_notional=50.0,
+        ),
+        allocation_rules=_allocation_rules(),
+        guardrail_limits=_guardrail_limits(),
+    )
+
+    assert result.approved_signal_ids == ()
+    assert result.rejected_signal_ids == ("sig-small",)
+    assert result.constraint_hit_signal_ids == ()
+    assert result.final_state.positions == ()
+    assert result.decisions[0].outcome == "rejected"
+    assert result.decisions[0].outcome_reasons == ("below_min_allocation",)
+    assert result.decisions[0].allocation_assessment is None
+    assert result.decisions[0].guardrail_assessment is None
+
+
+def test_pipeline_resolves_prioritization_conflicts_deterministically() -> None:
+    result = run_portfolio_decision_pipeline(
+        state=PortfolioState(account_equity=1_000.0, positions=()),
+        signals=(
+            PrioritizedAllocationSignal(
+                signal_id="sig-b",
+                strategy_id="alpha",
+                symbol="ETHUSDT",
+                priority_score=90.0,
+                requested_notional=100.0,
+                signal_timestamp="2026-03-24T09:00:00Z",
+            ),
+            PrioritizedAllocationSignal(
+                signal_id="sig-a",
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                priority_score=90.0,
+                requested_notional=100.0,
+                signal_timestamp="2026-03-24T09:00:00Z",
+            ),
+        ),
+        allocation_config=PrioritizedAllocationConfig(
+            available_capital_notional=200.0,
+            max_positions=1,
+            default_position_cap_notional=100.0,
+            min_allocation_notional=10.0,
+        ),
+        allocation_rules=_allocation_rules(),
+        guardrail_limits=_guardrail_limits(),
+    )
+
+    assert [item.signal_id for item in result.decisions] == ["sig-a", "sig-b"]
+    assert [item.intent.priority_rank for item in result.decisions] == [1, 2]
+    assert result.approved_signal_ids == ("sig-a",)
+    assert result.rejected_signal_ids == ("sig-b",)
+    assert result.decisions[1].outcome_reasons == ("position_limit_reached",)
+
+
+def test_pipeline_marks_exposure_limit_constraint_hits_without_mutating_state() -> None:
+    initial_state = PortfolioState(
+        account_equity=1_000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                quantity=4.5,
+                mark_price=100.0,
+            ),
+        ),
+    )
+
+    result = run_portfolio_decision_pipeline(
+        state=initial_state,
+        signals=(
+            PrioritizedAllocationSignal(
+                signal_id="sig-risk",
+                strategy_id="alpha",
+                symbol="ETHUSDT",
+                priority_score=90.0,
+                requested_notional=200.0,
+                signal_timestamp="2026-03-24T09:00:00Z",
+                mark_price=100.0,
+            ),
+        ),
+        allocation_config=PrioritizedAllocationConfig(
+            available_capital_notional=300.0,
+            max_positions=2,
+            default_position_cap_notional=300.0,
+            min_allocation_notional=10.0,
+        ),
+        allocation_rules=_allocation_rules(),
+        guardrail_limits=_guardrail_limits(),
+    )
+
+    assert result.approved_signal_ids == ()
+    assert result.rejected_signal_ids == ()
+    assert result.constraint_hit_signal_ids == ("sig-risk",)
+    assert result.final_state == initial_state
+    assert result.remaining_capital_notional == 300.0
+    assert result.decisions[0].outcome == "constraint_hit"
+    assert "global_cap_exceeded" in result.decisions[0].outcome_reasons[0]
+    assert result.decisions[0].allocation_assessment is not None
+    assert result.decisions[0].guardrail_assessment is not None


### PR DESCRIPTION
Closes #759

## Summary
- add un_portfolio_decision_pipeline(...) as the canonical ranked-signal to approval/rejection/constraint-hit flow
- expose inspectable decision artifacts for allocation intent, exposure checks, and final outcomes
- keep state and capital mutation limited to fully approved decisions
- document the canonical sequence in the portfolio framework architecture doc

## Testing
- python -m pytest tests\portfolio tests\risk

## Covered decision cases
- approval path
- pre-exposure rejection path
- deterministic prioritization conflict resolution
- exposure-limit constraint-hit path

## Readiness Classification
- Engineering: READY
- Trader Validation: PARTIAL
- Operational: LIMITED

## Scope Guard
- no broker or execution integration
- no live-trading rollout
- no UI expansion
- no architecture drift outside portfolio framework scope