### PR TITLE
ARCH-P45B: Reduce api.main to minimal composition root and extract runtime/app-state wiring

### DIFF
--- a/docs/architecture/arch-p45a-api-module-split.md
+++ b/docs/architecture/arch-p45a-api-module-split.md
@@ -1,7 +1,8 @@
 # ARCH-P45A API Module Split
 
 Issue: `#775`  
-Date: `2026-03-24`
+Date: `2026-03-24`  
+Updated: `2026-03-26` (`#790`)
 
 ## Summary
 
@@ -9,9 +10,14 @@ Date: `2026-03-24`
 
 - app creation
 - static `/ui` mount
-- startup/shutdown lifecycle hooks
-- dependency/repository wiring
+- bounded dependency/repository wiring
 - router inclusion
+
+Runtime lifecycle registration and mutable app-state setup are delegated to explicit bounded modules:
+
+- `src/api/composition/runtime_lifecycle.py`
+- `src/api/composition/router_wiring.py`
+- `src/api/state/alerts_state.py`
 
 Bounded routers own transport handlers:
 
@@ -43,7 +49,9 @@ API DTO/query model ownership moved from `main.py` into:
 - **Analysis router**: strategy analysis, manual analysis trigger, and basic screener transport endpoints.
 - **Services**: non-transport orchestration/helpers used by routers.
 - **Models**: request/response/query DTO definitions.
-- **Main module**: composition/wiring only (app, mount, lifecycle hooks, dependency/repository wiring, router inclusion) plus compatibility symbol exports with no helper/transport implementations.
+- **Main module**: composition/wiring only (app, mount, dependency/repository wiring, router inclusion) plus compatibility symbol exports with no helper/transport implementations.
+- **Composition modules**: runtime startup/shutdown registration and router inclusion wiring.
+- **State modules**: mutable alert app-state initialization and access.
 
 ## Behavior
 

--- a/src/api/alerts_api.py
+++ b/src/api/alerts_api.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from cilly_trading.alerts.alert_models import AlertEvent
 
+from .state import get_alert_configuration_store, get_alert_history_store
+
 
 class AlertConfigurationPayload(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -86,19 +88,11 @@ class AlertConfigurationDeleteResponse(BaseModel):
 
 
 def _get_store(request: Request) -> Dict[str, Dict[str, Any]]:
-    store = getattr(request.app.state, "alert_configuration_store", None)
-    if store is None:
-        store = {}
-        request.app.state.alert_configuration_store = store
-    return store
+    return get_alert_configuration_store(request)
 
 
 def _get_alert_history_store(request: Request) -> List[Dict[str, Any]]:
-    store = getattr(request.app.state, "alert_history_store", None)
-    if store is None:
-        store = []
-        request.app.state.alert_history_store = store
-    return store
+    return get_alert_history_store(request)
 
 
 def _sorted_items(store: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/src/api/composition/__init__.py
+++ b/src/api/composition/__init__.py
@@ -1,0 +1,11 @@
+"""Bounded composition helpers for api.main."""
+
+from .router_wiring import ApiRouterWiring, include_api_routers
+from .runtime_lifecycle import RuntimeLifecycleDependencies, register_runtime_lifecycle
+
+__all__ = [
+    "ApiRouterWiring",
+    "RuntimeLifecycleDependencies",
+    "include_api_routers",
+    "register_runtime_lifecycle",
+]

--- a/src/api/composition/router_wiring.py
+++ b/src/api/composition/router_wiring.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict
+
+from fastapi import FastAPI
+
+from ..alerts_api import build_alerts_router
+from ..routers import (
+    AnalysisRouterDependencies,
+    ControlPlaneRouterDependencies,
+    InspectionRouterDependencies,
+    WatchlistsRouterDependencies,
+    build_analysis_router,
+    build_control_plane_router,
+    build_inspection_router,
+    build_watchlists_router,
+)
+
+
+@dataclass
+class ApiRouterWiring:
+    require_role: Callable[[str], Callable[..., str]]
+    assert_phase_13_read_only_endpoint: Callable[[str], None]
+    get_health_now: Callable[[], Any]
+    get_resolve_analysis_db_path: Callable[[], str]
+    get_runtime_introspection_payload: Callable[[], dict[str, Any]]
+    get_runtime_health_evaluator: Callable[..., Any]
+    get_system_state_payload: Callable[[], dict[str, Any]]
+    get_start_engine_runtime: Callable[[], str]
+    get_shutdown_engine_runtime: Callable[[], str]
+    get_pause_engine_runtime: Callable[[], str]
+    get_resume_engine_runtime: Callable[[], str]
+    get_lifecycle_transition_error: Callable[[], type[Exception]]
+    get_analysis_run_repo: Callable[[], Any]
+    get_signal_repo: Callable[[], Any]
+    get_order_event_repo: Callable[[], Any]
+    get_canonical_execution_repo: Callable[[], Any]
+    get_journal_artifacts_root: Callable[[], Any]
+    get_default_strategy_configs: Callable[[], Dict[str, Dict[str, Any]]]
+    get_watchlist_repo: Callable[[], Any]
+    get_require_ingestion_run: Callable[..., None]
+    get_require_snapshot_ready: Callable[..., None]
+    get_run_snapshot_analysis: Callable[..., Any]
+    get_create_strategy: Callable[[str], Any]
+    get_create_registered_strategies: Callable[[], list[Any]]
+    get_trigger_operator_analysis_run: Callable[..., Any]
+
+
+def include_api_routers(*, app: FastAPI, wiring: ApiRouterWiring) -> None:
+    app.include_router(build_alerts_router(wiring.require_role))
+    app.include_router(
+        build_control_plane_router(
+            deps=ControlPlaneRouterDependencies(
+                require_role=wiring.require_role,
+                assert_phase_13_read_only_endpoint=wiring.assert_phase_13_read_only_endpoint,
+                get_health_now=lambda: wiring.get_health_now,
+                get_resolve_analysis_db_path=lambda: wiring.get_resolve_analysis_db_path,
+                get_runtime_introspection_payload=lambda: wiring.get_runtime_introspection_payload,
+                get_runtime_health_evaluator=lambda: wiring.get_runtime_health_evaluator,
+                get_system_state_payload=lambda: wiring.get_system_state_payload,
+                get_start_engine_runtime=lambda: wiring.get_start_engine_runtime,
+                get_shutdown_engine_runtime=lambda: wiring.get_shutdown_engine_runtime,
+                get_pause_engine_runtime=lambda: wiring.get_pause_engine_runtime,
+                get_resume_engine_runtime=lambda: wiring.get_resume_engine_runtime,
+                get_lifecycle_transition_error=wiring.get_lifecycle_transition_error,
+            ),
+        )
+    )
+    app.include_router(
+        build_inspection_router(
+            deps=InspectionRouterDependencies(
+                require_role=wiring.require_role,
+                get_analysis_run_repo=wiring.get_analysis_run_repo,
+                get_signal_repo=wiring.get_signal_repo,
+                get_order_event_repo=wiring.get_order_event_repo,
+                get_canonical_execution_repo=wiring.get_canonical_execution_repo,
+                get_journal_artifacts_root=wiring.get_journal_artifacts_root,
+                get_default_strategy_configs=wiring.get_default_strategy_configs,
+            ),
+        )
+    )
+    app.include_router(
+        build_watchlists_router(
+            deps=WatchlistsRouterDependencies(
+                require_role=wiring.require_role,
+                get_watchlist_repo=wiring.get_watchlist_repo,
+                get_analysis_run_repo=wiring.get_analysis_run_repo,
+                get_signal_repo=wiring.get_signal_repo,
+                get_default_strategy_configs=wiring.get_default_strategy_configs,
+                get_require_ingestion_run=lambda: wiring.get_require_ingestion_run,
+                get_require_snapshot_ready=lambda: wiring.get_require_snapshot_ready,
+                get_run_snapshot_analysis=lambda: wiring.get_run_snapshot_analysis,
+                get_resolve_analysis_db_path=lambda: wiring.get_resolve_analysis_db_path,
+                get_create_strategy=lambda: wiring.get_create_strategy,
+                get_create_registered_strategies=lambda: wiring.get_create_registered_strategies,
+                get_trigger_operator_analysis_run=lambda: wiring.get_trigger_operator_analysis_run,
+            ),
+        )
+    )
+    app.include_router(
+        build_analysis_router(
+            deps=AnalysisRouterDependencies(
+                require_role=wiring.require_role,
+                get_analysis_run_repo=wiring.get_analysis_run_repo,
+                get_signal_repo=wiring.get_signal_repo,
+                get_watchlist_repo=wiring.get_watchlist_repo,
+                get_default_strategy_configs=wiring.get_default_strategy_configs,
+                get_require_ingestion_run=lambda: wiring.get_require_ingestion_run,
+                get_require_snapshot_ready=lambda: wiring.get_require_snapshot_ready,
+                get_run_snapshot_analysis=lambda: wiring.get_run_snapshot_analysis,
+                get_resolve_analysis_db_path=lambda: wiring.get_resolve_analysis_db_path,
+                get_create_strategy=lambda: wiring.get_create_strategy,
+                get_create_registered_strategies=lambda: wiring.get_create_registered_strategies,
+                get_trigger_operator_analysis_run=lambda: wiring.get_trigger_operator_analysis_run,
+            ),
+        )
+    )

--- a/src/api/composition/runtime_lifecycle.py
+++ b/src/api/composition/runtime_lifecycle.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+from fastapi import FastAPI
+
+
+@dataclass
+class RuntimeLifecycleDependencies:
+    logger: logging.Logger
+    start_runtime: Callable[[], str]
+    shutdown_runtime: Callable[[], str]
+    set_runtime_guard_active: Callable[[bool], None]
+    lifecycle_transition_error: type[Exception]
+
+
+def register_runtime_lifecycle(
+    *,
+    app: FastAPI,
+    deps: RuntimeLifecycleDependencies,
+) -> tuple[Callable[[], None], Callable[[], None]]:
+    @app.on_event("startup")
+    def _startup_runtime() -> None:
+        deps.start_runtime()
+        deps.set_runtime_guard_active(True)
+
+    @app.on_event("shutdown")
+    def _shutdown_runtime() -> None:
+        deps.set_runtime_guard_active(False)
+        try:
+            deps.shutdown_runtime()
+        except deps.lifecycle_transition_error:
+            deps.logger.exception("Engine runtime shutdown failed")
+
+    return _startup_runtime, _shutdown_runtime

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -45,7 +45,12 @@ from cilly_trading.strategies.registry import (
     initialize_default_registry,
 )
 
-from .alerts_api import build_alerts_router
+from .composition import (
+    ApiRouterWiring,
+    RuntimeLifecycleDependencies,
+    include_api_routers,
+    register_runtime_lifecycle,
+)
 from .models import (
     ComplianceGuardStatusResponse,
     DecisionCardInspectionResponse,
@@ -64,17 +69,8 @@ from .models import (
     TradingCoreTradesReadResponse,
 )
 from .order_events_sqlite import SqliteOrderEventRepository
-from .routers import (
-    AnalysisRouterDependencies,
-    ControlPlaneRouterDependencies,
-    InspectionRouterDependencies,
-    WatchlistsRouterDependencies,
-    build_analysis_router,
-    build_control_plane_router,
-    build_inspection_router,
-    build_watchlists_router,
-)
 from .services.composition_runtime_service import CompositionRuntimeService, configure_logging
+from .state import initialize_alert_state
 
 
 configure_logging()
@@ -86,8 +82,7 @@ app = FastAPI(
     description="MVP-API fuer die Cilly Trading Engine (RSI2 & Turtle, D1, SQLite).",
 )
 
-app.state.alert_configuration_store = {}
-app.state.alert_history_store = []
+initialize_alert_state(app)
 
 UI_DIRECTORY = Path(__file__).resolve().parent.parent / "ui"
 JOURNAL_ARTIFACTS_ROOT = Path(__file__).resolve().parents[2] / "runs" / "phase6"
@@ -172,90 +167,51 @@ runtime_introspection = _runtime_service.runtime_introspection
 system_state = _runtime_service.system_state
 
 
-@app.on_event("startup")
-def _startup_runtime() -> None:
+def _set_engine_runtime_guard_active(is_active: bool) -> None:
     global ENGINE_RUNTIME_GUARD_ACTIVE
-    start_engine_runtime()
-    ENGINE_RUNTIME_GUARD_ACTIVE = True
+    ENGINE_RUNTIME_GUARD_ACTIVE = is_active
 
 
-@app.on_event("shutdown")
-def _shutdown_runtime() -> None:
-    global ENGINE_RUNTIME_GUARD_ACTIVE
-    ENGINE_RUNTIME_GUARD_ACTIVE = False
-    try:
-        shutdown_engine_runtime()
-    except LifecycleTransitionError:
-        logger.exception("Engine runtime shutdown failed")
-
-
-app.include_router(build_alerts_router(_require_role))
-app.include_router(
-    build_control_plane_router(
-        deps=ControlPlaneRouterDependencies(
-            require_role=_require_role,
-            assert_phase_13_read_only_endpoint=_assert_phase_13_read_only_endpoint,
-            get_health_now=lambda: _health_now,
-            get_resolve_analysis_db_path=lambda: _resolve_analysis_db_path,
-            get_runtime_introspection_payload=lambda: get_runtime_introspection_payload,
-            get_runtime_health_evaluator=lambda: evaluate_runtime_health,
-            get_system_state_payload=lambda: get_system_state_payload,
-            get_start_engine_runtime=lambda: start_engine_runtime,
-            get_shutdown_engine_runtime=lambda: shutdown_engine_runtime,
-            get_pause_engine_runtime=lambda: pause_engine_runtime,
-            get_resume_engine_runtime=lambda: resume_engine_runtime,
-            get_lifecycle_transition_error=lambda: LifecycleTransitionError,
-        ),
-    )
+_startup_runtime, _shutdown_runtime = register_runtime_lifecycle(
+    app=app,
+    deps=RuntimeLifecycleDependencies(
+        logger=logger,
+        start_runtime=lambda: start_engine_runtime(),
+        shutdown_runtime=lambda: shutdown_engine_runtime(),
+        set_runtime_guard_active=_set_engine_runtime_guard_active,
+        lifecycle_transition_error=LifecycleTransitionError,
+    ),
 )
-app.include_router(
-    build_inspection_router(
-        deps=InspectionRouterDependencies(
-            require_role=_require_role,
-            get_analysis_run_repo=lambda: analysis_run_repo,
-            get_signal_repo=lambda: signal_repo,
-            get_order_event_repo=lambda: order_event_repo,
-            get_canonical_execution_repo=lambda: canonical_execution_repo,
-            get_journal_artifacts_root=lambda: JOURNAL_ARTIFACTS_ROOT,
-            get_default_strategy_configs=lambda: default_strategy_configs,
-        ),
-    )
-)
-app.include_router(
-    build_watchlists_router(
-        deps=WatchlistsRouterDependencies(
-            require_role=_require_role,
-            get_watchlist_repo=lambda: watchlist_repo,
-            get_analysis_run_repo=lambda: analysis_run_repo,
-            get_signal_repo=lambda: signal_repo,
-            get_default_strategy_configs=lambda: default_strategy_configs,
-            get_require_ingestion_run=lambda: _require_ingestion_run,
-            get_require_snapshot_ready=lambda: _require_snapshot_ready,
-            get_run_snapshot_analysis=lambda: _run_snapshot_analysis,
-            get_resolve_analysis_db_path=lambda: _resolve_analysis_db_path,
-            get_create_strategy=lambda: create_strategy,
-            get_create_registered_strategies=lambda: create_registered_strategies,
-            get_trigger_operator_analysis_run=lambda: trigger_operator_analysis_run,
-        ),
-    )
-)
-app.include_router(
-    build_analysis_router(
-        deps=AnalysisRouterDependencies(
-            require_role=_require_role,
-            get_analysis_run_repo=lambda: analysis_run_repo,
-            get_signal_repo=lambda: signal_repo,
-            get_watchlist_repo=lambda: watchlist_repo,
-            get_default_strategy_configs=lambda: default_strategy_configs,
-            get_require_ingestion_run=lambda: _require_ingestion_run,
-            get_require_snapshot_ready=lambda: _require_snapshot_ready,
-            get_run_snapshot_analysis=lambda: _run_snapshot_analysis,
-            get_resolve_analysis_db_path=lambda: _resolve_analysis_db_path,
-            get_create_strategy=lambda: create_strategy,
-            get_create_registered_strategies=lambda: create_registered_strategies,
-            get_trigger_operator_analysis_run=lambda: trigger_operator_analysis_run,
-        ),
-    )
+
+include_api_routers(
+    app=app,
+    wiring=ApiRouterWiring(
+        require_role=_require_role,
+        assert_phase_13_read_only_endpoint=_assert_phase_13_read_only_endpoint,
+        get_health_now=lambda: _health_now(),
+        get_resolve_analysis_db_path=lambda: _resolve_analysis_db_path(),
+        get_runtime_introspection_payload=lambda: get_runtime_introspection_payload(),
+        get_runtime_health_evaluator=lambda *args, **kwargs: evaluate_runtime_health(*args, **kwargs),
+        get_system_state_payload=lambda: get_system_state_payload(),
+        get_start_engine_runtime=lambda: start_engine_runtime(),
+        get_shutdown_engine_runtime=lambda: shutdown_engine_runtime(),
+        get_pause_engine_runtime=lambda: pause_engine_runtime(),
+        get_resume_engine_runtime=lambda: resume_engine_runtime(),
+        get_lifecycle_transition_error=lambda: LifecycleTransitionError,
+        get_analysis_run_repo=lambda: analysis_run_repo,
+        get_signal_repo=lambda: signal_repo,
+        get_order_event_repo=lambda: order_event_repo,
+        get_canonical_execution_repo=lambda: canonical_execution_repo,
+        get_journal_artifacts_root=lambda: JOURNAL_ARTIFACTS_ROOT,
+        get_default_strategy_configs=lambda: default_strategy_configs,
+        get_watchlist_repo=lambda: watchlist_repo,
+        get_require_ingestion_run=lambda *args, **kwargs: _require_ingestion_run(*args, **kwargs),
+        get_require_snapshot_ready=lambda *args, **kwargs: _require_snapshot_ready(*args, **kwargs),
+        get_run_snapshot_analysis=lambda *args, **kwargs: _run_snapshot_analysis(*args, **kwargs),
+        get_create_strategy=lambda strategy_name: create_strategy(strategy_name),
+        get_create_registered_strategies=lambda: create_registered_strategies(),
+        get_trigger_operator_analysis_run=lambda *args, **kwargs: trigger_operator_analysis_run(*args, **kwargs),
+    ),
 )
 
 

--- a/src/api/state/__init__.py
+++ b/src/api/state/__init__.py
@@ -1,0 +1,17 @@
+"""Bounded mutable API state helpers."""
+
+from .alerts_state import (
+    ALERT_CONFIGURATION_STORE_ATTR,
+    ALERT_HISTORY_STORE_ATTR,
+    get_alert_configuration_store,
+    get_alert_history_store,
+    initialize_alert_state,
+)
+
+__all__ = [
+    "ALERT_CONFIGURATION_STORE_ATTR",
+    "ALERT_HISTORY_STORE_ATTR",
+    "get_alert_configuration_store",
+    "get_alert_history_store",
+    "initialize_alert_state",
+]

--- a/src/api/state/alerts_state.py
+++ b/src/api/state/alerts_state.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, Request
+
+
+ALERT_CONFIGURATION_STORE_ATTR = "alert_configuration_store"
+ALERT_HISTORY_STORE_ATTR = "alert_history_store"
+
+
+def initialize_alert_state(app: FastAPI) -> None:
+    app.state.alert_configuration_store = {}
+    app.state.alert_history_store = []
+
+
+def get_alert_configuration_store(request: Request) -> dict[str, dict[str, Any]]:
+    store = getattr(request.app.state, ALERT_CONFIGURATION_STORE_ATTR, None)
+    if store is None:
+        store = {}
+        setattr(request.app.state, ALERT_CONFIGURATION_STORE_ATTR, store)
+    return store
+
+
+def get_alert_history_store(request: Request) -> list[dict[str, Any]]:
+    store = getattr(request.app.state, ALERT_HISTORY_STORE_ATTR, None)
+    if store is None:
+        store = []
+        setattr(request.app.state, ALERT_HISTORY_STORE_ATTR, store)
+    return store


### PR DESCRIPTION
Closes #790

## Summary
- Reduced `src/api/main.py` composition noise and kept it focused on app creation, static mount, bounded dependency assembly, compatibility exports, and top-level wiring.
- Extracted runtime startup/shutdown hook registration into `src/api/composition/runtime_lifecycle.py`.
- Extracted router inclusion/dependency wiring into `src/api/composition/router_wiring.py`.
- Isolated mutable alert app-state initialization and retrieval in `src/api/state/alerts_state.py`.
- Updated architecture boundary documentation to reflect the new composition/state modules.

## Behavior
- Structural refactor only; API routes, response contracts, role behavior, runtime lifecycle semantics, and `/ui` serving behavior remain unchanged.

## Validation
- Ran full suite: `python -m pytest`
- Result: `743 passed, 4 warnings`