### PR TITLE
ARCH-P45B: reduce api main to a minimal composition root

### DIFF
--- a/docs/architecture/arch-p45a-api-module-split.md
+++ b/docs/architecture/arch-p45a-api-module-split.md
@@ -9,12 +9,18 @@ Updated: `2026-03-26` (`#790`)
 `src/api/main.py` is now a composition root focused on:
 
 - app creation
+- alert/app-state initialization entrypoint
 - static `/ui` mount
-- bounded dependency/repository wiring
+- lifecycle registration
 - router inclusion
+- `__main__` startup block
 
-Runtime lifecycle registration and mutable app-state setup are delegated to explicit bounded modules:
+Runtime lifecycle registration, repository assembly, default strategy config assembly, and compatibility/export wiring are delegated to explicit bounded modules:
 
+- `src/api/composition/runtime_settings.py`
+- `src/api/composition/repositories.py`
+- `src/api/composition/main_compat.py`
+- `src/api/composition/runtime_assembly.py`
 - `src/api/composition/runtime_lifecycle.py`
 - `src/api/composition/router_wiring.py`
 - `src/api/state/alerts_state.py`
@@ -49,8 +55,8 @@ API DTO/query model ownership moved from `main.py` into:
 - **Analysis router**: strategy analysis, manual analysis trigger, and basic screener transport endpoints.
 - **Services**: non-transport orchestration/helpers used by routers.
 - **Models**: request/response/query DTO definitions.
-- **Main module**: composition/wiring only (app, mount, dependency/repository wiring, router inclusion) plus compatibility symbol exports with no helper/transport implementations.
-- **Composition modules**: runtime startup/shutdown registration and router inclusion wiring.
+- **Main module**: thin composition root only (app creation, alert-state init, `/ui` mount, lifecycle registration, router inclusion, `__main__`) plus compatibility symbol exports.
+- **Composition modules**: repository assembly, strategy-config assembly, compatibility export binding, runtime startup/shutdown registration, and router dependency wiring.
 - **State modules**: mutable alert app-state initialization and access.
 
 ## Behavior

--- a/docs/operations/ui/owner_dashboard.md
+++ b/docs/operations/ui/owner_dashboard.md
@@ -78,7 +78,7 @@ The frontend route structure in `frontend/src/App.tsx` may still reference `/own
 ## Evidence Pointers
 Use these repository artifacts when validating this document:
 
-1. `src/api/main.py` mounts `/ui` and defines `GET /system/state`, `POST /analysis/run`, watchlist CRUD routes, `POST /watchlists/{watchlist_id}/execute`, `GET /strategies`, `GET /signals`, `GET /journal/artifacts`, `GET /journal/decision-trace`, and `GET /execution/orders`.
+1. `src/api/main.py` mounts `/ui` and includes the bounded API routers serving `GET /system/state`, `POST /analysis/run`, watchlist CRUD routes, `POST /watchlists/{watchlist_id}/execute`, `GET /strategies`, `GET /signals`, `GET /journal/artifacts`, `GET /journal/decision-trace`, and `GET /execution/orders`.
 2. `src/ui/index.html` contains the runtime shell and the implemented browser workflow, including watchlist panels, chart-panel markers, and chart-source markers.
 3. `tests/api/test_health_endpoints_api.py` verifies the runtime health endpoint surface.
 4. `src/api/test_operator_workbench_surface.py` verifies the `/ui` shell markers, watchlist panels, chart-panel markers, and linked runtime endpoints.

--- a/docs/operations/ui/phase-36-web-activation-contract.md
+++ b/docs/operations/ui/phase-36-web-activation-contract.md
@@ -83,7 +83,7 @@ The following repository evidence is sufficient to support later Phase 36 status
 
 | Evidence area | Repository basis |
 | --- | --- |
-| Runtime entrypoint | `src/api/main.py` mounts `/ui` with `StaticFiles(..., html=True)` |
+| Runtime entrypoint | `src/api/main.py` mounts `/ui` with `StaticFiles(..., html=True)` and includes the bounded API routers behind the documented workflow routes |
 | Browser workflow | `src/ui/index.html` loads `/system/state`, `/strategies`, `/signals`, `/journal/artifacts`, `/journal/decision-trace`, `/execution/orders`, and submits `POST /analysis/run` |
 | Route reachability tests | `tests/health_endpoint.py`, `src/api/test_operator_workbench_surface.py`, and `tests/test_ui_runtime_browser_flow.py` verify the `/ui` surface and its browser workflow |
 | Manual analysis behavior | `tests/test_api_manual_analysis_trigger.py` verifies the deterministic `POST /analysis/run` flow |
@@ -92,7 +92,7 @@ The following repository evidence is sufficient to support later Phase 36 status
 ## Review Checklist
 Reviewers should verify:
 
-1. `src/api/main.py` still mounts `/ui` as the runtime-served browser surface.
+1. `src/api/main.py` still mounts `/ui` as the runtime-served browser surface and includes the bounded API routers used by this workflow.
 2. `src/ui/index.html` still implements the bounded Phase 36 workflow described here.
 3. `/owner` is not presented anywhere as a runtime-equivalent route.
 4. The docs remain silent on unimplemented watchlist, trading-desk, alerts, paper-trading product, and live-trading claims.

--- a/src/api/composition/__init__.py
+++ b/src/api/composition/__init__.py
@@ -1,11 +1,34 @@
 """Bounded composition helpers for api.main."""
 
+from .main_compat import (
+    MainModuleCompatibilitySurface,
+    bind_main_runtime_exports,
+    bind_main_runtime_service_exports,
+)
+from .repositories import ApiRepositories, create_api_repositories
 from .router_wiring import ApiRouterWiring, include_api_routers
+from .runtime_assembly import (
+    build_api_router_wiring,
+    build_runtime_lifecycle_dependencies,
+    create_runtime_service,
+)
 from .runtime_lifecycle import RuntimeLifecycleDependencies, register_runtime_lifecycle
+from .runtime_settings import ApiRuntimeSettings, build_api_runtime_settings, build_default_strategy_configs
 
 __all__ = [
+    "ApiRepositories",
     "ApiRouterWiring",
+    "ApiRuntimeSettings",
+    "MainModuleCompatibilitySurface",
     "RuntimeLifecycleDependencies",
+    "bind_main_runtime_exports",
+    "bind_main_runtime_service_exports",
+    "build_api_router_wiring",
+    "build_api_runtime_settings",
+    "build_default_strategy_configs",
+    "build_runtime_lifecycle_dependencies",
+    "create_api_repositories",
+    "create_runtime_service",
     "include_api_routers",
     "register_runtime_lifecycle",
 ]

--- a/src/api/composition/main_compat.py
+++ b/src/api/composition/main_compat.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any, MutableMapping
+
+from cilly_trading.engine.analysis import trigger_operator_analysis_run
+from cilly_trading.engine.core import run_watchlist_analysis
+from cilly_trading.engine.data import SnapshotDataError
+from cilly_trading.engine.runtime_controller import (
+    LifecycleTransitionError,
+    get_runtime_controller,
+    pause_engine_runtime,
+    resume_engine_runtime,
+    shutdown_engine_runtime,
+    start_engine_runtime,
+)
+from cilly_trading.engine.runtime_introspection import get_runtime_introspection_payload
+from cilly_trading.engine.runtime_state import get_system_state_payload
+from cilly_trading.strategies.registry import create_registered_strategies, create_strategy
+
+from ..services.composition_runtime_service import CompositionRuntimeService
+from .repositories import ApiRepositories
+from .runtime_settings import ApiRuntimeSettings
+
+
+@dataclass(frozen=True)
+class MainModuleCompatibilitySurface:
+    module_name: str
+
+    def get(self, name: str) -> Any:
+        return getattr(sys.modules[self.module_name], name)
+
+    def set(self, name: str, value: Any) -> None:
+        setattr(sys.modules[self.module_name], name, value)
+
+
+def bind_main_runtime_exports(
+    *,
+    module_globals: MutableMapping[str, Any],
+    settings: ApiRuntimeSettings,
+    repositories: ApiRepositories,
+) -> MainModuleCompatibilitySurface:
+    module_globals.update(
+        {
+            "UI_DIRECTORY": settings.ui_directory,
+            "JOURNAL_ARTIFACTS_ROOT": settings.journal_artifacts_root,
+            "ENGINE_RUNTIME_NOT_RUNNING_STATUS": settings.engine_runtime_not_running_status,
+            "ENGINE_RUNTIME_NOT_RUNNING_CODE": settings.engine_runtime_not_running_code,
+            "ENGINE_RUNTIME_GUARD_ACTIVE": False,
+            "PHASE_13_READ_ONLY_ENDPOINTS": settings.phase_13_read_only_endpoints,
+            "ROLE_HEADER_NAME": settings.role_header_name,
+            "ROLE_PRECEDENCE": settings.role_precedence,
+            "default_strategy_configs": settings.default_strategy_configs,
+            "ANALYSIS_DB_PATH": None,
+            "signal_repo": repositories.signal_repo,
+            "order_event_repo": repositories.order_event_repo,
+            "canonical_execution_repo": repositories.canonical_execution_repo,
+            "analysis_run_repo": repositories.analysis_run_repo,
+            "watchlist_repo": repositories.watchlist_repo,
+            "LifecycleTransitionError": LifecycleTransitionError,
+            "SnapshotDataError": SnapshotDataError,
+            "start_engine_runtime": start_engine_runtime,
+            "shutdown_engine_runtime": shutdown_engine_runtime,
+            "pause_engine_runtime": pause_engine_runtime,
+            "resume_engine_runtime": resume_engine_runtime,
+            "get_runtime_controller": get_runtime_controller,
+            "run_watchlist_analysis": run_watchlist_analysis,
+            "trigger_operator_analysis_run": trigger_operator_analysis_run,
+            "create_strategy": create_strategy,
+            "create_registered_strategies": create_registered_strategies,
+            "get_runtime_introspection_payload": get_runtime_introspection_payload,
+            "get_system_state_payload": get_system_state_payload,
+        }
+    )
+    return MainModuleCompatibilitySurface(module_name=str(module_globals["__name__"]))
+
+
+def bind_main_runtime_service_exports(
+    *,
+    module_globals: MutableMapping[str, Any],
+    runtime_service: CompositionRuntimeService,
+) -> None:
+    module_globals.update(
+        {
+            "_runtime_service": runtime_service,
+            "_assert_phase_13_read_only_endpoint": runtime_service.assert_phase_13_read_only_endpoint,
+            "_require_role": runtime_service.require_role,
+            "_health_now": runtime_service.health_now,
+            "_resolve_analysis_db_path": runtime_service.resolve_analysis_db_path,
+            "_require_ingestion_run": runtime_service.require_ingestion_run,
+            "_require_snapshot_ready": runtime_service.require_snapshot_ready,
+            "_require_engine_runtime_running": runtime_service.require_engine_runtime_running,
+            "_run_snapshot_analysis": runtime_service.run_snapshot_analysis,
+            "_analysis_service_dependencies": runtime_service.analysis_service_dependencies,
+            "basic_screener": runtime_service.basic_screener,
+            "read_compliance_guard_status": runtime_service.read_compliance_guard_status,
+            "runtime_introspection": runtime_service.runtime_introspection,
+            "system_state": runtime_service.system_state,
+        }
+    )

--- a/src/api/composition/repositories.py
+++ b/src/api/composition/repositories.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from cilly_trading.db import DEFAULT_DB_PATH
+from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
+from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
+from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
+
+from ..order_events_sqlite import SqliteOrderEventRepository
+
+
+@dataclass(frozen=True)
+class ApiRepositories:
+    signal_repo: SqliteSignalRepository
+    order_event_repo: SqliteOrderEventRepository
+    canonical_execution_repo: SqliteCanonicalExecutionRepository
+    analysis_run_repo: SqliteAnalysisRunRepository
+    watchlist_repo: SqliteWatchlistRepository
+
+
+def create_api_repositories(*, default_db_path: Path = DEFAULT_DB_PATH) -> ApiRepositories:
+    return ApiRepositories(
+        signal_repo=SqliteSignalRepository(),
+        order_event_repo=SqliteOrderEventRepository(db_path=default_db_path),
+        canonical_execution_repo=SqliteCanonicalExecutionRepository(db_path=default_db_path),
+        analysis_run_repo=SqliteAnalysisRunRepository(db_path=default_db_path),
+        watchlist_repo=SqliteWatchlistRepository(db_path=default_db_path),
+    )

--- a/src/api/composition/runtime_assembly.py
+++ b/src/api/composition/runtime_assembly.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+
+from cilly_trading.db import DEFAULT_DB_PATH
+from cilly_trading.engine.health.evaluator import evaluate_runtime_health
+
+from ..services.composition_runtime_service import CompositionRuntimeService
+from .main_compat import MainModuleCompatibilitySurface
+from .router_wiring import ApiRouterWiring
+from .runtime_lifecycle import RuntimeLifecycleDependencies
+
+
+def create_runtime_service(
+    *,
+    logger: logging.Logger,
+    compat: MainModuleCompatibilitySurface,
+) -> CompositionRuntimeService:
+    return CompositionRuntimeService(
+        logger=logger,
+        default_db_path=str(DEFAULT_DB_PATH),
+        role_header_name=compat.get("ROLE_HEADER_NAME"),
+        role_precedence=compat.get("ROLE_PRECEDENCE"),
+        phase_13_read_only_endpoints=compat.get("PHASE_13_READ_ONLY_ENDPOINTS"),
+        engine_runtime_not_running_status=compat.get("ENGINE_RUNTIME_NOT_RUNNING_STATUS"),
+        engine_runtime_not_running_code=compat.get("ENGINE_RUNTIME_NOT_RUNNING_CODE"),
+        get_analysis_db_path_override=lambda: compat.get("ANALYSIS_DB_PATH"),
+        get_analysis_run_repo=lambda: compat.get("analysis_run_repo"),
+        get_signal_repo=lambda: compat.get("signal_repo"),
+        get_watchlist_repo=lambda: compat.get("watchlist_repo"),
+        get_default_strategy_configs=lambda: compat.get("default_strategy_configs"),
+        get_create_strategy=lambda: compat.get("create_strategy"),
+        get_create_registered_strategies=lambda: compat.get("create_registered_strategies"),
+        get_trigger_operator_analysis_run=lambda: compat.get("trigger_operator_analysis_run"),
+        get_runtime_controller=lambda: compat.get("get_runtime_controller")(),
+        get_engine_runtime_guard_active=lambda: compat.get("ENGINE_RUNTIME_GUARD_ACTIVE"),
+        get_run_watchlist_analysis=lambda: compat.get("run_watchlist_analysis"),
+        get_require_ingestion_run_compat=lambda: compat.get("_require_ingestion_run"),
+        get_require_snapshot_ready_compat=lambda: compat.get("_require_snapshot_ready"),
+        get_run_snapshot_analysis_compat=lambda: compat.get("_run_snapshot_analysis"),
+        get_require_engine_runtime_running_compat=lambda: compat.get("_require_engine_runtime_running"),
+        snapshot_data_error_class=compat.get("SnapshotDataError"),
+        get_runtime_introspection_payload=lambda: compat.get("get_runtime_introspection_payload"),
+        get_system_state_payload=lambda: compat.get("get_system_state_payload"),
+    )
+
+
+def build_runtime_lifecycle_dependencies(
+    *,
+    logger: logging.Logger,
+    compat: MainModuleCompatibilitySurface,
+) -> RuntimeLifecycleDependencies:
+    return RuntimeLifecycleDependencies(
+        logger=logger,
+        start_runtime=lambda: compat.get("start_engine_runtime")(),
+        shutdown_runtime=lambda: compat.get("shutdown_engine_runtime")(),
+        set_runtime_guard_active=lambda is_active: compat.set("ENGINE_RUNTIME_GUARD_ACTIVE", is_active),
+        lifecycle_transition_error=compat.get("LifecycleTransitionError"),
+    )
+
+
+def build_api_router_wiring(*, compat: MainModuleCompatibilitySurface) -> ApiRouterWiring:
+    return ApiRouterWiring(
+        require_role=lambda minimum_role: compat.get("_require_role")(minimum_role),
+        assert_phase_13_read_only_endpoint=lambda endpoint_path: compat.get(
+            "_assert_phase_13_read_only_endpoint"
+        )(endpoint_path),
+        get_health_now=lambda: compat.get("_health_now")(),
+        get_resolve_analysis_db_path=lambda: compat.get("_resolve_analysis_db_path")(),
+        get_runtime_introspection_payload=lambda: compat.get("get_runtime_introspection_payload")(),
+        get_runtime_health_evaluator=lambda *args, **kwargs: evaluate_runtime_health(*args, **kwargs),
+        get_system_state_payload=lambda: compat.get("get_system_state_payload")(),
+        get_start_engine_runtime=lambda: compat.get("start_engine_runtime")(),
+        get_shutdown_engine_runtime=lambda: compat.get("shutdown_engine_runtime")(),
+        get_pause_engine_runtime=lambda: compat.get("pause_engine_runtime")(),
+        get_resume_engine_runtime=lambda: compat.get("resume_engine_runtime")(),
+        get_lifecycle_transition_error=lambda: compat.get("LifecycleTransitionError"),
+        get_analysis_run_repo=lambda: compat.get("analysis_run_repo"),
+        get_signal_repo=lambda: compat.get("signal_repo"),
+        get_order_event_repo=lambda: compat.get("order_event_repo"),
+        get_canonical_execution_repo=lambda: compat.get("canonical_execution_repo"),
+        get_journal_artifacts_root=lambda: compat.get("JOURNAL_ARTIFACTS_ROOT"),
+        get_default_strategy_configs=lambda: compat.get("default_strategy_configs"),
+        get_watchlist_repo=lambda: compat.get("watchlist_repo"),
+        get_require_ingestion_run=lambda *args, **kwargs: compat.get("_require_ingestion_run")(
+            *args,
+            **kwargs,
+        ),
+        get_require_snapshot_ready=lambda *args, **kwargs: compat.get("_require_snapshot_ready")(
+            *args,
+            **kwargs,
+        ),
+        get_run_snapshot_analysis=lambda *args, **kwargs: compat.get("_run_snapshot_analysis")(
+            *args,
+            **kwargs,
+        ),
+        get_create_strategy=lambda strategy_name: compat.get("create_strategy")(strategy_name),
+        get_create_registered_strategies=lambda: compat.get("create_registered_strategies")(),
+        get_trigger_operator_analysis_run=lambda *args, **kwargs: compat.get(
+            "trigger_operator_analysis_run"
+        )(
+            *args,
+            **kwargs,
+        ),
+    )

--- a/src/api/composition/runtime_settings.py
+++ b/src/api/composition/runtime_settings.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from cilly_trading.strategies.registry import initialize_default_registry
+
+
+@dataclass(frozen=True)
+class ApiRuntimeSettings:
+    ui_directory: Path
+    journal_artifacts_root: Path
+    engine_runtime_not_running_status: int
+    engine_runtime_not_running_code: str
+    phase_13_read_only_endpoints: frozenset[str]
+    role_header_name: str
+    role_precedence: dict[str, int]
+    default_strategy_configs: dict[str, dict[str, Any]]
+
+
+def build_default_strategy_configs() -> dict[str, dict[str, Any]]:
+    initialize_default_registry()
+    return {
+        "RSI2": {
+            "rsi_period": 2,
+            "oversold_threshold": 10.0,
+            "min_score": 20.0,
+        },
+        "TURTLE": {
+            "breakout_lookback": 20,
+            "proximity_threshold_pct": 0.03,
+            "min_score": 30.0,
+        },
+    }
+
+
+def build_api_runtime_settings() -> ApiRuntimeSettings:
+    return ApiRuntimeSettings(
+        ui_directory=Path(__file__).resolve().parents[2] / "ui",
+        journal_artifacts_root=Path(__file__).resolve().parents[3] / "runs" / "phase6",
+        engine_runtime_not_running_status=503,
+        engine_runtime_not_running_code="engine_runtime_not_running",
+        phase_13_read_only_endpoints=frozenset({"/health", "/runtime/introspection"}),
+        role_header_name="X-Cilly-Role",
+        role_precedence={
+            "read_only": 1,
+            "operator": 2,
+            "owner": 3,
+        },
+        default_strategy_configs=build_default_strategy_configs(),
+    )

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,53 +1,18 @@
-"""
-FastAPI application for the Cilly Trading Engine (MVP).
-
-Included endpoints:
-- GET /health
-- POST /strategy/analyze
-- POST /screener/basic
-
-Strategies:
-- RSI2 (Rebound)
-- TURTLE (Breakout)
-"""
-
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 
-from cilly_trading.db import DEFAULT_DB_PATH
-from cilly_trading.engine.analysis import trigger_operator_analysis_run
-from cilly_trading.engine.core import run_watchlist_analysis
-from cilly_trading.engine.data import SnapshotDataError
-from cilly_trading.engine.health.evaluator import evaluate_runtime_health
-from cilly_trading.engine.runtime_controller import (
-    LifecycleTransitionError,
-    get_runtime_controller,
-    pause_engine_runtime,
-    resume_engine_runtime,
-    shutdown_engine_runtime,
-    start_engine_runtime,
-)
-from cilly_trading.engine.runtime_introspection import get_runtime_introspection_payload
-from cilly_trading.engine.runtime_state import get_system_state_payload
-from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
-from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
-from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
-from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
-from cilly_trading.strategies.registry import (
-    create_registered_strategies,
-    create_strategy,
-    initialize_default_registry,
-)
-
 from .composition import (
-    ApiRouterWiring,
-    RuntimeLifecycleDependencies,
+    bind_main_runtime_exports,
+    bind_main_runtime_service_exports,
+    build_api_router_wiring,
+    build_api_runtime_settings,
+    build_runtime_lifecycle_dependencies,
+    create_api_repositories,
+    create_runtime_service,
     include_api_routers,
     register_runtime_lifecycle,
 )
@@ -68,13 +33,22 @@ from .models import (
     TradingCorePositionsReadResponse,
     TradingCoreTradesReadResponse,
 )
-from .order_events_sqlite import SqliteOrderEventRepository
-from .services.composition_runtime_service import CompositionRuntimeService, configure_logging
+from .services.composition_runtime_service import configure_logging
 from .state import initialize_alert_state
 
 
 configure_logging()
 logger = logging.getLogger(__name__)
+
+settings = build_api_runtime_settings()
+repositories = create_api_repositories()
+_main_compat = bind_main_runtime_exports(
+    module_globals=globals(),
+    settings=settings,
+    repositories=repositories,
+)
+_runtime_service = create_runtime_service(logger=logger, compat=_main_compat)
+bind_main_runtime_service_exports(module_globals=globals(), runtime_service=_runtime_service)
 
 app = FastAPI(
     title="Cilly Trading Engine API",
@@ -83,135 +57,18 @@ app = FastAPI(
 )
 
 initialize_alert_state(app)
-
-UI_DIRECTORY = Path(__file__).resolve().parent.parent / "ui"
-JOURNAL_ARTIFACTS_ROOT = Path(__file__).resolve().parents[2] / "runs" / "phase6"
 app.mount("/ui", StaticFiles(directory=UI_DIRECTORY, html=True), name="ui")
 
 logger.info("Cilly Trading Engine API starting up")
 
-ENGINE_RUNTIME_NOT_RUNNING_STATUS = 503
-ENGINE_RUNTIME_NOT_RUNNING_CODE = "engine_runtime_not_running"
-ENGINE_RUNTIME_GUARD_ACTIVE = False
-PHASE_13_READ_ONLY_ENDPOINTS = frozenset({"/health", "/runtime/introspection"})
-ROLE_HEADER_NAME = "X-Cilly-Role"
-ROLE_PRECEDENCE: dict[str, int] = {
-    "read_only": 1,
-    "operator": 2,
-    "owner": 3,
-}
-
-initialize_default_registry()
-default_strategy_configs: Dict[str, Dict[str, Any]] = {
-    "RSI2": {
-        "rsi_period": 2,
-        "oversold_threshold": 10.0,
-        "min_score": 20.0,
-    },
-    "TURTLE": {
-        "breakout_lookback": 20,
-        "proximity_threshold_pct": 0.03,
-        "min_score": 30.0,
-    },
-}
-
-ANALYSIS_DB_PATH: Optional[str] = None
-
-signal_repo = SqliteSignalRepository()
-order_event_repo = SqliteOrderEventRepository(db_path=DEFAULT_DB_PATH)
-canonical_execution_repo = SqliteCanonicalExecutionRepository(db_path=DEFAULT_DB_PATH)
-analysis_run_repo = SqliteAnalysisRunRepository(db_path=DEFAULT_DB_PATH)
-watchlist_repo = SqliteWatchlistRepository(db_path=DEFAULT_DB_PATH)
-
-_runtime_service = CompositionRuntimeService(
-    logger=logger,
-    default_db_path=str(DEFAULT_DB_PATH),
-    role_header_name=ROLE_HEADER_NAME,
-    role_precedence=ROLE_PRECEDENCE,
-    phase_13_read_only_endpoints=PHASE_13_READ_ONLY_ENDPOINTS,
-    engine_runtime_not_running_status=ENGINE_RUNTIME_NOT_RUNNING_STATUS,
-    engine_runtime_not_running_code=ENGINE_RUNTIME_NOT_RUNNING_CODE,
-    get_analysis_db_path_override=lambda: ANALYSIS_DB_PATH,
-    get_analysis_run_repo=lambda: analysis_run_repo,
-    get_signal_repo=lambda: signal_repo,
-    get_watchlist_repo=lambda: watchlist_repo,
-    get_default_strategy_configs=lambda: default_strategy_configs,
-    get_create_strategy=lambda: create_strategy,
-    get_create_registered_strategies=lambda: create_registered_strategies,
-    get_trigger_operator_analysis_run=lambda: trigger_operator_analysis_run,
-    get_runtime_controller=lambda: get_runtime_controller(),
-    get_engine_runtime_guard_active=lambda: ENGINE_RUNTIME_GUARD_ACTIVE,
-    get_run_watchlist_analysis=lambda: run_watchlist_analysis,
-    get_require_ingestion_run_compat=lambda: _require_ingestion_run,
-    get_require_snapshot_ready_compat=lambda: _require_snapshot_ready,
-    get_run_snapshot_analysis_compat=lambda: _run_snapshot_analysis,
-    get_require_engine_runtime_running_compat=lambda: _require_engine_runtime_running,
-    snapshot_data_error_class=SnapshotDataError,
-    get_runtime_introspection_payload=lambda: get_runtime_introspection_payload,
-    get_system_state_payload=lambda: get_system_state_payload,
-)
-
-# Compatibility exports for existing test patch points.
-_assert_phase_13_read_only_endpoint = _runtime_service.assert_phase_13_read_only_endpoint
-_require_role = _runtime_service.require_role
-_health_now = _runtime_service.health_now
-_resolve_analysis_db_path = _runtime_service.resolve_analysis_db_path
-_require_ingestion_run = _runtime_service.require_ingestion_run
-_require_snapshot_ready = _runtime_service.require_snapshot_ready
-_require_engine_runtime_running = _runtime_service.require_engine_runtime_running
-_run_snapshot_analysis = _runtime_service.run_snapshot_analysis
-_analysis_service_dependencies = _runtime_service.analysis_service_dependencies
-basic_screener = _runtime_service.basic_screener
-read_compliance_guard_status = _runtime_service.read_compliance_guard_status
-runtime_introspection = _runtime_service.runtime_introspection
-system_state = _runtime_service.system_state
-
-
-def _set_engine_runtime_guard_active(is_active: bool) -> None:
-    global ENGINE_RUNTIME_GUARD_ACTIVE
-    ENGINE_RUNTIME_GUARD_ACTIVE = is_active
-
-
 _startup_runtime, _shutdown_runtime = register_runtime_lifecycle(
     app=app,
-    deps=RuntimeLifecycleDependencies(
-        logger=logger,
-        start_runtime=lambda: start_engine_runtime(),
-        shutdown_runtime=lambda: shutdown_engine_runtime(),
-        set_runtime_guard_active=_set_engine_runtime_guard_active,
-        lifecycle_transition_error=LifecycleTransitionError,
-    ),
+    deps=build_runtime_lifecycle_dependencies(logger=logger, compat=_main_compat),
 )
 
 include_api_routers(
     app=app,
-    wiring=ApiRouterWiring(
-        require_role=_require_role,
-        assert_phase_13_read_only_endpoint=_assert_phase_13_read_only_endpoint,
-        get_health_now=lambda: _health_now(),
-        get_resolve_analysis_db_path=lambda: _resolve_analysis_db_path(),
-        get_runtime_introspection_payload=lambda: get_runtime_introspection_payload(),
-        get_runtime_health_evaluator=lambda *args, **kwargs: evaluate_runtime_health(*args, **kwargs),
-        get_system_state_payload=lambda: get_system_state_payload(),
-        get_start_engine_runtime=lambda: start_engine_runtime(),
-        get_shutdown_engine_runtime=lambda: shutdown_engine_runtime(),
-        get_pause_engine_runtime=lambda: pause_engine_runtime(),
-        get_resume_engine_runtime=lambda: resume_engine_runtime(),
-        get_lifecycle_transition_error=lambda: LifecycleTransitionError,
-        get_analysis_run_repo=lambda: analysis_run_repo,
-        get_signal_repo=lambda: signal_repo,
-        get_order_event_repo=lambda: order_event_repo,
-        get_canonical_execution_repo=lambda: canonical_execution_repo,
-        get_journal_artifacts_root=lambda: JOURNAL_ARTIFACTS_ROOT,
-        get_default_strategy_configs=lambda: default_strategy_configs,
-        get_watchlist_repo=lambda: watchlist_repo,
-        get_require_ingestion_run=lambda *args, **kwargs: _require_ingestion_run(*args, **kwargs),
-        get_require_snapshot_ready=lambda *args, **kwargs: _require_snapshot_ready(*args, **kwargs),
-        get_run_snapshot_analysis=lambda *args, **kwargs: _run_snapshot_analysis(*args, **kwargs),
-        get_create_strategy=lambda strategy_name: create_strategy(strategy_name),
-        get_create_registered_strategies=lambda: create_registered_strategies(),
-        get_trigger_operator_analysis_run=lambda *args, **kwargs: trigger_operator_analysis_run(*args, **kwargs),
-    ),
+    wiring=build_api_router_wiring(compat=_main_compat),
 )
 
 

--- a/tests/api/test_main_composition_root.py
+++ b/tests/api/test_main_composition_root.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import api.main as api_main
+
+
+def test_analysis_service_dependencies_follow_main_patch_points(monkeypatch) -> None:
+    signal_repo = object()
+    analysis_run_repo = object()
+    watchlist_repo = object()
+    require_ingestion_run = lambda *_args, **_kwargs: None
+    require_snapshot_ready = lambda *_args, **_kwargs: None
+    run_snapshot_analysis = lambda *_args, **_kwargs: []
+
+    monkeypatch.setattr(api_main, "signal_repo", signal_repo)
+    monkeypatch.setattr(api_main, "analysis_run_repo", analysis_run_repo)
+    monkeypatch.setattr(api_main, "watchlist_repo", watchlist_repo)
+    monkeypatch.setattr(api_main, "_require_ingestion_run", require_ingestion_run)
+    monkeypatch.setattr(api_main, "_require_snapshot_ready", require_snapshot_ready)
+    monkeypatch.setattr(api_main, "_run_snapshot_analysis", run_snapshot_analysis)
+
+    deps = api_main._analysis_service_dependencies()
+
+    assert deps.signal_repo is signal_repo
+    assert deps.analysis_run_repo is analysis_run_repo
+    assert deps.watchlist_repo is watchlist_repo
+    assert deps.require_ingestion_run is require_ingestion_run
+    assert deps.require_snapshot_ready is require_snapshot_ready
+    assert deps.run_snapshot_analysis is run_snapshot_analysis
+
+
+def test_resolve_analysis_db_path_follows_main_override(monkeypatch) -> None:
+    analysis_db_path = Path("patched-analysis.db")
+
+    monkeypatch.setattr(api_main, "ANALYSIS_DB_PATH", analysis_db_path)
+
+    assert api_main._resolve_analysis_db_path() == str(analysis_db_path)

--- a/tests/health_endpoint.py
+++ b/tests/health_endpoint.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
 
 class _SideEffectProbe:
     def __init__(self) -> None:
@@ -39,7 +41,7 @@ def test_health_endpoint_reports_runtime_health_from_simulated_snapshot(monkeypa
     monkeypatch.setattr(api_main, "_health_now", _health_now)
 
     with TestClient(api_main.app) as client:
-        response = client.get("/health")
+        response = client.get("/health", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json() == {
@@ -91,7 +93,7 @@ def test_health_endpoint_is_read_only_without_runtime_transitions_or_writes(monk
     monkeypatch.setattr(api_main.analysis_run_repo, "save_run", _unexpected_write)
 
     with TestClient(api_main.app) as client:
-        response = client.get("/health")
+        response = client.get("/health", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json()["status"] == "degraded"
@@ -126,7 +128,7 @@ def test_health_endpoint_reports_unavailable_boundary(monkeypatch) -> None:
     monkeypatch.setattr(api_main, "_health_now", _health_now)
 
     with TestClient(api_main.app) as client:
-        response = client.get("/health")
+        response = client.get("/health", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
     assert response.json()["status"] == "unavailable"


### PR DESCRIPTION
Closes #797

## Summary
- reduce src/api/main.py to a thin composition root
- move repository assembly, runtime settings, compatibility export binding, and runtime/router dependency assembly into bounded composition modules
- preserve existing pi.main patch surfaces used by tests by resolving runtime dependencies through a compatibility surface
- update architecture and operations docs to reflect the final composition boundary

## Scope
- in scope: src/api/main.py, src/api/composition/**, targeted docs, and regression coverage for preserved compatibility surfaces
- out of scope: endpoint contract changes, auth model changes, trader workflow expansion, runtime behavior changes, and unrelated worktree modifications

## Behavior
- structural refactor only
- API routes, payload contracts, role behavior, /ui mounting, and runtime lifecycle semantics remain unchanged

## Testing
- python -m pytest
- result: 745 passed, 4 warnings

## Notes
- warnings are existing FastAPI on_event deprecation warnings from lifecycle registration and are not expanded in scope for #797
