### PR TITLE
P43A: Replace env-derived portfolio inspection state with bounded simulation source of truth

### DIFF
--- a/docs/architecture/phases/phase-43-portfolio-inspection-contract.md
+++ b/docs/architecture/phases/phase-43-portfolio-inspection-contract.md
@@ -1,0 +1,31 @@
+# Phase 43 Portfolio Inspection Contract
+
+This document defines the bounded Phase 43 contract for `GET /portfolio/positions`.
+
+## Scope
+
+- The endpoint is a read-only inspection surface.
+- Position state is derived from canonical simulation artifacts persisted by the trading-core execution repository.
+- The endpoint does not execute orders, mutate portfolio state, or expose live broker state.
+
+## Source Of Truth
+
+- `src/cilly_trading/engine/portfolio/state.py`
+- `load_portfolio_state_from_simulation_repository(...)`
+
+The source of truth is the canonical trade stream (`list_trades`) from the internal execution repository. Open exposure is derived from `quantity_opened - quantity_closed`.
+
+## Derivation Rules
+
+- Closed exposure (`remaining_quantity <= 0`) is excluded.
+- Positions are aggregated by `(strategy_id, symbol)`.
+- `size` is the sum of remaining quantities in the aggregate group.
+- `average_price` is a weighted entry average over remaining quantity.
+- `unrealized_pnl` is the sum of unrealized PnL values (missing values treated as `0`).
+- Output ordering is deterministic: `symbol`, `strategy_id`, `size`, `average_price`, `unrealized_pnl`.
+
+## Explicit Non-Claims
+
+- No live broker portfolio sync.
+- No mutation workflow for paper-trading state.
+- No execution-capability claim beyond deterministic inspection of bounded internal artifacts.

--- a/src/api/routers/inspection_router.py
+++ b/src/api/routers/inspection_router.py
@@ -251,7 +251,7 @@ def build_inspection_router(
     def read_portfolio_positions_handler(
         _: str = Depends(deps.require_role("read_only")),
     ) -> PortfolioPositionsResponse:
-        return inspection_service.read_portfolio_positions()
+        return inspection_service.read_portfolio_positions(deps=_service_dependencies(deps))
 
     @router.get(
         "/paper/account",

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from cilly_trading.engine.decision_card_contract import validate_decision_card
 from cilly_trading.engine.portfolio import (
     PortfolioPosition as PortfolioInspectionPosition,
-    load_portfolio_state_from_env,
+    load_portfolio_state_from_simulation_repository,
 )
 from cilly_trading.models import ExecutionEvent, Order, Position, SignalReadItemDTO, SignalReadResponseDTO, Trade
 
@@ -130,8 +130,13 @@ def portfolio_position_response(
     )
 
 
-def read_portfolio_positions() -> PortfolioPositionsResponse:
-    state = load_portfolio_state_from_env()
+def read_portfolio_positions(
+    *,
+    deps: InspectionServiceDependencies,
+) -> PortfolioPositionsResponse:
+    state = load_portfolio_state_from_simulation_repository(
+        repository=deps.canonical_execution_repo,
+    )
     items = [portfolio_position_response(position) for position in state.positions]
     return PortfolioPositionsResponse(positions=items, total=len(items))
 

--- a/src/cilly_trading/engine/portfolio/__init__.py
+++ b/src/cilly_trading/engine/portfolio/__init__.py
@@ -3,14 +3,17 @@
 from .state import (
     DEFAULT_PORTFOLIO_POSITIONS_ENV,
     PortfolioPosition,
+    PortfolioSimulationStateRepository,
     PortfolioState,
+    load_portfolio_state_from_simulation_repository,
     load_portfolio_state_from_env,
 )
 
 __all__ = (
     "DEFAULT_PORTFOLIO_POSITIONS_ENV",
     "PortfolioPosition",
+    "PortfolioSimulationStateRepository",
     "PortfolioState",
+    "load_portfolio_state_from_simulation_repository",
     "load_portfolio_state_from_env",
 )
-

--- a/src/cilly_trading/engine/portfolio/state.py
+++ b/src/cilly_trading/engine/portfolio/state.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from typing import Any
+from decimal import Decimal
+from typing import Any, Protocol
+
+from cilly_trading.models import Trade
 
 DEFAULT_PORTFOLIO_POSITIONS_ENV = "CILLY_PORTFOLIO_POSITIONS"
 
@@ -26,6 +29,98 @@ class PortfolioState:
     """Read-only portfolio state containing current positions."""
 
     positions: tuple[PortfolioPosition, ...]
+
+
+class PortfolioSimulationStateRepository(Protocol):
+    """Bounded read-only repository contract for simulation-derived portfolio state."""
+
+    def list_trades(
+        self,
+        *,
+        strategy_id: str | None = None,
+        symbol: str | None = None,
+        position_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Trade]: ...
+
+
+@dataclass(frozen=True)
+class _AggregatedPortfolioPosition:
+    strategy_id: str
+    symbol: str
+    size: Decimal
+    weighted_notional: Decimal
+    unrealized_pnl: Decimal
+
+
+def load_portfolio_state_from_simulation_repository(
+    *,
+    repository: PortfolioSimulationStateRepository,
+) -> PortfolioState:
+    """Derive deterministic inspection state from canonical simulation artifacts."""
+
+    trades = repository.list_trades(limit=1_000_000, offset=0)
+    if not trades:
+        return PortfolioState(positions=tuple())
+
+    aggregates: dict[tuple[str, str], _AggregatedPortfolioPosition] = {}
+    for trade in trades:
+        remaining_quantity = trade.quantity_opened - trade.quantity_closed
+        if remaining_quantity <= Decimal("0"):
+            continue
+
+        key = (trade.strategy_id, trade.symbol)
+        existing = aggregates.get(key)
+        remaining_notional = remaining_quantity * trade.average_entry_price
+        trade_unrealized_pnl = trade.unrealized_pnl or Decimal("0")
+
+        if existing is None:
+            aggregates[key] = _AggregatedPortfolioPosition(
+                strategy_id=trade.strategy_id,
+                symbol=trade.symbol,
+                size=remaining_quantity,
+                weighted_notional=remaining_notional,
+                unrealized_pnl=trade_unrealized_pnl,
+            )
+            continue
+
+        aggregates[key] = _AggregatedPortfolioPosition(
+            strategy_id=existing.strategy_id,
+            symbol=existing.symbol,
+            size=existing.size + remaining_quantity,
+            weighted_notional=existing.weighted_notional + remaining_notional,
+            unrealized_pnl=existing.unrealized_pnl + trade_unrealized_pnl,
+        )
+
+    positions: list[PortfolioPosition] = []
+    for aggregate in aggregates.values():
+        if aggregate.size <= Decimal("0"):
+            continue
+        average_price = aggregate.weighted_notional / aggregate.size
+        positions.append(
+            PortfolioPosition(
+                strategy_id=aggregate.strategy_id,
+                symbol=aggregate.symbol,
+                size=float(aggregate.size),
+                average_price=float(average_price),
+                unrealized_pnl=float(aggregate.unrealized_pnl),
+            )
+        )
+
+    ordered_positions = tuple(
+        sorted(
+            positions,
+            key=lambda item: (
+                item.symbol,
+                item.strategy_id,
+                item.size,
+                item.average_price,
+                item.unrealized_pnl,
+            ),
+        )
+    )
+    return PortfolioState(positions=ordered_positions)
 
 
 def load_portfolio_state_from_env(
@@ -89,4 +184,3 @@ def _parse_position(item: Any) -> PortfolioPosition | None:
         average_price=average_price,
         unrealized_pnl=unrealized_pnl,
     )
-

--- a/tests/cilly_trading/engine/test_portfolio_state_derivation.py
+++ b/tests/cilly_trading/engine/test_portfolio_state_derivation.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from cilly_trading.engine.portfolio import load_portfolio_state_from_simulation_repository
+from cilly_trading.models import Trade
+
+
+class _FakeSimulationRepository:
+    def __init__(self, trades: list[Trade]) -> None:
+        self._trades = trades
+
+    def list_trades(
+        self,
+        *,
+        strategy_id: str | None = None,
+        symbol: str | None = None,
+        position_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Trade]:
+        items = self._trades
+        if strategy_id is not None:
+            items = [item for item in items if item.strategy_id == strategy_id]
+        if symbol is not None:
+            items = [item for item in items if item.symbol == symbol]
+        if position_id is not None:
+            items = [item for item in items if item.position_id == position_id]
+        return items[offset : offset + limit]
+
+
+def _trade(
+    *,
+    trade_id: str,
+    position_id: str,
+    strategy_id: str,
+    symbol: str,
+    quantity_opened: str,
+    quantity_closed: str = "0",
+    average_entry_price: str,
+    unrealized_pnl: str | None = None,
+    status: str = "open",
+) -> Trade:
+    closed_quantity = Decimal(quantity_closed)
+    return Trade.model_validate(
+        {
+            "trade_id": trade_id,
+            "position_id": position_id,
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "direction": "long",
+            "status": status,
+            "opened_at": "2026-03-26T09:30:00Z",
+            "closed_at": "2026-03-26T16:00:00Z" if status == "closed" else None,
+            "quantity_opened": Decimal(quantity_opened),
+            "quantity_closed": closed_quantity,
+            "average_entry_price": Decimal(average_entry_price),
+            "average_exit_price": Decimal("100") if status == "closed" or closed_quantity > Decimal("0") else None,
+            "exposure_notional": (
+                (Decimal(quantity_opened) - closed_quantity)
+                * Decimal(average_entry_price)
+            ),
+            "realized_pnl": Decimal("0") if status == "closed" else None,
+            "unrealized_pnl": Decimal(unrealized_pnl) if unrealized_pnl is not None else None,
+            "opening_order_ids": ["ord-open"],
+            "closing_order_ids": ["ord-close"] if status == "closed" else [],
+            "execution_event_ids": ["evt-1"],
+        }
+    )
+
+
+def test_portfolio_state_derivation_is_deterministic_and_aggregated() -> None:
+    repo = _FakeSimulationRepository(
+        [
+            _trade(
+                trade_id="t3",
+                position_id="p2",
+                strategy_id="beta",
+                symbol="AAPL",
+                quantity_opened="1",
+                average_entry_price="190",
+                unrealized_pnl="2",
+            ),
+            _trade(
+                trade_id="t2",
+                position_id="p1",
+                strategy_id="alpha",
+                symbol="AAPL",
+                quantity_opened="1",
+                average_entry_price="180",
+                unrealized_pnl="3",
+            ),
+            _trade(
+                trade_id="t1",
+                position_id="p1",
+                strategy_id="alpha",
+                symbol="AAPL",
+                quantity_opened="2",
+                quantity_closed="1",
+                average_entry_price="200",
+                unrealized_pnl="4",
+            ),
+            _trade(
+                trade_id="t4",
+                position_id="p3",
+                strategy_id="gamma",
+                symbol="MSFT",
+                quantity_opened="2",
+                quantity_closed="2",
+                average_entry_price="300",
+                unrealized_pnl="0",
+                status="closed",
+            ),
+        ]
+    )
+
+    first = load_portfolio_state_from_simulation_repository(repository=repo)
+    second = load_portfolio_state_from_simulation_repository(repository=repo)
+
+    assert first == second
+    assert [(item.symbol, item.strategy_id) for item in first.positions] == [
+        ("AAPL", "alpha"),
+        ("AAPL", "beta"),
+    ]
+    alpha_position = first.positions[0]
+    assert alpha_position.size == 2.0
+    assert alpha_position.average_price == 190.0
+    assert alpha_position.unrealized_pnl == 7.0
+
+
+def test_portfolio_state_derivation_returns_empty_state_when_no_open_exposure() -> None:
+    repo = _FakeSimulationRepository(
+        [
+            _trade(
+                trade_id="t-closed",
+                position_id="p-closed",
+                strategy_id="alpha",
+                symbol="NVDA",
+                quantity_opened="1",
+                quantity_closed="1",
+                average_entry_price="700",
+                unrealized_pnl="0",
+                status="closed",
+            )
+        ]
+    )
+
+    state = load_portfolio_state_from_simulation_repository(repository=repo)
+    assert state.positions == tuple()

--- a/tests/test_api_portfolio_positions_read.py
+++ b/tests/test_api_portfolio_positions_read.py
@@ -1,13 +1,77 @@
 from __future__ import annotations
 
-import json
+from decimal import Decimal
 
 from fastapi.testclient import TestClient
 
 import api.main as api_main
+from cilly_trading.models import Trade
 from tests.utils.json_schema_validator import validate_json_schema
 
 READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
+
+class _FakeCanonicalExecutionRepo:
+    def __init__(self, trades: list[Trade]) -> None:
+        self._trades = trades
+
+    def list_trades(
+        self,
+        *,
+        strategy_id: str | None = None,
+        symbol: str | None = None,
+        position_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Trade]:
+        items = self._trades
+        if strategy_id is not None:
+            items = [item for item in items if item.strategy_id == strategy_id]
+        if symbol is not None:
+            items = [item for item in items if item.symbol == symbol]
+        if position_id is not None:
+            items = [item for item in items if item.position_id == position_id]
+        return items[offset : offset + limit]
+
+
+def _trade(
+    *,
+    trade_id: str,
+    position_id: str,
+    strategy_id: str,
+    symbol: str,
+    quantity_opened: str,
+    quantity_closed: str = "0",
+    average_entry_price: str,
+    unrealized_pnl: str | None = None,
+    status: str = "open",
+) -> Trade:
+    closed_quantity = Decimal(quantity_closed)
+    return Trade.model_validate(
+        {
+            "trade_id": trade_id,
+            "position_id": position_id,
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "direction": "long",
+            "status": status,
+            "opened_at": "2026-03-25T09:30:00Z",
+            "closed_at": "2026-03-25T15:30:00Z" if status == "closed" else None,
+            "quantity_opened": Decimal(quantity_opened),
+            "quantity_closed": closed_quantity,
+            "average_entry_price": Decimal(average_entry_price),
+            "average_exit_price": Decimal("105") if status == "closed" or closed_quantity > Decimal("0") else None,
+            "exposure_notional": (
+                (Decimal(quantity_opened) - closed_quantity)
+                * Decimal(average_entry_price)
+            ),
+            "realized_pnl": Decimal("0") if status == "closed" else None,
+            "unrealized_pnl": Decimal(unrealized_pnl) if unrealized_pnl is not None else None,
+            "opening_order_ids": ["ord-open"],
+            "closing_order_ids": ["ord-close"] if status == "closed" else [],
+            "execution_event_ids": ["evt-1"],
+        }
+    )
 
 
 def _test_client(monkeypatch: object) -> TestClient:
@@ -16,23 +80,29 @@ def _test_client(monkeypatch: object) -> TestClient:
 
 
 def test_portfolio_positions_returns_current_positions(monkeypatch) -> None:
-    positions_payload = [
-        {
-            "strategy_id": "alpha",
-            "symbol": "MSFT",
-            "size": 3.0,
-            "average_price": 312.5,
-            "unrealized_pnl": 21.1,
-        },
-        {
-            "strategy_id": "beta",
-            "symbol": "AAPL",
-            "size": -1.0,
-            "average_price": 201.0,
-            "unrealized_pnl": -4.25,
-        },
+    trades = [
+        _trade(
+            trade_id="t-aapl-beta",
+            position_id="p-aapl-beta",
+            strategy_id="beta",
+            symbol="AAPL",
+            quantity_opened="2",
+            quantity_closed="0",
+            average_entry_price="201",
+            unrealized_pnl="-4.25",
+        ),
+        _trade(
+            trade_id="t-msft-alpha",
+            position_id="p-msft-alpha",
+            strategy_id="alpha",
+            symbol="MSFT",
+            quantity_opened="3",
+            quantity_closed="0",
+            average_entry_price="312.5",
+            unrealized_pnl="21.1",
+        ),
     ]
-    monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
+    monkeypatch.setattr(api_main, "canonical_execution_repo", _FakeCanonicalExecutionRepo(trades))
 
     with _test_client(monkeypatch) as client:
         response = client.get("/portfolio/positions", headers=READ_ONLY_HEADERS)
@@ -43,7 +113,7 @@ def test_portfolio_positions_returns_current_positions(monkeypatch) -> None:
     assert payload["positions"] == [
         {
             "symbol": "AAPL",
-            "size": -1.0,
+            "size": 2.0,
             "average_price": 201.0,
             "unrealized_pnl": -4.25,
             "strategy_id": "beta",
@@ -59,16 +129,19 @@ def test_portfolio_positions_returns_current_positions(monkeypatch) -> None:
 
 
 def test_portfolio_positions_response_schema(monkeypatch) -> None:
-    positions_payload = [
-        {
-            "strategy_id": "trend-a",
-            "symbol": "NVDA",
-            "size": 4.5,
-            "average_price": 920.0,
-            "unrealized_pnl": 12.0,
-        }
+    trades = [
+        _trade(
+            trade_id="t-nvda-trend-a",
+            position_id="p-nvda-trend-a",
+            strategy_id="trend-a",
+            symbol="NVDA",
+            quantity_opened="4.5",
+            quantity_closed="0",
+            average_entry_price="920",
+            unrealized_pnl="12",
+        )
     ]
-    monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
+    monkeypatch.setattr(api_main, "canonical_execution_repo", _FakeCanonicalExecutionRepo(trades))
 
     with _test_client(monkeypatch) as client:
         payload = client.get("/portfolio/positions", headers=READ_ONLY_HEADERS).json()
@@ -79,30 +152,60 @@ def test_portfolio_positions_response_schema(monkeypatch) -> None:
 
 
 def test_portfolio_positions_output_is_deterministic(monkeypatch) -> None:
-    positions_payload = [
-        {
-            "strategy_id": "zeta",
-            "symbol": "TSLA",
-            "size": 2.0,
-            "average_price": 150.0,
-            "unrealized_pnl": 1.0,
-        },
-        {
-            "strategy_id": "alpha",
-            "symbol": "AAPL",
-            "size": 2.0,
-            "average_price": 180.0,
-            "unrealized_pnl": 5.0,
-        },
-        {
-            "strategy_id": "beta",
-            "symbol": "AAPL",
-            "size": 1.0,
-            "average_price": 181.0,
-            "unrealized_pnl": 2.0,
-        },
+    trades = [
+        _trade(
+            trade_id="t-zeta-tsla",
+            position_id="p-zeta-tsla",
+            strategy_id="zeta",
+            symbol="TSLA",
+            quantity_opened="2",
+            quantity_closed="0",
+            average_entry_price="150",
+            unrealized_pnl="1",
+        ),
+        _trade(
+            trade_id="t-alpha-aapl-1",
+            position_id="p-alpha-aapl",
+            strategy_id="alpha",
+            symbol="AAPL",
+            quantity_opened="1",
+            quantity_closed="0",
+            average_entry_price="180",
+            unrealized_pnl="2",
+        ),
+        _trade(
+            trade_id="t-alpha-aapl-2",
+            position_id="p-alpha-aapl",
+            strategy_id="alpha",
+            symbol="AAPL",
+            quantity_opened="1",
+            quantity_closed="0",
+            average_entry_price="182",
+            unrealized_pnl="3",
+        ),
+        _trade(
+            trade_id="t-beta-aapl",
+            position_id="p-beta-aapl",
+            strategy_id="beta",
+            symbol="AAPL",
+            quantity_opened="1",
+            quantity_closed="0",
+            average_entry_price="181",
+            unrealized_pnl="2",
+        ),
+        _trade(
+            trade_id="t-closed-ignored",
+            position_id="p-closed",
+            strategy_id="ignored",
+            symbol="QQQ",
+            quantity_opened="2",
+            quantity_closed="2",
+            average_entry_price="300",
+            unrealized_pnl="0",
+            status="closed",
+        ),
     ]
-    monkeypatch.setenv("CILLY_PORTFOLIO_POSITIONS", json.dumps(positions_payload))
+    monkeypatch.setattr(api_main, "canonical_execution_repo", _FakeCanonicalExecutionRepo(trades))
 
     with _test_client(monkeypatch) as client:
         first = client.get("/portfolio/positions", headers=READ_ONLY_HEADERS)
@@ -113,3 +216,6 @@ def test_portfolio_positions_output_is_deterministic(monkeypatch) -> None:
     assert first.json() == second.json()
     assert [item["symbol"] for item in first.json()["positions"]] == ["AAPL", "AAPL", "TSLA"]
     assert [item["strategy_id"] for item in first.json()["positions"][:2]] == ["alpha", "beta"]
+    assert first.json()["positions"][0]["size"] == 2.0
+    assert first.json()["positions"][0]["average_price"] == 181.0
+    assert first.json()["positions"][0]["unrealized_pnl"] == 5.0


### PR DESCRIPTION
Closes #793

## What changed
- Replaced /portfolio/positions core derivation path from env payload to canonical simulation repository artifacts.
- Added load_portfolio_state_from_simulation_repository(...) and bounded repository protocol in engine/portfolio.
- Wired inspection router/service to pass canonical execution repository dependencies into portfolio inspection reads.
- Updated portfolio API tests to validate repository-derived outputs and deterministic ordering and aggregation behavior.
- Added deterministic engine-level derivation tests.
- Added Phase 43 contract doc defining bounded scope, source of truth, derivation rules, and explicit non-claims.

## Acceptance Criteria mapping
- /portfolio/positions is no longer solely env-driven.
- Portfolio inspection state now derives from explicit internal repository artifacts (list_trades).
- Deterministic ordering and derivation behavior are covered by tests.
- Documentation now states the bounded Phase 43 contract without execution overclaims.

## Validation
- .\.venv\Scripts\python -m pytest -q
- Result: 731 passed, 4 warnings

## Scope
- in scope: bounded read-only portfolio inspection derivation, deterministic repository-backed aggregation, targeted endpoint and engine tests, and Phase 43 contract documentation
- out of scope: broker sync, live portfolio state, mutation workflows, order execution, and broader paper-trading or live-trading capability claims

## Notes
- warnings are existing FastAPI on_event deprecation warnings and are not expanded in scope for #793
