### PR TITLE
P42B2: Define canonical handoff from backtest evidence to portfolio simulation and paper-trading readiness

### DIFF
--- a/docs/architecture/backtest_execution_contract.md
+++ b/docs/architecture/backtest_execution_contract.md
@@ -74,3 +74,27 @@ For identical snapshots and identical run contract:
 
 The run artifact now surfaces both the explicit `run_config` contract and realized `orders` / `fills` / `positions`.
 
+## Canonical Handoff (Phase 42b -> Phase 43 -> Phase 44)
+
+The canonical handoff from backtest evidence is explicit in `backtest-result.json` under `phase_handoff`.
+
+- `phase_handoff.source_phase` MUST be `42b`.
+- `phase_handoff.target_phases` MUST include `43` and `44`.
+- `phase_handoff.required_evidence.phase_43_portfolio_simulation` defines the required fields for Phase 43 consumers.
+- `phase_handoff.required_evidence.phase_44_paper_trading_readiness` defines the additional required fields for Phase 44 evidence consumers.
+- `phase_handoff.authoritative_outputs.trader_interpretation` defines which outputs are authoritative for trader-facing interpretation.
+- `phase_handoff.assumption_alignment.run_config_execution_assumptions_match_metrics_baseline_assumptions` MUST be true before readiness evidence is considered valid.
+
+Acceptance gates are explicit and non-inferential:
+
+- `phase_handoff.acceptance_gates.technically_valid_backtest_artifact`
+  distinguishes "artifact is structurally valid" from downstream readiness claims.
+- `phase_handoff.acceptance_gates.phase_43_portfolio_simulation_ready`
+  indicates evidence is complete and aligned for Phase 43 portfolio simulation usage.
+- `phase_handoff.acceptance_gates.phase_44_paper_trading_readiness_evidence_ready`
+  indicates evidence handoff completeness for Phase 44 readiness review.
+
+Boundary clarification:
+
+- Passing the handoff gates does not implement portfolio simulation or paper-trading workflows.
+- Passing the handoff gates does not imply live trading or broker readiness.

--- a/docs/testing/backtesting/backtest_cli.md
+++ b/docs/testing/backtesting/backtest_cli.md
@@ -58,6 +58,22 @@ Evidence alignment rule for covered outputs:
 
 - `metrics_baseline.assumptions` MUST match `run_config.execution_assumptions`.
 
+## Phase 42b -> 43 -> 44 Handoff Contract
+
+The produced artifact includes explicit downstream handoff metadata at `phase_handoff`:
+
+- `phase_handoff.required_evidence.phase_43_portfolio_simulation`: required evidence fields for Phase 43.
+- `phase_handoff.required_evidence.phase_44_paper_trading_readiness`: additional evidence fields for Phase 44.
+- `phase_handoff.authoritative_outputs.trader_interpretation`: authoritative outputs for trader-facing interpretation.
+- `phase_handoff.acceptance_gates.technically_valid_backtest_artifact`: structural validity gate only.
+- `phase_handoff.acceptance_gates.phase_43_portfolio_simulation_ready`: Phase 43 readiness evidence gate.
+- `phase_handoff.acceptance_gates.phase_44_paper_trading_readiness_evidence_ready`: Phase 44 readiness evidence gate.
+
+Review interpretation rule:
+
+- A technically valid artifact is not automatically Phase 43/44 readiness evidence.
+- Phase 43/44 usage MUST follow the explicit handoff gate outcomes.
+
 ## Trader Interpretation Boundary
 
 The produced evidence is valid only for deterministic replay under the declared assumptions and snapshot input.

--- a/docs/testing/backtesting/result_artifact_schema.md
+++ b/docs/testing/backtesting/result_artifact_schema.md
@@ -55,6 +55,21 @@ Top-level object keys and minimal semantics:
 - `orders` (required): array (may be empty)
 - `fills` (required): array (may be empty)
 - `positions` (required): array (may be empty)
+- `phase_handoff` (required): object
+  - `contract_version` (required): string
+  - `source_phase` (required): string literal `"42b"`
+  - `target_phases` (required): array containing `"43"` and `"44"`
+  - `required_evidence` (required): object
+    - `phase_43_portfolio_simulation` (required): array of field-path strings
+    - `phase_44_paper_trading_readiness` (required): array of field-path strings
+  - `authoritative_outputs` (required): object
+    - `trader_interpretation` (required): array of field-path strings
+  - `assumption_alignment` (required): object
+    - `run_config_execution_assumptions_match_metrics_baseline_assumptions` (required): boolean
+  - `acceptance_gates` (required): object
+    - `technically_valid_backtest_artifact` (required): object with `passed`, `missing_fields`, `reasons`
+    - `phase_43_portfolio_simulation_ready` (required): object with `passed`, `missing_fields`, `reasons`
+    - `phase_44_paper_trading_readiness_evidence_ready` (required): object with `passed`, `missing_fields`, `reasons`
 
 ## Hash reproducibility
 

--- a/src/cilly_trading/engine/backtest_handoff_contract.py
+++ b/src/cilly_trading/engine/backtest_handoff_contract.py
@@ -1,0 +1,174 @@
+"""Canonical Phase 42b handoff contract for downstream Phase 43/44 usage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+HANDOFF_CONTRACT_VERSION = "1.0.0"
+
+PHASE_43_REQUIRED_FIELDS: tuple[str, ...] = (
+    "artifact_version",
+    "run.run_id",
+    "run.deterministic",
+    "snapshot_linkage.mode",
+    "snapshot_linkage.start",
+    "snapshot_linkage.end",
+    "snapshot_linkage.count",
+    "strategy.name",
+    "strategy.params",
+    "run_config.contract_version",
+    "run_config.execution_assumptions",
+    "run_config.reproducibility_metadata",
+    "summary.start_equity",
+    "summary.end_equity",
+    "equity_curve",
+    "metrics_baseline.assumptions",
+    "metrics_baseline.summary",
+    "metrics_baseline.metrics.cost_aware",
+)
+
+PHASE_44_REQUIRED_FIELDS: tuple[str, ...] = (
+    "orders",
+    "fills",
+    "positions",
+    "metrics_baseline.trades",
+)
+
+TRADER_AUTHORITATIVE_FIELDS: tuple[str, ...] = (
+    "run.run_id",
+    "snapshot_linkage",
+    "strategy",
+    "run_config.execution_assumptions",
+    "metrics_baseline.summary",
+    "metrics_baseline.metrics.cost_aware",
+    "metrics_baseline.metrics.deltas",
+)
+
+
+@dataclass(frozen=True)
+class GateStatus:
+    """Deterministic gate status for one downstream phase boundary."""
+
+    passed: bool
+    missing_fields: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "missing_fields": list(self.missing_fields),
+            "reasons": list(self.reasons),
+        }
+
+
+def build_phase_handoff_contract(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Build canonical handoff evidence contract for Phase 42b outputs."""
+
+    assumptions_aligned = _assumptions_aligned(payload)
+    technical_gate = _technical_gate(payload)
+    phase_43_gate = _phase_43_gate(payload, assumptions_aligned=assumptions_aligned)
+    phase_44_gate = _phase_44_gate(payload, phase_43_gate=phase_43_gate)
+
+    return {
+        "contract_version": HANDOFF_CONTRACT_VERSION,
+        "source_phase": "42b",
+        "target_phases": ["43", "44"],
+        "required_evidence": {
+            "phase_43_portfolio_simulation": list(PHASE_43_REQUIRED_FIELDS),
+            "phase_44_paper_trading_readiness": list(PHASE_44_REQUIRED_FIELDS),
+        },
+        "authoritative_outputs": {
+            "trader_interpretation": list(TRADER_AUTHORITATIVE_FIELDS),
+        },
+        "assumption_alignment": {
+            "run_config_execution_assumptions_match_metrics_baseline_assumptions": assumptions_aligned,
+        },
+        "acceptance_gates": {
+            "technically_valid_backtest_artifact": technical_gate.to_payload(),
+            "phase_43_portfolio_simulation_ready": phase_43_gate.to_payload(),
+            "phase_44_paper_trading_readiness_evidence_ready": phase_44_gate.to_payload(),
+        },
+    }
+
+
+def _phase_43_gate(payload: Mapping[str, Any], *, assumptions_aligned: bool) -> GateStatus:
+    missing_fields = _missing_fields(payload, PHASE_43_REQUIRED_FIELDS)
+    reasons: list[str] = []
+    if missing_fields:
+        reasons.append("missing_phase_43_required_fields")
+    if not assumptions_aligned:
+        reasons.append("run_config_and_metrics_baseline_assumptions_mismatch")
+    return GateStatus(
+        passed=(not missing_fields and assumptions_aligned),
+        missing_fields=missing_fields,
+        reasons=tuple(reasons),
+    )
+
+
+def _phase_44_gate(payload: Mapping[str, Any], *, phase_43_gate: GateStatus) -> GateStatus:
+    missing_fields = _missing_fields(payload, PHASE_44_REQUIRED_FIELDS)
+    reasons: list[str] = []
+    if not phase_43_gate.passed:
+        reasons.append("phase_43_gate_not_passed")
+    if missing_fields:
+        reasons.append("missing_phase_44_required_fields")
+    return GateStatus(
+        passed=(phase_43_gate.passed and not missing_fields),
+        missing_fields=missing_fields,
+        reasons=tuple(reasons),
+    )
+
+
+def _technical_gate(payload: Mapping[str, Any]) -> GateStatus:
+    required_fields = (
+        "artifact_version",
+        "run.run_id",
+        "run.deterministic",
+        "snapshot_linkage",
+        "strategy",
+        "summary",
+        "equity_curve",
+    )
+    missing_fields = _missing_fields(payload, required_fields)
+    deterministic_flag = _get_path(payload, "run.deterministic")
+    reasons: list[str] = []
+    if missing_fields:
+        reasons.append("missing_backtest_artifact_fields")
+    if deterministic_flag is not True:
+        reasons.append("run_not_marked_deterministic")
+    return GateStatus(
+        passed=(not missing_fields and deterministic_flag is True),
+        missing_fields=missing_fields,
+        reasons=tuple(reasons),
+    )
+
+
+def _assumptions_aligned(payload: Mapping[str, Any]) -> bool:
+    run_assumptions = _get_path(payload, "run_config.execution_assumptions")
+    baseline_assumptions = _get_path(payload, "metrics_baseline.assumptions")
+    if not isinstance(run_assumptions, Mapping) or not isinstance(baseline_assumptions, Mapping):
+        return False
+    return dict(run_assumptions) == dict(baseline_assumptions)
+
+
+def _missing_fields(payload: Mapping[str, Any], paths: Iterable[str]) -> tuple[str, ...]:
+    missing: list[str] = []
+    for path in paths:
+        value = _get_path(payload, path)
+        if value is _MISSING:
+            missing.append(path)
+    return tuple(missing)
+
+
+_MISSING = object()
+
+
+def _get_path(payload: Mapping[str, Any], path: str) -> Any:
+    current: Any = payload
+    for token in path.split("."):
+        if not isinstance(current, Mapping) or token not in current:
+            return _MISSING
+        current = current[token]
+    return current

--- a/src/cilly_trading/engine/backtest_runner.py
+++ b/src/cilly_trading/engine/backtest_runner.py
@@ -14,6 +14,7 @@ from cilly_trading.engine.backtest_execution_contract import (
     serialize_positions,
     simulate_execution_flow,
 )
+from cilly_trading.engine.backtest_handoff_contract import build_phase_handoff_contract
 from cilly_trading.engine.journal.execution_journal import (
     build_execution_journal_artifact,
     write_execution_journal_artifact,
@@ -247,7 +248,7 @@ class BacktestRunner:
             execution_assumptions=config.run_contract.execution_assumptions,
         )
 
-        return {
+        payload = {
             "artifact_version": "1",
             "engine": {
                 "name": config.engine_name,
@@ -289,6 +290,8 @@ class BacktestRunner:
             "trades": metrics_baseline["trades"],
             "metrics_baseline": metrics_baseline,
         }
+        payload["phase_handoff"] = build_phase_handoff_contract(payload)
+        return payload
 
     def _snapshot_boundaries(
         self,

--- a/tests/cilly_trading/engine/test_backtest_handoff_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_handoff_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from cilly_trading.engine.backtest_handoff_contract import build_phase_handoff_contract
+
+
+def _base_payload() -> dict[str, Any]:
+    run_assumptions = {
+        "fill_model": "deterministic_market",
+        "fill_timing": "next_snapshot",
+        "price_source": "open_then_price",
+        "slippage_bps": 0,
+        "commission_per_order": "0",
+        "partial_fills_allowed": False,
+    }
+    baseline_assumptions = dict(run_assumptions)
+    return {
+        "artifact_version": "1",
+        "run": {"run_id": "run-1", "deterministic": True, "created_at": None},
+        "snapshot_linkage": {
+            "mode": "timestamp",
+            "start": "2024-01-01T00:00:00Z",
+            "end": "2024-01-02T00:00:00Z",
+            "count": 2,
+        },
+        "strategy": {"name": "REFERENCE", "version": None, "params": {}},
+        "run_config": {
+            "contract_version": "1.0.0",
+            "execution_assumptions": run_assumptions,
+            "reproducibility_metadata": {
+                "run_id": "run-1",
+                "strategy_name": "REFERENCE",
+                "strategy_params": {},
+                "engine_name": "cilly_trading_engine",
+                "engine_version": None,
+            },
+        },
+        "summary": {"start_equity": 100000.0, "end_equity": 100001.0},
+        "equity_curve": [{"timestamp": "2024-01-01T00:00:00Z", "equity": 100000.0}],
+        "orders": [],
+        "fills": [],
+        "positions": [],
+        "metrics_baseline": {
+            "assumptions": baseline_assumptions,
+            "summary": {
+                "starting_equity": 100000.0,
+                "ending_equity_cost_free": 100001.0,
+                "ending_equity_cost_aware": 100001.0,
+                "total_transaction_cost": 0.0,
+                "total_commission": 0.0,
+                "total_slippage_cost": 0.0,
+                "fill_count": 0,
+            },
+            "metrics": {
+                "cost_free": {"total_return": 0.00001},
+                "cost_aware": {"total_return": 0.00001},
+                "deltas": {"total_return": 0.0},
+            },
+            "trades": [],
+        },
+    }
+
+
+def test_phase_handoff_contract_reports_passed_gates_for_complete_payload() -> None:
+    handoff = build_phase_handoff_contract(_base_payload())
+    gates = handoff["acceptance_gates"]
+
+    assert handoff["source_phase"] == "42b"
+    assert handoff["target_phases"] == ["43", "44"]
+    assert gates["technically_valid_backtest_artifact"]["passed"] is True
+    assert gates["phase_43_portfolio_simulation_ready"]["passed"] is True
+    assert gates["phase_44_paper_trading_readiness_evidence_ready"]["passed"] is True
+    assert (
+        handoff["assumption_alignment"][
+            "run_config_execution_assumptions_match_metrics_baseline_assumptions"
+        ]
+        is True
+    )
+
+
+def test_phase_handoff_contract_marks_phase_43_gate_failed_when_required_fields_missing() -> None:
+    payload = _base_payload()
+    del payload["run_config"]
+
+    handoff = build_phase_handoff_contract(payload)
+    phase_43_gate = handoff["acceptance_gates"]["phase_43_portfolio_simulation_ready"]
+    phase_44_gate = handoff["acceptance_gates"]["phase_44_paper_trading_readiness_evidence_ready"]
+
+    assert phase_43_gate["passed"] is False
+    assert "run_config.contract_version" in phase_43_gate["missing_fields"]
+    assert "missing_phase_43_required_fields" in phase_43_gate["reasons"]
+    assert phase_44_gate["passed"] is False
+    assert "phase_43_gate_not_passed" in phase_44_gate["reasons"]
+
+
+def test_phase_handoff_contract_marks_assumption_mismatch_as_not_ready() -> None:
+    payload = deepcopy(_base_payload())
+    payload["metrics_baseline"]["assumptions"]["slippage_bps"] = 9
+
+    handoff = build_phase_handoff_contract(payload)
+    phase_43_gate = handoff["acceptance_gates"]["phase_43_portfolio_simulation_ready"]
+    phase_44_gate = handoff["acceptance_gates"]["phase_44_paper_trading_readiness_evidence_ready"]
+
+    assert (
+        handoff["assumption_alignment"][
+            "run_config_execution_assumptions_match_metrics_baseline_assumptions"
+        ]
+        is False
+    )
+    assert phase_43_gate["passed"] is False
+    assert "run_config_and_metrics_baseline_assumptions_mismatch" in phase_43_gate["reasons"]
+    assert phase_44_gate["passed"] is False

--- a/tests/cilly_trading/engine/test_backtest_runner.py
+++ b/tests/cilly_trading/engine/test_backtest_runner.py
@@ -244,6 +244,14 @@ def test_backtest_runner_artifact_contains_explicit_run_contract(tmp_path: Path)
     assert run_config["execution_assumptions"]["commission_per_order"] == "7"
     assert run_config["reproducibility_metadata"]["run_id"] == "contract-run"
     assert run_config["reproducibility_metadata"]["strategy_name"] == "REFERENCE"
+    handoff = payload["phase_handoff"]
+    assert handoff["source_phase"] == "42b"
+    assert handoff["target_phases"] == ["43", "44"]
+    assert handoff["acceptance_gates"]["phase_43_portfolio_simulation_ready"]["passed"] is True
+    assert (
+        handoff["acceptance_gates"]["phase_44_paper_trading_readiness_evidence_ready"]["passed"]
+        is True
+    )
 
 
 def test_backtest_runner_emits_deterministic_orders_fills_positions(tmp_path: Path) -> None:
@@ -334,3 +342,9 @@ def test_backtest_runner_metrics_baseline_cost_aware_differs_from_cost_free(tmp_
         < baseline["summary"]["ending_equity_cost_free"]
     )
     assert baseline["metrics"]["cost_aware"]["total_return"] < baseline["metrics"]["cost_free"]["total_return"]
+    assert (
+        payload["phase_handoff"]["assumption_alignment"][
+            "run_config_execution_assumptions_match_metrics_baseline_assumptions"
+        ]
+        is True
+    )

--- a/tests/test_backtest_evidence_docs.py
+++ b/tests/test_backtest_evidence_docs.py
@@ -28,3 +28,25 @@ def test_backtest_cli_doc_defines_trader_interpretation_boundary() -> None:
     assert "does **not** prove" in content
     assert "Live trading readiness." in content
     assert "Future performance" in content
+
+
+def test_backtest_cli_doc_defines_phase_handoff_contract_and_gate_distinction() -> None:
+    content = (REPO_ROOT / "docs" / "testing" / "backtesting" / "backtest_cli.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Phase 42b -> 43 -> 44 Handoff Contract" in content
+    assert "phase_handoff.required_evidence.phase_43_portfolio_simulation" in content
+    assert "phase_handoff.required_evidence.phase_44_paper_trading_readiness" in content
+    assert "technically valid artifact is not automatically Phase 43/44 readiness evidence" in content
+
+
+def test_backtest_architecture_doc_defines_canonical_handoff() -> None:
+    content = (REPO_ROOT / "docs" / "architecture" / "backtest_execution_contract.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Canonical Handoff (Phase 42b -> Phase 43 -> Phase 44)" in content
+    assert "phase_handoff.acceptance_gates.technically_valid_backtest_artifact" in content
+    assert "phase_handoff.acceptance_gates.phase_43_portfolio_simulation_ready" in content
+    assert "phase_handoff.acceptance_gates.phase_44_paper_trading_readiness_evidence_ready" in content

--- a/tests/test_cli_evaluate_metrics.py
+++ b/tests/test_cli_evaluate_metrics.py
@@ -117,6 +117,14 @@ def test_cli_evaluate_accepts_backtest_artifact_with_baseline_outputs(tmp_path: 
         ]
     )
     assert backtest_result.returncode == 0
+    backtest_payload = json.loads((backtest_out / "backtest-result.json").read_text(encoding="utf-8"))
+    assert "phase_handoff" in backtest_payload
+    assert (
+        backtest_payload["phase_handoff"]["acceptance_gates"]["phase_43_portfolio_simulation_ready"][
+            "passed"
+        ]
+        is True
+    )
 
     evaluate_out = tmp_path / "eval-out"
     evaluate_result = _run_cli(


### PR DESCRIPTION
Closes #794

## What changed

- Added explicit canonical handoff contract in acktest-result.json under phase_handoff.
- Defined required evidence fields for:
  - Phase 43 portfolio simulation
  - Phase 44 paper-trading readiness evidence
- Added explicit acceptance gates to distinguish:
  - technically valid artifact
  - Phase 43-ready evidence
  - Phase 44-ready evidence
- Added deterministic assumption-alignment gate between:
  - un_config.execution_assumptions
  - metrics_baseline.assumptions
- Updated docs to make the handoff contract explicit.
- Added and updated tests for contract behavior, runner artifacts, docs, and downstream evaluate regression.

## Scope / non-goals honored

- No new strategy implementations
- No UI changes
- No live trading or broker integration changes
- No portfolio engine redesign
- Contract-first, evidence-first implementation only

## Validation

- python -m pytest
- Result: 734 passed, 4 warnings

## Notes

- warnings are existing FastAPI on_event deprecation warnings and are not expanded in scope for #794
