### PR TITLE
P44A: Define bounded paper-trading operator workflow on canonical inspection/reconciliation surfaces

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Use this order:
 ## CLI Usage
 - [CLI usage](operations/cli/usage.md)
 - [Paper trading boundary](operations/paper-trading.md)
+- [Phase 44 bounded paper operator workflow](operations/runtime/phase-44-paper-operator-workflow.md)
 
 ## UI Surfaces
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
@@ -93,6 +94,12 @@ Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surfa
 Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
 - [Paper trading boundary](operations/paper-trading.md)
 - [Runbook](operations/runbook.md)
+
+### Phase 44 Reference Materials
+Phase 44 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
+- [Phase 44 bounded paper operator workflow](operations/runtime/phase-44-paper-operator-workflow.md)
+- [Paper inspection and reconciliation API](api/paper_inspection.md)
+- [Paper deployment acceptance gate](operations/runtime/paper-deployment-acceptance-gate.md)
 
 ### Phase 37 Reference Materials
 Phase 37 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.

--- a/docs/operations/paper-trading.md
+++ b/docs/operations/paper-trading.md
@@ -57,4 +57,5 @@ or broker go-live approval.
 
 ## Roadmap Readiness Interpretation
 - Phase 24 focuses on documentation and governance alignment for the simulator and its boundaries.
+- Phase 44 is currently claimed only as one bounded operator runtime workflow across simulator evidence, canonical inspection, and reconciliation surfaces (see `docs/operations/runtime/phase-44-paper-operator-workflow.md`).
 - Phase 44 remains the broader paper-trading product phase and should only be treated as complete when workflow, operator surfaces, and broader runtime handling are fully verified.

--- a/docs/operations/runtime/phase-44-paper-operator-workflow.md
+++ b/docs/operations/runtime/phase-44-paper-operator-workflow.md
@@ -1,0 +1,63 @@
+# Phase 44 Bounded Paper Operator Workflow
+
+## Purpose
+Define the minimum bounded Phase 44 operator workflow using existing simulator, inspection, and reconciliation surfaces.
+
+This workflow is a runtime inspection and validation claim only. It does not introduce new mutation-heavy workflows, broker integrations, or live-trading behavior.
+
+## Bounded Workflow Claim
+Phase 44 is bounded to one operator verification workflow:
+
+1. Confirm deterministic paper lifecycle behavior from canonical simulator artifacts.
+2. Inspect canonical trading-core lifecycle entities (orders, execution events, trades, positions).
+3. Inspect paper-facing account/trade/position views derived from canonical entities.
+4. Reconcile canonical and paper-facing state and require zero mismatches.
+5. Treat the result as bounded paper-runtime coherence evidence only.
+
+## Required Runtime Surfaces
+
+### Simulator and lifecycle evidence surfaces
+- `src/cilly_trading/engine/paper_trading.py`
+- `src/cilly_trading/engine/paper_order_lifecycle.py`
+- `tests/test_paper_trading_simulator.py`
+- `tests/cilly_trading/engine/test_paper_order_lifecycle.py`
+
+### Canonical inspection surfaces
+- `GET /trading-core/orders`
+- `GET /trading-core/execution-events`
+- `GET /trading-core/trades`
+- `GET /trading-core/positions`
+
+### Paper inspection and reconciliation surfaces
+- `GET /paper/trades`
+- `GET /paper/positions`
+- `GET /paper/account`
+- `GET /paper/reconciliation`
+
+## Minimum Operator Evidence
+The bounded Phase 44 workflow claim requires all of the following evidence:
+
+- Deterministic simulator behavior is passing (`tests/test_paper_trading_simulator.py`).
+- Paper inspection and reconciliation contract coverage is passing (`tests/test_api_paper_inspection_read.py`).
+- Reconciliation returns `ok: true` and `summary.mismatches: 0` for valid lifecycle data.
+- Paper inspection views are derived from canonical trading-core entities, not legacy trade payload authority.
+- Full repository regression gate remains green (`python -m pytest`).
+
+## Phase 24 vs Phase 44 Boundary
+
+### Phase 24 (implemented simulator governance boundary)
+- Defines and governs deterministic paper-trading simulator capability.
+- Enforces non-live and non-broker constraints.
+- Does not claim an operator runtime workflow as complete.
+
+### Phase 44 (bounded runtime workflow claim in this phase slice)
+- Claims one coherent operator workflow across simulator evidence, canonical inspection, paper inspection, and reconciliation.
+- Remains read-only and verification-oriented.
+- Does not claim full product workflow completeness or a broad paper-trading dashboard layer.
+
+## Explicit Non-Goals
+- Live trading
+- Broker integration
+- Full paper-trading UI redesign
+- Mutation-heavy order-entry workflow
+- Unrelated portfolio or strategy refactors

--- a/tests/test_api_paper_inspection_read.py
+++ b/tests/test_api_paper_inspection_read.py
@@ -268,6 +268,8 @@ def test_paper_endpoints_are_exposed_and_schema_valid(tmp_path: Path, monkeypatc
     assert "/paper/positions" in openapi["paths"]
     assert "/paper/account" in openapi["paths"]
     assert "/paper/reconciliation" in openapi["paths"]
+    for path in ("/paper/trades", "/paper/positions", "/paper/account", "/paper/reconciliation"):
+        assert set(openapi["paths"][path].keys()) == {"get"}
 
     assert validate_json_schema(trades.json(), api_main.PaperTradesReadResponse.model_json_schema()) == []
     assert validate_json_schema(positions.json(), api_main.PaperPositionsReadResponse.model_json_schema()) == []

--- a/tests/test_phase44_paper_operator_workflow_docs.py
+++ b/tests/test_phase44_paper_operator_workflow_docs.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_phase44_workflow_doc_defines_bounded_operator_flow_and_surfaces() -> None:
+    content = (
+        REPO_ROOT / "docs" / "operations" / "runtime" / "phase-44-paper-operator-workflow.md"
+    ).read_text(encoding="utf-8")
+
+    assert content.startswith("# Phase 44 Bounded Paper Operator Workflow")
+    assert "## Bounded Workflow Claim" in content
+    assert "## Required Runtime Surfaces" in content
+    assert "GET /trading-core/orders" in content
+    assert "GET /trading-core/execution-events" in content
+    assert "GET /trading-core/trades" in content
+    assert "GET /trading-core/positions" in content
+    assert "GET /paper/trades" in content
+    assert "GET /paper/positions" in content
+    assert "GET /paper/account" in content
+    assert "GET /paper/reconciliation" in content
+    assert "## Minimum Operator Evidence" in content
+    assert "tests/test_api_paper_inspection_read.py" in content
+    assert "python -m pytest" in content
+
+
+def test_phase44_workflow_doc_preserves_phase24_boundary_and_non_goals() -> None:
+    content = (
+        REPO_ROOT / "docs" / "operations" / "runtime" / "phase-44-paper-operator-workflow.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## Phase 24 vs Phase 44 Boundary" in content
+    assert "Phase 24 (implemented simulator governance boundary)" in content
+    assert "Phase 44 (bounded runtime workflow claim in this phase slice)" in content
+    assert "## Explicit Non-Goals" in content
+    assert "Live trading" in content
+    assert "Broker integration" in content
+    assert "Mutation-heavy order-entry workflow" in content
+
+
+def test_docs_index_links_phase44_workflow_contract() -> None:
+    content = (REPO_ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+
+    assert "operations/runtime/phase-44-paper-operator-workflow.md" in content
+    assert "### Phase 44 Reference Materials" in content


### PR DESCRIPTION
Closes #795

## Summary
- Adds a dedicated bounded Phase 44 operator workflow contract:
  - docs/operations/runtime/phase-44-paper-operator-workflow.md
- Updates paper-trading boundary docs and index navigation:
  - docs/operations/paper-trading.md
  - docs/index.md
- Adds regression checks for bounded workflow claims:
  - 	ests/test_phase44_paper_operator_workflow_docs.py
- Tightens paper inspection API contract test to enforce read-only paper surface:
  - 	ests/test_api_paper_inspection_read.py (/paper/* endpoints assert GET only)

## Scope and Boundaries
- In scope: bounded runtime workflow coherence using existing simulator, inspection, and reconciliation surfaces.
- Explicitly out of scope: live trading, broker integration, mutation-heavy order entry, UI redesign, unrelated refactors.

## Validation
- Ran full suite:
  - .\.venv\Scripts\python -m pytest
  - Result: 732 passed, 4 warnings

## Notes
- warnings are existing FastAPI on_event deprecation warnings and are not expanded in scope for #795
