### PR TITLE
DEC-P43B: Implement qualification engine with hard gates, confidence tiers, and traffic-light decision output

### DIFF
--- a/docs/architecture/decision_card_contract.md
+++ b/docs/architecture/decision_card_contract.md
@@ -12,6 +12,14 @@ The contract separates:
 - explicit rationale requirements
 
 The canonical implementation is `src/cilly_trading/engine/decision_card_contract.py`.
+Deterministic evaluation logic is implemented in `src/cilly_trading/engine/qualification_engine.py`.
+
+## Active Version
+
+- Active contract version: `2.0.0`
+- This is a breaking revision from `1.0.0` because qualification action-state vocabulary changed from
+  `qualified | watchlist | rejected` to
+  `reject | watch | paper_candidate | paper_approved`.
 
 ## Canonical Vocabulary
 
@@ -44,7 +52,7 @@ Per-gate fields:
 Contract semantics:
 
 - blocking gate failures are terminal for qualification
-- a blocking failure requires qualification state `rejected` and color `red`
+- a blocking failure requires qualification state `reject` and color `red`
 - gate evidence must be explicit (no opaque gate result)
 
 ## Score Semantics
@@ -71,15 +79,25 @@ Hard-gate outcomes and score outcomes remain separate objects by contract.
 
 Qualification is explicit and not inferred from a single score field:
 
-- `state`: `qualified` | `watchlist` | `rejected`
+- `state`: `reject` | `watch` | `paper_candidate` | `paper_approved`
 - `color`: `green` | `yellow` | `red`
 - `summary`
 
 State-to-color mapping is fixed:
 
-- `qualified -> green`
-- `watchlist -> yellow`
-- `rejected -> red`
+- `reject -> red`
+- `watch -> yellow`
+- `paper_candidate -> yellow`
+- `paper_approved -> green`
+
+Deterministic action-state resolution:
+
+1. Any blocking hard-gate failure resolves to `reject` / `red`.
+2. If no blocking failure and confidence is `low` (or aggregate score is below the medium threshold), resolve to `watch` / `yellow`.
+3. If confidence is `high` and aggregate score is above the high threshold, resolve to `paper_approved` / `green`.
+4. Otherwise resolve to `paper_candidate` / `yellow`.
+
+This output is bounded to paper-trading readiness only and does not imply live-trading approval.
 
 ## Rationale Requirements
 

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-DECISION_CARD_CONTRACT_VERSION = "1.0.0"
+DECISION_CARD_CONTRACT_VERSION = "2.0.0"
 
 DecisionComponentCategory = Literal[
     "signal_quality",
@@ -19,7 +19,7 @@ DecisionComponentCategory = Literal[
 ]
 DecisionConfidenceTier = Literal["low", "medium", "high"]
 HardGateStatus = Literal["pass", "fail"]
-QualificationState = Literal["qualified", "watchlist", "rejected"]
+QualificationState = Literal["reject", "watch", "paper_candidate", "paper_approved"]
 QualificationColor = Literal["green", "yellow", "red"]
 
 REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
@@ -31,9 +31,10 @@ REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
 )
 
 QUALIFICATION_COLOR_BY_STATE: dict[QualificationState, QualificationColor] = {
-    "qualified": "green",
-    "watchlist": "yellow",
-    "rejected": "red",
+    "reject": "red",
+    "watch": "yellow",
+    "paper_candidate": "yellow",
+    "paper_approved": "green",
 }
 
 
@@ -213,8 +214,8 @@ class DecisionCard(BaseModel):
 
     @model_validator(mode="after")
     def _validate_qualification_semantics(self) -> "DecisionCard":
-        if self.hard_gates.has_blocking_failure and self.qualification.state != "rejected":
-            raise ValueError("Blocking hard-gate failures require rejected qualification state")
+        if self.hard_gates.has_blocking_failure and self.qualification.state != "reject":
+            raise ValueError("Blocking hard-gate failures require reject qualification state")
         if self.hard_gates.has_blocking_failure and self.qualification.color != "red":
             raise ValueError("Blocking hard-gate failures require red qualification color")
         return self

--- a/src/cilly_trading/engine/qualification_engine.py
+++ b/src/cilly_trading/engine/qualification_engine.py
@@ -1,0 +1,236 @@
+"""Deterministic qualification engine for decision-card evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cilly_trading.engine.decision_card_contract import (
+    DECISION_CARD_CONTRACT_VERSION,
+    REQUIRED_COMPONENT_CATEGORIES,
+    ComponentScore,
+    DecisionCard,
+    DecisionComponentCategory,
+    DecisionConfidenceTier,
+    HardGateEvaluation,
+    HardGateResult,
+    QualificationColor,
+    QualificationState,
+    validate_decision_card,
+)
+
+DecisionActionState = QualificationState
+
+COMPONENT_WEIGHTS: dict[DecisionComponentCategory, float] = {
+    "signal_quality": 0.30,
+    "backtest_quality": 0.25,
+    "portfolio_fit": 0.15,
+    "risk_alignment": 0.20,
+    "execution_readiness": 0.10,
+}
+
+CONFIDENCE_THRESHOLDS: dict[str, float] = {
+    "high_aggregate": 80.0,
+    "high_min_component": 70.0,
+    "medium_aggregate": 60.0,
+    "medium_min_component": 50.0,
+}
+
+
+@dataclass(frozen=True)
+class QualificationEngineInput:
+    decision_card_id: str
+    generated_at_utc: str
+    symbol: str
+    strategy_id: str
+    hard_gates: list[HardGateResult]
+    component_scores: list[ComponentScore]
+    hard_gate_policy_version: str = "hard-gates.v1"
+    metadata: dict[str, object] | None = None
+
+
+def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard:
+    """Evaluate hard gates, component scores, and output a deterministic decision card."""
+    hard_gate_evaluation = HardGateEvaluation(
+        policy_version=input_data.hard_gate_policy_version,
+        gates=list(input_data.hard_gates),
+    )
+    aggregate_score = compute_aggregate_score(component_scores=input_data.component_scores)
+    confidence_tier = assign_confidence_tier(
+        aggregate_score=aggregate_score,
+        component_scores=input_data.component_scores,
+    )
+    confidence_reason = _confidence_reason(confidence_tier=confidence_tier, aggregate_score=aggregate_score)
+    state, color, qualification_summary = resolve_qualification_state(
+        hard_gate_evaluation=hard_gate_evaluation,
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+    )
+    payload = {
+        "contract_version": DECISION_CARD_CONTRACT_VERSION,
+        "decision_card_id": input_data.decision_card_id,
+        "generated_at_utc": input_data.generated_at_utc,
+        "symbol": input_data.symbol,
+        "strategy_id": input_data.strategy_id,
+        "hard_gates": {
+            "policy_version": input_data.hard_gate_policy_version,
+            "gates": [gate.model_dump(mode="python") for gate in hard_gate_evaluation.gates],
+        },
+        "score": {
+            "component_scores": [
+                component.model_dump(mode="python")
+                for component in sorted(
+                    input_data.component_scores,
+                    key=lambda item: item.category,
+                )
+            ],
+            "confidence_tier": confidence_tier,
+            "confidence_reason": confidence_reason,
+            "aggregate_score": aggregate_score,
+        },
+        "qualification": {
+            "state": state,
+            "color": color,
+            "summary": qualification_summary,
+        },
+        "rationale": {
+            "summary": "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules.",
+            "gate_explanations": _gate_explanations(hard_gate_evaluation=hard_gate_evaluation),
+            "score_explanations": _score_explanations(
+                component_scores=input_data.component_scores,
+                aggregate_score=aggregate_score,
+                confidence_tier=confidence_tier,
+            ),
+            "final_explanation": (
+                "Action state is deterministic and does not imply live-trading approval; "
+                "it indicates reject, watch, paper candidate, or paper approved."
+            ),
+        },
+        "metadata": dict(sorted((input_data.metadata or {}).items())),
+    }
+    return validate_decision_card(payload)
+
+
+def compute_aggregate_score(*, component_scores: list[ComponentScore]) -> float:
+    """Compute bounded weighted aggregate score in [0, 100]."""
+    score_by_category = {component.category: float(component.score) for component in component_scores}
+    required_categories = set(REQUIRED_COMPONENT_CATEGORIES)
+    if set(score_by_category) != required_categories:
+        missing = sorted(required_categories - set(score_by_category))
+        extra = sorted(set(score_by_category) - required_categories)
+        details: list[str] = []
+        if missing:
+            details.append(f"missing={','.join(missing)}")
+        if extra:
+            details.append(f"extra={','.join(extra)}")
+        raise ValueError(f"Component scores must cover required categories ({'; '.join(details)})")
+    weighted = sum(score_by_category[category] * COMPONENT_WEIGHTS[category] for category in REQUIRED_COMPONENT_CATEGORIES)
+    return max(0.0, min(100.0, round(weighted, 4)))
+
+
+def assign_confidence_tier(
+    *,
+    aggregate_score: float,
+    component_scores: list[ComponentScore],
+) -> DecisionConfidenceTier:
+    """Assign deterministic confidence tier from bounded aggregate and minimum component score."""
+    min_component = min(float(component.score) for component in component_scores)
+    if (
+        aggregate_score >= CONFIDENCE_THRESHOLDS["high_aggregate"]
+        and min_component >= CONFIDENCE_THRESHOLDS["high_min_component"]
+    ):
+        return "high"
+    if (
+        aggregate_score >= CONFIDENCE_THRESHOLDS["medium_aggregate"]
+        and min_component >= CONFIDENCE_THRESHOLDS["medium_min_component"]
+    ):
+        return "medium"
+    return "low"
+
+
+def resolve_qualification_state(
+    *,
+    hard_gate_evaluation: HardGateEvaluation,
+    aggregate_score: float,
+    confidence_tier: DecisionConfidenceTier,
+) -> tuple[DecisionActionState, QualificationColor, str]:
+    """Resolve action-state and traffic-light output deterministically."""
+    if hard_gate_evaluation.has_blocking_failure:
+        return (
+            "reject",
+            "red",
+            "Blocking hard gate failed; opportunity is rejected.",
+        )
+    if confidence_tier == "low" or aggregate_score < CONFIDENCE_THRESHOLDS["medium_aggregate"]:
+        return (
+            "watch",
+            "yellow",
+            "Opportunity remains on watch pending stronger confidence or score.",
+        )
+    if confidence_tier == "high" and aggregate_score >= CONFIDENCE_THRESHOLDS["high_aggregate"]:
+        return (
+            "paper_approved",
+            "green",
+            "Opportunity is approved for bounded paper-trading only.",
+        )
+    return (
+        "paper_candidate",
+        "yellow",
+        "Opportunity is a paper-trading candidate but not yet approved.",
+    )
+
+
+def _confidence_reason(*, confidence_tier: DecisionConfidenceTier, aggregate_score: float) -> str:
+    if confidence_tier == "high":
+        return (
+            f"Aggregate score {aggregate_score:.4f} and all components satisfy high-confidence thresholds."
+        )
+    if confidence_tier == "medium":
+        return (
+            f"Aggregate score {aggregate_score:.4f} satisfies medium-confidence thresholds with bounded component support."
+        )
+    return (
+        f"Aggregate score {aggregate_score:.4f} or component minimum is below medium-confidence thresholds."
+    )
+
+
+def _gate_explanations(*, hard_gate_evaluation: HardGateEvaluation) -> list[str]:
+    ordered = sorted(hard_gate_evaluation.gates, key=lambda gate: gate.gate_id)
+    explanations: list[str] = []
+    for gate in ordered:
+        if gate.status == "pass":
+            explanations.append(f"Gate {gate.gate_id} passed: {gate.reason}")
+        else:
+            suffix = "blocking" if gate.blocking else "non-blocking"
+            explanations.append(
+                f"Gate {gate.gate_id} failed ({suffix}): {gate.failure_reason}"
+            )
+    return explanations
+
+
+def _score_explanations(
+    *,
+    component_scores: list[ComponentScore],
+    aggregate_score: float,
+    confidence_tier: DecisionConfidenceTier,
+) -> list[str]:
+    ordered = sorted(component_scores, key=lambda component: component.category)
+    component_summary = ", ".join(
+        f"{component.category}={component.score:.2f}" for component in ordered
+    )
+    return [
+        f"Bounded weighted aggregate score={aggregate_score:.4f} using fixed category weights.",
+        f"Component scores by category: {component_summary}.",
+        f"Confidence tier resolved deterministically as {confidence_tier}.",
+    ]
+
+
+__all__ = [
+    "COMPONENT_WEIGHTS",
+    "CONFIDENCE_THRESHOLDS",
+    "DecisionActionState",
+    "QualificationEngineInput",
+    "assign_confidence_tier",
+    "compute_aggregate_score",
+    "evaluate_qualification",
+    "resolve_qualification_state",
+]

--- a/tests/cilly_trading/engine/test_decision_card_contract.py
+++ b/tests/cilly_trading/engine/test_decision_card_contract.py
@@ -7,15 +7,16 @@ import pytest
 from pydantic import ValidationError
 
 from cilly_trading.engine.decision_card_contract import (
+    DECISION_CARD_CONTRACT_VERSION,
     DecisionCard,
     serialize_decision_card,
     validate_decision_card,
 )
 
 
-def _valid_payload(*, qualification_state: str = "qualified", qualification_color: str = "green") -> dict[str, Any]:
+def _valid_payload(*, qualification_state: str = "paper_approved", qualification_color: str = "green") -> dict[str, Any]:
     return {
-        "contract_version": "1.0.0",
+        "contract_version": DECISION_CARD_CONTRACT_VERSION,
         "decision_card_id": "dc_20260324_AAPL_RSI2",
         "generated_at_utc": "2026-03-24T08:10:00Z",
         "symbol": "AAPL",
@@ -103,6 +104,7 @@ def test_decision_card_model_validation_representative_payload() -> None:
     card = validate_decision_card(_valid_payload())
 
     assert isinstance(card, DecisionCard)
+    assert card.contract_version == DECISION_CARD_CONTRACT_VERSION
     assert card.hard_gates.has_blocking_failure is False
     assert card.score.aggregate_score == 79.0
     assert [component.category for component in card.score.component_scores] == [
@@ -123,6 +125,7 @@ def test_decision_card_serialization_is_deterministic() -> None:
     serialized_b = serialize_decision_card(card_b)
     assert serialized_a == serialized_b
     assert serialized_a == card_a.to_canonical_json()
+    assert f'"contract_version":"{DECISION_CARD_CONTRACT_VERSION}"' in serialized_a
 
 
 def test_negative_validation_rejects_missing_component_category() -> None:
@@ -134,7 +137,7 @@ def test_negative_validation_rejects_missing_component_category() -> None:
 
 
 def test_negative_validation_rejects_gate_fail_without_failure_reason() -> None:
-    payload = _valid_payload(qualification_state="rejected", qualification_color="red")
+    payload = _valid_payload(qualification_state="reject", qualification_color="red")
     payload["hard_gates"]["gates"][0]["status"] = "fail"
     payload["hard_gates"]["gates"][0]["failure_reason"] = None
 
@@ -143,13 +146,13 @@ def test_negative_validation_rejects_gate_fail_without_failure_reason() -> None:
 
 
 def test_negative_validation_rejects_non_rejected_state_on_blocking_failure() -> None:
-    payload = _valid_payload(qualification_state="watchlist", qualification_color="yellow")
+    payload = _valid_payload(qualification_state="watch", qualification_color="yellow")
     payload["hard_gates"]["gates"][0]["status"] = "fail"
     payload["hard_gates"]["gates"][0]["failure_reason"] = "Exposure cap would be exceeded"
 
     with pytest.raises(
         ValidationError,
-        match="Blocking hard-gate failures require rejected qualification state",
+        match="Blocking hard-gate failures require reject qualification state",
     ):
         validate_decision_card(payload)
 
@@ -157,18 +160,19 @@ def test_negative_validation_rejects_non_rejected_state_on_blocking_failure() ->
 @pytest.mark.parametrize(
     ("state", "color"),
     [
-        ("qualified", "green"),
-        ("watchlist", "yellow"),
-        ("rejected", "red"),
+        ("paper_approved", "green"),
+        ("paper_candidate", "yellow"),
+        ("watch", "yellow"),
+        ("reject", "red"),
     ],
 )
 def test_representative_qualification_payloads_validate(state: str, color: str) -> None:
     payload = _valid_payload(qualification_state=state, qualification_color=color)
-    if state == "rejected":
+    if state == "reject":
         payload["hard_gates"]["gates"][0]["status"] = "fail"
         payload["hard_gates"]["gates"][0]["failure_reason"] = "Risk cap breach"
         payload["qualification"]["summary"] = "Opportunity is rejected because a blocking gate failed"
-    if state == "watchlist":
+    if state == "watch":
         payload["score"]["confidence_tier"] = "low"
         payload["score"]["confidence_reason"] = "Sample depth is limited for full qualification"
         payload["qualification"]["summary"] = "Opportunity requires further evidence before qualification"

--- a/tests/cilly_trading/engine/test_qualification_engine.py
+++ b/tests/cilly_trading/engine/test_qualification_engine.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import pytest
+
+from cilly_trading.engine.decision_card_contract import (
+    DECISION_CARD_CONTRACT_VERSION,
+    ComponentScore,
+    HardGateResult,
+)
+from cilly_trading.engine.qualification_engine import (
+    QualificationEngineInput,
+    assign_confidence_tier,
+    compute_aggregate_score,
+    evaluate_qualification,
+)
+
+
+def _base_component_scores() -> list[ComponentScore]:
+    return [
+        ComponentScore(
+            category="signal_quality",
+            score=88.0,
+            rationale="Signal quality demonstrates stable hit rate in recent windows",
+            evidence=["hit_rate=0.64", "window=120d"],
+        ),
+        ComponentScore(
+            category="backtest_quality",
+            score=84.0,
+            rationale="Backtest quality remains stable under deterministic assumptions",
+            evidence=["sharpe=1.40", "profit_factor=1.60"],
+        ),
+        ComponentScore(
+            category="portfolio_fit",
+            score=79.0,
+            rationale="Portfolio fit remains within concentration and correlation limits",
+            evidence=["sector=0.17", "corr_cluster=0.42"],
+        ),
+        ComponentScore(
+            category="risk_alignment",
+            score=86.0,
+            rationale="Risk alignment is consistent with exposure and drawdown policies",
+            evidence=["risk_trade=0.005", "max_dd=0.10"],
+        ),
+        ComponentScore(
+            category="execution_readiness",
+            score=77.0,
+            rationale="Execution readiness is supported by bounded slippage assumptions",
+            evidence=["slippage_bps=9", "commission=1.00"],
+        ),
+    ]
+
+
+def _base_hard_gates() -> list[HardGateResult]:
+    return [
+        HardGateResult(
+            gate_id="drawdown_safety",
+            status="pass",
+            blocking=True,
+            reason="Drawdown remains within guard threshold",
+            evidence=["max_dd=0.08", "threshold=0.12"],
+        ),
+        HardGateResult(
+            gate_id="portfolio_exposure_cap",
+            status="pass",
+            blocking=True,
+            reason="Exposure remains under policy cap",
+            evidence=["gross_exposure=0.41", "cap=0.60"],
+        ),
+    ]
+
+
+def _engine_input(
+    *,
+    hard_gates: list[HardGateResult] | None = None,
+    component_scores: list[ComponentScore] | None = None,
+) -> QualificationEngineInput:
+    return QualificationEngineInput(
+        decision_card_id="dc_20260324_AAPL_RSI2",
+        generated_at_utc="2026-03-24T08:10:00Z",
+        symbol="AAPL",
+        strategy_id="RSI2",
+        hard_gates=list(hard_gates or _base_hard_gates()),
+        component_scores=list(component_scores or _base_component_scores()),
+        metadata={"analysis_run_id": "run_20260324_0810"},
+    )
+
+
+def test_hard_gate_blocking_failure_is_deterministically_rejected() -> None:
+    gates = _base_hard_gates()
+    gates[0] = HardGateResult(
+        gate_id="drawdown_safety",
+        status="fail",
+        blocking=True,
+        reason="Drawdown guard check failed",
+        failure_reason="Max drawdown breached threshold",
+        evidence=["max_dd=0.15", "threshold=0.12"],
+    )
+    card = evaluate_qualification(_engine_input(hard_gates=gates))
+
+    assert card.contract_version == DECISION_CARD_CONTRACT_VERSION
+    assert card.hard_gates.has_blocking_failure is True
+    assert card.qualification.state == "reject"
+    assert card.qualification.color == "red"
+    assert card.rationale.gate_explanations == sorted(card.rationale.gate_explanations)
+
+
+def test_score_aggregation_is_bounded_and_reproducible() -> None:
+    components = _base_component_scores()
+    score_a = compute_aggregate_score(component_scores=components)
+    score_b = compute_aggregate_score(component_scores=list(reversed(components)))
+
+    assert score_a == score_b
+    assert 0.0 <= score_a <= 100.0
+    assert score_a == 84.15
+
+
+@pytest.mark.parametrize(
+    ("scores", "expected"),
+    [
+        ([90.0, 88.0, 85.0, 87.0, 82.0], "high"),
+        ([72.0, 70.0, 65.0, 68.0, 61.0], "medium"),
+        ([61.0, 58.0, 55.0, 60.0, 45.0], "low"),
+    ],
+)
+def test_confidence_tier_assignment(scores: list[float], expected: str) -> None:
+    components = _base_component_scores()
+    for index, value in enumerate(scores):
+        components[index] = ComponentScore(
+            category=components[index].category,
+            score=value,
+            rationale=components[index].rationale,
+            evidence=components[index].evidence,
+        )
+    aggregate = compute_aggregate_score(component_scores=components)
+
+    assert assign_confidence_tier(aggregate_score=aggregate, component_scores=components) == expected
+
+
+def test_qualification_state_regression_representative_scenarios() -> None:
+    approved = evaluate_qualification(_engine_input())
+    assert approved.contract_version == DECISION_CARD_CONTRACT_VERSION
+    assert approved.qualification.state == "paper_approved"
+    assert approved.qualification.color == "green"
+
+    candidate_components = _base_component_scores()
+    candidate_components[2] = ComponentScore(
+        category="portfolio_fit",
+        score=62.0,
+        rationale="Portfolio fit remains acceptable but with weaker diversification",
+        evidence=["sector=0.23", "corr_cluster=0.55"],
+    )
+    candidate = evaluate_qualification(_engine_input(component_scores=candidate_components))
+    assert candidate.qualification.state == "paper_candidate"
+    assert candidate.qualification.color == "yellow"
+
+    watch_components = _base_component_scores()
+    watch_components[4] = ComponentScore(
+        category="execution_readiness",
+        score=42.0,
+        rationale="Execution assumptions require further evidence before paper approval",
+        evidence=["slippage_bps=18", "commission=1.00"],
+    )
+    watch = evaluate_qualification(_engine_input(component_scores=watch_components))
+    assert watch.qualification.state == "watch"
+    assert watch.qualification.color == "yellow"


### PR DESCRIPTION
Closes #771

## What changed
- Added deterministic qualification evaluation engine:
  - hard-gate ordering and blocking-failure handling
  - bounded fixed-weight component-score aggregation
  - explicit confidence-tier assignment
  - deterministic action-state + traffic-light output
- Updated decision-card contract to breaking revision 2.0.0
- Updated decision-card contract state vocabulary to:
  - eject, watch, paper_candidate, paper_approved
- Added representative tests:
  - hard-gate tests
  - score aggregation tests
  - confidence-tier tests
  - qualification-state regression tests
  - explicit contract-version assertions
- Updated architecture documentation to match the implemented evaluation path and active contract version.

## Validation
- Ran focused tests:
  - .\.venv\Scripts\python -m pytest tests/cilly_trading/engine/test_decision_card_contract.py tests/cilly_trading/engine/test_qualification_engine.py
  - Result: 16 passed
- Ran full test suite:
  - .\.venv\Scripts\python -m pytest
  - Result: 720 passed, 4 warnings

## Governance Notes
- Breaking contract change is now versioned explicitly as 2.0.0.
- Scope remained limited to the allowed paths for issue #771.
- This PR does not claim live-trading approval.
- This PR establishes deterministic decision-support and paper-trading qualification semantics only.