### PR TITLE
DEC-P43B: Integrate backtest evidence, portfolio fit, and bounded sentiment overlay into decision card

### DIFF
--- a/docs/architecture/decision_card_contract.md
+++ b/docs/architecture/decision_card_contract.md
@@ -75,6 +75,20 @@ Additional score fields:
 
 Hard-gate outcomes and score outcomes remain separate objects by contract.
 
+### Subsystem Input Integration
+
+The qualification engine supports explicit subsystem input paths:
+
+- `backtest_evidence` -> bounded `backtest_quality` score contribution
+- `portfolio_fit_input` -> bounded `portfolio_fit` score contribution
+- `sentiment_overlay` -> bounded aggregate overlay only (not a primary component category)
+
+Integration rules:
+
+- backtest evidence and portfolio-fit inputs are each bounded to `[0, 100]`
+- these paths replace their respective component values explicitly for the decision card
+- sentiment does not replace component categories and is never treated as primary alpha
+
 ## Qualification Output
 
 Qualification is explicit and not inferred from a single score field:
@@ -98,6 +112,17 @@ Deterministic action-state resolution:
 4. Otherwise resolve to `paper_candidate` / `yellow`.
 
 This output is bounded to paper-trading readiness only and does not imply live-trading approval.
+
+## Sentiment Overlay Boundaries
+
+Sentiment is modeled as a bounded overlay to aggregate score, not as an independent qualification source.
+
+- overlay is applied after weighted component aggregation
+- overlay score input is bounded to `[-1, 1]`
+- overlay points are bounded by a fixed cap and by stronger evidence layers (`backtest_quality`, `portfolio_fit`, `risk_alignment`)
+- missing sentiment yields neutral overlay (`0.0` points)
+- stale sentiment yields neutral overlay (`0.0` points)
+- stale/missing handling is explicit in rationale and metadata; no silent corruption is permitted
 
 ## Rationale Requirements
 

--- a/src/cilly_trading/engine/qualification_engine.py
+++ b/src/cilly_trading/engine/qualification_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 
 from cilly_trading.engine.decision_card_contract import (
     DECISION_CARD_CONTRACT_VERSION,
@@ -35,6 +36,41 @@ CONFIDENCE_THRESHOLDS: dict[str, float] = {
     "medium_min_component": 50.0,
 }
 
+SENTIMENT_OVERLAY_MAX_POINTS = 4.0
+SENTIMENT_DEFAULT_STALE_AFTER_HOURS = 24
+
+
+@dataclass(frozen=True)
+class BacktestEvidenceInput:
+    quality_score: float
+    rationale: str
+    evidence: list[str]
+
+
+@dataclass(frozen=True)
+class PortfolioFitInput:
+    fit_score: float
+    rationale: str
+    evidence: list[str]
+
+
+@dataclass(frozen=True)
+class SentimentOverlayInput:
+    sentiment_score: float
+    as_of_utc: str
+    rationale: str
+    evidence: list[str]
+    stale_after_hours: int = SENTIMENT_DEFAULT_STALE_AFTER_HOURS
+
+
+@dataclass(frozen=True)
+class SentimentOverlayResolution:
+    status: str
+    points: float
+    cap_points: float
+    reason: str
+    sentiment_score: float | None = None
+
 
 @dataclass(frozen=True)
 class QualificationEngineInput:
@@ -44,6 +80,9 @@ class QualificationEngineInput:
     strategy_id: str
     hard_gates: list[HardGateResult]
     component_scores: list[ComponentScore]
+    backtest_evidence: BacktestEvidenceInput | None = None
+    portfolio_fit_input: PortfolioFitInput | None = None
+    sentiment_overlay: SentimentOverlayInput | None = None
     hard_gate_policy_version: str = "hard-gates.v1"
     metadata: dict[str, object] | None = None
 
@@ -54,10 +93,20 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         policy_version=input_data.hard_gate_policy_version,
         gates=list(input_data.hard_gates),
     )
-    aggregate_score = compute_aggregate_score(component_scores=input_data.component_scores)
+    integrated_component_scores = _integrate_component_inputs(input_data=input_data)
+    base_aggregate_score = compute_aggregate_score(component_scores=integrated_component_scores)
+    sentiment_resolution = _resolve_sentiment_overlay(
+        sentiment_overlay=input_data.sentiment_overlay,
+        generated_at_utc=input_data.generated_at_utc,
+        component_scores=integrated_component_scores,
+    )
+    aggregate_score = _apply_sentiment_overlay(
+        base_aggregate_score=base_aggregate_score,
+        sentiment_resolution=sentiment_resolution,
+    )
     confidence_tier = assign_confidence_tier(
         aggregate_score=aggregate_score,
-        component_scores=input_data.component_scores,
+        component_scores=integrated_component_scores,
     )
     confidence_reason = _confidence_reason(confidence_tier=confidence_tier, aggregate_score=aggregate_score)
     state, color, qualification_summary = resolve_qualification_state(
@@ -79,7 +128,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             "component_scores": [
                 component.model_dump(mode="python")
                 for component in sorted(
-                    input_data.component_scores,
+                    integrated_component_scores,
                     key=lambda item: item.category,
                 )
             ],
@@ -96,16 +145,24 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             "summary": "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules.",
             "gate_explanations": _gate_explanations(hard_gate_evaluation=hard_gate_evaluation),
             "score_explanations": _score_explanations(
-                component_scores=input_data.component_scores,
+                component_scores=integrated_component_scores,
+                base_aggregate_score=base_aggregate_score,
                 aggregate_score=aggregate_score,
                 confidence_tier=confidence_tier,
+                sentiment_resolution=sentiment_resolution,
+                backtest_input_applied=input_data.backtest_evidence is not None,
+                portfolio_fit_input_applied=input_data.portfolio_fit_input is not None,
             ),
             "final_explanation": (
                 "Action state is deterministic and does not imply live-trading approval; "
                 "it indicates reject, watch, paper candidate, or paper approved."
             ),
         },
-        "metadata": dict(sorted((input_data.metadata or {}).items())),
+        "metadata": _build_metadata(
+            input_data=input_data,
+            base_aggregate_score=base_aggregate_score,
+            sentiment_resolution=sentiment_resolution,
+        ),
     }
     return validate_decision_card(payload)
 
@@ -125,6 +182,105 @@ def compute_aggregate_score(*, component_scores: list[ComponentScore]) -> float:
         raise ValueError(f"Component scores must cover required categories ({'; '.join(details)})")
     weighted = sum(score_by_category[category] * COMPONENT_WEIGHTS[category] for category in REQUIRED_COMPONENT_CATEGORIES)
     return max(0.0, min(100.0, round(weighted, 4)))
+
+
+def _integrate_component_inputs(*, input_data: QualificationEngineInput) -> list[ComponentScore]:
+    score_by_category = {component.category: component for component in input_data.component_scores}
+    if input_data.backtest_evidence is not None:
+        backtest = input_data.backtest_evidence
+        score_by_category["backtest_quality"] = ComponentScore(
+            category="backtest_quality",
+            score=_bounded_score(backtest.quality_score, field_name="backtest_evidence.quality_score"),
+            rationale=backtest.rationale,
+            evidence=list(backtest.evidence) + ["input_path=backtest_evidence"],
+        )
+    if input_data.portfolio_fit_input is not None:
+        portfolio = input_data.portfolio_fit_input
+        score_by_category["portfolio_fit"] = ComponentScore(
+            category="portfolio_fit",
+            score=_bounded_score(portfolio.fit_score, field_name="portfolio_fit_input.fit_score"),
+            rationale=portfolio.rationale,
+            evidence=list(portfolio.evidence) + ["input_path=portfolio_fit_input"],
+        )
+    return list(score_by_category.values())
+
+
+def _bounded_score(value: float, *, field_name: str) -> float:
+    if value < 0.0 or value > 100.0:
+        raise ValueError(f"{field_name} must be within [0, 100]")
+    return round(float(value), 4)
+
+
+def _resolve_sentiment_overlay(
+    *,
+    sentiment_overlay: SentimentOverlayInput | None,
+    generated_at_utc: str,
+    component_scores: list[ComponentScore],
+) -> SentimentOverlayResolution:
+    if sentiment_overlay is None:
+        return SentimentOverlayResolution(
+            status="missing",
+            points=0.0,
+            cap_points=0.0,
+            reason="Sentiment overlay missing; applying neutral 0.0000 points.",
+        )
+    if sentiment_overlay.sentiment_score < -1.0 or sentiment_overlay.sentiment_score > 1.0:
+        raise ValueError("sentiment_overlay.sentiment_score must be within [-1, 1]")
+    if sentiment_overlay.stale_after_hours < 1:
+        raise ValueError("sentiment_overlay.stale_after_hours must be >= 1")
+
+    generated_at = _parse_iso_timestamp(generated_at_utc)
+    sentiment_as_of = _parse_iso_timestamp(sentiment_overlay.as_of_utc)
+    stale_cutoff = generated_at - timedelta(hours=sentiment_overlay.stale_after_hours)
+    if sentiment_as_of < stale_cutoff:
+        return SentimentOverlayResolution(
+            status="stale",
+            points=0.0,
+            cap_points=0.0,
+            reason=(
+                "Sentiment overlay stale relative to decision timestamp; applying neutral 0.0000 points."
+            ),
+            sentiment_score=round(sentiment_overlay.sentiment_score, 4),
+        )
+
+    score_by_category = {component.category: float(component.score) for component in component_scores}
+    stronger_average = (
+        score_by_category["backtest_quality"]
+        + score_by_category["portfolio_fit"]
+        + score_by_category["risk_alignment"]
+    ) / 3.0
+    cap_points = min(
+        SENTIMENT_OVERLAY_MAX_POINTS,
+        round((stronger_average / 100.0) * SENTIMENT_OVERLAY_MAX_POINTS, 4),
+    )
+    raw_points = round(sentiment_overlay.sentiment_score * SENTIMENT_OVERLAY_MAX_POINTS, 4)
+    points = max(-cap_points, min(cap_points, raw_points))
+    return SentimentOverlayResolution(
+        status="applied",
+        points=round(points, 4),
+        cap_points=round(cap_points, 4),
+        reason=(
+            f"Sentiment overlay applied with bounded impact {points:.4f} "
+            f"(raw={raw_points:.4f}, cap={cap_points:.4f})."
+        ),
+        sentiment_score=round(sentiment_overlay.sentiment_score, 4),
+    )
+
+
+def _apply_sentiment_overlay(
+    *,
+    base_aggregate_score: float,
+    sentiment_resolution: SentimentOverlayResolution,
+) -> float:
+    return max(0.0, min(100.0, round(base_aggregate_score + sentiment_resolution.points, 4)))
+
+
+def _parse_iso_timestamp(value: str) -> datetime:
+    iso_value = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    timestamp = datetime.fromisoformat(iso_value)
+    if timestamp.tzinfo is None:
+        raise ValueError("Timestamp must include timezone information")
+    return timestamp.astimezone(timezone.utc)
 
 
 def assign_confidence_tier(
@@ -210,25 +366,60 @@ def _gate_explanations(*, hard_gate_evaluation: HardGateEvaluation) -> list[str]
 def _score_explanations(
     *,
     component_scores: list[ComponentScore],
+    base_aggregate_score: float,
     aggregate_score: float,
     confidence_tier: DecisionConfidenceTier,
+    sentiment_resolution: SentimentOverlayResolution,
+    backtest_input_applied: bool,
+    portfolio_fit_input_applied: bool,
 ) -> list[str]:
     ordered = sorted(component_scores, key=lambda component: component.category)
     component_summary = ", ".join(
         f"{component.category}={component.score:.2f}" for component in ordered
     )
     return [
-        f"Bounded weighted aggregate score={aggregate_score:.4f} using fixed category weights.",
+        f"Backtest input path is {'explicitly integrated' if backtest_input_applied else 'not provided; component value is used as-is'}.",
+        f"Portfolio-fit input path is {'explicitly integrated' if portfolio_fit_input_applied else 'not provided; component value is used as-is'}.",
+        f"Bounded weighted aggregate score={base_aggregate_score:.4f} using fixed category weights.",
+        (
+            f"Sentiment overlay status={sentiment_resolution.status}, points={sentiment_resolution.points:.4f}, "
+            f"cap={sentiment_resolution.cap_points:.4f}."
+        ),
+        f"Final aggregate score after sentiment overlay={aggregate_score:.4f}.",
         f"Component scores by category: {component_summary}.",
         f"Confidence tier resolved deterministically as {confidence_tier}.",
     ]
 
 
+def _build_metadata(
+    *,
+    input_data: QualificationEngineInput,
+    base_aggregate_score: float,
+    sentiment_resolution: SentimentOverlayResolution,
+) -> dict[str, object]:
+    metadata = dict(input_data.metadata or {})
+    metadata["base_aggregate_score"] = base_aggregate_score
+    metadata["backtest_input_applied"] = input_data.backtest_evidence is not None
+    metadata["portfolio_fit_input_applied"] = input_data.portfolio_fit_input is not None
+    metadata["sentiment_overlay_status"] = sentiment_resolution.status
+    metadata["sentiment_overlay_points"] = sentiment_resolution.points
+    metadata["sentiment_overlay_cap_points"] = sentiment_resolution.cap_points
+    metadata["sentiment_overlay_reason"] = sentiment_resolution.reason
+    if sentiment_resolution.sentiment_score is not None:
+        metadata["sentiment_overlay_score"] = sentiment_resolution.sentiment_score
+    return dict(sorted(metadata.items()))
+
+
 __all__ = [
     "COMPONENT_WEIGHTS",
     "CONFIDENCE_THRESHOLDS",
+    "BacktestEvidenceInput",
     "DecisionActionState",
+    "PortfolioFitInput",
     "QualificationEngineInput",
+    "SentimentOverlayInput",
+    "SENTIMENT_DEFAULT_STALE_AFTER_HOURS",
+    "SENTIMENT_OVERLAY_MAX_POINTS",
     "assign_confidence_tier",
     "compute_aggregate_score",
     "evaluate_qualification",

--- a/tests/cilly_trading/engine/test_qualification_engine.py
+++ b/tests/cilly_trading/engine/test_qualification_engine.py
@@ -8,7 +8,11 @@ from cilly_trading.engine.decision_card_contract import (
     HardGateResult,
 )
 from cilly_trading.engine.qualification_engine import (
+    BacktestEvidenceInput,
+    PortfolioFitInput,
     QualificationEngineInput,
+    SENTIMENT_OVERLAY_MAX_POINTS,
+    SentimentOverlayInput,
     assign_confidence_tier,
     compute_aggregate_score,
     evaluate_qualification,
@@ -73,6 +77,9 @@ def _engine_input(
     *,
     hard_gates: list[HardGateResult] | None = None,
     component_scores: list[ComponentScore] | None = None,
+    backtest_evidence: BacktestEvidenceInput | None = None,
+    portfolio_fit_input: PortfolioFitInput | None = None,
+    sentiment_overlay: SentimentOverlayInput | None = None,
 ) -> QualificationEngineInput:
     return QualificationEngineInput(
         decision_card_id="dc_20260324_AAPL_RSI2",
@@ -81,6 +88,9 @@ def _engine_input(
         strategy_id="RSI2",
         hard_gates=list(hard_gates or _base_hard_gates()),
         component_scores=list(component_scores or _base_component_scores()),
+        backtest_evidence=backtest_evidence,
+        portfolio_fit_input=portfolio_fit_input,
+        sentiment_overlay=sentiment_overlay,
         metadata={"analysis_run_id": "run_20260324_0810"},
     )
 
@@ -163,3 +173,131 @@ def test_qualification_state_regression_representative_scenarios() -> None:
     watch = evaluate_qualification(_engine_input(component_scores=watch_components))
     assert watch.qualification.state == "watch"
     assert watch.qualification.color == "yellow"
+
+
+def test_backtest_evidence_input_is_explicitly_integrated() -> None:
+    input_data = _engine_input(
+        backtest_evidence=BacktestEvidenceInput(
+            quality_score=55.0,
+            rationale="Backtest quality is reduced after stricter out-of-sample checks",
+            evidence=["oos_sharpe=0.74", "profit_factor=1.08"],
+        )
+    )
+    card = evaluate_qualification(input_data)
+
+    backtest_component = next(
+        component for component in card.score.component_scores if component.category == "backtest_quality"
+    )
+    assert backtest_component.score == 55.0
+    assert "input_path=backtest_evidence" in backtest_component.evidence
+    assert card.metadata["backtest_input_applied"] is True
+    assert "Backtest input path is explicitly integrated." in card.rationale.score_explanations
+
+
+def test_portfolio_fit_input_is_explicitly_integrated() -> None:
+    input_data = _engine_input(
+        portfolio_fit_input=PortfolioFitInput(
+            fit_score=52.0,
+            rationale="Portfolio fit weakens due to concentration drift",
+            evidence=["sector_weight=0.27", "corr_cluster=0.69"],
+        )
+    )
+    card = evaluate_qualification(input_data)
+
+    portfolio_component = next(
+        component for component in card.score.component_scores if component.category == "portfolio_fit"
+    )
+    assert portfolio_component.score == 52.0
+    assert "input_path=portfolio_fit_input" in portfolio_component.evidence
+    assert card.metadata["portfolio_fit_input_applied"] is True
+    assert "Portfolio-fit input path is explicitly integrated." in card.rationale.score_explanations
+
+
+def test_missing_sentiment_is_neutral_and_explicit() -> None:
+    card = evaluate_qualification(_engine_input())
+
+    assert card.metadata["sentiment_overlay_status"] == "missing"
+    assert card.metadata["sentiment_overlay_points"] == 0.0
+    assert card.score.aggregate_score == card.metadata["base_aggregate_score"]
+
+
+def test_stale_sentiment_is_neutral_and_explicit() -> None:
+    card = evaluate_qualification(
+        _engine_input(
+            sentiment_overlay=SentimentOverlayInput(
+                sentiment_score=0.90,
+                as_of_utc="2026-03-23T00:00:00Z",
+                rationale="Positive sentiment snapshot from earlier session",
+                evidence=["source=synthetic"],
+                stale_after_hours=12,
+            )
+        )
+    )
+
+    assert card.metadata["sentiment_overlay_status"] == "stale"
+    assert card.metadata["sentiment_overlay_points"] == 0.0
+    assert card.score.aggregate_score == card.metadata["base_aggregate_score"]
+
+
+def test_sentiment_overlay_impact_is_bounded_by_stronger_evidence_layers() -> None:
+    components = _base_component_scores()
+    components[1] = ComponentScore(
+        category="backtest_quality",
+        score=60.0,
+        rationale=components[1].rationale,
+        evidence=components[1].evidence,
+    )
+    components[2] = ComponentScore(
+        category="portfolio_fit",
+        score=50.0,
+        rationale=components[2].rationale,
+        evidence=components[2].evidence,
+    )
+    components[3] = ComponentScore(
+        category="risk_alignment",
+        score=40.0,
+        rationale=components[3].rationale,
+        evidence=components[3].evidence,
+    )
+    card = evaluate_qualification(
+        _engine_input(
+            component_scores=components,
+            sentiment_overlay=SentimentOverlayInput(
+                sentiment_score=1.0,
+                as_of_utc="2026-03-24T07:59:59Z",
+                rationale="Positive sentiment overlay",
+                evidence=["source=synthetic"],
+            ),
+        )
+    )
+
+    assert card.metadata["sentiment_overlay_status"] == "applied"
+    assert card.metadata["sentiment_overlay_points"] == 2.0
+    assert card.metadata["sentiment_overlay_cap_points"] == 2.0
+    assert card.metadata["sentiment_overlay_points"] <= card.metadata["sentiment_overlay_cap_points"]
+    assert card.metadata["sentiment_overlay_cap_points"] < SENTIMENT_OVERLAY_MAX_POINTS
+
+
+def test_sentiment_overlay_does_not_override_blocking_gate_rejection() -> None:
+    gates = _base_hard_gates()
+    gates[0] = HardGateResult(
+        gate_id="drawdown_safety",
+        status="fail",
+        blocking=True,
+        reason="Drawdown guard check failed",
+        failure_reason="Max drawdown breached threshold",
+        evidence=["max_dd=0.15", "threshold=0.12"],
+    )
+    card = evaluate_qualification(
+        _engine_input(
+            hard_gates=gates,
+            sentiment_overlay=SentimentOverlayInput(
+                sentiment_score=1.0,
+                as_of_utc="2026-03-24T08:05:00Z",
+                rationale="Positive sentiment overlay",
+                evidence=["source=synthetic"],
+            ),
+        )
+    )
+    assert card.qualification.state == "reject"
+    assert card.qualification.color == "red"


### PR DESCRIPTION
Closes #772

## What changed
- Integrated explicit bounded acktest_evidence input path into decision-card qualification.
- Integrated explicit bounded portfolio_fit_input path into decision-card qualification.
- Added deterministic sentiment_overlay as a bounded aggregate overlay, not a primary alpha component.
- Added explicit neutral handling for missing and stale sentiment overlays.
- Added metadata and rationale trace fields for integration transparency.
- Added integration tests for:
  - backtest input integration
  - portfolio-fit integration
  - missing sentiment handling
  - stale sentiment handling
  - bounded sentiment impact
  - sentiment non-override of blocking safety gates
- Updated decision-card architecture documentation for these semantics.

## Validation
- Ran full suite:
  - python -m pytest
  - Result: 725 passed, 4 warnings

## Governance Notes
- Scope remained limited to the allowed paths for issue #772.
- Sentiment remains a bounded overlay and not a primary qualification source.
- This PR does not claim live-trading approval.
- This PR strengthens deterministic decision-support and paper-trading qualification semantics only.