### PR TITLE
Phase 38: correct market-data status and define bounded provider/runtime contract

### DIFF
--- a/docs/architecture/phases/phase-38-status.md
+++ b/docs/architecture/phases/phase-38-status.md
@@ -1,0 +1,60 @@
+# Phase 38 - Market Data Integration Status
+
+Status: Partially Implemented  
+Scope: Direct provider adapter presence, deterministic snapshot boundary, and runtime-safe claim evidence requirements  
+Owner: Governance
+
+## Purpose
+This file is the canonical Phase 38 status and contract artifact for repository-safe market-data claims.
+
+## Verified In-Repository Artifacts
+- Direct provider loaders exist in `src/cilly_trading/engine/data.py`:
+  - `_load_stock_yahoo` (yfinance)
+  - `_load_crypto_binance` (ccxt/binance)
+  - `load_ohlcv` (direct-provider path selector)
+- Deterministic snapshot loading exists in `src/cilly_trading/engine/data.py`:
+  - `load_ohlcv_snapshot`
+  - `load_snapshot_metadata`
+- Provider contract and deterministic failover artifacts exist in:
+  - `src/cilly_trading/engine/data/market_data_provider.py`
+  - `tests/data/test_market_data_provider_contract.py`
+  - `tests/data/test_market_data_provider_failover_telemetry.py`
+
+## Bounded Contract
+
+### 1) Direct provider adapter boundary
+- Direct provider loaders are implementation artifacts, not runtime determinism guarantees.
+- Calls through `load_ohlcv` can vary with wall-clock time and upstream provider behavior.
+
+### 2) Deterministic snapshot workflow boundary
+- Repository-safe deterministic analysis claims apply only to snapshot-bound paths.
+- Snapshot-bound paths require `ingestion_run_id` and load data through `load_ohlcv_snapshot`.
+- Snapshot readiness and validation failures remain deterministic request errors.
+
+### 3) Runtime-safe usage boundary
+- Runtime-safe market-data claims must be tied to snapshot-only API enforcement, not to the mere existence of direct provider loaders.
+- Direct provider adapters may exist in-repo without implying production-ready runtime integration.
+
+## Evidence Requirements For Repository-Safe Market-Data Claims
+A Phase 38 runtime-safe claim is acceptable only when all evidence classes are present together:
+
+1. Direct adapter presence evidence  
+`src/cilly_trading/engine/data.py` and/or `src/cilly_trading/engine/data/market_data_provider.py` show concrete provider-facing adapter code.
+
+2. Deterministic usage-boundary evidence  
+`docs/operations/api/usage_contract.md` documents snapshot-only API behavior and explicit non-deterministic direct engine paths.
+
+3. Operational/runtime evidence  
+Tests prove snapshot-only runtime paths do not use live provider loaders and that provider contract behavior is bounded and deterministic where claimed:
+- `tests/test_api_snapshot_first_enforcement.py`
+- `tests/test_api_manual_analysis_trigger.py`
+- `tests/test_ui_runtime_browser_flow.py`
+- `tests/data/test_market_data_provider_contract.py`
+
+## Remaining Unimplemented Scope After Status Correction
+- No claim that direct provider adapters are production-trustworthy runtime integration by themselves.
+- No claim that in-repo runtime APIs serve live provider data for deterministic analysis endpoints.
+- No claim that broker integration, live-trading feeds, or websocket market-data delivery is implemented.
+
+## Documentation Alignment Rule
+Phase 38 references in `docs/**` must align to this file, `docs/architecture/roadmap/execution_roadmap.md`, and `docs/operations/api/usage_contract.md`.

--- a/docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -717,10 +717,11 @@ Support real market-data integrations directly.
 
 **Current Status Basis**
 - Provider abstraction, provider contracts, failover logic, and data guardrails exist.
-- No repo-verifiable direct Yahoo Finance, Binance, or CCXT production integration module was confirmed.
+- Direct provider loaders are repo-verifiable in `src/cilly_trading/engine/data.py` (`_load_stock_yahoo`, `_load_crypto_binance`, `load_ohlcv`).
+- Deterministic runtime-safe claims remain bounded to snapshot-only paths and evidence-backed runtime enforcement (`docs/operations/api/usage_contract.md` and `docs/architecture/phases/phase-38-status.md`).
 
 **Outcome**
-- The data-integration foundation exists, but the named real-provider integrations remain incomplete.
+- The repository has direct provider adapter presence, while production-trustworthy runtime integration remains a bounded evidence problem (snapshot boundary + runtime proof), not a missing-adapter problem.
 
 ---
 
@@ -1514,10 +1515,11 @@ Reale Marktdaten-Integrationen direkt unterstuetzen.
 
 **Aktuelle Statusbasis**
 - Provider-Abstraktion, Provider-Contracts, Failover-Logik und Data-Guardrails sind vorhanden.
-- Eine direkte Yahoo-Finance-, Binance- oder CCXT-Produktionsintegration wurde im Repo nicht bestaetigt.
+- Direkte Provider-Loader sind im Repository nachweisbar in `src/cilly_trading/engine/data.py` (`_load_stock_yahoo`, `_load_crypto_binance`, `load_ohlcv`).
+- Deterministische runtime-sichere Claims bleiben auf snapshot-only-Pfade und evidenzgebundene Runtime-Enforcement-Artefakte begrenzt (`docs/operations/api/usage_contract.md` und `docs/architecture/phases/phase-38-status.md`).
 
 **Ergebnis**
-- Das Fundament fuer Datenintegration existiert, aber die konkret benannten Provider-Integrationen sind noch unvollstaendig.
+- Das Repository hat direkte Provider-Adapter-Praesenz; die verbleibende Luecke ist kein fehlender Adapter, sondern ein begrenzter Evidenznachweis fuer produktionsvertrauenswuerdige Runtime-Integration.
 
 ---
 

--- a/docs/architecture/roadmap/execution_roadmap.md
+++ b/docs/architecture/roadmap/execution_roadmap.md
@@ -1,7 +1,7 @@
 # Execution Roadmap - Authoritative Phase Taxonomy
 
 Status: Authoritative  
-Scope: Audited phase taxonomy for Phases 5, 16, 17, 17b, 23, 25, 26, 27, and 37  
+Scope: Audited phase taxonomy for Phases 5, 16, 17, 17b, 23, 25, 26, 27, 37, and 38  
 Owner: Governance  
 
 ## Purpose
@@ -40,6 +40,7 @@ This file is the single authoritative in-repo source for audited phase-number me
 | Phase 26 | No authoritative in-repo phase taxonomy artifact was located during the audit. | This roadmap entry is the governing clarification for audited artifacts. |
 | Phase 27 | Risk Framework | `docs/architecture/phases/phase-27-status.md` |
 | Phase 37 | Watchlist Engine | `docs/architecture/phases/phase-37-status.md` |
+| Phase 38 | Market Data Integration | `docs/architecture/phases/phase-38-status.md` |
 
 ## Taxonomy Guardrails
 - Phase 17 and Phase 17b are not interchangeable: Phase 17 is the umbrella phase, and Phase 17b is the Owner Dashboard sub-phase.
@@ -143,3 +144,27 @@ Define Phase 37 using the bounded watchlist workflow that is verifiable in the r
 ### Acceptance Evidence Requirements
 - Repository-verifiable code and tests exist for watchlist persistence, CRUD, execution, ranking, and `/ui` watchlist behavior.
 - Roadmap and runtime-facing docs describe the watchlist workflow as bounded Phase 37 scope rather than as later-phase product completion.
+
+---
+
+## Phase 38
+
+### Goal
+Define Phase 38 using a bounded contract that separates direct provider adapter presence from deterministic runtime-safe usage claims.
+
+> Governance Note  
+> The implementation status of Phase 38 is explicitly documented in:  
+> `docs/architecture/phases/phase-38-status.md`
+
+### Verified Existing Artifacts
+- Direct provider-facing loader functions exist in `src/cilly_trading/engine/data.py`.
+- Provider registry/failover contract artifacts exist in `src/cilly_trading/engine/data/market_data_provider.py`.
+- Snapshot-only API behavior and deterministic/non-deterministic boundary language is documented in `docs/operations/api/usage_contract.md`.
+
+### Explicitly Out of Scope
+- Treating direct adapter presence as proof of production-ready runtime integration.
+- Claiming broker integration, live feeds, or websocket delivery under Phase 38.
+
+### Acceptance Evidence Requirements
+- Repository status wording must not claim direct provider integrations are absent where code exists.
+- Runtime-safe claims must include deterministic snapshot-bound usage evidence, not only adapter-presence evidence.

--- a/docs/operations/api/usage_contract.md
+++ b/docs/operations/api/usage_contract.md
@@ -175,6 +175,20 @@ No validation is performed on the number of rows, date coverage, or completeness
 - Direct engine calls to `cilly_trading.engine.core.run_watchlist_analysis` with `snapshot_only=False` (default) and without `ingestion_run_id` load data via `cilly_trading.engine.data.load_ohlcv`, which depends on current time (`_utc_now`) and external data sources (`yfinance` for stocks, `ccxt`/Binance for crypto). Results can vary over time or with upstream data changes.
 - If `snapshot_only=False` and snapshot data is missing or invalid, the engine may skip symbols instead of failing the request, which makes outcomes dependent on snapshot availability at runtime.
 
+### Direct provider adapter status vs runtime-safe usage claims
+
+The repository contains direct provider adapter code in `cilly_trading.engine.data` (`_load_stock_yahoo`, `_load_crypto_binance`, and `load_ohlcv`).
+
+This presence does **not** by itself establish a runtime-safe deterministic API integration claim.
+
+A repository-safe market-data claim must distinguish:
+
+- **Adapter presence:** direct provider code exists.
+- **Deterministic usage boundary:** runtime API entrypoints enforce snapshot-only paths (`load_ohlcv_snapshot`) with `ingestion_run_id`.
+- **Operational/runtime evidence:** tests verify snapshot-only endpoints do not call direct provider loaders in the deterministic API path.
+
+The snapshot-only API contract remains the authoritative deterministic runtime boundary.
+
 ### Error semantics (analysis endpoints)
 
 These errors are emitted by `/strategy/analyze`, `/analysis/run`, `/watchlists/{watchlist_id}/execute`, and `/screener/basic` unless the endpoint-specific section below narrows the behavior:

--- a/tests/test_phase38_market_data_status_docs.py
+++ b/tests/test_phase38_market_data_status_docs.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_phase38_status_doc_defines_bounded_contract_and_evidence_classes() -> None:
+    content = (
+        REPO_ROOT / "docs" / "architecture" / "phases" / "phase-38-status.md"
+    ).read_text(encoding="utf-8")
+
+    assert content.startswith("# Phase 38 - Market Data Integration Status")
+    assert "_load_stock_yahoo" in content
+    assert "_load_crypto_binance" in content
+    assert "Deterministic snapshot workflow boundary" in content
+    assert "Runtime-safe usage boundary" in content
+    assert "Evidence Requirements For Repository-Safe Market-Data Claims" in content
+    assert "Remaining Unimplemented Scope After Status Correction" in content
+    assert "does not claim" not in content.lower()
+
+
+def test_phase38_master_roadmap_section_no_longer_claims_missing_direct_provider_integration() -> None:
+    content = (
+        REPO_ROOT
+        / "docs"
+        / "architecture"
+        / "roadmap"
+        / "cilly_trading_execution_roadmap_updated.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## Phase 38 - Market Data Integration" in content
+    assert "Direct provider loaders are repo-verifiable" in content
+    assert "No repo-verifiable direct Yahoo Finance, Binance, or CCXT production integration module was confirmed." not in content
+
+
+def test_execution_roadmap_and_usage_contract_reference_phase38_boundary() -> None:
+    execution_content = (
+        REPO_ROOT / "docs" / "architecture" / "roadmap" / "execution_roadmap.md"
+    ).read_text(encoding="utf-8")
+    usage_content = (
+        REPO_ROOT / "docs" / "operations" / "api" / "usage_contract.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Phase 38 | Market Data Integration" in execution_content
+    assert "docs/architecture/phases/phase-38-status.md" in execution_content
+    assert "Direct provider adapter status vs runtime-safe usage claims" in usage_content
+    assert "The snapshot-only API contract remains the authoritative deterministic runtime boundary." in usage_content


### PR DESCRIPTION
Closes #792

## Summary
- correct Phase 38 market-data integration status in the roadmap and supporting docs
- define the bounded distinction between direct provider adapter presence and runtime-safe deterministic snapshot-only API usage
- align the API usage contract with the current snapshot-first runtime boundary
- add focused documentation verification for the Phase 38 status wording

## Scope
- in scope: Phase 38 roadmap wording, execution-roadmap alignment, API usage contract clarification, and targeted doc verification
- out of scope: runtime behavior changes, provider implementation expansion, live market-data enablement, and broader product-scope changes

## Behavior
- documentation and governance correction only
- no API runtime behavior, auth behavior, or execution behavior changes

## Testing
- python -m pytest -q tests/test_phase38_market_data_status_docs.py tests/test_api_snapshot_first_enforcement.py tests/test_api_manual_analysis_trigger.py tests/data/test_market_data_provider_contract.py tests/test_phase6_snapshot_contract.py
- result: 60 passed, 4 warnings

## Notes
- warnings are existing FastAPI on_event deprecation warnings from lifecycle registration and are not expanded in scope for #792
