### PR TITLE
REL-P46: Define engine versioning, release tags, feature-flag boundaries, and rollback discipline

### DIFF
--- a/docs/architecture/versioning/declaration.md
+++ b/docs/architecture/versioning/declaration.md
@@ -1,16 +1,27 @@
 # Version declaration
 
 ## Source of truth
+The authoritative engine version is declared in `src/cilly_trading/version.py`.
 
-The authoritative project version is defined in `src/cilly_trading/version.py` as:
-
+Contractual exports:
 - `__version__: str`
 - `get_version() -> str`
+- `get_release_tag(version: str | None = None) -> str`
+- `get_release_state(version: str | None = None) -> str`
 
-All other version exposure mechanisms must read from this module.
+`get_version()` and `__version__` must always match.
+
+## Version contract
+Engine versions must satisfy the bounded SemVer contract from `model.md`:
+
+- `MAJOR.MINOR.PATCH`
+- `MAJOR.MINOR.PATCH-alpha.N`
+- `MAJOR.MINOR.PATCH-beta.N`
+- `MAJOR.MINOR.PATCH-rc.N`
+
+Release tags must be `v<version>` and validate against the same bounded forms.
 
 ## CLI exposure
-
 The package module entrypoint exposes version output:
 
 ```bash
@@ -19,17 +30,12 @@ PYTHONPATH=src python -m cilly_trading --version
 
 This prints the exact `__version__` value and exits with code `0`.
 
-Running without flags prints help text and exits with code `0`:
-
-```bash
-PYTHONPATH=src python -m cilly_trading
-```
-
 ## Python API exposure
-
-Version is exposed through the public Python API via:
+Version access points:
 
 - `cilly_trading.__version__`
 - `cilly_trading.version.get_version()`
+- `cilly_trading.version.get_release_tag()`
+- `cilly_trading.version.get_release_state()`
 
-These two values are contractually required to match.
+These APIs provide a single bounded vocabulary for engine version and release-state reporting.

--- a/docs/operations/release/rollback_discipline.md
+++ b/docs/operations/release/rollback_discipline.md
@@ -1,0 +1,64 @@
+# Rollback Discipline
+
+## 1. Purpose
+Define an operationally usable rollback path for staged and GA releases.
+Rollback is tag-based, auditable, and state-aware.
+
+## 2. Rollback triggers
+Start rollback when any of the following occurs after release:
+
+- compatibility regression against declared contracts
+- failed health/readiness checks
+- high-severity runtime regression not resolved by bounded flag disablement
+
+## 3. Required inputs before rollback
+- current release tag
+- last-known-good tag
+- release state (`alpha`, `beta`, `rc`, or `ga`)
+- rollback owner and decision timestamp
+
+## 4. Rollback procedure
+
+1. Freeze further promotion for the affected release.
+2. Disable flagged capability gates first when regression is flag-scoped.
+3. If issue persists, redeploy from last-known-good tag.
+4. Run post-rollback verification checks.
+5. Record rollback outcome and next action.
+
+## 5. Post-rollback verification
+Minimum required checks:
+
+- version check:
+  ```bash
+  PYTHONPATH=src python -m cilly_trading --version
+  ```
+
+- smoke run:
+  ```bash
+  PYTHONPATH=src python -c 'from cilly_trading.smoke_run import run_smoke_run; raise SystemExit(run_smoke_run())'
+  ```
+
+- staging validation when server deployment is in scope:
+  ```bash
+  python scripts/validate_staging_deployment.py
+  ```
+
+## 6. Release-state rollback expectations
+- `alpha`: rollback may target prior alpha, or nearest stable pre-release if needed.
+- `beta`: rollback should target prior beta or a last-known-good rc/ga as approved.
+- `rc`: rollback should target prior rc or last-known-good ga.
+- `ga`: rollback target must be a prior ga tag unless emergency approval states otherwise.
+
+## 7. Tag integrity rules
+- Do not delete release tags.
+- Do not move existing tags to new commits.
+- Rollback always deploys an existing tag or a new corrective tag.
+
+## 8. Recordkeeping
+Each rollback record must include:
+
+- incident reference (issue or incident ID)
+- from-tag and to-tag
+- rollback decision owner
+- executed verification evidence
+- follow-up fix plan


### PR DESCRIPTION
## Summary
- repairs the two approved markdown maintained assets for version declaration and rollback discipline
- preserves the approved release/versioning, CLI exposure, and rollback verification contracts
- keeps the fix strictly scoped to issue #778

## Validation
- python -m pytest tests/test_release_versioning_docs.py tests/test_version_declaration.py tests/test_release_contracts.py
- python -m pytest

Closes #778