### PR TITLE
BT-P42B2: Strengthen trader-facing reproducible backtest evidence and boundaries (#762)

### DIFF
--- a/docs/testing/backtesting/backtest_cli.md
+++ b/docs/testing/backtesting/backtest_cli.md
@@ -41,3 +41,31 @@ If the file cannot be read, cannot be parsed as JSON, or the top-level value is 
 
 The `backtest` command installs the determinism guard at startup and uninstalls it in a `finally` block.
 If forbidden non-deterministic APIs are used during execution, the command exits with code `10`.
+
+## Reproducible Evidence Fields
+
+The produced `backtest-result.json` is the trader-review evidence surface for the covered path.
+For reproducible review, the following fields are mandatory:
+
+- `run.run_id`: explicit run identity.
+- `run.deterministic`: explicit deterministic execution flag (`true` on covered path).
+- `snapshot_linkage`: bounded dataset window and count used for the run.
+- `run_config.execution_assumptions`: explicit execution assumptions used for fill timing, slippage, commission, and price source.
+- `run_config.reproducibility_metadata`: run identity context (`run_id`, strategy identity, params, engine identity).
+- `metrics_baseline.assumptions`: assumption echo used for cost-aware metric interpretation.
+
+Evidence alignment rule for covered outputs:
+
+- `metrics_baseline.assumptions` MUST match `run_config.execution_assumptions`.
+
+## Trader Interpretation Boundary
+
+The produced evidence is valid only for deterministic replay under the declared assumptions and snapshot input.
+It supports trader review for what this specific replay path did under those constraints.
+
+The evidence does **not** prove:
+
+- Live trading readiness.
+- Broker fill quality or market-impact realism beyond the fixed deterministic model.
+- Portfolio-level decision quality outside the covered backtest output scope.
+- Future performance, out-of-sample robustness, or production profitability.

--- a/tests/test_backtest_cli.py
+++ b/tests/test_backtest_cli.py
@@ -137,3 +137,135 @@ def test_cli_backtest_determinism_violation_exit_10(tmp_path: Path) -> None:
 
     assert result.returncode == 10
     assert "Determinism violation" in result.stderr
+
+
+def test_cli_backtest_repeated_runs_emit_reproducible_evidence_with_explicit_assumptions(
+    tmp_path: Path,
+) -> None:
+    snapshots_path = tmp_path / "snapshots.json"
+    snapshots_path.write_text(
+        json.dumps(
+            [
+                {"id": "s1", "timestamp": "2024-01-01T00:00:00Z", "symbol": "AAPL", "open": "100"},
+                {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "101"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    run_id = "evidence-run-001"
+    out_one = tmp_path / "out-one"
+    out_two = tmp_path / "out-two"
+
+    first = _run_cli(
+        [
+            "backtest",
+            "--snapshots",
+            str(snapshots_path),
+            "--strategy",
+            "REFERENCE",
+            "--out",
+            str(out_one),
+            "--run-id",
+            run_id,
+        ]
+    )
+    second = _run_cli(
+        [
+            "backtest",
+            "--snapshots",
+            str(snapshots_path),
+            "--strategy",
+            "REFERENCE",
+            "--out",
+            str(out_two),
+            "--run-id",
+            run_id,
+        ]
+    )
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+
+    artifact_one = out_one / "backtest-result.json"
+    artifact_two = out_two / "backtest-result.json"
+    hash_one = out_one / "backtest-result.sha256"
+    hash_two = out_two / "backtest-result.sha256"
+
+    assert artifact_one.read_bytes() == artifact_two.read_bytes()
+    assert hash_one.read_text(encoding="utf-8") == hash_two.read_text(encoding="utf-8")
+
+    payload = json.loads(artifact_one.read_text(encoding="utf-8"))
+    run_config = payload["run_config"]
+    execution_assumptions = run_config["execution_assumptions"]
+
+    assert payload["run"]["run_id"] == run_id
+    assert payload["run"]["deterministic"] is True
+    assert run_config["reproducibility_metadata"]["run_id"] == run_id
+    assert run_config["reproducibility_metadata"]["strategy_name"] == "REFERENCE"
+    assert execution_assumptions == {
+        "fill_model": "deterministic_market",
+        "fill_timing": "next_snapshot",
+        "price_source": "open_then_price",
+        "slippage_bps": 0,
+        "commission_per_order": "0",
+        "partial_fills_allowed": False,
+    }
+    assert payload["metrics_baseline"]["assumptions"] == execution_assumptions
+
+
+def test_cli_backtest_different_run_ids_change_evidence_identity(tmp_path: Path) -> None:
+    snapshots_path = tmp_path / "snapshots.json"
+    snapshots_path.write_text(
+        json.dumps(
+            [
+                {"id": "s1", "timestamp": "2024-01-01T00:00:00Z", "price": 10},
+                {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "price": 11},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    out_alpha = tmp_path / "out-alpha"
+    out_beta = tmp_path / "out-beta"
+
+    alpha = _run_cli(
+        [
+            "backtest",
+            "--snapshots",
+            str(snapshots_path),
+            "--strategy",
+            "REFERENCE",
+            "--out",
+            str(out_alpha),
+            "--run-id",
+            "identity-alpha",
+        ]
+    )
+    beta = _run_cli(
+        [
+            "backtest",
+            "--snapshots",
+            str(snapshots_path),
+            "--strategy",
+            "REFERENCE",
+            "--out",
+            str(out_beta),
+            "--run-id",
+            "identity-beta",
+        ]
+    )
+
+    assert alpha.returncode == 0
+    assert beta.returncode == 0
+
+    alpha_artifact = out_alpha / "backtest-result.json"
+    beta_artifact = out_beta / "backtest-result.json"
+    alpha_payload = json.loads(alpha_artifact.read_text(encoding="utf-8"))
+    beta_payload = json.loads(beta_artifact.read_text(encoding="utf-8"))
+
+    assert alpha_payload["run"]["run_id"] == "identity-alpha"
+    assert beta_payload["run"]["run_id"] == "identity-beta"
+    assert alpha_payload["run_config"]["reproducibility_metadata"]["run_id"] == "identity-alpha"
+    assert beta_payload["run_config"]["reproducibility_metadata"]["run_id"] == "identity-beta"
+    assert alpha_artifact.read_bytes() != beta_artifact.read_bytes()

--- a/tests/test_backtest_evidence_docs.py
+++ b/tests/test_backtest_evidence_docs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_backtest_cli_doc_defines_reproducible_evidence_fields() -> None:
+    content = (REPO_ROOT / "docs" / "testing" / "backtesting" / "backtest_cli.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Reproducible Evidence Fields" in content
+    assert "`run.run_id`" in content
+    assert "`run_config.execution_assumptions`" in content
+    assert "`run_config.reproducibility_metadata`" in content
+    assert "`metrics_baseline.assumptions`" in content
+    assert "MUST match" in content
+
+
+def test_backtest_cli_doc_defines_trader_interpretation_boundary() -> None:
+    content = (REPO_ROOT / "docs" / "testing" / "backtesting" / "backtest_cli.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Trader Interpretation Boundary" in content
+    assert "does **not** prove" in content
+    assert "Live trading readiness." in content
+    assert "Future performance" in content


### PR DESCRIPTION
Closes #762

## Summary
- Adds CLI-level reproducibility checks for covered backtest runs
- Verifies identical artifact bytes and SHA-256 for repeated runs with same run identity
- Asserts explicit run identity and execution assumptions in artifact payload
- Documents trader-facing interpretation boundaries and evidence alignment rules

## In Scope
- tests/test_backtest_cli.py
- tests/test_backtest_evidence_docs.py
- docs/testing/backtesting/backtest_cli.md

## Out of Scope
- No execution model changes
- No metrics logic changes
- No engine or CLI behavior changes

## Validation
- python -m pytest tests/test_backtest_cli.py tests/test_backtest_evidence_docs.py

## Results
- 9 tests passed
- Deterministic evidence reproducibility verified
- Documentation boundaries enforced via tests

## Readiness Classification
- Engineering: READY
- Trader Validation: PARTIAL
- Operational: LIMITED (backtest evidence scope only)

## Notes
- Strengthens reproducibility and auditability of backtest outputs
- Does not increase predictive validity or live-trading readiness