### PR TITLE
OPS-P46: Add paper deployment acceptance gate and operator checklist

### DIFF
--- a/docs/operations/paper-trading.md
+++ b/docs/operations/paper-trading.md
@@ -41,6 +41,20 @@ The repository contains a deterministic engine-level paper-trading simulator. It
 - No owner-facing production runtime command for paper-trading execution is declared in the runbook.
 - This document does not claim a complete user-facing paper-trading product workflow.
 
+## Server Deployment Acceptance Gate
+For server-based paper usage, "running on a server" is not sufficient.
+
+Staging install readiness and paper-operational readiness are separate states:
+- Staging install readiness: deployment mechanics and runtime health checks pass.
+- Paper-operational readiness: staging readiness plus acceptance evidence defined
+  in `docs/operations/runtime/paper-deployment-acceptance-gate.md`.
+
+Operator sign-off must use:
+- `docs/operations/runtime/paper-deployment-operator-checklist.md`
+
+Passing the paper-operational gate still does not imply live-trading readiness
+or broker go-live approval.
+
 ## Roadmap Readiness Interpretation
 - Phase 24 focuses on documentation and governance alignment for the simulator and its boundaries.
 - Phase 44 remains the broader paper-trading product phase and should only be treated as complete when workflow, operator surfaces, and broader runtime handling are fully verified.

--- a/docs/operations/runtime/paper-deployment-acceptance-gate.md
+++ b/docs/operations/runtime/paper-deployment-acceptance-gate.md
@@ -1,0 +1,96 @@
+# Paper Deployment Acceptance Gate (Staging -> Paper-Operational)
+
+## Purpose
+Define the explicit acceptance gate that must pass before a server deployment is
+treated as paper-operational for serious paper-trading usage.
+
+This gate exists to prevent a false equivalence between:
+- "the engine is installed and running on a server", and
+- "the engine is operationally ready for paper-trading decisions".
+
+## Scope
+In scope:
+- staging-to-paper acceptance gate definition
+- minimum evidence categories and pass requirements
+- operator-facing decision rule for paper-operational declaration
+
+Out of scope:
+- live-trading go-live criteria
+- broker launch process
+- product/marketing readiness claims
+
+## Boundary: Server Install vs Paper-Operational
+Server install readiness is a prerequisite only. It means deployment mechanics
+and basic runtime health checks pass on a staging host.
+
+Paper-operational readiness is a stricter state. It is reached only when all
+acceptance-gate evidence categories in this document are satisfied.
+
+Decision rule:
+- If any required evidence item is missing or fails, status remains `staging`.
+- Only when every required evidence item passes, status may be declared
+  `paper-operational`.
+
+## Required Evidence Categories (Minimum)
+
+### 1) Backtesting Evidence
+Minimum required evidence:
+- A bounded backtest evidence set exists for the exact strategy/config inputs
+  intended for paper usage.
+- Evidence includes run context (symbol universe, timeframe/window, config
+  identity, and execution timestamp).
+- The evidence shows deterministic reproducibility for the same inputs (no
+  unexplained result drift between repeated runs).
+- Any strategy candidate proposed for paper usage has no unresolved blocking
+  risk findings in the recorded evidence set.
+
+### 2) Decision-Card Behavior Evidence
+Minimum required evidence:
+- Decision cards are produced and reviewable for the candidates in scope.
+- Contract behavior is consistent with documented semantics in
+  `docs/architecture/decision_card_contract.md`.
+- Blocking hard-gate failures resolve to reject outcomes.
+- Candidates considered for paper operation resolve only through explicit
+  qualification states (`paper_candidate` or `paper_approved`), with rationale
+  fields present.
+
+### 3) Runtime Health Evidence
+Minimum required evidence:
+- Staging deployment validation passes using
+  `python scripts/validate_staging_deployment.py`.
+- Required success markers are captured, including
+  `STAGING_VALIDATE:SUCCESS`.
+- Read-only health endpoints show readiness for `engine`, `data`, and `guards`
+  according to `docs/operations/runtime/staging-server-deployment.md`.
+- Restart validation is included and health remains ready after restart.
+
+### 4) Paper-Trading Consistency Evidence
+Minimum required evidence:
+- Paper-trading lifecycle behavior remains deterministic and bounded to
+  simulation-only semantics.
+- Canonical paper-trading tests remain passing, including
+  `tests/test_paper_trading_simulator.py`.
+- Paper inspection outputs are consistent with canonical order/event/trade
+  semantics documented in `docs/operations/paper-trading.md`.
+- Evidence explicitly confirms no live order routing or broker side effects.
+
+## Mandatory Validation Artifacts
+The following artifacts are required for gate review:
+- Completed operator checklist:
+  `docs/operations/runtime/paper-deployment-operator-checklist.md`
+- Captured staging validation output including success markers.
+- Captured repository test evidence (`python -m pytest` remains mandatory).
+
+## Operator Gate Outcome
+Use the operator checklist final decision rule:
+- Any `NO` item -> Gate result `NOT ACCEPTED`, deployment remains `staging`.
+- All items `YES` -> Gate result `ACCEPTED`, deployment may be treated as
+  `paper-operational` (still non-live, non-broker).
+
+## Explicit Non-Goals Relative to Live Trading
+Passing this gate does not imply:
+- live-trading readiness
+- broker connectivity approval
+- capital-at-risk authorization
+- production incident/SRE maturity for live execution
+

--- a/docs/operations/runtime/paper-deployment-operator-checklist.md
+++ b/docs/operations/runtime/paper-deployment-operator-checklist.md
@@ -1,0 +1,68 @@
+# Paper Deployment Operator Acceptance Checklist
+
+## Instructions
+1. Fill every item with `YES` or `NO`.
+2. Provide concrete evidence references (command output, artifact path, run id).
+3. If any item is `NO`, the deployment is not paper-operational.
+
+## A) Staging Install Prerequisite
+
+| # | Item | Evidence reference | Answer (YES/NO) |
+| --- | --- | --- | --- |
+| A1 | Staging deployment validation command completed: `python scripts/validate_staging_deployment.py` | | |
+| A2 | Validation output includes `STAGING_VALIDATE:SUCCESS` | | |
+| A3 | Restart validation passed and post-restart health remained ready | | |
+
+## B) Backtesting Evidence
+
+| # | Item | Evidence reference | Answer (YES/NO) |
+| --- | --- | --- | --- |
+| B1 | Backtest evidence set exists for the same strategy/config scope intended for paper usage | | |
+| B2 | Evidence includes bounded run context (symbol/time window/config identity) | | |
+| B3 | Repeated runs for identical inputs are reproducible without unexplained drift | | |
+| B4 | No unresolved blocking risk findings remain for candidates entering paper operation | | |
+
+## C) Decision-Card Behavior Evidence
+
+| # | Item | Evidence reference | Answer (YES/NO) |
+| --- | --- | --- | --- |
+| C1 | Decision cards are available and reviewable for in-scope candidates | | |
+| C2 | Blocking hard-gate failures resolve to `reject` per contract | | |
+| C3 | Paper candidates use explicit qualification states (`paper_candidate` or `paper_approved`) | | |
+| C4 | Rationale fields are present and complete (gate explanations, score explanations, final explanation) | | |
+
+## D) Runtime Health Evidence
+
+| # | Item | Evidence reference | Answer (YES/NO) |
+| --- | --- | --- | --- |
+| D1 | `/health/engine` shows `ready: true` | | |
+| D2 | `/health/data` shows `ready: true` | | |
+| D3 | `/health/guards` shows `ready: true` and allowing decision under bounded staging defaults | | |
+| D4 | Runtime remained healthy after restart check | | |
+
+## E) Paper-Trading Consistency Evidence
+
+| # | Item | Evidence reference | Answer (YES/NO) |
+| --- | --- | --- | --- |
+| E1 | Paper-trading simulator behavior remains deterministic for repeated identical inputs | | |
+| E2 | Paper-trading simulator tests pass (`tests/test_paper_trading_simulator.py`) | | |
+| E3 | Paper inspection outputs align with canonical order/event/trade semantics | | |
+| E4 | No live routing or broker side effects are present in the validated path | | |
+
+## F) Repository Test Gate (Mandatory)
+
+| # | Item | Evidence reference | Answer (YES/NO) |
+| --- | --- | --- | --- |
+| F1 | Full repository test suite passed with `python -m pytest` | | |
+
+## Final Operator Decision
+Decision rule:
+- Any `NO` -> `NOT ACCEPTED` (status remains `staging`)
+- All `YES` -> `ACCEPTED` (status may be declared `paper-operational`)
+
+Final decision (`ACCEPTED` or `NOT ACCEPTED`):
+
+Operator name:
+
+Date (UTC):
+

--- a/docs/operations/runtime/staging-first-deployment-topology.md
+++ b/docs/operations/runtime/staging-first-deployment-topology.md
@@ -123,6 +123,19 @@ Until those gates exist and are accepted, this topology must be treated as:
 - no live order execution
 - no broker-integrated production behavior
 
+## Install-Ready vs Paper-Operational Boundary
+In this repository, these are separate states:
+- `install-ready (staging)`: deployment and runtime mechanics are healthy on the
+  staging host.
+- `paper-operational`: install-ready plus explicit acceptance evidence for
+  backtesting, decision-card behavior, runtime health, and paper-trading
+  consistency.
+
+Passing staging deployment checks alone does not grant paper-operational status.
+The required gate and operator checklist are:
+- `docs/operations/runtime/paper-deployment-acceptance-gate.md`
+- `docs/operations/runtime/paper-deployment-operator-checklist.md`
+
 ## Validation and Verification Path
 
 ### Canonical Staging Artifact Path
@@ -172,5 +185,7 @@ Pass condition:
 ## Related References
 - `docs/operations/runbook.md`
 - `docs/operations/paper-trading.md`
+- `docs/operations/runtime/paper-deployment-acceptance-gate.md`
+- `docs/operations/runtime/paper-deployment-operator-checklist.md`
 - `docs/architecture/engine_runtime_lifecycle_contract.md`
 - `docs/architecture/configuration_boundary.md`


### PR DESCRIPTION
## Summary
- adds a bounded paper-deployment acceptance gate for staging-to-paper-operational transition
- adds a binary operator checklist artifact for required evidence and sign-off
- makes the install-ready vs paper-operational boundary explicit in the staging topology and paper-trading docs
- keeps the change strictly scoped to the four approved documentation files for issue #779

## Validation
- python -m pytest

Closes #779