### PR TITLE
RISK-P43A: Harden portfolio-level risk decisions and concentration outcomes (#760)

### DIFF
--- a/docs/architecture/risk/portfolio_framework.md
+++ b/docs/architecture/risk/portfolio_framework.md
@@ -254,5 +254,25 @@ The record also carries:
 - the capital-allocation assessment
 - the portfolio-guardrail assessment
 - deterministic ordered outcome reasons
+- `primary_constraint` for the first blocking reason in deterministic order
+- `constraint_categories` derived deterministically from the blocking reason set:
+  - `capacity`
+  - `allocation`
+  - `exposure`
+  - `concentration`
+  - `sizing`
 
 This removes the ambiguous partial path where allocation and exposure enforcement could be reasoned about separately instead of through one inspectable decision sequence.
+
+### 11.2 Competing-Signal Capacity Semantics
+
+When signals compete for constrained portfolio capacity, the pipeline remains strictly rank-ordered and inspectable:
+
+1. Higher-priority approved signals consume capital and position slots first.
+2. Lower-priority signals never displace earlier approvals.
+3. A capacity rejection is emitted explicitly with:
+   - `primary_constraint` of `capital_exhausted` or `position_limit_reached`
+   - `constraint_categories=("capacity",)`
+   - `intent.higher_priority_approved_signal_ids` listing the approved signals that consumed capacity earlier in the same run
+
+This keeps constrained-capacity behavior deterministic and operator-inspectable without introducing optimization or trader-readiness claims beyond the verified decision semantics.

--- a/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
+++ b/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
@@ -170,6 +170,7 @@ class PortfolioDecisionIntent:
     allocated_notional: float
     capital_before_signal: float
     capital_after_signal: float
+    higher_priority_approved_signal_ids: tuple[str, ...]
     accepted: bool
     rejection_reason: str | None
 
@@ -184,6 +185,11 @@ class PortfolioDecisionRecord:
     intent: PortfolioDecisionIntent
     outcome: Literal["approved", "rejected", "constraint_hit"]
     outcome_reasons: tuple[str, ...]
+    primary_constraint: str | None
+    constraint_categories: tuple[
+        Literal["allocation", "capacity", "concentration", "exposure", "sizing"],
+        ...
+    ]
     proposed_state: PortfolioState | None
     allocation_assessment: CapitalAllocationAssessment | None
     guardrail_assessment: PortfolioGuardrailAssessment | None
@@ -389,6 +395,7 @@ def run_portfolio_decision_pipeline(
     approved_positions = 0
     working_state = state
     decisions: list[PortfolioDecisionRecord] = []
+    approved_signal_ids_in_order: list[str] = []
 
     for index, signal in enumerate(ranked_signals):
         priority_rank = index + 1
@@ -398,6 +405,7 @@ def run_portfolio_decision_pipeline(
             config=allocation_config,
         )
         capital_before_signal = remaining_capital
+        higher_priority_approved_signal_ids = tuple(approved_signal_ids_in_order)
         intent_rejection_reason = _allocation_rejection_reason(
             remaining_capital=remaining_capital,
             accepted_positions=approved_positions,
@@ -417,9 +425,11 @@ def run_portfolio_decision_pipeline(
                 allocated_notional=0.0,
                 capital_before_signal=capital_before_signal,
                 capital_after_signal=remaining_capital,
+                higher_priority_approved_signal_ids=higher_priority_approved_signal_ids,
                 accepted=False,
                 rejection_reason=intent_rejection_reason,
             )
+            outcome_reasons = (intent_rejection_reason,)
             decisions.append(
                 PortfolioDecisionRecord(
                     signal_id=signal.signal_id,
@@ -427,7 +437,9 @@ def run_portfolio_decision_pipeline(
                     symbol=signal.symbol,
                     intent=intent,
                     outcome="rejected",
-                    outcome_reasons=(intent_rejection_reason,),
+                    outcome_reasons=outcome_reasons,
+                    primary_constraint=intent_rejection_reason,
+                    constraint_categories=_classify_constraint_categories(outcome_reasons),
                     proposed_state=None,
                     allocation_assessment=None,
                     guardrail_assessment=None,
@@ -455,9 +467,11 @@ def run_portfolio_decision_pipeline(
                 allocated_notional=0.0,
                 capital_before_signal=capital_before_signal,
                 capital_after_signal=remaining_capital,
+                higher_priority_approved_signal_ids=higher_priority_approved_signal_ids,
                 accepted=False,
                 rejection_reason="below_min_allocation_after_bounded_sizing",
             )
+            outcome_reasons = ("below_min_allocation_after_bounded_sizing",)
             decisions.append(
                 PortfolioDecisionRecord(
                     signal_id=signal.signal_id,
@@ -465,7 +479,9 @@ def run_portfolio_decision_pipeline(
                     symbol=signal.symbol,
                     intent=intent,
                     outcome="rejected",
-                    outcome_reasons=("below_min_allocation_after_bounded_sizing",),
+                    outcome_reasons=outcome_reasons,
+                    primary_constraint="below_min_allocation_after_bounded_sizing",
+                    constraint_categories=_classify_constraint_categories(outcome_reasons),
                     proposed_state=None,
                     allocation_assessment=None,
                     guardrail_assessment=None,
@@ -494,6 +510,7 @@ def run_portfolio_decision_pipeline(
                 allocated_notional=allocated_notional,
                 capital_before_signal=capital_before_signal,
                 capital_after_signal=remaining_capital,
+                higher_priority_approved_signal_ids=higher_priority_approved_signal_ids,
                 accepted=True,
                 rejection_reason=None,
             )
@@ -505,6 +522,8 @@ def run_portfolio_decision_pipeline(
                     intent=intent,
                     outcome="constraint_hit",
                     outcome_reasons=constraint_reasons,
+                    primary_constraint=constraint_reasons[0] if constraint_reasons else None,
+                    constraint_categories=_classify_constraint_categories(constraint_reasons),
                     proposed_state=proposed_state,
                     allocation_assessment=allocation_assessment,
                     guardrail_assessment=guardrail_assessment,
@@ -515,6 +534,7 @@ def run_portfolio_decision_pipeline(
         remaining_capital -= allocated_notional
         approved_positions += 1
         working_state = proposed_state
+        approved_signal_ids_in_order.append(signal.signal_id)
         intent = PortfolioDecisionIntent(
             signal_id=signal.signal_id,
             strategy_id=signal.strategy_id,
@@ -526,6 +546,7 @@ def run_portfolio_decision_pipeline(
             allocated_notional=allocated_notional,
             capital_before_signal=capital_before_signal,
             capital_after_signal=remaining_capital,
+            higher_priority_approved_signal_ids=higher_priority_approved_signal_ids,
             accepted=True,
             rejection_reason=None,
         )
@@ -537,6 +558,8 @@ def run_portfolio_decision_pipeline(
                 intent=intent,
                 outcome="approved",
                 outcome_reasons=(),
+                primary_constraint=None,
+                constraint_categories=(),
                 proposed_state=proposed_state,
                 allocation_assessment=allocation_assessment,
                 guardrail_assessment=guardrail_assessment,
@@ -644,6 +667,41 @@ def _allocation_rejection_reason(
     if bounded_requested_notional < config.min_allocation_notional:
         return "below_min_allocation"
     return "not_allocated"
+
+
+def _classify_constraint_categories(
+    reasons: tuple[str, ...],
+) -> tuple[Literal["allocation", "capacity", "concentration", "exposure", "sizing"], ...]:
+    ordered_categories: list[
+        Literal["allocation", "capacity", "concentration", "exposure", "sizing"]
+    ] = []
+
+    for reason in reasons:
+        category = _constraint_category(reason)
+        if category not in ordered_categories:
+            ordered_categories.append(category)
+
+    return tuple(ordered_categories)
+
+
+def _constraint_category(
+    reason: str,
+) -> Literal["allocation", "capacity", "concentration", "exposure", "sizing"]:
+    if reason in {"position_limit_reached", "capital_exhausted"}:
+        return "capacity"
+    if reason in {"below_min_allocation", "below_min_allocation_after_bounded_sizing"}:
+        return "sizing"
+    if reason.startswith("global_cap_exceeded") or reason.startswith("strategy_cap_exceeded"):
+        return "allocation"
+    if "type=gross_exposure_pct" in reason or "type=abs_net_exposure_pct" in reason or "type=offset_exposure_pct" in reason:
+        return "exposure"
+    if (
+        "type=strategy_concentration_pct" in reason
+        or "type=symbol_concentration_pct" in reason
+        or "type=position_concentration_pct" in reason
+    ):
+        return "concentration"
+    raise ValueError(f"unsupported portfolio decision reason: {reason}")
 
 
 def _build_reasons(

--- a/tests/portfolio/test_portfolio_decision_pipeline.py
+++ b/tests/portfolio/test_portfolio_decision_pipeline.py
@@ -73,8 +73,11 @@ def test_pipeline_approves_signal_and_persists_it_in_final_state() -> None:
     assert result.remaining_capital_notional == 50.0
     assert len(result.final_state.positions) == 1
     assert result.decisions[0].outcome == "approved"
+    assert result.decisions[0].primary_constraint is None
+    assert result.decisions[0].constraint_categories == ()
     assert result.decisions[0].allocation_assessment is not None
     assert result.decisions[0].guardrail_assessment is not None
+    assert result.decisions[0].intent.higher_priority_approved_signal_ids == ()
     assert result.decisions[0].intent.capital_after_signal == 50.0
 
 
@@ -106,6 +109,8 @@ def test_pipeline_rejects_signal_before_exposure_checks_when_intent_is_below_min
     assert result.constraint_hit_signal_ids == ()
     assert result.final_state.positions == ()
     assert result.decisions[0].outcome == "rejected"
+    assert result.decisions[0].primary_constraint == "below_min_allocation"
+    assert result.decisions[0].constraint_categories == ("sizing",)
     assert result.decisions[0].outcome_reasons == ("below_min_allocation",)
     assert result.decisions[0].allocation_assessment is None
     assert result.decisions[0].guardrail_assessment is None
@@ -146,10 +151,13 @@ def test_pipeline_resolves_prioritization_conflicts_deterministically() -> None:
     assert [item.intent.priority_rank for item in result.decisions] == [1, 2]
     assert result.approved_signal_ids == ("sig-a",)
     assert result.rejected_signal_ids == ("sig-b",)
+    assert result.decisions[1].primary_constraint == "position_limit_reached"
+    assert result.decisions[1].constraint_categories == ("capacity",)
+    assert result.decisions[1].intent.higher_priority_approved_signal_ids == ("sig-a",)
     assert result.decisions[1].outcome_reasons == ("position_limit_reached",)
 
 
-def test_pipeline_marks_exposure_limit_constraint_hits_without_mutating_state() -> None:
+def test_pipeline_marks_exposure_guardrail_constraint_hits_without_mutating_state() -> None:
     initial_state = PortfolioState(
         account_equity=1_000.0,
         positions=(
@@ -166,7 +174,7 @@ def test_pipeline_marks_exposure_limit_constraint_hits_without_mutating_state() 
         state=initial_state,
         signals=(
             PrioritizedAllocationSignal(
-                signal_id="sig-risk",
+                signal_id="sig-exposure",
                 strategy_id="alpha",
                 symbol="ETHUSDT",
                 priority_score=90.0,
@@ -181,16 +189,93 @@ def test_pipeline_marks_exposure_limit_constraint_hits_without_mutating_state() 
             default_position_cap_notional=300.0,
             min_allocation_notional=10.0,
         ),
-        allocation_rules=_allocation_rules(),
-        guardrail_limits=_guardrail_limits(),
+        allocation_rules=CapitalAllocationRules(
+            global_capital_cap_pct=1.0,
+            strategy_rules=(
+                StrategyAllocationRule(
+                    strategy_id="alpha",
+                    capital_cap_pct=1.0,
+                    allocation_score=1.0,
+                ),
+            ),
+        ),
+        guardrail_limits=PortfolioGuardrailLimits(
+            max_gross_exposure_pct=0.60,
+            max_abs_net_exposure_pct=1.0,
+            max_offset_exposure_pct=1.0,
+            max_strategy_concentration_pct=1.0,
+            max_symbol_concentration_pct=1.0,
+            max_position_concentration_pct=1.0,
+        ),
     )
 
     assert result.approved_signal_ids == ()
     assert result.rejected_signal_ids == ()
-    assert result.constraint_hit_signal_ids == ("sig-risk",)
+    assert result.constraint_hit_signal_ids == ("sig-exposure",)
     assert result.final_state == initial_state
     assert result.remaining_capital_notional == 300.0
     assert result.decisions[0].outcome == "constraint_hit"
-    assert "global_cap_exceeded" in result.decisions[0].outcome_reasons[0]
+    assert result.decisions[0].primary_constraint == (
+        "guardrail_exceeded: type=gross_exposure_pct observed=0.65 limit=0.6"
+    )
+    assert result.decisions[0].constraint_categories == ("exposure",)
+    assert result.decisions[0].intent.higher_priority_approved_signal_ids == ()
+    assert result.decisions[0].outcome_reasons == (
+        "guardrail_exceeded: type=gross_exposure_pct observed=0.65 limit=0.6",
+    )
     assert result.decisions[0].allocation_assessment is not None
     assert result.decisions[0].guardrail_assessment is not None
+
+
+def test_pipeline_marks_concentration_constraint_hits_with_explicit_categories() -> None:
+    result = run_portfolio_decision_pipeline(
+        state=PortfolioState(account_equity=1_000.0, positions=()),
+        signals=(
+            PrioritizedAllocationSignal(
+                signal_id="sig-concentration",
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                priority_score=90.0,
+                requested_notional=250.0,
+                signal_timestamp="2026-03-24T09:00:00Z",
+                mark_price=100.0,
+            ),
+        ),
+        allocation_config=PrioritizedAllocationConfig(
+            available_capital_notional=300.0,
+            max_positions=2,
+            default_position_cap_notional=300.0,
+            min_allocation_notional=10.0,
+        ),
+        allocation_rules=CapitalAllocationRules(
+            global_capital_cap_pct=1.0,
+            strategy_rules=(
+                StrategyAllocationRule(
+                    strategy_id="alpha",
+                    capital_cap_pct=1.0,
+                    allocation_score=1.0,
+                ),
+            ),
+        ),
+        guardrail_limits=PortfolioGuardrailLimits(
+            max_gross_exposure_pct=1.0,
+            max_abs_net_exposure_pct=1.0,
+            max_offset_exposure_pct=1.0,
+            max_strategy_concentration_pct=0.90,
+            max_symbol_concentration_pct=0.90,
+            max_position_concentration_pct=0.90,
+        ),
+    )
+
+    assert result.approved_signal_ids == ()
+    assert result.constraint_hit_signal_ids == ("sig-concentration",)
+    assert result.decisions[0].outcome == "constraint_hit"
+    assert result.decisions[0].constraint_categories == ("concentration",)
+    assert result.decisions[0].primary_constraint == (
+        "guardrail_exceeded: type=strategy_concentration_pct observed=1.0 limit=0.9"
+    )
+    assert result.decisions[0].outcome_reasons == (
+        "guardrail_exceeded: type=strategy_concentration_pct observed=1.0 limit=0.9",
+        "guardrail_exceeded: type=symbol_concentration_pct observed=1.0 limit=0.9",
+        "guardrail_exceeded: type=position_concentration_pct observed=1.0 limit=0.9",
+    )


### PR DESCRIPTION
Closes #760

## Summary
- add explicit inspectable portfolio decision semantics with primary_constraint and deterministic constraint_categories
- record higher_priority_approved_signal_ids so constrained-capacity competing-signal outcomes are attributable to earlier approvals
- add deterministic scenario coverage for capacity competition, exposure guardrail hits, and concentration guardrail hits
- document bounded operator-inspection semantics for portfolio decision outcomes

## Test Evidence
- python -m pytest tests\portfolio
- 30 tests passed

## Trader-Relevant Evidence
- portfolio decisions now explicitly distinguish exposure, concentration, allocation, capacity, and sizing outcomes
- higher-priority approved signals are now visible on later constrained-capacity rejections
- constraint-hit decisions are verified to leave the working portfolio state unchanged

## Scope Guard
- no broker or execution integration
- no live-trading rollout
- no UI expansion
- no architecture drift outside portfolio framework scope