### PR TITLE
OPS-P46: Define bounded server environment and filesystem contract (#833)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# OPS-P46 bounded first-paper deployment environment contract.
+# Copy to `.env` for staging deployment:
+#   cp .env.example .env
+
+# Container runtime settings (required)
+PYTHONPATH=/app/src
+CILLY_DB_PATH=/data/db/cilly_trading.db
+CILLY_LOG_LEVEL=INFO
+CILLY_LOG_FORMAT=json
+
+# Host bind-mount contract (required, absolute host paths recommended)
+CILLY_STAGING_DB_DIR=/srv/cilly/staging/db
+CILLY_STAGING_ARTIFACT_DIR=/srv/cilly/staging/artifacts
+CILLY_STAGING_JOURNAL_DIR=/srv/cilly/staging/journal
+CILLY_STAGING_LOG_DIR=/srv/cilly/staging/logs
+CILLY_STAGING_RUNTIME_STATE_DIR=/srv/cilly/staging/runtime-state
+
+# Container process identity for ownership/permissions contract (required)
+CILLY_CONTAINER_UID=1000
+CILLY_CONTAINER_GID=1000
+
+# Conditional provider secret contract:
+# Canonical first paper deployment is snapshot-first and does not require
+# provider secrets. If a future provider integration is explicitly enabled,
+# its provider credentials become mandatory and must be supplied separately.

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -12,10 +12,11 @@ COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
 
 RUN uv sync --frozen --no-dev
+RUN mkdir -p /data/db /data/artifacts /data/logs /data/runtime-state /app/runs/phase6
 
 ENV PATH="/app/.venv/bin:${PATH}" \
     PYTHONPATH="/app/src" \
-    CILLY_DB_PATH="/data/cilly_trading.db"
+    CILLY_DB_PATH="/data/db/cilly_trading.db"
 
 WORKDIR /data
 

--- a/docker/staging/docker-compose.staging.yml
+++ b/docker/staging/docker-compose.staging.yml
@@ -3,16 +3,31 @@ services:
     build:
       context: ../..
       dockerfile: docker/staging/Dockerfile
+    user: "${CILLY_CONTAINER_UID:?set CILLY_CONTAINER_UID}:${CILLY_CONTAINER_GID:?set CILLY_CONTAINER_GID}"
     ports:
       - "18000:8000"
     working_dir: /data
     environment:
-      PYTHONPATH: /app/src
-      CILLY_DB_PATH: /data/cilly_trading.db
-      CILLY_LOG_LEVEL: INFO
-      CILLY_LOG_FORMAT: json
+      PYTHONPATH: "${PYTHONPATH:?set PYTHONPATH}"
+      CILLY_DB_PATH: "${CILLY_DB_PATH:?set CILLY_DB_PATH}"
+      CILLY_LOG_LEVEL: "${CILLY_LOG_LEVEL:?set CILLY_LOG_LEVEL}"
+      CILLY_LOG_FORMAT: "${CILLY_LOG_FORMAT:?set CILLY_LOG_FORMAT}"
     volumes:
-      - cilly_staging_data:/data
+      - type: bind
+        source: "${CILLY_STAGING_DB_DIR:?set CILLY_STAGING_DB_DIR}"
+        target: /data/db
+      - type: bind
+        source: "${CILLY_STAGING_ARTIFACT_DIR:?set CILLY_STAGING_ARTIFACT_DIR}"
+        target: /data/artifacts
+      - type: bind
+        source: "${CILLY_STAGING_JOURNAL_DIR:?set CILLY_STAGING_JOURNAL_DIR}"
+        target: /app/runs/phase6
+      - type: bind
+        source: "${CILLY_STAGING_LOG_DIR:?set CILLY_STAGING_LOG_DIR}"
+        target: /data/logs
+      - type: bind
+        source: "${CILLY_STAGING_RUNTIME_STATE_DIR:?set CILLY_STAGING_RUNTIME_STATE_DIR}"
+        target: /data/runtime-state
     restart: unless-stopped
     healthcheck:
       test:
@@ -26,6 +41,3 @@ services:
       timeout: 5s
       start_period: 10s
       retries: 3
-
-volumes:
-  cilly_staging_data:

--- a/docs/architecture/configuration_boundary.md
+++ b/docs/architecture/configuration_boundary.md
@@ -41,6 +41,30 @@ The canonical owners are:
 | Request transport parsing | API request models and query models in `src/api/main.py` | HTTP payload shape, basic request-entry validation needed to parse a request | Canonical ownership of runtime defaults, strategy defaults, or normalization semantics |
 | Documentation references for config behavior | This document | Ownership rules, boundary rules, precedence rules, and documentation-routing rules | Repeating detailed default tables or transport examples that belong elsewhere |
 
+## OPS-P46 Bounded Server Environment and Filesystem Contract
+
+For issue `#833`, this document also defines ownership of the bounded
+first-paper server environment contract.
+
+Canonical ownership for the deployment contract:
+
+| Responsibility | Canonical owner | Contract scope |
+| --- | --- | --- |
+| First-clean-server environment variable contract | `docs/operations/runtime/staging-server-deployment.md` and `.env.example` | Required env keys, host bind-mount variables, runtime env defaults, UID/GID contract |
+| Conditional provider secret requirements | `docs/operations/runtime/staging-server-deployment.md` | Snapshot-first default (no provider secrets required), explicit out-of-scope condition for future provider-secreted modes |
+| Bounded filesystem path contract | `docker/staging/docker-compose.staging.yml` and `docs/operations/runtime/staging-server-deployment.md` | DB/artifact/journal/log/runtime-state path mapping and persistence class per path |
+| Ownership and permissions expectations | `docker/staging/docker-compose.staging.yml` and `docs/operations/runtime/staging-server-deployment.md` | Container runtime UID/GID and host writable-directory precondition |
+
+Server deployment boundary rules for first paper deployment:
+- One bounded server environment contract exists and is authoritative in the
+  staging runbook plus `.env.example`.
+- Compose, docs, and env guidance must define the same path values.
+- Persistence expectations must explicitly distinguish restart/redeploy
+  continuity from host-directory deletion reset behavior.
+- Runtime-state and file-log paths may be bind-mounted while runtime authority
+  remains in-process and stdout/stderr logs remain authoritative unless a later
+  issue changes that contract.
+
 ## Single Source of Truth Rules
 
 The single source of truth is determined by decision type:

--- a/docs/operations/runtime/staging-first-deployment-topology.md
+++ b/docs/operations/runtime/staging-first-deployment-topology.md
@@ -8,14 +8,15 @@ environment boundary for bounded non-live server operation.
 Exactly one canonical staging-first topology is valid in this stage:
 - one staging host
 - one `api` service process (`uvicorn api.main:app`)
-- one local SQLite persistence volume mounted at `/data`
+- explicit host bind mounts for DB, artifact, journal, logs, and runtime-state
 - no broker process
 - no live trading process
 
 Primary deployment profile:
 - `docker/staging/docker-compose.staging.yml`
 - host port `18000` mapped to container port `8000`
-- named volume `cilly_staging_data` mounted at `/data`
+- bind-mounted host DB directory at `/data/db`
+- bind-mounted host journal directory at `/app/runs/phase6`
 
 No alternative equal-status topology is defined for this stage.
 
@@ -39,14 +40,14 @@ Canonical install/runbook authority:
  [Engine runtime + control-plane lifecycle]
                  |
                  v
-        [SQLite persistence at /data]
+ [SQLite persistence at /data/db/cilly_trading.db]
 ```
 
 ## Runtime Contract and Service Boundary
 Required runtime services in this topology:
 - HTTP API service (`api.main:app`)
 - in-process engine runtime and control plane
-- SQLite persistence file on the mounted staging volume
+- SQLite persistence file on the mounted staging host directories
 
 Operating assumptions:
 - single runtime authority instance per staging host
@@ -82,9 +83,9 @@ Authoritative ownership of configuration semantics remains:
 
 ## Persistence, Logging, and Health Expectations
 Persistence expectations at topology level:
-- canonical persistence is SQLite at `/data/cilly_trading.db`
-- durability boundary is the mounted staging volume (`cilly_staging_data`)
-- volume removal resets staging state
+- canonical persistence is SQLite at `/data/db/cilly_trading.db`
+- durability boundary is host bind mounts configured through `.env`
+- deleting bind-mounted host directory contents resets staging state
 
 Logging expectations at topology level:
 - runtime logs emitted to stdout/stderr

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -12,6 +12,7 @@ authoritative contract.
 Deployment artifacts used by this runbook:
 - `docker/staging/Dockerfile`
 - `docker/staging/docker-compose.staging.yml`
+- `.env.example`
 - `scripts/validate_staging_deployment.py`
 
 Legacy `requirements.txt` installation is non-canonical for first deployment
@@ -39,26 +40,67 @@ Optional on host:
 Required repository paths:
 - `docker/staging/Dockerfile`
 - `docker/staging/docker-compose.staging.yml`
+- `.env.example`
 - `scripts/validate_staging_deployment.py`
 
-Required runtime persistence paths:
-- Docker named volume: `cilly_staging_data`
-- Container mount: `/data`
-- SQLite file path: `/data/cilly_trading.db`
+Required host bind-mounted directories (configure in `.env`):
+- `CILLY_STAGING_DB_DIR` -> container `/data/db`
+- `CILLY_STAGING_ARTIFACT_DIR` -> container `/data/artifacts`
+- `CILLY_STAGING_JOURNAL_DIR` -> container `/app/runs/phase6`
+- `CILLY_STAGING_LOG_DIR` -> container `/data/logs`
+- `CILLY_STAGING_RUNTIME_STATE_DIR` -> container `/data/runtime-state`
 
-No host bind-mount directory is required by the canonical first-clean-server
-path because persistence uses the named Docker volume above.
+Path definitions for bounded first deployment:
+- Database path (persistent): `/data/db/cilly_trading.db`
+- Artifact path (bind-mounted; writer behavior not guaranteed in this stage): `/data/artifacts`
+- Journal path (persistent): `/app/runs/phase6`
+- Runtime-state path (bind-mounted; in-memory runtime authority remains canonical): `/data/runtime-state`
+- Log path (bind-mounted path reserved for operator tooling): `/data/logs`
+
+Required persistent directories are explicit:
+- Database host directory (`CILLY_STAGING_DB_DIR`) MUST persist across container restart/redeploy.
+- Journal host directory (`CILLY_STAGING_JOURNAL_DIR`) MUST persist across container restart/redeploy.
 
 ## Required Environment Variables (Bounded First Deploy / Paper Mode)
 Required runtime environment variables for bounded first deployment:
 - `PYTHONPATH=/app/src`
-- `CILLY_DB_PATH=/data/cilly_trading.db`
+- `CILLY_DB_PATH=/data/db/cilly_trading.db`
 - `CILLY_LOG_LEVEL=INFO`
 - `CILLY_LOG_FORMAT=json`
+
+Required ownership/permission environment variables:
+- `CILLY_CONTAINER_UID`
+- `CILLY_CONTAINER_GID`
+
+Required host path environment variables:
+- `CILLY_STAGING_DB_DIR`
+- `CILLY_STAGING_ARTIFACT_DIR`
+- `CILLY_STAGING_JOURNAL_DIR`
+- `CILLY_STAGING_LOG_DIR`
+- `CILLY_STAGING_RUNTIME_STATE_DIR`
+
+Conditional provider secret requirements are explicit:
+- Canonical first paper deployment is snapshot-first and requires no provider
+  secret variables.
+- If a future provider integration is explicitly enabled, provider secrets are
+  mandatory for that provider and are outside this stage contract.
+
+## Ownership and Permission Expectations
+Ownership expectations are explicit:
+- Compose runs the API container as `${CILLY_CONTAINER_UID}:${CILLY_CONTAINER_GID}`.
+- Each required host bind-mounted directory MUST be writable by this UID/GID.
+- If host ownership differs, operators MUST pre-create directories and set
+  ownership/permissions before `docker compose up`.
+
+Unsupported in this stage:
+- Automatic host permission repair inside the container.
+- External secret manager integration.
 
 ## Exact Startup Commands
 Run exactly from repository root:
 ```bash
+cp .env.example .env
+mkdir -p /srv/cilly/staging/db /srv/cilly/staging/artifacts /srv/cilly/staging/journal /srv/cilly/staging/logs /srv/cilly/staging/runtime-state
 docker compose -f docker/staging/docker-compose.staging.yml config
 docker compose -f docker/staging/docker-compose.staging.yml up -d --build
 ```
@@ -67,6 +109,8 @@ Reproducibility constraints in this path:
 - Base image and dependency resolution are pinned through repository deployment
   artifacts.
 - Runtime process, health checks, and persistence bindings are compose-defined.
+- Required env and bind mounts are bounded and validated through compose variable
+  expansion.
 
 ## Exact Smoke Commands
 Use read-only role headers when validating control-plane health endpoints.
@@ -89,6 +133,9 @@ output and JSON log formatting for API events.
 docker compose -f docker/staging/docker-compose.staging.yml logs -f api
 ```
 
+File-based log persistence in `/data/logs` is explicitly non-authoritative in
+this stage; stdout/stderr compose logs remain authoritative.
+
 ## Exact Restart Validation Commands
 Restart safety is bounded to container restart with persisted state continuity.
 ```bash
@@ -103,11 +150,14 @@ Expected result:
   through the configured staging data path.
 
 ## Storage and Persistence Expectations
-Staging persistence is backed by the compose-managed `/data` volume; removing
-the volume resets bounded staging state.
+Persistence expectations across restart and redeploy are explicit:
+- Container restart (`docker compose restart api`) preserves DB and journal data.
+- Container redeploy (`docker compose up -d --build`) preserves DB and journal
+  data if bind-mounted host directories are unchanged.
+- Deleting bind-mounted host directory contents resets bounded staging state.
 
 ```bash
-docker compose -f docker/staging/docker-compose.staging.yml down -v
+docker compose -f docker/staging/docker-compose.staging.yml down --remove-orphans
 ```
 
 ## Bounded Staging Validation

--- a/tests/test_configuration_boundary_server_contract.py
+++ b/tests/test_configuration_boundary_server_contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_configuration_boundary_declares_ops_p46_server_contract_scope() -> None:
+    content = (
+        REPO_ROOT / "docs" / "architecture" / "configuration_boundary.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## OPS-P46 Bounded Server Environment and Filesystem Contract" in content
+    assert "first-paper server environment contract" in content
+    assert ".env.example" in content
+    assert "docker/staging/docker-compose.staging.yml" in content
+    assert "Conditional provider secret requirements" in content
+
+
+def test_configuration_boundary_defines_required_env_and_path_alignment_rules() -> None:
+    content = (
+        REPO_ROOT / "docs" / "architecture" / "configuration_boundary.md"
+    ).read_text(encoding="utf-8")
+
+    assert "One bounded server environment contract exists and is authoritative" in content
+    assert "Compose, docs, and env guidance must define the same path values." in content
+    assert "Persistence expectations must explicitly distinguish restart/redeploy" in content

--- a/tests/test_staging_deployment_docs.py
+++ b/tests/test_staging_deployment_docs.py
@@ -58,6 +58,7 @@ def test_staging_topology_doc_references_canonical_staging_artifacts() -> None:
     assert content.lstrip().startswith("# Staging Server Deployment and Runtime Validation")
     assert "docker/staging/Dockerfile" in content
     assert "docker/staging/docker-compose.staging.yml" in content
+    assert ".env.example" in content
     assert "python scripts/validate_staging_deployment.py" in content
     assert "STAGING_VALIDATE:SUCCESS" in content
     assert "/health/engine" in content
@@ -68,6 +69,7 @@ def test_staging_topology_doc_references_canonical_staging_artifacts() -> None:
     assert "## Host Prerequisites and Package Contract" in content
     assert "## Required Directories and Persistence Paths" in content
     assert "## Required Environment Variables (Bounded First Deploy / Paper Mode)" in content
+    assert "## Ownership and Permission Expectations" in content
     assert "## Exact Startup Commands" in content
     assert "## Exact Smoke Commands" in content
     assert "## Logging and Observability Expectations" in content
@@ -98,9 +100,15 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     assert "`uv` (not required for first-clean-server startup/smoke/restart validation" in content
     assert "Required runtime environment variables for bounded first deployment:" in content
     assert "- `PYTHONPATH=/app/src`" in content
-    assert "- `CILLY_DB_PATH=/data/cilly_trading.db`" in content
+    assert "- `CILLY_DB_PATH=/data/db/cilly_trading.db`" in content
     assert "- `CILLY_LOG_LEVEL=INFO`" in content
     assert "- `CILLY_LOG_FORMAT=json`" in content
+    assert "- `CILLY_STAGING_DB_DIR`" in content
+    assert "- `CILLY_STAGING_ARTIFACT_DIR`" in content
+    assert "- `CILLY_STAGING_JOURNAL_DIR`" in content
+    assert "- `CILLY_STAGING_LOG_DIR`" in content
+    assert "- `CILLY_STAGING_RUNTIME_STATE_DIR`" in content
+    assert "Conditional provider secret requirements are explicit:" in content
     assert "Any local-run or local development installation guidance is non-canonical for" in content
     assert (
         "docker compose -f docker/staging/docker-compose.staging.yml up -d --build\n```\n\n"
@@ -146,7 +154,7 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="docker compose -f docker/staging/docker-compose.staging.yml down -v",
+        block_marker="docker compose -f docker/staging/docker-compose.staging.yml down --remove-orphans",
         expected_transition="## Bounded Staging Validation",
     )
     _assert_fence_closes_to_transition(

--- a/tests/test_staging_deployment_validation.py
+++ b/tests/test_staging_deployment_validation.py
@@ -37,18 +37,31 @@ def test_staging_artifacts_define_canonical_runtime_contract() -> None:
     assert "FROM python:3.12.8-slim" in dockerfile_content
     assert "python -m pip install -U pip uv" in dockerfile_content
     assert "uv sync --frozen --no-dev" in dockerfile_content
-    assert 'CILLY_DB_PATH="/data/cilly_trading.db"' in dockerfile_content
+    assert 'CILLY_DB_PATH="/data/db/cilly_trading.db"' in dockerfile_content
+    assert "RUN mkdir -p /data/db /data/artifacts /data/logs /data/runtime-state /app/runs/phase6" in dockerfile_content
     assert "HEALTHCHECK" in dockerfile_content
     assert 'CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]' in dockerfile_content
 
     assert "dockerfile: docker/staging/Dockerfile" in compose_content
     assert '"18000:8000"' in compose_content
+    assert 'user: "${CILLY_CONTAINER_UID:?set CILLY_CONTAINER_UID}:${CILLY_CONTAINER_GID:?set CILLY_CONTAINER_GID}"' in compose_content
     assert "working_dir: /data" in compose_content
-    assert "CILLY_DB_PATH: /data/cilly_trading.db" in compose_content
-    assert "CILLY_LOG_FORMAT: json" in compose_content
+    assert 'PYTHONPATH: "${PYTHONPATH:?set PYTHONPATH}"' in compose_content
+    assert 'CILLY_DB_PATH: "${CILLY_DB_PATH:?set CILLY_DB_PATH}"' in compose_content
+    assert 'CILLY_LOG_LEVEL: "${CILLY_LOG_LEVEL:?set CILLY_LOG_LEVEL}"' in compose_content
+    assert 'CILLY_LOG_FORMAT: "${CILLY_LOG_FORMAT:?set CILLY_LOG_FORMAT}"' in compose_content
     assert "restart: unless-stopped" in compose_content
     assert "healthcheck:" in compose_content
-    assert "cilly_staging_data:/data" in compose_content
+    assert 'source: "${CILLY_STAGING_DB_DIR:?set CILLY_STAGING_DB_DIR}"' in compose_content
+    assert "target: /data/db" in compose_content
+    assert 'source: "${CILLY_STAGING_ARTIFACT_DIR:?set CILLY_STAGING_ARTIFACT_DIR}"' in compose_content
+    assert "target: /data/artifacts" in compose_content
+    assert 'source: "${CILLY_STAGING_JOURNAL_DIR:?set CILLY_STAGING_JOURNAL_DIR}"' in compose_content
+    assert "target: /app/runs/phase6" in compose_content
+    assert 'source: "${CILLY_STAGING_LOG_DIR:?set CILLY_STAGING_LOG_DIR}"' in compose_content
+    assert "target: /data/logs" in compose_content
+    assert 'source: "${CILLY_STAGING_RUNTIME_STATE_DIR:?set CILLY_STAGING_RUNTIME_STATE_DIR}"' in compose_content
+    assert "target: /data/runtime-state" in compose_content
 
 
 def test_run_staging_validation_includes_logging_and_persistence_checks() -> None:

--- a/tests/test_staging_env_contract.py
+++ b/tests/test_staging_env_contract.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
+COMPOSE_PATH = REPO_ROOT / "docker" / "staging" / "docker-compose.staging.yml"
+STAGING_DOC_PATH = (
+    REPO_ROOT / "docs" / "operations" / "runtime" / "staging-server-deployment.md"
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_env_example_declares_required_bounded_first_paper_keys() -> None:
+    content = _read(ENV_EXAMPLE_PATH)
+
+    required_keys = [
+        "PYTHONPATH",
+        "CILLY_DB_PATH",
+        "CILLY_LOG_LEVEL",
+        "CILLY_LOG_FORMAT",
+        "CILLY_STAGING_DB_DIR",
+        "CILLY_STAGING_ARTIFACT_DIR",
+        "CILLY_STAGING_JOURNAL_DIR",
+        "CILLY_STAGING_LOG_DIR",
+        "CILLY_STAGING_RUNTIME_STATE_DIR",
+        "CILLY_CONTAINER_UID",
+        "CILLY_CONTAINER_GID",
+    ]
+
+    for key in required_keys:
+        assert f"{key}=" in content
+
+
+def test_env_example_declares_db_path_and_snapshot_first_secret_wording() -> None:
+    content = _read(ENV_EXAMPLE_PATH)
+
+    assert "CILLY_DB_PATH=/data/db/cilly_trading.db" in content
+    assert "Canonical first paper deployment is snapshot-first" in content
+    assert "does not require" in content
+    assert "provider secrets" in content
+
+
+def test_env_example_contract_aligns_with_compose_and_staging_doc() -> None:
+    env_content = _read(ENV_EXAMPLE_PATH)
+    compose_content = _read(COMPOSE_PATH)
+    doc_content = _read(STAGING_DOC_PATH)
+
+    # DB path contract
+    assert "CILLY_DB_PATH=/data/db/cilly_trading.db" in env_content
+    assert 'CILLY_DB_PATH: "${CILLY_DB_PATH:?set CILLY_DB_PATH}"' in compose_content
+    assert "- `CILLY_DB_PATH=/data/db/cilly_trading.db`" in doc_content
+    assert "Database path (persistent): `/data/db/cilly_trading.db`" in doc_content
+
+    # Bind-mount variable contract
+    bind_vars = [
+        ("CILLY_STAGING_DB_DIR", "/data/db"),
+        ("CILLY_STAGING_ARTIFACT_DIR", "/data/artifacts"),
+        ("CILLY_STAGING_JOURNAL_DIR", "/app/runs/phase6"),
+        ("CILLY_STAGING_LOG_DIR", "/data/logs"),
+        ("CILLY_STAGING_RUNTIME_STATE_DIR", "/data/runtime-state"),
+    ]
+    for var_name, target in bind_vars:
+        assert f"{var_name}=" in env_content
+        assert f'source: "${{{var_name}:?set {var_name}}}"' in compose_content
+        assert f"target: {target}" in compose_content
+        assert f"`{var_name}`" in doc_content
+        assert f"`{target}`" in doc_content
+
+    # UID/GID runtime contract
+    assert "CILLY_CONTAINER_UID=" in env_content
+    assert "CILLY_CONTAINER_GID=" in env_content
+    assert (
+        'user: "${CILLY_CONTAINER_UID:?set CILLY_CONTAINER_UID}:${CILLY_CONTAINER_GID:?set CILLY_CONTAINER_GID}"'
+        in compose_content
+    )
+    assert "- `CILLY_CONTAINER_UID`" in doc_content
+    assert "- `CILLY_CONTAINER_GID`" in doc_content
+    assert "${CILLY_CONTAINER_UID}:${CILLY_CONTAINER_GID}" in doc_content

--- a/tests/test_staging_first_topology_contract_docs.py
+++ b/tests/test_staging_first_topology_contract_docs.py
@@ -65,7 +65,9 @@ def test_staging_topology_doc_defines_single_canonical_topology() -> None:
     assert "Canonical install/runbook authority:" in content
     assert "`docs/operations/runtime/staging-server-deployment.md`" in content
     assert "one `api` service process (`uvicorn api.main:app`)" in content
-    assert "one local SQLite persistence volume mounted at `/data`" in content
+    assert "explicit host bind mounts for DB, artifact, journal, logs, and runtime-state" in content
+    assert "bind-mounted host DB directory at `/data/db`" in content
+    assert "bind-mounted host journal directory at `/app/runs/phase6`" in content
 
 
 def test_staging_topology_doc_defines_runtime_environment_and_boundary_non_goals() -> None:
@@ -85,10 +87,7 @@ def test_staging_topology_doc_defines_runtime_environment_and_boundary_non_goals
     assert "- broker integrations" in content
     assert "- production high availability" in content
     assert "- any runtime mode that places live market orders" in content
-    assert (
-        "        [SQLite persistence at /data]\n```\n\n"
-        "## Runtime Contract and Service Boundary"
-    ) in content
+    assert " [SQLite persistence at /data/db/cilly_trading.db]\n```\n\n## Runtime Contract and Service Boundary" in content
     _assert_fence_closes_to_transition(
         content,
         block_marker="[Operator client or bounded automation]",


### PR DESCRIPTION
﻿Closes #833

## What changed
- Added canonical `.env.example` for first-clean-server paper deployment contract.
- Updated staging compose to:
  - require explicit env contract variables,
  - define explicit bind-mounted directories for DB/artifacts/journal/logs/runtime-state,
  - run container as configured UID/GID.
- Updated staging Dockerfile default DB path to `/data/db/cilly_trading.db` and created contract directories.
- Updated staging deployment runbook with:
  - required env contract,
  - conditional provider secret contract,
  - explicit persistent directory requirements,
  - ownership/permission expectations,
  - explicit restart vs redeploy persistence behavior.
- Updated staging-first topology doc and configuration boundary doc for consistent contract ownership/path definitions.
- Added/updated docs and deployment contract tests for env/path wording and compose/doc alignment.

## Validation
- `python -m pytest tests/test_staging_env_contract.py tests/test_configuration_boundary_server_contract.py tests/test_staging_deployment_docs.py tests/test_staging_deployment_validation.py tests/test_staging_first_topology_contract_docs.py -q`
- `python -m pytest`

Both passed.
