### PR TITLE
DEC-P43B: Expose read-only decision-card inspection surfaces (#773)

### DIFF
--- a/docs/api/decision_card_inspection.md
+++ b/docs/api/decision_card_inspection.md
@@ -1,0 +1,90 @@
+# Decision Card Inspection API
+
+This document defines the bounded read-only inspection surface for decision-card outputs used by operator and research review workflows.
+
+## Read-Only Endpoint
+
+All access requires `X-Cilly-Role: read_only` (or a higher role).
+
+- `GET /decision-cards`
+
+No mutation endpoints are introduced by this surface.
+
+## Purpose
+
+The endpoint exposes decision-card outcomes and their explanations so reviewers can inspect why a candidate was blocked, approved, or kept in ranked review flow.
+
+## Deterministic Ordering
+
+Default ordering is deterministic:
+
+- `generated_at_utc DESC`
+- tie-breaker: `decision_card_id ASC`
+- tie-breaker: `run_id ASC`
+- tie-breaker: `artifact_name ASC`
+
+Optional `sort=generated_at_asc` reverses only the primary timestamp direction while preserving deterministic tie-breakers.
+
+## Filtering
+
+Supported query filters:
+
+- `run_id`
+- `symbol`
+- `strategy_id`
+- `decision_card_id`
+- `qualification_state` (`reject`, `watch`, `paper_candidate`, `paper_approved`)
+- `review_state`:
+  - `blocked` -> `qualification_state=reject`
+  - `approved` -> `qualification_state=paper_approved`
+  - `ranked` -> non-reject outcomes (`watch`, `paper_candidate`, `paper_approved`)
+
+Pagination:
+
+- `limit` (`1..500`, default `50`)
+- `offset` (`>=0`, default `0`)
+
+## Response Contract
+
+```json
+{
+  "items": [
+    {
+      "run_id": "run-a",
+      "artifact_name": "decision_card.json",
+      "decision_card_id": "dc-001",
+      "generated_at_utc": "2026-03-24T08:00:00Z",
+      "symbol": "AAPL",
+      "strategy_id": "RSI2",
+      "qualification_state": "paper_approved",
+      "qualification_color": "green",
+      "qualification_summary": "Opportunity is approved for bounded paper-trading only.",
+      "aggregate_score": 84.15,
+      "confidence_tier": "high",
+      "hard_gate_policy_version": "hard-gates.v1",
+      "hard_gate_blocking_failure": false,
+      "hard_gates": [],
+      "component_scores": [],
+      "rationale_summary": "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules.",
+      "gate_explanations": [],
+      "score_explanations": [],
+      "final_explanation": "Action state is deterministic and does not imply live-trading approval.",
+      "metadata": {}
+    }
+  ],
+  "limit": 50,
+  "offset": 0,
+  "total": 1
+}
+```
+
+## Explanation Fields for Operator Review
+
+The inspection payload explicitly includes:
+
+- hard-gate evaluations (`hard_gates`)
+- component-level score rationales (`component_scores`)
+- gate and score explanation lists (`gate_explanations`, `score_explanations`)
+- final qualification explanation (`final_explanation`)
+
+This keeps decision outputs explainable without introducing mutation or live-trading controls.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ Use this order:
 - [API usage](operations/api/usage.md)
 - [Trading core inspection API](api/trading_core_inspection.md)
 - [Paper inspection and reconciliation API](api/paper_inspection.md)
+- [Decision card inspection API](api/decision_card_inspection.md)
 - [Phase 39 runtime chart data contract](operations/api/runtime_chart_data_contract.md)
 - Legacy compatibility alias: `docs/api/runtime_chart_data_contract.md`
 

--- a/docs/operations/api/usage_contract.md
+++ b/docs/operations/api/usage_contract.md
@@ -1047,6 +1047,81 @@ curl -s -X POST http://localhost:8000/watchlists/tech-growth/execute \
 
 ---
 
+## GET /decision-cards
+
+### Purpose
+
+Inspect decision-card outputs through a bounded read-only surface for operator and research review workflows.
+
+### Request
+
+**Query parameters:**
+
+| Name | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| `run_id` | string | optional | none | Filter by artifact run directory. |
+| `symbol` | string | optional | none | Filter by decision-card symbol. |
+| `strategy_id` | string | optional | none | Filter by decision-card strategy ID. |
+| `decision_card_id` | string | optional | none | Filter by exact decision-card ID. |
+| `qualification_state` | string | optional | none | One of `reject`, `watch`, `paper_candidate`, `paper_approved`. |
+| `review_state` | string | optional | none | One of `ranked`, `blocked`, `approved` (`blocked` maps to `reject`, `approved` maps to `paper_approved`, `ranked` maps to non-reject states). |
+| `sort` | string | optional | `generated_at_desc` | One of `generated_at_desc`, `generated_at_asc`. |
+| `limit` | integer | optional | `50` | Range `1..500`. |
+| `offset` | integer | optional | `0` | Must be `>= 0`. |
+
+### Success response
+
+- **Status:** `200 OK`
+- **Body:**
+  ```json
+  {
+    "items": [
+      {
+        "run_id": "run-a",
+        "artifact_name": "decision_card.json",
+        "decision_card_id": "dc-001",
+        "generated_at_utc": "2026-03-24T08:00:00Z",
+        "symbol": "AAPL",
+        "strategy_id": "RSI2",
+        "qualification_state": "paper_approved",
+        "qualification_color": "green",
+        "qualification_summary": "Opportunity is approved for bounded paper-trading only.",
+        "aggregate_score": 84.15,
+        "confidence_tier": "high",
+        "hard_gate_policy_version": "hard-gates.v1",
+        "hard_gate_blocking_failure": false,
+        "hard_gates": [],
+        "component_scores": [],
+        "rationale_summary": "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules.",
+        "gate_explanations": [],
+        "score_explanations": [],
+        "final_explanation": "Action state is deterministic and does not imply live-trading approval.",
+        "metadata": {}
+      }
+    ],
+    "limit": 50,
+    "offset": 0,
+    "total": 1
+  }
+  ```
+
+**Deterministic ordering:**
+
+- Primary: `generated_at_utc` (`DESC` by default, `ASC` when `sort=generated_at_asc`)
+- Tie-breakers: `decision_card_id ASC`, `run_id ASC`, `artifact_name ASC`
+
+**Empty/no-result behavior:** Returns `items: []` and `total: 0` when no matching decision cards are available.
+
+### Errors
+
+| Status | Error body shape | Error detail | Trigger |
+| --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+| 403 | `{"detail":"forbidden"}` | `forbidden` | Caller has a valid role but lacks read access. |
+| 422 | Pydantic validation list | varies | Invalid query constraints or enum values (for example `limit=0` or unsupported `review_state`). |
+
+---
+
 ## POST /screener/basic
 
 ### Purpose

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from cilly_trading.engine.analysis import trigger_operator_analysis_run
 from cilly_trading.compliance.daily_loss_guard import (
@@ -45,6 +45,7 @@ from cilly_trading.engine.core import (
     compute_analysis_run_id,
     run_watchlist_analysis,
 )
+from cilly_trading.engine.decision_card_contract import validate_decision_card
 from cilly_trading.engine.data import SnapshotDataError
 from cilly_trading.engine.health.evaluator import (
     RuntimeHealthSnapshot,
@@ -772,6 +773,82 @@ class DecisionTraceResponse(BaseModel):
     trace_id: Optional[str] = None
     entries: List[Dict[str, Any]]
     total_entries: int
+
+
+class DecisionCardHardGateInspectionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    gate_id: str
+    status: Literal["pass", "fail"]
+    blocking: bool
+    reason: str
+    evidence: List[str]
+    failure_reason: Optional[str] = None
+
+
+class DecisionCardComponentScoreInspectionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    category: Literal[
+        "signal_quality",
+        "backtest_quality",
+        "portfolio_fit",
+        "risk_alignment",
+        "execution_readiness",
+    ]
+    score: float
+    rationale: str
+    evidence: List[str]
+
+
+class DecisionCardInspectionItemResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    artifact_name: str
+    decision_card_id: str
+    generated_at_utc: str
+    symbol: str
+    strategy_id: str
+    qualification_state: Literal["reject", "watch", "paper_candidate", "paper_approved"]
+    qualification_color: Literal["green", "yellow", "red"]
+    qualification_summary: str
+    aggregate_score: float
+    confidence_tier: Literal["low", "medium", "high"]
+    hard_gate_policy_version: str
+    hard_gate_blocking_failure: bool
+    hard_gates: List[DecisionCardHardGateInspectionResponse]
+    component_scores: List[DecisionCardComponentScoreInspectionResponse]
+    rationale_summary: str
+    gate_explanations: List[str]
+    score_explanations: List[str]
+    final_explanation: str
+    metadata: Dict[str, Any]
+
+
+class DecisionCardInspectionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[DecisionCardInspectionItemResponse]
+    limit: int
+    offset: int
+    total: int
+
+
+class DecisionCardInspectionQuery(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: Optional[str] = Field(default=None)
+    symbol: Optional[str] = Field(default=None)
+    strategy_id: Optional[str] = Field(default=None)
+    decision_card_id: Optional[str] = Field(default=None)
+    qualification_state: Optional[
+        Literal["reject", "watch", "paper_candidate", "paper_approved"]
+    ] = Field(default=None)
+    review_state: Optional[Literal["ranked", "blocked", "approved"]] = Field(default=None)
+    sort: Literal["generated_at_desc", "generated_at_asc"] = Field(default="generated_at_desc")
+    limit: int = Field(default=50, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
 
 
 class WatchlistPayload(BaseModel):
@@ -2127,6 +2204,32 @@ def _get_screener_results_query(
     )
 
 
+def _get_decision_card_inspection_query(
+    run_id: Optional[str] = Query(default=None),
+    symbol: Optional[str] = Query(default=None),
+    strategy_id: Optional[str] = Query(default=None),
+    decision_card_id: Optional[str] = Query(default=None),
+    qualification_state: Optional[
+        Literal["reject", "watch", "paper_candidate", "paper_approved"]
+    ] = Query(default=None),
+    review_state: Optional[Literal["ranked", "blocked", "approved"]] = Query(default=None),
+    sort: Literal["generated_at_desc", "generated_at_asc"] = Query(default="generated_at_desc"),
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> DecisionCardInspectionQuery:
+    return DecisionCardInspectionQuery(
+        run_id=run_id,
+        symbol=symbol,
+        strategy_id=strategy_id,
+        decision_card_id=decision_card_id,
+        qualification_state=qualification_state,
+        review_state=review_state,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+    )
+
+
 def _iter_journal_artifact_files() -> List[tuple[str, Path]]:
     if not JOURNAL_ARTIFACTS_ROOT.exists() or not JOURNAL_ARTIFACTS_ROOT.is_dir():
         return []
@@ -2205,6 +2308,142 @@ def _extract_trace_entries(content: Any) -> tuple[Optional[str], List[Dict[str, 
         else:
             normalized_entries.append({"value": entry})
     return trace_id, normalized_entries
+
+
+def _extract_decision_card_candidates(content: Any) -> List[Dict[str, Any]]:
+    candidates: List[Dict[str, Any]] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if {
+                "contract_version",
+                "decision_card_id",
+                "generated_at_utc",
+                "hard_gates",
+                "score",
+                "qualification",
+                "rationale",
+            }.issubset(node.keys()):
+                candidates.append(node)
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    _walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(content)
+    return candidates
+
+
+def _matches_decision_card_review_state(
+    qualification_state: str,
+    review_state: Optional[Literal["ranked", "blocked", "approved"]],
+) -> bool:
+    if review_state is None:
+        return True
+    if review_state == "blocked":
+        return qualification_state == "reject"
+    if review_state == "approved":
+        return qualification_state == "paper_approved"
+    return qualification_state != "reject"
+
+
+def _decision_card_item_sort_key(
+    item: DecisionCardInspectionItemResponse,
+    *,
+    sort: Literal["generated_at_desc", "generated_at_asc"],
+) -> tuple[float, str, str, str]:
+    generated_at = datetime.fromisoformat(
+        item.generated_at_utc.replace("Z", "+00:00")
+        if item.generated_at_utc.endswith("Z")
+        else item.generated_at_utc
+    )
+    timestamp = generated_at.timestamp()
+    if sort == "generated_at_desc":
+        timestamp = -timestamp
+    return (timestamp, item.decision_card_id, item.run_id, item.artifact_name)
+
+
+def _build_decision_card_inspection_items(
+    params: DecisionCardInspectionQuery,
+) -> List[DecisionCardInspectionItemResponse]:
+    items: List[DecisionCardInspectionItemResponse] = []
+    seen: set[tuple[str, str, str, str]] = set()
+
+    for run_id, artifact_path in _iter_journal_artifact_files():
+        if params.run_id is not None and run_id != params.run_id:
+            continue
+
+        content_type, content = _read_journal_artifact_content(artifact_path)
+        if content_type != "json":
+            continue
+
+        for candidate in _extract_decision_card_candidates(content):
+            try:
+                card = validate_decision_card(candidate)
+            except (ValidationError, ValueError):
+                continue
+
+            if params.decision_card_id is not None and card.decision_card_id != params.decision_card_id:
+                continue
+            if params.symbol is not None and card.symbol != params.symbol:
+                continue
+            if params.strategy_id is not None and card.strategy_id != params.strategy_id:
+                continue
+            if (
+                params.qualification_state is not None
+                and card.qualification.state != params.qualification_state
+            ):
+                continue
+            if not _matches_decision_card_review_state(card.qualification.state, params.review_state):
+                continue
+
+            dedupe_key = (
+                run_id,
+                artifact_path.name,
+                card.decision_card_id,
+                card.to_canonical_json(),
+            )
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+
+            items.append(
+                DecisionCardInspectionItemResponse(
+                    run_id=run_id,
+                    artifact_name=artifact_path.name,
+                    decision_card_id=card.decision_card_id,
+                    generated_at_utc=card.generated_at_utc,
+                    symbol=card.symbol,
+                    strategy_id=card.strategy_id,
+                    qualification_state=card.qualification.state,
+                    qualification_color=card.qualification.color,
+                    qualification_summary=card.qualification.summary,
+                    aggregate_score=card.score.aggregate_score,
+                    confidence_tier=card.score.confidence_tier,
+                    hard_gate_policy_version=card.hard_gates.policy_version,
+                    hard_gate_blocking_failure=card.hard_gates.has_blocking_failure,
+                    hard_gates=[
+                        DecisionCardHardGateInspectionResponse(**gate.model_dump(mode="python"))
+                        for gate in card.hard_gates.gates
+                    ],
+                    component_scores=[
+                        DecisionCardComponentScoreInspectionResponse(
+                            **component.model_dump(mode="python")
+                        )
+                        for component in card.score.component_scores
+                    ],
+                    rationale_summary=card.rationale.summary,
+                    gate_explanations=list(card.rationale.gate_explanations),
+                    score_explanations=list(card.rationale.score_explanations),
+                    final_explanation=card.rationale.final_explanation,
+                    metadata=dict(card.metadata),
+                )
+            )
+
+    items.sort(key=lambda item: _decision_card_item_sort_key(item, sort=params.sort))
+    return items
 
 
 def _to_watchlist_response(watchlist: Any) -> WatchlistResponse:
@@ -2436,6 +2675,29 @@ def read_decision_trace(
         trace_id=trace_id,
         entries=entries,
         total_entries=len(entries),
+    )
+
+
+@app.get(
+    "/decision-cards",
+    response_model=DecisionCardInspectionResponse,
+    summary="Decision Card Inspection",
+    description=(
+        "Read-only inspection surface for decision-card outputs with deterministic "
+        "ordering, filtering, and explanation fields."
+    ),
+)
+def read_decision_cards(
+    params: DecisionCardInspectionQuery = Depends(_get_decision_card_inspection_query),
+    _: str = Depends(_require_role("read_only")),
+) -> DecisionCardInspectionResponse:
+    all_items = _build_decision_card_inspection_items(params)
+    page, total = _paginate_items(all_items, limit=params.limit, offset=params.offset)
+    return DecisionCardInspectionResponse(
+        items=page,
+        limit=params.limit,
+        offset=params.offset,
+        total=total,
     )
 
 

--- a/tests/test_api_decision_card_inspection_read.py
+++ b/tests/test_api_decision_card_inspection_read.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+from tests.utils.json_schema_validator import validate_json_schema
+
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
+
+def _write_artifact(root: Path, run_id: str, artifact_name: str, payload: Any) -> None:
+    run_dir = root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / artifact_name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _decision_card_payload(
+    *,
+    decision_card_id: str,
+    generated_at_utc: str,
+    symbol: str,
+    strategy_id: str,
+    qualification_state: str,
+) -> dict[str, Any]:
+    color_by_state = {
+        "reject": "red",
+        "watch": "yellow",
+        "paper_candidate": "yellow",
+        "paper_approved": "green",
+    }
+    gates = [
+        {
+            "gate_id": "drawdown_safety",
+            "status": "pass",
+            "blocking": True,
+            "reason": "Drawdown remains within threshold",
+            "evidence": ["max_dd=0.08", "threshold=0.12"],
+            "failure_reason": None,
+        },
+        {
+            "gate_id": "portfolio_exposure_cap",
+            "status": "pass",
+            "blocking": True,
+            "reason": "Exposure remains within policy bounds",
+            "evidence": ["gross_exposure=0.41", "cap=0.60"],
+            "failure_reason": None,
+        },
+    ]
+    if qualification_state == "reject":
+        gates[0] = {
+            "gate_id": "drawdown_safety",
+            "status": "fail",
+            "blocking": True,
+            "reason": "Drawdown guard failed",
+            "evidence": ["max_dd=0.15", "threshold=0.12"],
+            "failure_reason": "Max drawdown breached policy threshold",
+        }
+
+    return {
+        "contract_version": "2.0.0",
+        "decision_card_id": decision_card_id,
+        "generated_at_utc": generated_at_utc,
+        "symbol": symbol,
+        "strategy_id": strategy_id,
+        "hard_gates": {
+            "policy_version": "hard-gates.v1",
+            "gates": gates,
+        },
+        "score": {
+            "component_scores": [
+                {
+                    "category": "signal_quality",
+                    "score": 88.0,
+                    "rationale": "Signal quality remains stable across the review window",
+                    "evidence": ["hit_rate=0.64", "window=120d"],
+                },
+                {
+                    "category": "backtest_quality",
+                    "score": 84.0,
+                    "rationale": "Backtest quality remains bounded and reproducible",
+                    "evidence": ["sharpe=1.40", "profit_factor=1.60"],
+                },
+                {
+                    "category": "portfolio_fit",
+                    "score": 79.0,
+                    "rationale": "Portfolio fit remains inside concentration limits",
+                    "evidence": ["sector=0.17", "corr_cluster=0.42"],
+                },
+                {
+                    "category": "risk_alignment",
+                    "score": 86.0,
+                    "rationale": "Risk alignment is within configured guardrail bounds",
+                    "evidence": ["risk_trade=0.005", "max_dd=0.10"],
+                },
+                {
+                    "category": "execution_readiness",
+                    "score": 77.0,
+                    "rationale": "Execution readiness remains consistent with assumptions",
+                    "evidence": ["slippage_bps=9", "commission=1.00"],
+                },
+            ],
+            "confidence_tier": "high",
+            "confidence_reason": "Aggregate and minimum component scores satisfy high thresholds.",
+            "aggregate_score": 84.15,
+        },
+        "qualification": {
+            "state": qualification_state,
+            "color": color_by_state[qualification_state],
+            "summary": "Qualification is deterministic and bounded for operator inspection.",
+        },
+        "rationale": {
+            "summary": "Qualification is resolved from explicit hard gates and bounded score semantics.",
+            "gate_explanations": [
+                "Gate drawdown_safety was evaluated with explicit threshold evidence.",
+                "Gate portfolio_exposure_cap was evaluated with explicit exposure evidence.",
+            ],
+            "score_explanations": [
+                "Component scores are integrated by deterministic category ordering.",
+                "Aggregate score uses fixed weights and bounded confidence tiers.",
+            ],
+            "final_explanation": "Decision output is explainable and bounded to reject/watch/candidate/approved states.",
+        },
+        "metadata": {
+            "analysis_run_id": "run-abc",
+            "source": "qualification_engine",
+        },
+    }
+
+
+def _client(monkeypatch, artifacts_root: Path) -> TestClient:
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "JOURNAL_ARTIFACTS_ROOT", artifacts_root)
+    return TestClient(api_main.app)
+
+
+def test_decision_card_inspection_endpoint_is_exposed_and_schema_valid(
+    monkeypatch, tmp_path: Path
+) -> None:
+    artifacts_root = tmp_path / "runs" / "phase6"
+    _write_artifact(
+        artifacts_root,
+        run_id="run-1",
+        artifact_name="decision_card.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-001",
+            generated_at_utc="2026-03-24T08:00:00Z",
+            symbol="AAPL",
+            strategy_id="RSI2",
+            qualification_state="paper_approved",
+        ),
+    )
+
+    with _client(monkeypatch, artifacts_root) as client:
+        response = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+        openapi = client.get("/openapi.json").json()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["decision_card_id"] == "dc-001"
+    assert payload["items"][0]["rationale_summary"]
+    assert payload["items"][0]["gate_explanations"]
+    assert payload["items"][0]["score_explanations"]
+    assert "/decision-cards" in openapi["paths"]
+
+    errors = validate_json_schema(payload, api_main.DecisionCardInspectionResponse.model_json_schema())
+    assert errors == []
+
+
+def test_decision_card_inspection_ordering_and_filtering_are_deterministic(
+    monkeypatch, tmp_path: Path
+) -> None:
+    artifacts_root = tmp_path / "runs" / "phase6"
+    _write_artifact(
+        artifacts_root,
+        run_id="run-a",
+        artifact_name="dc-1.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-001",
+            generated_at_utc="2026-03-24T08:00:00Z",
+            symbol="AAPL",
+            strategy_id="RSI2",
+            qualification_state="paper_approved",
+        ),
+    )
+    _write_artifact(
+        artifacts_root,
+        run_id="run-a",
+        artifact_name="dc-2.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-002",
+            generated_at_utc="2026-03-24T09:00:00Z",
+            symbol="MSFT",
+            strategy_id="RSI2",
+            qualification_state="reject",
+        ),
+    )
+    _write_artifact(
+        artifacts_root,
+        run_id="run-b",
+        artifact_name="dc-3.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-003",
+            generated_at_utc="2026-03-24T09:00:00Z",
+            symbol="AAPL",
+            strategy_id="TURTLE",
+            qualification_state="paper_candidate",
+        ),
+    )
+
+    with _client(monkeypatch, artifacts_root) as client:
+        first = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+        second = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+        aapl = client.get(
+            "/decision-cards",
+            headers=READ_ONLY_HEADERS,
+            params={"symbol": "AAPL"},
+        )
+        rejected = client.get(
+            "/decision-cards",
+            headers=READ_ONLY_HEADERS,
+            params={"qualification_state": "reject"},
+        )
+        approved = client.get(
+            "/decision-cards",
+            headers=READ_ONLY_HEADERS,
+            params={"review_state": "approved"},
+        )
+        ranked = client.get(
+            "/decision-cards",
+            headers=READ_ONLY_HEADERS,
+            params={"review_state": "ranked"},
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert [item["decision_card_id"] for item in first.json()["items"]] == [
+        "dc-002",
+        "dc-003",
+        "dc-001",
+    ]
+
+    assert [item["decision_card_id"] for item in aapl.json()["items"]] == ["dc-003", "dc-001"]
+    assert [item["decision_card_id"] for item in rejected.json()["items"]] == ["dc-002"]
+    assert [item["decision_card_id"] for item in approved.json()["items"]] == ["dc-001"]
+    assert [item["decision_card_id"] for item in ranked.json()["items"]] == ["dc-003", "dc-001"]
+
+
+def test_decision_card_inspection_empty_and_error_cases(monkeypatch, tmp_path: Path) -> None:
+    artifacts_root = tmp_path / "runs" / "phase6"
+
+    with _client(monkeypatch, artifacts_root) as client:
+        empty = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+        unauthorized = client.get("/decision-cards")
+        invalid_limit = client.get(
+            "/decision-cards",
+            headers=READ_ONLY_HEADERS,
+            params={"limit": 0},
+        )
+        invalid_review_state = client.get(
+            "/decision-cards",
+            headers=READ_ONLY_HEADERS,
+            params={"review_state": "unknown"},
+        )
+
+    assert empty.status_code == 200
+    assert empty.json() == {"items": [], "limit": 50, "offset": 0, "total": 0}
+    assert unauthorized.status_code == 401
+    assert unauthorized.json() == {"detail": "unauthorized"}
+    assert invalid_limit.status_code == 422
+    assert invalid_review_state.status_code == 422
+
+
+def test_decision_card_inspection_regression_ignores_non_contract_artifacts(
+    monkeypatch, tmp_path: Path
+) -> None:
+    artifacts_root = tmp_path / "runs" / "phase6"
+    _write_artifact(
+        artifacts_root,
+        run_id="run-1",
+        artifact_name="invalid.json",
+        payload={"decision_card": {"decision_card_id": "missing-fields"}},
+    )
+    (artifacts_root / "run-1" / "notes.txt").write_text("not json", encoding="utf-8")
+    _write_artifact(
+        artifacts_root,
+        run_id="run-2",
+        artifact_name="valid.json",
+        payload={
+            "decision_cards": [
+                _decision_card_payload(
+                    decision_card_id="dc-010",
+                    generated_at_utc="2026-03-24T11:00:00Z",
+                    symbol="NVDA",
+                    strategy_id="TURTLE",
+                    qualification_state="watch",
+                )
+            ]
+        },
+    )
+
+    with _client(monkeypatch, artifacts_root) as client:
+        response = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert [item["decision_card_id"] for item in payload["items"]] == ["dc-010"]


### PR DESCRIPTION
Closes #773

## Summary
- Added `GET /decision-cards` as a bounded read-only inspection surface.
- Added deterministic ordering (`generated_at_desc|generated_at_asc` with stable tie-breakers) and deterministic filtering (`run_id`, `symbol`, `strategy_id`, `decision_card_id`, `qualification_state`, `review_state`).
- Exposed rationale/explanation fields and hard-gate/component-score evidence needed for operator review.
- Added API/read-path tests including ordering, empty/error, and regression handling for invalid/non-contract artifacts.
- Documented the inspection contract in:
  - `docs/api/decision_card_inspection.md`
  - `docs/operations/api/usage_contract.md`
  - `docs/index.md`

## Validation
- Full suite: `.\.venv\Scripts\python -m pytest`
- Result: `729 passed`