### PR TITLE
OPS-P46: Freeze canonical first-clean-server install contract

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -5,6 +5,10 @@ This guide provides the single authoritative setup path for local development.
 Use it to prepare the environment, install the repository, and then hand off to
 the canonical local-run or testing documents.
 
+This guide is not the canonical first-clean-server install contract.
+For first-clean-server install/startup, use:
+- `docs/operations/runtime/staging-server-deployment.md`
+
 ## B. Prerequisites
 - Python 3.12+
 - `pip`
@@ -38,6 +42,10 @@ python -m pip install -e ".[test]"
 
 The install step is canonical because it comes from the repository-controlled
 `pyproject.toml`. It replaces older requirements-file-based instructions.
+
+Canonical scope note:
+- Canonical for local development setup only.
+- Non-canonical for first-clean-server install/startup.
 
 ## E. Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,11 @@
 ## Start Here
 The Cilly Trading Engine is a deterministic execution and analysis engine for teams that need reproducible workflows, stable interfaces, and controlled change management. This index is intended for new consumers who need a fixed, step-by-step path to start using documented capabilities.
 
+Canonical first-clean-server install contract:
+- `docs/operations/runtime/staging-server-deployment.md`
+- Docker/Compose (`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`) is the only canonical first-clean-server startup path.
+- Local development setup guides are non-canonical for first-clean-server installation.
+
 Use this order:
 1. Quickstart
 2. Run deterministic smoke test

--- a/docs/operations/runtime/staging-first-deployment-topology.md
+++ b/docs/operations/runtime/staging-first-deployment-topology.md
@@ -20,8 +20,12 @@ Primary deployment profile:
 No alternative equal-status topology is defined for this stage.
 
 ## Canonical First-Deployment Install Path
-The canonical first-deployment install path in this stage is:
+Docker/Compose is the canonical and only first-clean-server install path in
+this stage. The canonical first-deployment install path is:
 - `docker compose -f docker/staging/docker-compose.staging.yml up -d --build`
+
+Canonical install/runbook authority:
+- `docs/operations/runtime/staging-server-deployment.md`
 
 ## Runtime Topology
 

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -5,8 +5,8 @@ This runbook defines the bounded staging deployment contract for non-live server
 operation. It does not define production HA, broker integrations, or live
 trading behavior.
 
-The canonical first-deployment install path in this repository is:
-`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`
+For a first-clean-server install in this repository, this runbook is the single
+authoritative contract.
 
 ## Deployment Artifacts
 Deployment artifacts used by this runbook:
@@ -17,14 +17,47 @@ Deployment artifacts used by this runbook:
 Legacy `requirements.txt` installation is non-canonical for first deployment
 in this repository contract.
 
-## Canonical First-Deployment Install Path
-The canonical first-deployment install path in this repository is:
+## Canonical First-Clean-Server Install Contract
+Docker/Compose is the canonical and only first-clean-server install path in this
+repository.
+
+The canonical first-clean-server startup command is:
 `docker compose -f docker/staging/docker-compose.staging.yml up -d --build`
 
-## Reproducible Build and Deploy Path
-The canonical install path remains:
-`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`
+## Host Prerequisites and Package Contract
+Required on host:
+- Docker Engine (with `docker` CLI available)
+- Docker Compose v2 plugin (`docker compose`)
+- `curl` (for smoke and health validation commands)
+- Python 3.12+ (required to run `python scripts/validate_staging_deployment.py`)
 
+Optional on host:
+- `uv` (not required for first-clean-server startup/smoke/restart validation,
+  only used for optional repository-managed test execution wrappers)
+
+## Required Directories and Persistence Paths
+Required repository paths:
+- `docker/staging/Dockerfile`
+- `docker/staging/docker-compose.staging.yml`
+- `scripts/validate_staging_deployment.py`
+
+Required runtime persistence paths:
+- Docker named volume: `cilly_staging_data`
+- Container mount: `/data`
+- SQLite file path: `/data/cilly_trading.db`
+
+No host bind-mount directory is required by the canonical first-clean-server
+path because persistence uses the named Docker volume above.
+
+## Required Environment Variables (Bounded First Deploy / Paper Mode)
+Required runtime environment variables for bounded first deployment:
+- `PYTHONPATH=/app/src`
+- `CILLY_DB_PATH=/data/cilly_trading.db`
+- `CILLY_LOG_LEVEL=INFO`
+- `CILLY_LOG_FORMAT=json`
+
+## Exact Startup Commands
+Run exactly from repository root:
 ```bash
 docker compose -f docker/staging/docker-compose.staging.yml config
 docker compose -f docker/staging/docker-compose.staging.yml up -d --build
@@ -35,9 +68,8 @@ Reproducibility constraints in this path:
   artifacts.
 - Runtime process, health checks, and persistence bindings are compose-defined.
 
-## Health and Readiness Checks
+## Exact Smoke Commands
 Use read-only role headers when validating control-plane health endpoints.
-
 ```bash
 curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health
 curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/engine
@@ -57,12 +89,13 @@ output and JSON log formatting for API events.
 docker compose -f docker/staging/docker-compose.staging.yml logs -f api
 ```
 
-## Restart-Safe Runtime Behavior
+## Exact Restart Validation Commands
 Restart safety is bounded to container restart with persisted state continuity.
-
 ```bash
 docker compose -f docker/staging/docker-compose.staging.yml restart api
 curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/engine
+curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/data
+curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/guards
 ```
 
 Expected result:
@@ -90,6 +123,11 @@ Validation stages:
   persistence checks.
 
 Expected success marker: `STAGING_VALIDATE:SUCCESS`.
+
+## Conflicting Guidance Handling
+Any local-run or local development installation guidance is non-canonical for
+first-clean-server install. For first-clean-server install and startup, use this
+runbook only.
 
 ## Acceptance-Gate Alignment
 This deployment runbook defines the `server-ready (staging)` boundary only.

--- a/tests/test_staging_deployment_docs.py
+++ b/tests/test_staging_deployment_docs.py
@@ -64,13 +64,17 @@ def test_staging_topology_doc_references_canonical_staging_artifacts() -> None:
     assert "/health/data" in content
     assert "/health/guards" in content
     assert "docker compose -f docker/staging/docker-compose.staging.yml restart api" in content
-    assert "## Canonical First-Deployment Install Path" in content
-    assert "## Reproducible Build and Deploy Path" in content
-    assert "## Health and Readiness Checks" in content
+    assert "## Canonical First-Clean-Server Install Contract" in content
+    assert "## Host Prerequisites and Package Contract" in content
+    assert "## Required Directories and Persistence Paths" in content
+    assert "## Required Environment Variables (Bounded First Deploy / Paper Mode)" in content
+    assert "## Exact Startup Commands" in content
+    assert "## Exact Smoke Commands" in content
     assert "## Logging and Observability Expectations" in content
-    assert "## Restart-Safe Runtime Behavior" in content
+    assert "## Exact Restart Validation Commands" in content
     assert "## Storage and Persistence Expectations" in content
     assert "## Bounded Staging Validation" in content
+    assert "## Conflicting Guidance Handling" in content
     assert "## Acceptance-Gate Alignment" in content
     assert "`server-ready (staging)`" in content
     assert "`paper-install-ready`" in content
@@ -83,9 +87,21 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
         REPO_ROOT / "docs" / "operations" / "runtime" / "staging-server-deployment.md"
     ).read_text(encoding="utf-8")
 
-    assert "The canonical first-deployment install path in this repository is:" in content
+    assert "Docker/Compose is the canonical and only first-clean-server install path" in content
+    assert "The canonical first-clean-server startup command is:" in content
     assert "docker compose -f docker/staging/docker-compose.staging.yml up -d --build" in content
     assert "Legacy `requirements.txt` installation is non-canonical" in content
+    assert "Required on host:" in content
+    assert "Docker Engine" in content
+    assert "Docker Compose v2 plugin" in content
+    assert "Optional on host:" in content
+    assert "`uv` (not required for first-clean-server startup/smoke/restart validation" in content
+    assert "Required runtime environment variables for bounded first deployment:" in content
+    assert "- `PYTHONPATH=/app/src`" in content
+    assert "- `CILLY_DB_PATH=/data/cilly_trading.db`" in content
+    assert "- `CILLY_LOG_LEVEL=INFO`" in content
+    assert "- `CILLY_LOG_FORMAT=json`" in content
+    assert "Any local-run or local development installation guidance is non-canonical for" in content
     assert (
         "docker compose -f docker/staging/docker-compose.staging.yml up -d --build\n```\n\n"
         "Reproducibility constraints in this path:"
@@ -106,7 +122,7 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     _assert_fence_closes_to_transition(
         content,
         block_marker="docker compose -f docker/staging/docker-compose.staging.yml config",
-        expected_transition="## Health and Readiness Checks",
+        expected_transition="## Exact Smoke Commands",
     )
     _assert_fence_closes_to_transition(
         content,
@@ -116,7 +132,7 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     _assert_fence_closes_to_transition(
         content,
         block_marker="docker compose -f docker/staging/docker-compose.staging.yml logs -f api",
-        expected_transition="## Restart-Safe Runtime Behavior",
+        expected_transition="## Exact Restart Validation Commands",
     )
     _assert_fence_closes_to_transition(
         content,
@@ -135,11 +151,11 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="python scripts/validate_staging_deployment.py",
+        block_marker="```bash\npython scripts/validate_staging_deployment.py",
         expected_transition="Validation stages:",
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="python scripts/validate_staging_deployment.py",
+        block_marker="```bash\npython scripts/validate_staging_deployment.py",
         expected_transition="## Test Gate",
     )

--- a/tests/test_staging_first_topology_contract_docs.py
+++ b/tests/test_staging_first_topology_contract_docs.py
@@ -61,6 +61,9 @@ def test_staging_topology_doc_defines_single_canonical_topology() -> None:
     assert "No alternative equal-status topology is defined for this stage." in content
     assert "`docker/staging/docker-compose.staging.yml`" in content
     assert "## Canonical First-Deployment Install Path" in content
+    assert "Docker/Compose is the canonical and only first-clean-server install path in" in content
+    assert "Canonical install/runbook authority:" in content
+    assert "`docs/operations/runtime/staging-server-deployment.md`" in content
     assert "one `api` service process (`uvicorn api.main:app`)" in content
     assert "one local SQLite persistence volume mounted at `/data`" in content
 
@@ -127,3 +130,17 @@ def test_docs_index_links_staging_first_topology_contract() -> None:
     content = (REPO_ROOT / "docs" / "index.md").read_text(encoding="utf-8")
 
     assert "operations/runtime/staging-first-deployment-topology.md" in content
+    assert "Canonical first-clean-server install contract:" in content
+    assert "Docker/Compose (`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`) is the only canonical first-clean-server startup path." in content
+    assert "Local development setup guides are non-canonical for first-clean-server installation." in content
+
+
+def test_getting_started_marks_local_setup_non_canonical_for_first_clean_server() -> None:
+    content = (
+        REPO_ROOT / "docs" / "getting-started" / "getting-started.md"
+    ).read_text(encoding="utf-8")
+
+    assert "This guide is not the canonical first-clean-server install contract." in content
+    assert "docs/operations/runtime/staging-server-deployment.md" in content
+    assert "Canonical for local development setup only." in content
+    assert "Non-canonical for first-clean-server install/startup." in content


### PR DESCRIPTION
Closes #832

## Summary
- Freezes `docs/operations/runtime/staging-server-deployment.md` as the sole canonical first-clean-server install contract.
- Explicitly defines host prerequisites, required/optional packages (including Python/uv status), required runtime env vars, and required directories/persistence paths.
- Adds exact startup, smoke, restart, and bounded validation command surfaces.
- Aligns `staging-first-deployment-topology.md`, `docs/index.md`, and `getting-started.md` wording to remove first-install ambiguity and mark local setup as non-canonical for first-clean-server install.
- Updates targeted staging doc contract tests to enforce the canonical wording.

## Validation
- `python -m pytest tests/test_staging_deployment_docs.py tests/test_staging_first_topology_contract_docs.py tests/test_staging_deployment_validation.py`
- `python -m pytest`