### PR TITLE
OPS-P46: Verify and align canonical server install path and runtime boundary

### DIFF
--- a/docs/operations/exploration/exploration-guide.md
+++ b/docs/operations/exploration/exploration-guide.md
@@ -1,4 +1,4 @@
-# Exploration Guide: Cilly Trading Engine MVP v1.1 (Snapshot-First)
+﻿# Exploration Guide: Cilly Trading Engine MVP v1.1 (Snapshot-First)
 
 This guide documents **current behavior only**. It is written for a single technical user exploring the MVP locally in VS Code. It assumes you will run the API and issue HTTP requests from a terminal. All analysis is snapshot-first and deterministic when using the API endpoints described below.
 
@@ -8,16 +8,16 @@ This guide documents **current behavior only**. It is written for a single techn
 
 **What the MVP actually does**
 
-- Provides a FastAPI service with analysis endpoints that **only** run against existing snapshot data in SQLite. The API enforces snapshot readiness before analysis and always uses the snapshot-only execution path. 【F:api/main.py†L620-L898】【F:docs/operations/api/usage_contract.md†L9-L49】
-- Runs two implemented strategies: `RSI2` and `TURTLE`. 【F:api/main.py†L287-L295】【F:docs/operations/api/usage_contract.md†L70-L73】
-- Stores generated signals and manual analysis runs in SQLite (`cilly_trading.db`). 【F:src/cilly_trading/db/init_db.py†L10-L77】【F:api/main.py†L770-L855】
-- Exposes read endpoints for stored signals (`GET /signals`) and screener results (`GET /screener/v2/results`). 【F:api/main.py†L468-L615】
+- Provides a FastAPI service with analysis endpoints that **only** run against existing snapshot data in SQLite. The API enforces snapshot readiness before analysis and always uses the snapshot-only execution path. ã€F:api/main.pyâ€ L620-L898ã€‘ã€F:docs/operations/api/usage_contract.mdâ€ L9-L49ã€‘
+- Runs two implemented strategies: `RSI2` and `TURTLE`. ã€F:api/main.pyâ€ L287-L295ã€‘ã€F:docs/operations/api/usage_contract.mdâ€ L70-L73ã€‘
+- Stores generated signals and manual analysis runs in SQLite (`cilly_trading.db`). ã€F:src/cilly_trading/db/init_db.pyâ€ L10-L77ã€‘ã€F:api/main.pyâ€ L770-L855ã€‘
+- Exposes read endpoints for stored signals (`GET /signals`) and screener results (`GET /screener/v2/results`). ã€F:api/main.pyâ€ L468-L615ã€‘
 
 **What it explicitly does NOT do yet**
 
-- It does **not** ingest snapshots. Snapshot ingestion is out-of-band; the repository only reads snapshots already present in the database. 【F:docs/operations/analyst-workflow.md†L15-L23】【F:docs/operations/api/usage_contract.md†L21-L32】
-- It does **not** run live data pulls when using the API. All API analysis is snapshot-only; live/external data is only used by engine calls outside the API. 【F:docs/operations/api/usage_contract.md†L13-L52】【F:src/cilly_trading/engine/data.py†L96-L207】
-- It does **not** support live trading, broker integrations, backtesting, or AI-based decision logic. 【F:docs/operations/analyst-workflow.md†L56-L56】
+- It does **not** ingest snapshots. Snapshot ingestion is out-of-band; the repository only reads snapshots already present in the database. ã€F:docs/operations/analyst-workflow.mdâ€ L15-L23ã€‘ã€F:docs/operations/api/usage_contract.mdâ€ L21-L32ã€‘
+- It does **not** run live data pulls when using the API. All API analysis is snapshot-only; live/external data is only used by engine calls outside the API. ã€F:docs/operations/api/usage_contract.mdâ€ L13-L52ã€‘ã€F:src/cilly_trading/engine/data.pyâ€ L96-L207ã€‘
+- It does **not** support live trading, broker integrations, backtesting, or AI-based decision logic. ã€F:docs/operations/analyst-workflow.mdâ€ L56-L56ã€‘
 
 ---
 
@@ -25,17 +25,17 @@ This guide documents **current behavior only**. It is written for a single techn
 
 ### Snapshot-first execution
 
-- Every analysis request must reference an existing `ingestion_run_id`. The API validates the ID and checks that snapshot rows exist for every requested symbol and timeframe (D1). 【F:docs/operations/analyst-workflow.md†L24-L30】【F:api/main.py†L314-L344】
-- When the API runs analysis, it forces `snapshot_only=True`, so data is loaded **only** from `ohlcv_snapshots`. 【F:docs/operations/analyst-workflow.md†L31-L41】【F:api/main.py†L359-L366】
+- Every analysis request must reference an existing `ingestion_run_id`. The API validates the ID and checks that snapshot rows exist for every requested symbol and timeframe (D1). ã€F:docs/operations/analyst-workflow.mdâ€ L24-L30ã€‘ã€F:api/main.pyâ€ L314-L344ã€‘
+- When the API runs analysis, it forces `snapshot_only=True`, so data is loaded **only** from `ohlcv_snapshots`. ã€F:docs/operations/analyst-workflow.mdâ€ L31-L41ã€‘ã€F:api/main.pyâ€ L359-L366ã€‘
 
 ### Determinism vs non-determinism
 
-- **Deterministic path (API):** The API uses snapshot-only analysis, so the same snapshot produces the same signals. 【F:docs/operations/analyst-workflow.md†L31-L50】【F:docs/operations/api/usage_contract.md†L43-L49】
-- **Non-deterministic path (engine only):** Direct engine calls with `snapshot_only=False` can pull live data from Yahoo Finance or Binance via `yfinance`/`ccxt`, which varies over time. This is **not** the API path. 【F:docs/operations/api/usage_contract.md†L49-L52】【F:src/cilly_trading/engine/data.py†L96-L207】
+- **Deterministic path (API):** The API uses snapshot-only analysis, so the same snapshot produces the same signals. ã€F:docs/operations/analyst-workflow.mdâ€ L31-L50ã€‘ã€F:docs/operations/api/usage_contract.mdâ€ L43-L49ã€‘
+- **Non-deterministic path (engine only):** Direct engine calls with `snapshot_only=False` can pull live data from Yahoo Finance or Binance via `yfinance`/`ccxt`, which varies over time. This is **not** the API path. ã€F:docs/operations/api/usage_contract.mdâ€ L49-L52ã€‘ã€F:src/cilly_trading/engine/data.pyâ€ L96-L207ã€‘
 
 ### Why snapshots exist and what problem they solve
 
-- Snapshots create a fixed, immutable dataset so analysis runs can be repeated and compared without data drift. Immutability is enforced by SQLite triggers that block updates/deletes on `ohlcv_snapshots`. 【F:docs/operations/analyst-workflow.md†L20-L23】【F:src/cilly_trading/db/init_db.py†L156-L195】
+- Snapshots create a fixed, immutable dataset so analysis runs can be repeated and compared without data drift. Immutability is enforced by SQLite triggers that block updates/deletes on `ohlcv_snapshots`. ã€F:docs/operations/analyst-workflow.mdâ€ L20-L23ã€‘ã€F:src/cilly_trading/db/init_db.pyâ€ L156-L195ã€‘
 
 ---
 
@@ -43,15 +43,15 @@ This guide documents **current behavior only**. It is written for a single techn
 
 ### Yahoo / external sources
 
-- The engine **can** load live stock data from Yahoo Finance and crypto data from Binance via `yfinance` and `ccxt`. This happens only in non-snapshot engine calls. 【F:src/cilly_trading/engine/data.py†L96-L207】
+- The engine **can** load live stock data from Yahoo Finance and crypto data from Binance via `yfinance` and `ccxt`. This happens only in non-snapshot engine calls. ã€F:src/cilly_trading/engine/data.pyâ€ L96-L207ã€‘
 
 ### Why live data is NOT used by the API
 
-- The API endpoints enforce snapshot-only execution and require `ingestion_run_id`. Live data is not consulted when using `/strategy/analyze`, `/analysis/run`, or `/screener/basic`. 【F:docs/operations/api/usage_contract.md†L13-L49】【F:api/main.py†L620-L898】
+- The API endpoints enforce snapshot-only execution and require `ingestion_run_id`. Live data is not consulted when using `/strategy/analyze`, `/analysis/run`, or `/screener/basic`. ã€F:docs/operations/api/usage_contract.mdâ€ L13-L49ã€‘ã€F:api/main.pyâ€ L620-L898ã€‘
 
-### What “out-of-band ingestion” means in practice
+### What â€œout-of-band ingestionâ€ means in practice
 
-- This repository does **not** create `ingestion_runs` or populate `ohlcv_snapshots`. Those rows must be inserted externally. The API only reads what already exists in the SQLite database. 【F:docs/operations/analyst-workflow.md†L15-L23】【F:docs/operations/api/usage_contract.md†L21-L32】
+- This repository does **not** create `ingestion_runs` or populate `ohlcv_snapshots`. Those rows must be inserted externally. The API only reads what already exists in the SQLite database. ã€F:docs/operations/analyst-workflow.mdâ€ L15-L23ã€‘ã€F:docs/operations/api/usage_contract.mdâ€ L21-L32ã€‘
 
 ---
 
@@ -59,24 +59,24 @@ This guide documents **current behavior only**. It is written for a single techn
 
 ### Local setup assumptions
 
-- You are running locally in VS Code with a Python 3.10+ environment.
-- The SQLite database file is `cilly_trading.db` in the project root. 【F:src/cilly_trading/db/init_db.py†L1-L23】
-- Snapshot data (`ingestion_runs` and `ohlcv_snapshots`) already exists in that database (inserted out-of-band). 【F:docs/operations/analyst-workflow.md†L15-L30】
+- You are running locally in VS Code with a Python 3.12+ environment.
+- The SQLite database file is `cilly_trading.db` in the project root. ã€F:src/cilly_trading/db/init_db.pyâ€ L1-L23ã€‘
+- Snapshot data (`ingestion_runs` and `ohlcv_snapshots`) already exists in that database (inserted out-of-band). ã€F:docs/operations/analyst-workflow.mdâ€ L15-L30ã€‘
 
-### Step 1 — Start the API
+### Step 1 - Start the API
 
 From the VS Code terminal:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+python -m pip install -e ".[test]"
 PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
-The API defaults to `http://127.0.0.1:8000`. 【F:docs/getting-started/local-run.md†L7-L31】
+The API defaults to `http://127.0.0.1:8000`. ã€F:docs/getting-started/local-run.mdâ€ L7-L31ã€‘
 
-### Step 2 — Confirm the API is running
+### Step 2 - Confirm the API is running
 
 ```bash
 curl http://127.0.0.1:8000/health
@@ -88,25 +88,22 @@ Expected:
 {"status":"ok"}
 ```
 
-【F:api/main.py†L292-L312】
+ã€F:api/main.pyâ€ L292-L312ã€‘
 
-### Step 3 — Confirm you have a valid snapshot ID
+### Step 3 - Confirm you have a valid snapshot ID
 
-You **must** supply a valid UUIDv4 `ingestion_run_id` that exists in `ingestion_runs` and has at least one `ohlcv_snapshots` row for each requested symbol/timeframe. If either check fails, the API returns `422` with an error code. 【F:docs/operations/api/usage_contract.md†L34-L63】【F:api/main.py†L304-L344】
+You **must** supply a valid UUIDv4 `ingestion_run_id` that exists in `ingestion_runs` and has at least one `ohlcv_snapshots` row for each requested symbol/timeframe. If either check fails, the API returns `422` with an error code. ã€F:docs/operations/api/usage_contract.mdâ€ L34-L63ã€‘ã€F:api/main.pyâ€ L304-L344ã€‘
 
 Practical check (from a VS Code terminal):
 
 ```bash
 sqlite3 cilly_trading.db "SELECT ingestion_run_id, timeframe, created_at FROM ingestion_runs ORDER BY created_at DESC LIMIT 5;"
-```
-
-```bash
 sqlite3 cilly_trading.db "SELECT symbol, timeframe, COUNT(*) FROM ohlcv_snapshots WHERE ingestion_run_id='<YOUR_ID>' GROUP BY symbol, timeframe;"
 ```
 
 > Use the `ingestion_run_id` that has rows for your target symbols and timeframe `D1`.
 
-### Step 4 — Trigger analysis for a single symbol
+### Step 4 - Trigger analysis for a single symbol
 
 #### Option A: `/strategy/analyze` (single strategy, optional presets)
 
@@ -122,8 +119,8 @@ curl -X POST "http://127.0.0.1:8000/strategy/analyze" \
   }'
 ```
 
-- Required inputs: `ingestion_run_id`, `symbol`, `strategy`, `market_type` (`stock` or `crypto`), `lookback_days` (30–1000). 【F:api/main.py†L56-L118】
-- This endpoint runs **one strategy** for one symbol and returns signals directly. 【F:api/main.py†L620-L769】
+- Required inputs: `ingestion_run_id`, `symbol`, `strategy`, `market_type` (`stock` or `crypto`), `lookback_days` (30-1000). ã€F:api/main.pyâ€ L56-L118ã€‘
+- This endpoint runs **one strategy** for one symbol and returns signals directly. ã€F:api/main.pyâ€ L620-L769ã€‘
 
 #### Option B: `/analysis/run` (manual analysis with deterministic run ID)
 
@@ -139,9 +136,9 @@ curl -X POST "http://127.0.0.1:8000/analysis/run" \
   }'
 ```
 
-- The API computes a deterministic `analysis_run_id` based on the request payload. Repeating the same request returns the same stored result. 【F:api/main.py†L770-L855】
+- The API computes a deterministic `analysis_run_id` based on the request payload. Repeating the same request returns the same stored result. ã€F:api/main.pyâ€ L770-L855ã€‘
 
-### Step 5 — Run the basic screener
+### Step 5 - Run the basic screener
 
 ```bash
 curl -X POST "http://127.0.0.1:8000/screener/basic" \
@@ -154,69 +151,68 @@ curl -X POST "http://127.0.0.1:8000/screener/basic" \
   }'
 ```
 
-- If `symbols` is omitted, the screener uses a default watchlist (stocks: `AAPL`, `MSFT`, `NVDA`, `META`, `TSLA`; crypto: `BTC/USDT`, `ETH/USDT`, `SOL/USDT`, `BNB/USDT`, `XRP/USDT`). 【F:api/main.py†L860-L883】
-- The response groups setup signals by symbol and filters by `min_score`. 【F:api/main.py†L884-L980】
+- If `symbols` is omitted, the screener uses a default watchlist (stocks: `AAPL`, `MSFT`, `NVDA`, `META`, `TSLA`; crypto: `BTC/USDT`, `ETH/USDT`, `SOL/USDT`, `BNB/USDT`, `XRP/USDT`). ã€F:api/main.pyâ€ L860-L883ã€‘
+- The response groups setup signals by symbol and filters by `min_score`. ã€F:api/main.pyâ€ L884-L980ã€‘
 
-### Step 6 — Read stored signals
+### Step 6 - Read stored signals
 
 ```bash
 curl -X GET "http://127.0.0.1:8000/signals?strategy=RSI2&limit=10" \
   -H "Accept: application/json"
 ```
 
-- Use filters (`symbol`, `strategy`, `timeframe`, `from`/`to`) and pagination (`limit`, `offset`) to inspect stored results. 【F:api/main.py†L341-L615】
+- Use filters (`symbol`, `strategy`, `timeframe`, `from`/`to`) and pagination (`limit`, `offset`) to inspect stored results. ã€F:api/main.pyâ€ L341-L615ã€‘
 
 ---
-
 ## 5. Understanding the Results
 
 ### What signals mean
 
-Signals are structured outputs produced by strategies and stored in SQLite. Each signal includes fields like `stage` (`setup` or `entry_confirmed`), `score` (0–100), and `confirmation_rule`. 【F:src/cilly_trading/models.py†L33-L73】【F:src/cilly_trading/strategies/turtle.py†L1-L134】
+Signals are structured outputs produced by strategies and stored in SQLite. Each signal includes fields like `stage` (`setup` or `entry_confirmed`), `score` (0â€“100), and `confirmation_rule`. ã€F:src/cilly_trading/models.pyâ€ L33-L73ã€‘ã€F:src/cilly_trading/strategies/turtle.pyâ€ L1-L134ã€‘
 
-- `RSI2` produces **setup** signals when the last bar’s RSI is oversold enough. 【F:src/cilly_trading/strategies/rsi2.py†L1-L114】
-- `TURTLE` produces **setup** or **entry_confirmed** signals depending on whether the last close is near or above the breakout level. 【F:src/cilly_trading/strategies/turtle.py†L1-L134】
+- `RSI2` produces **setup** signals when the last barâ€™s RSI is oversold enough. ã€F:src/cilly_trading/strategies/rsi2.pyâ€ L1-L114ã€‘
+- `TURTLE` produces **setup** or **entry_confirmed** signals depending on whether the last close is near or above the breakout level. ã€F:src/cilly_trading/strategies/turtle.pyâ€ L1-L134ã€‘
 
 ### What empty results mean
 
-Empty results are valid and common. They mean **no signal conditions were met** for the given symbol and snapshot. Strategies only emit signals when their rules are triggered on the latest bar. 【F:src/cilly_trading/strategies/rsi2.py†L69-L114】【F:src/cilly_trading/strategies/turtle.py†L62-L134】
+Empty results are valid and common. They mean **no signal conditions were met** for the given symbol and snapshot. Strategies only emit signals when their rules are triggered on the latest bar. ã€F:src/cilly_trading/strategies/rsi2.pyâ€ L69-L114ã€‘ã€F:src/cilly_trading/strategies/turtle.pyâ€ L62-L134ã€‘
 
-### Difference between “no signal” and “skipped strategy”
+### Difference between â€œno signalâ€ and â€œskipped strategyâ€
 
-- **No signal:** The strategy ran successfully but returned an empty list because conditions were not met. 【F:src/cilly_trading/strategies/rsi2.py†L69-L114】
-- **Skipped strategy:** The strategy config was invalid (wrong type, out-of-range values, or alias conflicts). The engine logs an error and skips that strategy, producing no signals while still returning `200 OK`. 【F:docs/operations/api/usage_contract.md†L85-L107】【F:docs/architecture/strategy-configs.md†L9-L44】
+- **No signal:** The strategy ran successfully but returned an empty list because conditions were not met. ã€F:src/cilly_trading/strategies/rsi2.pyâ€ L69-L114ã€‘
+- **Skipped strategy:** The strategy config was invalid (wrong type, out-of-range values, or alias conflicts). The engine logs an error and skips that strategy, producing no signals while still returning `200 OK`. ã€F:docs/operations/api/usage_contract.mdâ€ L85-L107ã€‘ã€F:docs/architecture/strategy-configs.mdâ€ L9-L44ã€‘
 
 ### Common valid outcomes
 
-- `signals: []` on `/strategy/analyze` or `/analysis/run` means “no signal.” 【F:api/main.py†L747-L768】【F:api/main.py†L820-L855】
-- `/screener/basic` may return an empty `symbols` list if no setups meet the `min_score` threshold. 【F:api/main.py†L884-L980】
+- `signals: []` on `/strategy/analyze` or `/analysis/run` means â€œno signal.â€ ã€F:api/main.pyâ€ L747-L768ã€‘ã€F:api/main.pyâ€ L820-L855ã€‘
+- `/screener/basic` may return an empty `symbols` list if no setups meet the `min_score` threshold. ã€F:api/main.pyâ€ L884-L980ã€‘
 
 ---
 
 ## 6. Exploration Playbook (Several Days)
 
-### Day 1 — Verify snapshot readiness and baseline runs
+### Day 1 â€” Verify snapshot readiness and baseline runs
 
-- Identify a valid `ingestion_run_id` and confirm symbols/timeframe coverage in SQLite. 【F:docs/operations/api/usage_contract.md†L34-L39】
-- Run `/strategy/analyze` for one symbol and one strategy to confirm the snapshot path works. 【F:api/main.py†L620-L769】
-- Run `/analysis/run` for the same inputs and confirm the `analysis_run_id` stays the same on repeat. 【F:api/main.py†L770-L855】
+- Identify a valid `ingestion_run_id` and confirm symbols/timeframe coverage in SQLite. ã€F:docs/operations/api/usage_contract.mdâ€ L34-L39ã€‘
+- Run `/strategy/analyze` for one symbol and one strategy to confirm the snapshot path works. ã€F:api/main.pyâ€ L620-L769ã€‘
+- Run `/analysis/run` for the same inputs and confirm the `analysis_run_id` stays the same on repeat. ã€F:api/main.pyâ€ L770-L855ã€‘
 
-### Day 2 — Expand symbols and compare strategies
+### Day 2 â€” Expand symbols and compare strategies
 
-- Pick 3–5 symbols that exist in your snapshot and run:
+- Pick 3â€“5 symbols that exist in your snapshot and run:
   - `RSI2` vs `TURTLE` on the same symbol.
-  - `stock` vs `crypto` symbols (if both are in the snapshot). 【F:api/main.py†L620-L769】
-- Use `/signals` to confirm signals are persisted and filter by strategy. 【F:api/main.py†L341-L615】
+  - `stock` vs `crypto` symbols (if both are in the snapshot). ã€F:api/main.pyâ€ L620-L769ã€‘
+- Use `/signals` to confirm signals are persisted and filter by strategy. ã€F:api/main.pyâ€ L341-L615ã€‘
 
-### Day 3 — Screener behavior and threshold sensitivity
+### Day 3 â€” Screener behavior and threshold sensitivity
 
-- Run `/screener/basic` with default watchlists and adjust `min_score` to see how results change. 【F:api/main.py†L860-L980】
-- Record which symbols appear as setups at different thresholds. 【F:api/main.py†L884-L980】
+- Run `/screener/basic` with default watchlists and adjust `min_score` to see how results change. ã€F:api/main.pyâ€ L860-L980ã€‘
+- Record which symbols appear as setups at different thresholds. ã€F:api/main.pyâ€ L884-L980ã€‘
 
 ### What NOT to change during exploration
 
-- Do **not** modify snapshot data during exploration; snapshot immutability is part of the deterministic model. 【F:src/cilly_trading/db/init_db.py†L182-L195】
-- Do **not** bypass API endpoints with direct engine calls if you want deterministic results. 【F:docs/operations/analyst-workflow.md†L53-L56】
+- Do **not** modify snapshot data during exploration; snapshot immutability is part of the deterministic model. ã€F:src/cilly_trading/db/init_db.pyâ€ L182-L195ã€‘
+- Do **not** bypass API endpoints with direct engine calls if you want deterministic results. ã€F:docs/operations/analyst-workflow.mdâ€ L53-L56ã€‘
 
 ---
 
@@ -224,20 +220,20 @@ Empty results are valid and common. They mean **no signal conditions were met** 
 
 ### Signals of success
 
-- The API accepts valid `ingestion_run_id` values and returns `200 OK` for analysis endpoints. 【F:api/main.py†L620-L898】
-- Repeating the same `/analysis/run` request returns the same `analysis_run_id` and the same result. 【F:api/main.py†L770-L855】
-- Signals are persisted and can be retrieved via `/signals`. 【F:api/main.py†L468-L615】
+- The API accepts valid `ingestion_run_id` values and returns `200 OK` for analysis endpoints. ã€F:api/main.pyâ€ L620-L898ã€‘
+- Repeating the same `/analysis/run` request returns the same `analysis_run_id` and the same result. ã€F:api/main.pyâ€ L770-L855ã€‘
+- Signals are persisted and can be retrieved via `/signals`. ã€F:api/main.pyâ€ L468-L615ã€‘
 
 ### Signals of concern
 
-- `422 ingestion_run_not_found` or `422 ingestion_run_not_ready` indicates missing or incomplete snapshot data. 【F:docs/operations/api/usage_contract.md†L54-L63】
-- `422 snapshot_data_invalid` indicates snapshot rows exist but fail validation. 【F:docs/operations/api/usage_contract.md†L63-L63】【F:src/cilly_trading/engine/data.py†L120-L175】
-- `200 OK` with **consistently empty** results across multiple symbols may mean snapshot data is too sparse for the strategies’ requirements. 【F:src/cilly_trading/strategies/turtle.py†L72-L96】
+- `422 ingestion_run_not_found` or `422 ingestion_run_not_ready` indicates missing or incomplete snapshot data. ã€F:docs/operations/api/usage_contract.mdâ€ L54-L63ã€‘
+- `422 snapshot_data_invalid` indicates snapshot rows exist but fail validation. ã€F:docs/operations/api/usage_contract.mdâ€ L63-L63ã€‘ã€F:src/cilly_trading/engine/data.pyâ€ L120-L175ã€‘
+- `200 OK` with **consistently empty** results across multiple symbols may mean snapshot data is too sparse for the strategiesâ€™ requirements. ã€F:src/cilly_trading/strategies/turtle.pyâ€ L72-L96ã€‘
 
 ### When exploration should stop
 
-- If you cannot obtain a valid snapshot (`ingestion_runs` + `ohlcv_snapshots`) that passes readiness checks, exploration cannot proceed because the API will not run analysis. 【F:docs/operations/api/usage_contract.md†L34-L63】【F:api/main.py†L304-L344】
-- If repeated, valid runs return no signals across multiple symbols and strategies, you likely lack sufficient snapshot coverage or the market conditions don’t match current strategy rules. 【F:src/cilly_trading/strategies/rsi2.py†L69-L114】【F:src/cilly_trading/strategies/turtle.py†L72-L134】
+- If you cannot obtain a valid snapshot (`ingestion_runs` + `ohlcv_snapshots`) that passes readiness checks, exploration cannot proceed because the API will not run analysis. ã€F:docs/operations/api/usage_contract.mdâ€ L34-L63ã€‘ã€F:api/main.pyâ€ L304-L344ã€‘
+- If repeated, valid runs return no signals across multiple symbols and strategies, you likely lack sufficient snapshot coverage or the market conditions donâ€™t match current strategy rules. ã€F:src/cilly_trading/strategies/rsi2.pyâ€ L69-L114ã€‘ã€F:src/cilly_trading/strategies/turtle.pyâ€ L72-L134ã€‘
 
 ---
 
@@ -245,26 +241,27 @@ Empty results are valid and common. They mean **no signal conditions were met** 
 
 ### What to write down
 
-- The `ingestion_run_id` used, symbols tested, and endpoints called. 【F:docs/operations/api/usage_contract.md†L34-L39】【F:api/main.py†L620-L898】
-- Strategy config changes (if any), including exact parameters and whether they caused skips. 【F:docs/architecture/strategy-configs.md†L9-L44】【F:docs/operations/api/usage_contract.md†L85-L107】
-- Observed outputs: number of signals, stages, and scores from `/strategy/analyze`, `/analysis/run`, and `/screener/basic`. 【F:api/main.py†L620-L980】
+- The `ingestion_run_id` used, symbols tested, and endpoints called. ã€F:docs/operations/api/usage_contract.mdâ€ L34-L39ã€‘ã€F:api/main.pyâ€ L620-L898ã€‘
+- Strategy config changes (if any), including exact parameters and whether they caused skips. ã€F:docs/architecture/strategy-configs.mdâ€ L9-L44ã€‘ã€F:docs/operations/api/usage_contract.mdâ€ L85-L107ã€‘
+- Observed outputs: number of signals, stages, and scores from `/strategy/analyze`, `/analysis/run`, and `/screener/basic`. ã€F:api/main.pyâ€ L620-L980ã€‘
 
 ### What decisions should be supported by evidence
 
-- Whether snapshot coverage is sufficient to evaluate the strategies (check symbol/timeframe coverage and signal output rates). 【F:docs/operations/api/usage_contract.md†L34-L39】【F:api/main.py†L884-L980】
-- Whether deterministic behavior holds (repeat `/analysis/run` with identical input and verify results are the same). 【F:api/main.py†L770-L855】
+- Whether snapshot coverage is sufficient to evaluate the strategies (check symbol/timeframe coverage and signal output rates). ã€F:docs/operations/api/usage_contract.mdâ€ L34-L39ã€‘ã€F:api/main.pyâ€ L884-L980ã€‘
+- Whether deterministic behavior holds (repeat `/analysis/run` with identical input and verify results are the same). ã€F:api/main.pyâ€ L770-L855ã€‘
 
 ### What questions remain open after exploration
 
-- If you see empty results, determine whether they are due to market conditions or insufficient snapshot history (e.g., Turtle requires enough lookback bars for a breakout window). 【F:src/cilly_trading/strategies/turtle.py†L72-L96】
-- If a strategy was skipped, confirm the exact config key/type conflict that caused it. 【F:docs/architecture/strategy-configs.md†L9-L44】
+- If you see empty results, determine whether they are due to market conditions or insufficient snapshot history (e.g., Turtle requires enough lookback bars for a breakout window). ã€F:src/cilly_trading/strategies/turtle.pyâ€ L72-L96ã€‘
+- If a strategy was skipped, confirm the exact config key/type conflict that caused it. ã€F:docs/architecture/strategy-configs.mdâ€ L9-L44ã€‘
 
 ---
 
 ## Appendix: Required Inputs by Endpoint (Snapshot-Only)
 
-- `POST /strategy/analyze`: `ingestion_run_id`, `symbol`, `strategy`, `market_type`, `lookback_days` (30–1000). 【F:api/main.py†L56-L118】
-- `POST /analysis/run`: `ingestion_run_id`, `symbol`, `strategy`, `market_type`, `lookback_days` (30–1000). 【F:api/main.py†L120-L154】
-- `POST /screener/basic`: `ingestion_run_id`, `market_type`, `lookback_days` (30–1000), `min_score` (0–100). 【F:api/main.py†L156-L193】
+- `POST /strategy/analyze`: `ingestion_run_id`, `symbol`, `strategy`, `market_type`, `lookback_days` (30â€“1000). ã€F:api/main.pyâ€ L56-L118ã€‘
+- `POST /analysis/run`: `ingestion_run_id`, `symbol`, `strategy`, `market_type`, `lookback_days` (30â€“1000). ã€F:api/main.pyâ€ L120-L154ã€‘
+- `POST /screener/basic`: `ingestion_run_id`, `market_type`, `lookback_days` (30â€“1000), `min_score` (0â€“100). ã€F:api/main.pyâ€ L156-L193ã€‘
 
-If you follow the steps above, you can explore the MVP’s current behavior without modifying runtime code or adding new features.
+If you follow the steps above, you can explore the MVPâ€™s current behavior without modifying runtime code or adding new features.
+

--- a/docs/operations/owner-runbook.md
+++ b/docs/operations/owner-runbook.md
@@ -1,7 +1,8 @@
 # Owner Runbook: Start / Stop / Logs / Reset Cheatsheet
 
 ## Purpose & Safety Notes
-This runbook gives owners a short, safe checklist to run, stop, monitor, and reset the local system.
+This runbook gives owners a short, safe checklist to run, stop, monitor, and
+reset the local system.
 
 - Use this checklist exactly as written.
 - Perform these steps only in your local environment.
@@ -10,17 +11,19 @@ This runbook gives owners a short, safe checklist to run, stop, monitor, and res
 ## Canonical startup path (owner default)
 Run from the repository root:
 
+### Startup command
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+python -m pip install -e ".[test]"
 PYTHONPATH=src uvicorn api.main:app --reload
 ```
 
-What happens: FastAPI starts locally on port `8000`, and SQLite tables are initialized in `cilly_trading.db`.
+### What happens
+FastAPI starts locally on port `8000`, and SQLite tables are initialized in
+`cilly_trading.db`.
 
-Expected success signal (run in a second terminal):
-
+### Expected success signal
 ```bash
 curl http://127.0.0.1:8000/health
 ```
@@ -32,16 +35,13 @@ Expected response:
 ```
 
 ## Secondary / utility entrypoints (not the default owner path)
-- Module start (same API app, without typing the uvicorn target):
-  ```bash
-  PYTHONPATH=src python -m api.main
-  ```
-- Docker Compose start:
-  ```bash
-  docker compose up --build
-  ```
+```bash
+PYTHONPATH=src python -m api.main
+docker compose up --build
+```
 
-These are valid utility paths, but the canonical owner path is `PYTHONPATH=src uvicorn api.main:app --reload`.
+These are valid utility paths, but the canonical owner path is
+`PYTHONPATH=src uvicorn api.main:app --reload`.
 
 ## Stop
 Action (terminal where the server is running):
@@ -68,7 +68,7 @@ PYTHONPATH=src uvicorn api.main:app --reload 2>&1 | tee local-api.log
 What happens: logs stream to terminal and also to `local-api.log`.
 
 ## Reset / Cleanup
-> ⚠ WARNING — LOCAL DEVELOPMENT ONLY
+> WARNING - LOCAL DEVELOPMENT ONLY
 >
 > NEVER run this on production or shared systems.
 
@@ -85,7 +85,11 @@ Expected success signal:
 - After the next API start, `cilly_trading.db` is created again.
 
 ## Troubleshooting
-- If start fails, rerun the canonical startup command and read the first error line.
-- If `/health` fails while server is running, confirm the process uses `127.0.0.1:8000`.
-- If logs look empty, ensure you are looking at the terminal where `uvicorn` is running.
-- If reset appears ineffective, stop the API first, run `rm -f cilly_trading.db`, then start again.
+- If start fails, rerun the canonical startup command and read the first error
+  line.
+- If `/health` fails while server is running, confirm the process uses
+  `127.0.0.1:8000`.
+- If logs look empty, ensure you are looking at the terminal where `uvicorn` is
+  running.
+- If reset appears ineffective, stop the API first, run `rm -f cilly_trading.db`,
+  then start again.

--- a/docs/operations/runtime/staging-first-deployment-topology.md
+++ b/docs/operations/runtime/staging-first-deployment-topology.md
@@ -19,6 +19,10 @@ Primary deployment profile:
 
 No alternative equal-status topology is defined for this stage.
 
+## Canonical First-Deployment Install Path
+The canonical first-deployment install path in this stage is:
+- `docker compose -f docker/staging/docker-compose.staging.yml up -d --build`
+
 ## Runtime Topology
 
 ```text

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -5,6 +5,10 @@ This runbook defines the bounded, reproducible server deployment path for
 non-productive staging mode. It is explicitly not a production or live-broker
 contract.
 
+## Canonical First-Deployment Install Path
+The canonical first-deployment install path in this repository is:
+- `docker compose -f docker/staging/docker-compose.staging.yml up -d --build`
+
 ## Deployment Artifacts
 - Image build file:
   `docker/staging/Dockerfile`
@@ -27,6 +31,8 @@ Reproducibility constraints in this path:
   (`uv sync --frozen --no-dev` with `uv.lock`).
 - Runtime process entrypoint is fixed
   (`uvicorn api.main:app --host 0.0.0.0 --port 8000`).
+- Legacy `requirements.txt` installation is non-canonical for first deployment
+  in this repository contract.
 
 ## Health and Readiness Checks
 Use read-only role headers for control-plane health endpoints.

--- a/tests/test_staging_deployment_docs.py
+++ b/tests/test_staging_deployment_docs.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _assert_fence_closes_to_transition(
+    content: str,
+    *,
+    block_marker: str,
+    expected_transition: str,
+) -> None:
+    marker_index = content.index(block_marker)
+
+    opening_index = content.rfind("\n```", 0, marker_index)
+    if opening_index == -1:
+        opening_index = content.rfind("```", 0, marker_index)
+    else:
+        opening_index += 1
+    assert opening_index != -1
+
+    opening_line_end = content.find("\n", opening_index)
+    if opening_line_end == -1:
+        opening_line_end = len(content)
+    opening_line = content[opening_index:opening_line_end]
+    assert opening_line.startswith("```")
+
+    search_from = opening_line_end
+    closing_line_start = -1
+    while True:
+        candidate = content.find("\n```", search_from)
+        if candidate == -1:
+            break
+        line_start = candidate + 1
+        line_end = content.find("\n", line_start)
+        if line_end == -1:
+            line_end = len(content)
+        if content[line_start:line_end] == "```":
+            closing_line_start = line_start
+            break
+        search_from = line_end
+
+    assert closing_line_start != -1
+    assert opening_index < marker_index < closing_line_start
+
+    transition_index = content.index(expected_transition)
+    assert transition_index > closing_line_start
+    assert not (opening_index < transition_index < closing_line_start)
+
+
+def test_staging_topology_doc_references_canonical_staging_artifacts() -> None:
+    content = (
+        REPO_ROOT / "docs" / "operations" / "runtime" / "staging-server-deployment.md"
+    ).read_text(encoding="utf-8")
+
+    assert content.lstrip().startswith("# Staging Server Deployment and Runtime Validation")
+    assert "docker/staging/Dockerfile" in content
+    assert "docker/staging/docker-compose.staging.yml" in content
+    assert "python scripts/validate_staging_deployment.py" in content
+    assert "STAGING_VALIDATE:SUCCESS" in content
+    assert "/health/engine" in content
+    assert "/health/data" in content
+    assert "/health/guards" in content
+    assert "docker compose -f docker/staging/docker-compose.staging.yml restart api" in content
+    assert "## Canonical First-Deployment Install Path" in content
+    assert "## Reproducible Build and Deploy Path" in content
+    assert "## Health and Readiness Checks" in content
+    assert "## Logging and Observability Expectations" in content
+    assert "## Restart-Safe Runtime Behavior" in content
+    assert "## Storage and Persistence Expectations" in content
+    assert "## Bounded Staging Validation" in content
+    assert "## Test Gate" in content
+
+
+def test_staging_topology_doc_declares_single_canonical_first_deployment_path() -> None:
+    content = (
+        REPO_ROOT / "docs" / "operations" / "runtime" / "staging-server-deployment.md"
+    ).read_text(encoding="utf-8")
+
+    assert "The canonical first-deployment install path in this repository is:" in content
+    assert "docker compose -f docker/staging/docker-compose.staging.yml up -d --build" in content
+    assert "Legacy `requirements.txt` installation is non-canonical" in content
+    assert (
+        "docker compose -f docker/staging/docker-compose.staging.yml up -d --build\n```\n\n"
+        "Reproducibility constraints in this path:"
+    ) in content
+    assert (
+        "curl -sS -H \"X-Cilly-Role: read_only\" http://127.0.0.1:18000/health/guards\n```\n\n"
+        "Readiness expectations:"
+    ) in content
+    assert (
+        "python scripts/validate_staging_deployment.py\n```\n\n"
+        "Validation stages:"
+    ) in content
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="docker compose -f docker/staging/docker-compose.staging.yml config",
+        expected_transition="Reproducibility constraints in this path:",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="docker compose -f docker/staging/docker-compose.staging.yml config",
+        expected_transition="## Health and Readiness Checks",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="curl -sS -H \"X-Cilly-Role: read_only\" http://127.0.0.1:18000/health",
+        expected_transition="Readiness expectations:",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="docker compose -f docker/staging/docker-compose.staging.yml logs -f api",
+        expected_transition="## Restart-Safe Runtime Behavior",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="docker compose -f docker/staging/docker-compose.staging.yml restart api",
+        expected_transition="Expected result:",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="docker compose -f docker/staging/docker-compose.staging.yml restart api",
+        expected_transition="## Storage and Persistence Expectations",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="docker compose -f docker/staging/docker-compose.staging.yml down -v",
+        expected_transition="## Bounded Staging Validation",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="python scripts/validate_staging_deployment.py",
+        expected_transition="Validation stages:",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="python scripts/validate_staging_deployment.py",
+        expected_transition="## Test Gate",
+    )

--- a/tests/test_staging_first_topology_contract_docs.py
+++ b/tests/test_staging_first_topology_contract_docs.py
@@ -6,6 +6,50 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _assert_fence_closes_to_transition(
+    content: str,
+    *,
+    block_marker: str,
+    expected_transition: str,
+) -> None:
+    marker_index = content.index(block_marker)
+
+    opening_index = content.rfind("\n```", 0, marker_index)
+    if opening_index == -1:
+        opening_index = content.rfind("```", 0, marker_index)
+    else:
+        opening_index += 1
+    assert opening_index != -1
+
+    opening_line_end = content.find("\n", opening_index)
+    if opening_line_end == -1:
+        opening_line_end = len(content)
+    opening_line = content[opening_index:opening_line_end]
+    assert opening_line.startswith("```")
+
+    search_from = opening_line_end
+    closing_line_start = -1
+    while True:
+        candidate = content.find("\n```", search_from)
+        if candidate == -1:
+            break
+        line_start = candidate + 1
+        line_end = content.find("\n", line_start)
+        if line_end == -1:
+            line_end = len(content)
+        if content[line_start:line_end] == "```":
+            closing_line_start = line_start
+            break
+        search_from = line_end
+
+    assert closing_line_start != -1
+    assert opening_index < marker_index < closing_line_start
+
+    transition_index = content.index(expected_transition)
+    assert transition_index > closing_line_start
+    assert not (opening_index < transition_index < closing_line_start)
+
+
 def test_staging_topology_doc_defines_single_canonical_topology() -> None:
     content = (
         REPO_ROOT / "docs" / "operations" / "runtime" / "staging-first-deployment-topology.md"
@@ -16,6 +60,7 @@ def test_staging_topology_doc_defines_single_canonical_topology() -> None:
     assert "Exactly one canonical staging-first topology is valid in this stage" in content
     assert "No alternative equal-status topology is defined for this stage." in content
     assert "`docker/staging/docker-compose.staging.yml`" in content
+    assert "## Canonical First-Deployment Install Path" in content
     assert "one `api` service process (`uvicorn api.main:app`)" in content
     assert "one local SQLite persistence volume mounted at `/data`" in content
 
@@ -37,6 +82,45 @@ def test_staging_topology_doc_defines_runtime_environment_and_boundary_non_goals
     assert "- broker integrations" in content
     assert "- production high availability" in content
     assert "- any runtime mode that places live market orders" in content
+    assert (
+        "        [SQLite persistence at /data]\n```\n\n"
+        "## Runtime Contract and Service Boundary"
+    ) in content
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="[Operator client or bounded automation]",
+        expected_transition="## Runtime Contract and Service Boundary",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="[Operator client or bounded automation]",
+        expected_transition="## Environment Boundary",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="[Operator client or bounded automation]",
+        expected_transition="## Persistence, Logging, and Health Expectations",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="[Operator client or bounded automation]",
+        expected_transition="## Non-Goals and Excluded Runtime Modes",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="[Operator client or bounded automation]",
+        expected_transition="## Install-Ready Versus Later Scope",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="[Operator client or bounded automation]",
+        expected_transition="## Validation and Verification Path",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker="[Operator client or bounded automation]",
+        expected_transition="## Related References",
+    )
 
 
 def test_docs_index_links_staging_first_topology_contract() -> None:


### PR DESCRIPTION
Closes #805

## Summary
- fixes markdown structure in the staging topology, staging deployment, owner runbook, and exploration docs
- preserves one canonical first-deployment install path:
  docker compose -f docker/staging/docker-compose.staging.yml up -d --build
- keeps staging bounded to non-live operation and preserves non-canonical legacy equirements.txt wording
- tightens docs contract tests so headings and closing fences must exist outside fenced blocks

## Validation
- python -m pytest tests/test_staging_deployment_docs.py tests/test_staging_deployment_validation.py tests/test_staging_first_topology_contract_docs.py
- python -m pytest

## Scope
- docs and docs-contract tests only
- no Docker artifact changes
- no strategy, broker, live trading, or UI scope expansion