### PR TITLE
DEC-P43B: Define canonical decision-card contract with hard gates, component scores, and qualification state

### DIFF
--- a/docs/architecture/decision_card_contract.md
+++ b/docs/architecture/decision_card_contract.md
@@ -1,0 +1,118 @@
+# Decision-Card Contract
+
+## Purpose
+
+This document defines the canonical decision-card contract used to qualify or reject opportunities.  
+The contract separates:
+
+- hard-gate semantics (blocking policy checks)
+- bounded score semantics (component-based scoring)
+- explicit confidence tier
+- explicit qualification state and color
+- explicit rationale requirements
+
+The canonical implementation is `src/cilly_trading/engine/decision_card_contract.py`.
+
+## Canonical Vocabulary
+
+Top-level decision-card fields:
+
+- `contract_version`
+- `decision_card_id`
+- `generated_at_utc`
+- `symbol`
+- `strategy_id`
+- `hard_gates`
+- `score`
+- `qualification`
+- `rationale`
+- `metadata`
+
+## Hard-Gate Semantics
+
+Hard gates are represented by `hard_gates.gates[]` and are evaluated independently from scoring.
+
+Per-gate fields:
+
+- `gate_id`
+- `status` (`pass` | `fail`)
+- `blocking` (boolean)
+- `reason`
+- `evidence[]`
+- `failure_reason` (required when `status=fail`)
+
+Contract semantics:
+
+- blocking gate failures are terminal for qualification
+- a blocking failure requires qualification state `rejected` and color `red`
+- gate evidence must be explicit (no opaque gate result)
+
+## Score Semantics
+
+Scores are represented by `score.component_scores[]` and are bounded in `[0, 100]`.
+
+Required component categories (exact coverage required):
+
+- `signal_quality`
+- `backtest_quality`
+- `portfolio_fit`
+- `risk_alignment`
+- `execution_readiness`
+
+Additional score fields:
+
+- `aggregate_score` in `[0, 100]`
+- `confidence_tier` (`low` | `medium` | `high`)
+- `confidence_reason`
+
+Hard-gate outcomes and score outcomes remain separate objects by contract.
+
+## Qualification Output
+
+Qualification is explicit and not inferred from a single score field:
+
+- `state`: `qualified` | `watchlist` | `rejected`
+- `color`: `green` | `yellow` | `red`
+- `summary`
+
+State-to-color mapping is fixed:
+
+- `qualified -> green`
+- `watchlist -> yellow`
+- `rejected -> red`
+
+## Rationale Requirements
+
+`rationale` is required and must include:
+
+- `summary`
+- `gate_explanations[]`
+- `score_explanations[]`
+- `final_explanation`
+
+This prevents collapsing gates, evidence, and qualification into an opaque number.
+
+## Deterministic Serialization
+
+Decision cards serialize through deterministic canonical JSON:
+
+- sorted keys
+- stable separators
+- deterministic ordering of gate and component collections
+
+Deterministic serialization API:
+
+- `validate_decision_card(payload)`
+- `serialize_decision_card(card)`
+- `DecisionCard.to_canonical_json()`
+
+## Non-Goals
+
+This contract does not introduce:
+
+- sentiment ingestion implementation
+- new strategy logic
+- live-trading approval workflow
+- broker integrations
+- UI redesign
+- dashboard product scope

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -1,0 +1,258 @@
+"""Canonical decision-card contract with hard gates and score semantics."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+DECISION_CARD_CONTRACT_VERSION = "1.0.0"
+
+DecisionComponentCategory = Literal[
+    "signal_quality",
+    "backtest_quality",
+    "portfolio_fit",
+    "risk_alignment",
+    "execution_readiness",
+]
+DecisionConfidenceTier = Literal["low", "medium", "high"]
+HardGateStatus = Literal["pass", "fail"]
+QualificationState = Literal["qualified", "watchlist", "rejected"]
+QualificationColor = Literal["green", "yellow", "red"]
+
+REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
+    "signal_quality",
+    "backtest_quality",
+    "portfolio_fit",
+    "risk_alignment",
+    "execution_readiness",
+)
+
+QUALIFICATION_COLOR_BY_STATE: dict[QualificationState, QualificationColor] = {
+    "qualified": "green",
+    "watchlist": "yellow",
+    "rejected": "red",
+}
+
+
+class HardGateResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    gate_id: str = Field(min_length=1)
+    status: HardGateStatus
+    blocking: bool = True
+    reason: str = Field(min_length=1)
+    evidence: list[str] = Field(min_length=1)
+    failure_reason: str | None = None
+
+    @field_validator("evidence")
+    @classmethod
+    def _validate_evidence(cls, value: list[str]) -> list[str]:
+        normalized = [item.strip() for item in value if item and item.strip()]
+        if not normalized:
+            raise ValueError("Hard gate evidence must include at least one non-empty entry")
+        return sorted(set(normalized))
+
+    @model_validator(mode="after")
+    def _validate_failure_reason(self) -> "HardGateResult":
+        if self.status == "fail" and (self.failure_reason is None or not self.failure_reason.strip()):
+            raise ValueError("Hard gate failures must define failure_reason")
+        if self.status == "pass" and self.failure_reason is not None:
+            raise ValueError("Passing hard gates must not define failure_reason")
+        return self
+
+
+class HardGateEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    policy_version: str = Field(min_length=1)
+    gates: list[HardGateResult] = Field(min_length=1)
+
+    @field_validator("gates")
+    @classmethod
+    def _normalize_gates(cls, value: list[HardGateResult]) -> list[HardGateResult]:
+        gate_ids = [gate.gate_id for gate in value]
+        if len(set(gate_ids)) != len(gate_ids):
+            raise ValueError("Hard gate IDs must be unique")
+        return sorted(value, key=lambda gate: gate.gate_id)
+
+    @property
+    def has_blocking_failure(self) -> bool:
+        return any(gate.blocking and gate.status == "fail" for gate in self.gates)
+
+
+class ComponentScore(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    category: DecisionComponentCategory
+    score: float = Field(ge=0.0, le=100.0)
+    rationale: str = Field(min_length=8)
+    evidence: list[str] = Field(min_length=1)
+
+    @field_validator("evidence")
+    @classmethod
+    def _validate_evidence(cls, value: list[str]) -> list[str]:
+        normalized = [item.strip() for item in value if item and item.strip()]
+        if not normalized:
+            raise ValueError("Component score evidence must include at least one non-empty entry")
+        return sorted(set(normalized))
+
+
+class ScoreEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    component_scores: list[ComponentScore] = Field(min_length=1)
+    confidence_tier: DecisionConfidenceTier
+    confidence_reason: str = Field(min_length=8)
+    aggregate_score: float = Field(ge=0.0, le=100.0)
+
+    @field_validator("component_scores")
+    @classmethod
+    def _validate_component_coverage(cls, value: list[ComponentScore]) -> list[ComponentScore]:
+        categories = [component.category for component in value]
+        if len(set(categories)) != len(categories):
+            raise ValueError("Component score categories must be unique")
+        if set(categories) != set(REQUIRED_COMPONENT_CATEGORIES):
+            missing = sorted(set(REQUIRED_COMPONENT_CATEGORIES) - set(categories))
+            extra = sorted(set(categories) - set(REQUIRED_COMPONENT_CATEGORIES))
+            details = []
+            if missing:
+                details.append(f"missing={','.join(missing)}")
+            if extra:
+                details.append(f"extra={','.join(extra)}")
+            raise ValueError(
+                "Component score categories must match required set "
+                f"({'; '.join(details)})"
+            )
+        return sorted(value, key=lambda component: component.category)
+
+
+class Qualification(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    state: QualificationState
+    color: QualificationColor
+    summary: str = Field(min_length=8)
+
+    @model_validator(mode="after")
+    def _validate_color_mapping(self) -> "Qualification":
+        expected_color = QUALIFICATION_COLOR_BY_STATE[self.state]
+        if self.color != expected_color:
+            raise ValueError(
+                f"Qualification color must match state mapping: {self.state}->{expected_color}"
+            )
+        return self
+
+
+class DecisionRationale(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    summary: str = Field(min_length=16)
+    gate_explanations: list[str] = Field(min_length=1)
+    score_explanations: list[str] = Field(min_length=1)
+    final_explanation: str = Field(min_length=16)
+
+    @field_validator("gate_explanations", "score_explanations")
+    @classmethod
+    def _normalize_explanations(cls, value: list[str]) -> list[str]:
+        normalized = [item.strip() for item in value if item and item.strip()]
+        if not normalized:
+            raise ValueError("Rationale explanation lists must include non-empty values")
+        return normalized
+
+
+class DecisionCard(BaseModel):
+    """Canonical decision-card entity for qualification decisions."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_version: str = DECISION_CARD_CONTRACT_VERSION
+    decision_card_id: str = Field(min_length=1)
+    generated_at_utc: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    strategy_id: str = Field(min_length=1)
+    hard_gates: HardGateEvaluation
+    score: ScoreEvaluation
+    qualification: Qualification
+    rationale: DecisionRationale
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != DECISION_CARD_CONTRACT_VERSION:
+            raise ValueError(f"Unsupported decision-card contract_version: {value}")
+        return value
+
+    @field_validator("generated_at_utc")
+    @classmethod
+    def _validate_generated_at_utc(cls, value: str) -> str:
+        if value.endswith("Z"):
+            iso_value = value.replace("Z", "+00:00")
+        else:
+            iso_value = value
+        try:
+            timestamp = datetime.fromisoformat(iso_value)
+        except ValueError as exc:
+            raise ValueError("generated_at_utc must be ISO-8601 compatible") from exc
+        if timestamp.tzinfo is None:
+            raise ValueError("generated_at_utc must include timezone information")
+        return value
+
+    @field_validator("metadata")
+    @classmethod
+    def _validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ValueError("metadata must be an object")
+        for key in value:
+            if not isinstance(key, str):
+                raise ValueError("metadata keys must be strings")
+        return dict(sorted(value.items()))
+
+    @model_validator(mode="after")
+    def _validate_qualification_semantics(self) -> "DecisionCard":
+        if self.hard_gates.has_blocking_failure and self.qualification.state != "rejected":
+            raise ValueError("Blocking hard-gate failures require rejected qualification state")
+        if self.hard_gates.has_blocking_failure and self.qualification.color != "red":
+            raise ValueError("Blocking hard-gate failures require red qualification color")
+        return self
+
+    def to_canonical_payload(self) -> dict[str, Any]:
+        return self.model_dump(mode="python")
+
+    def to_canonical_json(self) -> str:
+        return json.dumps(
+            self.to_canonical_payload(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+
+
+def validate_decision_card(payload: dict[str, Any]) -> DecisionCard:
+    """Validate and return a canonical decision card instance."""
+    return DecisionCard.model_validate(payload)
+
+
+def serialize_decision_card(card: DecisionCard) -> str:
+    """Return deterministic JSON serialization for a decision card."""
+    return card.to_canonical_json()
+
+
+__all__ = [
+    "DECISION_CARD_CONTRACT_VERSION",
+    "REQUIRED_COMPONENT_CATEGORIES",
+    "QUALIFICATION_COLOR_BY_STATE",
+    "ComponentScore",
+    "DecisionCard",
+    "DecisionRationale",
+    "HardGateEvaluation",
+    "HardGateResult",
+    "Qualification",
+    "ScoreEvaluation",
+    "serialize_decision_card",
+    "validate_decision_card",
+]

--- a/tests/cilly_trading/engine/test_decision_card_contract.py
+++ b/tests/cilly_trading/engine/test_decision_card_contract.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from cilly_trading.engine.decision_card_contract import (
+    DecisionCard,
+    serialize_decision_card,
+    validate_decision_card,
+)
+
+
+def _valid_payload(*, qualification_state: str = "qualified", qualification_color: str = "green") -> dict[str, Any]:
+    return {
+        "contract_version": "1.0.0",
+        "decision_card_id": "dc_20260324_AAPL_RSI2",
+        "generated_at_utc": "2026-03-24T08:10:00Z",
+        "symbol": "AAPL",
+        "strategy_id": "RSI2",
+        "hard_gates": {
+            "policy_version": "hard-gates.v1",
+            "gates": [
+                {
+                    "gate_id": "portfolio_exposure_cap",
+                    "status": "pass",
+                    "blocking": True,
+                    "reason": "Gross exposure remains under policy cap",
+                    "evidence": ["gross_exposure_pct=0.42", "policy_cap=0.60"],
+                },
+                {
+                    "gate_id": "drawdown_safety",
+                    "status": "pass",
+                    "blocking": True,
+                    "reason": "Drawdown guard remains within threshold",
+                    "evidence": ["max_drawdown_pct=0.07", "threshold_pct=0.12"],
+                },
+            ],
+        },
+        "score": {
+            "component_scores": [
+                {
+                    "category": "execution_readiness",
+                    "score": 78.0,
+                    "rationale": "Execution assumptions remain deterministic and bounded",
+                    "evidence": ["slippage_bps=10", "commission_per_order=1.00"],
+                },
+                {
+                    "category": "portfolio_fit",
+                    "score": 76.0,
+                    "rationale": "Portfolio concentration constraints remain satisfied",
+                    "evidence": ["sector_weight_pct=0.19", "sector_limit_pct=0.25"],
+                },
+                {
+                    "category": "signal_quality",
+                    "score": 82.0,
+                    "rationale": "Signal quality remains consistent across recent windows",
+                    "evidence": ["signal_hit_rate=0.61", "window_days=90"],
+                },
+                {
+                    "category": "backtest_quality",
+                    "score": 74.0,
+                    "rationale": "Backtest quality supports bounded forward expectation",
+                    "evidence": ["sharpe=1.34", "profit_factor=1.52"],
+                },
+                {
+                    "category": "risk_alignment",
+                    "score": 85.0,
+                    "rationale": "Risk controls align with per-trade and portfolio policy",
+                    "evidence": ["risk_per_trade_pct=0.005", "max_risk_pct=0.01"],
+                },
+            ],
+            "confidence_tier": "high",
+            "confidence_reason": "Recent sample depth and stability support high confidence",
+            "aggregate_score": 79.0,
+        },
+        "qualification": {
+            "state": qualification_state,
+            "color": qualification_color,
+            "summary": "Opportunity qualifies for operator review and bounded execution",
+        },
+        "rationale": {
+            "summary": "Hard gates pass and bounded component scores support qualification",
+            "gate_explanations": [
+                "Hard-gate checks passed under the current policy baseline",
+            ],
+            "score_explanations": [
+                "Component scores are bounded and represent distinct evaluation axes",
+            ],
+            "final_explanation": "Qualification is explicit and not derived from a single opaque score",
+        },
+        "metadata": {
+            "analysis_run_id": "run_20260324_0810",
+            "source": "deterministic_pipeline",
+            "universe": "us_equities",
+        },
+    }
+
+
+def test_decision_card_model_validation_representative_payload() -> None:
+    card = validate_decision_card(_valid_payload())
+
+    assert isinstance(card, DecisionCard)
+    assert card.hard_gates.has_blocking_failure is False
+    assert card.score.aggregate_score == 79.0
+    assert [component.category for component in card.score.component_scores] == [
+        "backtest_quality",
+        "execution_readiness",
+        "portfolio_fit",
+        "risk_alignment",
+        "signal_quality",
+    ]
+
+
+def test_decision_card_serialization_is_deterministic() -> None:
+    payload = _valid_payload()
+    card_a = validate_decision_card(payload)
+    card_b = validate_decision_card(payload)
+
+    serialized_a = serialize_decision_card(card_a)
+    serialized_b = serialize_decision_card(card_b)
+    assert serialized_a == serialized_b
+    assert serialized_a == card_a.to_canonical_json()
+
+
+def test_negative_validation_rejects_missing_component_category() -> None:
+    payload = _valid_payload()
+    payload["score"]["component_scores"] = payload["score"]["component_scores"][:-1]
+
+    with pytest.raises(ValidationError, match="Component score categories must match required set"):
+        validate_decision_card(payload)
+
+
+def test_negative_validation_rejects_gate_fail_without_failure_reason() -> None:
+    payload = _valid_payload(qualification_state="rejected", qualification_color="red")
+    payload["hard_gates"]["gates"][0]["status"] = "fail"
+    payload["hard_gates"]["gates"][0]["failure_reason"] = None
+
+    with pytest.raises(ValidationError, match="must define failure_reason"):
+        validate_decision_card(payload)
+
+
+def test_negative_validation_rejects_non_rejected_state_on_blocking_failure() -> None:
+    payload = _valid_payload(qualification_state="watchlist", qualification_color="yellow")
+    payload["hard_gates"]["gates"][0]["status"] = "fail"
+    payload["hard_gates"]["gates"][0]["failure_reason"] = "Exposure cap would be exceeded"
+
+    with pytest.raises(
+        ValidationError,
+        match="Blocking hard-gate failures require rejected qualification state",
+    ):
+        validate_decision_card(payload)
+
+
+@pytest.mark.parametrize(
+    ("state", "color"),
+    [
+        ("qualified", "green"),
+        ("watchlist", "yellow"),
+        ("rejected", "red"),
+    ],
+)
+def test_representative_qualification_payloads_validate(state: str, color: str) -> None:
+    payload = _valid_payload(qualification_state=state, qualification_color=color)
+    if state == "rejected":
+        payload["hard_gates"]["gates"][0]["status"] = "fail"
+        payload["hard_gates"]["gates"][0]["failure_reason"] = "Risk cap breach"
+        payload["qualification"]["summary"] = "Opportunity is rejected because a blocking gate failed"
+    if state == "watchlist":
+        payload["score"]["confidence_tier"] = "low"
+        payload["score"]["confidence_reason"] = "Sample depth is limited for full qualification"
+        payload["qualification"]["summary"] = "Opportunity requires further evidence before qualification"
+
+    card = validate_decision_card(payload)
+    assert card.qualification.state == state
+    assert card.qualification.color == color
+
+
+def test_no_competing_decision_card_model_exists() -> None:
+    root = Path(__file__).resolve().parents[3]
+    model_files = sorted(root.glob("src/cilly_trading/**/*decision*card*.py"))
+
+    assert [path.relative_to(root).as_posix() for path in model_files] == [
+        "src/cilly_trading/engine/decision_card_contract.py"
+    ]


### PR DESCRIPTION
Closes #770

## What Changed
- Added canonical decision-card contract in src/cilly_trading/engine/decision_card_contract.py
- Explicitly separated hard-gate semantics from bounded component score semantics
- Added explicit confidence tiers and qualification state/color modeling
- Added deterministic serialization and validation entrypoints
- Added representative, deterministic, and negative tests in 	ests/cilly_trading/engine/test_decision_card_contract.py
- Added architecture documentation in docs/architecture/decision_card_contract.md

## Acceptance Criteria Mapping
- One canonical decision-card contract exists: implemented DecisionCard and related canonical models.
- Hard gates separated from score components: distinct hard_gates and score objects.
- Confidence and qualification modeled: explicit confidence_tier, confidence_reason, and qualification state/color.
- Representative payloads validate and serialize deterministically: added validation + deterministic serialization tests.
- No competing model exists: added guard test asserting a single decision-card model file in src/cilly_trading.

## Test Evidence
- .\.venv\Scripts\python -m pytest tests/cilly_trading/engine/test_decision_card_contract.py -q
- .\.venv\Scripts\python -m pytest
- Result: full suite green (713 passed).

## Governance Notes
- Scope remained limited to the allowed paths for issue #770.
- No trader-validation claim is made by this PR.
- No operational-readiness claim is made by this PR.