### PR TITLE
DEC-P49: Define canonical decision-card contract with hard gates, bounded scores, and qualification states

### DIFF
--- a/docs/api/decision_card_inspection.md
+++ b/docs/api/decision_card_inspection.md
@@ -18,6 +18,7 @@ Claim boundary discipline for this surface:
 
 - confidence language is evidence-aligned only; confidence text must reference bounded aggregate/component/threshold evidence semantics
 - qualification and rationale language is bounded to paper-trading qualification scope
+- qualification state is contract-bounded (`reject` | `watch` | `paper_candidate` | `paper_approved`) and deterministic from hard-gate + score semantics
 - inspection outputs must not imply live-trading approval, broker readiness, production readiness, trader validation, or guaranteed outcomes
 
 ## Deterministic Ordering

--- a/docs/architecture/decision_card_contract.md
+++ b/docs/architecture/decision_card_contract.md
@@ -112,11 +112,12 @@ State-to-color mapping is fixed:
 Deterministic action-state resolution:
 
 1. Any blocking hard-gate failure resolves to `reject` / `red`.
-2. If no blocking failure and confidence is `low` (or aggregate score is below the medium threshold), resolve to `watch` / `yellow`.
-3. If confidence is `high` and aggregate score is above the high threshold, resolve to `paper_approved` / `green`.
+2. If no blocking failure and confidence is `low` (or aggregate score is below the medium threshold `60.0`), resolve to `watch` / `yellow`.
+3. If confidence is `high` and aggregate score is at/above the high threshold `80.0`, resolve to `paper_approved` / `green`.
 4. Otherwise resolve to `paper_candidate` / `yellow`.
 
 This output is bounded to paper-trading readiness only and does not imply live-trading approval.
+State assignment is validated by the canonical contract and cannot be overridden by arbitrary payload values.
 
 Qualification summary language is claim-bounded:
 

--- a/docs/phases/dec-p49-canonical-decision-card-contract.md
+++ b/docs/phases/dec-p49-canonical-decision-card-contract.md
@@ -1,0 +1,80 @@
+# DEC-P49 - Canonical Decision-Card Contract
+
+## Goal
+
+Define the canonical decision-card contract with explicit hard-gate behavior, bounded component-score semantics, and bounded qualification state semantics.
+
+## Canonical Runtime Contract
+
+- Contract implementation: `src/cilly_trading/engine/decision_card_contract.py`
+- Inspection read-surface alignment: `docs/api/decision_card_inspection.md`
+- Architecture contract reference: `docs/architecture/decision_card_contract.md`
+
+## Contract Boundaries
+
+The contract is canonical and deterministic:
+
+1. hard gates are explicit and independently represented
+2. component scores are explicit, category-complete, and bounded
+3. qualification state is bounded and deterministically resolved from gate + score semantics
+
+## Hard-Gate Behavior
+
+- hard-gate payload shape is explicit (`gate_id`, `status`, `blocking`, `reason`, `evidence`, `failure_reason`)
+- hard-gate IDs are unique
+- hard-gate failures require `failure_reason`
+- passing hard gates must not provide `failure_reason`
+- any blocking hard-gate failure requires `qualification.state=reject` and `qualification.color=red`
+
+## Component-Score Semantics
+
+- required categories are fixed:
+  - `signal_quality`
+  - `backtest_quality`
+  - `portfolio_fit`
+  - `risk_alignment`
+  - `execution_readiness`
+- per-component score range is bounded to `[0, 100]`
+- aggregate score range is bounded to `[0, 100]`
+- confidence tier is bounded (`low` | `medium` | `high`)
+- confidence reason is evidence-bounded and rejects unsupported inflation language
+
+## Qualification-State Semantics
+
+State vocabulary is bounded:
+
+- `reject`
+- `watch`
+- `paper_candidate`
+- `paper_approved`
+
+Deterministic state resolution is contract-enforced:
+
+1. blocking hard-gate failure -> `reject`
+2. no blocking failure + (`confidence_tier=low` or `aggregate_score < 60.0`) -> `watch`
+3. no blocking failure + (`confidence_tier=high` and `aggregate_score >= 80.0`) -> `paper_approved`
+4. otherwise -> `paper_candidate`
+
+State/color mapping is bounded:
+
+- `reject -> red`
+- `watch -> yellow`
+- `paper_candidate -> yellow`
+- `paper_approved -> green`
+
+## Inspection Wording Alignment
+
+Inspection wording aligns with the canonical contract by requiring:
+
+- explicit hard-gate evidence
+- bounded component and aggregate scoring language
+- bounded paper-trading qualification wording
+- explicit non-implication of live-trading approval
+
+## Non-Goals
+
+- live-trading approval
+- broker execution
+- unrestricted sentiment expansion
+- unrelated dashboard growth
+- broad strategy-lab expansion

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 DECISION_CARD_CONTRACT_VERSION = "2.0.0"
+QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD = 60.0
+QUALIFICATION_HIGH_AGGREGATE_THRESHOLD = 80.0
 
 DecisionComponentCategory = Literal[
     "signal_quality",
@@ -285,11 +287,30 @@ class DecisionCard(BaseModel):
 
     @model_validator(mode="after")
     def _validate_qualification_semantics(self) -> "DecisionCard":
-        if self.hard_gates.has_blocking_failure and self.qualification.state != "reject":
-            raise ValueError("Blocking hard-gate failures require reject qualification state")
+        expected_state = self._expected_qualification_state()
+        if self.qualification.state != expected_state:
+            raise ValueError(
+                "Qualification state must match deterministic resolution "
+                f"(expected={expected_state}, actual={self.qualification.state})"
+            )
         if self.hard_gates.has_blocking_failure and self.qualification.color != "red":
             raise ValueError("Blocking hard-gate failures require red qualification color")
         return self
+
+    def _expected_qualification_state(self) -> QualificationState:
+        if self.hard_gates.has_blocking_failure:
+            return "reject"
+        if (
+            self.score.confidence_tier == "low"
+            or self.score.aggregate_score < QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD
+        ):
+            return "watch"
+        if (
+            self.score.confidence_tier == "high"
+            and self.score.aggregate_score >= QUALIFICATION_HIGH_AGGREGATE_THRESHOLD
+        ):
+            return "paper_approved"
+        return "paper_candidate"
 
     def to_canonical_payload(self) -> dict[str, Any]:
         return self.model_dump(mode="python")
@@ -316,6 +337,8 @@ def serialize_decision_card(card: DecisionCard) -> str:
 
 __all__ = [
     "DECISION_CARD_CONTRACT_VERSION",
+    "QUALIFICATION_HIGH_AGGREGATE_THRESHOLD",
+    "QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD",
     "REQUIRED_COMPONENT_CATEGORIES",
     "QUALIFICATION_COLOR_BY_STATE",
     "ComponentScore",

--- a/tests/cilly_trading/engine/test_decision_card_contract.py
+++ b/tests/cilly_trading/engine/test_decision_card_contract.py
@@ -14,7 +14,7 @@ from cilly_trading.engine.decision_card_contract import (
 )
 
 
-def _valid_payload(*, qualification_state: str = "paper_approved", qualification_color: str = "green") -> dict[str, Any]:
+def _valid_payload(*, qualification_state: str = "paper_candidate", qualification_color: str = "yellow") -> dict[str, Any]:
     return {
         "contract_version": DECISION_CARD_CONTRACT_VERSION,
         "decision_card_id": "dc_20260324_AAPL_RSI2",
@@ -153,10 +153,7 @@ def test_negative_validation_rejects_non_rejected_state_on_blocking_failure() ->
     payload["hard_gates"]["gates"][0]["status"] = "fail"
     payload["hard_gates"]["gates"][0]["failure_reason"] = "Exposure cap would be exceeded"
 
-    with pytest.raises(
-        ValidationError,
-        match="Blocking hard-gate failures require reject qualification state",
-    ):
+    with pytest.raises(ValidationError, match="Qualification state must match deterministic resolution"):
         validate_decision_card(payload)
 
 
@@ -185,6 +182,45 @@ def test_representative_qualification_payloads_validate(state: str, color: str) 
         payload["qualification"]["summary"] = (
             "Opportunity requires further evidence before paper-trading qualification."
         )
+    if state == "paper_approved":
+        payload["score"]["component_scores"] = [
+            {
+                "category": "execution_readiness",
+                "score": 82.0,
+                "rationale": "Execution assumptions remain deterministic and bounded",
+                "evidence": ["slippage_bps=9", "commission_per_order=1.00"],
+            },
+            {
+                "category": "portfolio_fit",
+                "score": 84.0,
+                "rationale": "Portfolio concentration constraints remain satisfied",
+                "evidence": ["sector_weight_pct=0.18", "sector_limit_pct=0.25"],
+            },
+            {
+                "category": "signal_quality",
+                "score": 88.0,
+                "rationale": "Signal quality remains consistent across recent windows",
+                "evidence": ["signal_hit_rate=0.64", "window_days=90"],
+            },
+            {
+                "category": "backtest_quality",
+                "score": 84.0,
+                "rationale": "Backtest quality supports bounded forward expectation",
+                "evidence": ["sharpe=1.48", "profit_factor=1.68"],
+            },
+            {
+                "category": "risk_alignment",
+                "score": 90.0,
+                "rationale": "Risk controls align with per-trade and portfolio policy",
+                "evidence": ["risk_per_trade_pct=0.005", "max_risk_pct=0.01"],
+            },
+        ]
+        payload["score"]["aggregate_score"] = 86.2
+        payload["score"]["confidence_tier"] = "high"
+        payload["score"]["confidence_reason"] = (
+            "Aggregate score and component thresholds satisfy high confidence with explicit evidence."
+        )
+        payload["qualification"]["summary"] = "Opportunity is approved for bounded paper-trading only."
 
     card = validate_decision_card(payload)
     assert card.qualification.state == state
@@ -233,3 +269,21 @@ def test_negative_validation_requires_final_explanation_live_trading_boundary() 
         match="must explicitly state that output does not imply live-trading approval",
     ):
         validate_decision_card(payload)
+
+
+def test_negative_validation_rejects_reject_without_blocking_failure() -> None:
+    payload = _valid_payload(qualification_state="reject", qualification_color="red")
+
+    with pytest.raises(ValidationError, match="Qualification state must match deterministic resolution"):
+        validate_decision_card(payload)
+
+
+def test_non_blocking_gate_failure_does_not_force_reject() -> None:
+    payload = _valid_payload(qualification_state="paper_candidate", qualification_color="yellow")
+    payload["hard_gates"]["gates"][0]["status"] = "fail"
+    payload["hard_gates"]["gates"][0]["blocking"] = False
+    payload["hard_gates"]["gates"][0]["failure_reason"] = "Observed drift requires monitoring"
+
+    card = validate_decision_card(payload)
+    assert card.hard_gates.has_blocking_failure is False
+    assert card.qualification.state == "paper_candidate"

--- a/tests/test_api_decision_card_inspection_read.py
+++ b/tests/test_api_decision_card_inspection_read.py
@@ -59,6 +59,21 @@ def _decision_card_payload(
             "evidence": ["max_dd=0.15", "threshold=0.12"],
             "failure_reason": "Max drawdown breached policy threshold",
         }
+    confidence_tier = "high"
+    confidence_reason = "Aggregate and minimum component scores satisfy high thresholds."
+    aggregate_score = 84.15
+    if qualification_state == "watch":
+        confidence_tier = "low"
+        confidence_reason = (
+            "Aggregate score or component threshold evidence is below medium-confidence thresholds."
+        )
+        aggregate_score = 55.0
+    elif qualification_state == "paper_candidate":
+        confidence_tier = "medium"
+        confidence_reason = (
+            "Aggregate score and component threshold evidence satisfy medium-confidence thresholds."
+        )
+        aggregate_score = 72.0
 
     return {
         "contract_version": "2.0.0",
@@ -103,9 +118,9 @@ def _decision_card_payload(
                     "evidence": ["slippage_bps=9", "commission=1.00"],
                 },
             ],
-            "confidence_tier": "high",
-            "confidence_reason": "Aggregate and minimum component scores satisfy high thresholds.",
-            "aggregate_score": 84.15,
+            "confidence_tier": confidence_tier,
+            "confidence_reason": confidence_reason,
+            "aggregate_score": aggregate_score,
         },
         "qualification": {
             "state": qualification_state,

--- a/tests/test_qualification_claim_boundary_docs.py
+++ b/tests/test_qualification_claim_boundary_docs.py
@@ -8,6 +8,7 @@ GOVERNANCE_DOC = REPO_ROOT / "docs" / "governance" / "qualification-claim-eviden
 ARCHITECTURE_DOC = REPO_ROOT / "docs" / "architecture" / "decision_card_contract.md"
 INSPECTION_DOC = REPO_ROOT / "docs" / "api" / "decision_card_inspection.md"
 PHASE_DOC = REPO_ROOT / "docs" / "phases" / "dec-p47-qualification-claim-boundary.md"
+DEC_P49_DOC = REPO_ROOT / "docs" / "phases" / "dec-p49-canonical-decision-card-contract.md"
 
 
 def test_governance_doc_defines_evidence_hierarchy_and_forbidden_claim_classes() -> None:
@@ -36,6 +37,7 @@ def test_decision_card_contract_doc_declares_claim_boundary_wording_requirements
     assert "must remain explicitly paper-trading scoped" in content
     assert "rationale.final_explanation" in content
     assert "does not imply live-trading approval" in content
+    assert "State assignment is validated by the canonical contract" in content
 
 
 def test_decision_card_inspection_doc_matches_claim_boundary_runtime_wording() -> None:
@@ -43,6 +45,7 @@ def test_decision_card_inspection_doc_matches_claim_boundary_runtime_wording() -
 
     assert "Claim boundary discipline for this surface:" in content
     assert "confidence language is evidence-aligned only" in content
+    assert "qualification state is contract-bounded" in content
     assert "must not imply live-trading approval" in content
     assert "rejects unsupported confidence inflation language" in content
 
@@ -54,3 +57,15 @@ def test_dec_p47_phase_doc_links_governance_contract_and_runtime_enforcement() -
     assert "Required evidence order:" in content
     assert "src/cilly_trading/engine/decision_card_contract.py" in content
     assert "does not imply" in content
+
+
+def test_dec_p49_phase_doc_defines_canonical_contract_and_bounded_state_rules() -> None:
+    content = DEC_P49_DOC.read_text(encoding="utf-8")
+
+    assert content.startswith("# DEC-P49 - Canonical Decision-Card Contract")
+    assert "src/cilly_trading/engine/decision_card_contract.py" in content
+    assert "hard-gate payload shape is explicit" in content
+    assert "required categories are fixed" in content
+    assert "aggregate_score < 60.0" in content
+    assert "aggregate_score >= 80.0" in content
+    assert "inspection wording aligns with the canonical contract" in content.casefold()


### PR DESCRIPTION
﻿Closes #814

## What Changed

- Enforced deterministic qualification-state resolution inside the canonical decision-card contract:
  - blocking hard-gate failure -> `reject`
  - low confidence or aggregate `< 60.0` -> `watch`
  - high confidence and aggregate `>= 80.0` -> `paper_approved`
  - otherwise -> `paper_candidate`
- Kept hard-gate and component-score semantics explicit and bounded.
- Added DEC-P49 phase documentation and aligned architecture/API inspection wording.
- Updated contract, API inspection fixture, and documentation-boundary tests to match the canonical contract.

## Scope Compliance

- Changes are limited to:
  - `src/decision/**` equivalent engine contract path under `src/cilly_trading/engine/**`
  - `docs/architecture/**`
  - `docs/phases/**`
  - `tests/**`
- No changes were made to restricted paths (`src/brokers/**`, `src/live_trading/**`, `frontend/**`).

## Validation

- Full test suite run:
  - `python -m pytest`
  - Result: `790 passed, 4 warnings`
