### PR TITLE
OPS-P46: Bound staging paper remote-access and trust model

### DIFF
--- a/docs/architecture/governance/external-readiness-checklist.md
+++ b/docs/architecture/governance/external-readiness-checklist.md
@@ -17,6 +17,9 @@ Instructions:
 | 6 | `docs/operations/api/usage_contract.md` includes a section titled "Error semantics". | |
 | 7 | `docs/operations/api/usage_contract.md` lists snapshot readiness/validation errors with status codes. | |
 | 8 | `docs/operations/api/external_api_happy_path.md` exists. | |
+| 9 | `docs/operations/runtime/staging-server-deployment.md` states localhost-only staging paper default. | |
+| 10 | Deployment, API usage, and paper acceptance docs consistently state that `X-Cilly-Role` headers are not a public authentication model. | |
+| 11 | Public exposure without an external trust boundary is explicitly disallowed in staging paper docs. | |
 
 ## Final decision rule
 

--- a/docs/operations/api/usage_contract.md
+++ b/docs/operations/api/usage_contract.md
@@ -5,6 +5,20 @@ This document defines the stable usage contract for the MVP v1 API. It documents
 ## Base URL
 
 - Local development: `http://localhost:8000`
+- Staging paper default: localhost-only (`http://127.0.0.1:18000` in the
+  staging runbook).
+
+## Access and Trust-Boundary Contract
+
+- Role headers such as `X-Cilly-Role` are not a public authentication model.
+- The role-header contract is bounded to trusted operator-controlled staging
+  contexts (localhost by default).
+- Remote access is not part of the default API usage contract and is either:
+  - an explicit operator-owned trust-boundary decision outside this repository
+    contract, or
+  - unsupported for this staging paper operation.
+- Public API exposure without an external trust boundary is explicitly
+  disallowed.
 
 ## Canonical Operator Analysis Contract
 
@@ -785,7 +799,8 @@ No request body.
 
 **Validation rules:**
 
-- Read access requires a valid authenticated role header and a role permitted to inspect watchlists.
+- Read access requires an accepted `X-Cilly-Role` value within the bounded
+  trusted operator context and a role permitted to inspect watchlists.
 
 ### Success response
 

--- a/docs/operations/runtime/paper-deployment-acceptance-gate.md
+++ b/docs/operations/runtime/paper-deployment-acceptance-gate.md
@@ -15,6 +15,7 @@ In scope:
 - required evidence outputs for acceptance
 - explicit pass/fail criteria
 - wording alignment with deployment documentation
+- bounded operator trust model and exposure wording for staging paper operation
 
 Out of scope:
 - live-trading approval
@@ -31,6 +32,14 @@ Boundary rule:
 - Local run success alone must never be interpreted as server-ready.
 - Server-ready alone must never be interpreted as paper-install-ready.
 - Paper-install-ready requires all steps in the acceptance sequence below.
+
+## Operator Access and Exposure Boundary
+- Localhost-only is the default staging paper access posture.
+- `X-Cilly-Role` headers are bounded trust inputs for local/operator-controlled
+  staging use and are not a public authentication model.
+- Remote access is outside default staging scope and must be treated as an
+  operator-owned trust-boundary decision or unsupported.
+- Public exposure without an external trust boundary is not allowed.
 
 ## Bounded Acceptance Sequence (Canonical and Reproducible)
 Run steps in order from repository root.

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -8,6 +8,26 @@ trading behavior.
 For a first-clean-server install in this repository, this runbook is the single
 authoritative contract.
 
+## Access and Trust Boundary (Staging Paper)
+Default access posture for staging paper operation is localhost-only:
+- Bind and validate API access through `127.0.0.1` only.
+- Treat `X-Cilly-Role` headers as bounded local operator-routing inputs, not as
+  a public authentication model.
+- Public or internet-exposed access without an external trust boundary is
+  explicitly disallowed.
+
+Remote access boundary:
+- Remote access is out of default staging scope and remains unsupported unless
+  an operator explicitly adds and owns an external trust boundary.
+- External trust boundary decisions are operator-owned and out of this runbook's
+  implementation scope.
+
+Minimum safe operator-access posture for staging paper operation:
+1. Keep API access localhost-only by default.
+2. Use role headers only for bounded non-public operator workflows.
+3. Do not expose the API publicly without an operator-managed external trust
+   boundary.
+
 ## Deployment Artifacts
 Deployment artifacts used by this runbook:
 - `docker/staging/Dockerfile`

--- a/tests/test_ops_p46_trust_boundary_docs.py
+++ b/tests/test_ops_p46_trust_boundary_docs.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _assert_fence_closes_to_transition(
+    content: str,
+    *,
+    block_marker: str,
+    expected_transition: str,
+) -> None:
+    marker_index = content.index(block_marker)
+
+    opening_index = content.rfind("\n```", 0, marker_index)
+    if opening_index == -1:
+        opening_index = content.rfind("```", 0, marker_index)
+    else:
+        opening_index += 1
+    assert opening_index != -1
+
+    opening_line_end = content.find("\n", opening_index)
+    if opening_line_end == -1:
+        opening_line_end = len(content)
+    opening_line = content[opening_index:opening_line_end]
+    assert opening_line.startswith("```")
+
+    search_from = opening_line_end
+    closing_line_start = -1
+    while True:
+        candidate = content.find("\n```", search_from)
+        if candidate == -1:
+            break
+        line_start = candidate + 1
+        line_end = content.find("\n", line_start)
+        if line_end == -1:
+            line_end = len(content)
+        if content[line_start:line_end] == "```":
+            closing_line_start = line_start
+            break
+        search_from = line_end
+
+    assert closing_line_start != -1
+    assert opening_index < marker_index < closing_line_start
+
+    transition_index = content.find(expected_transition, closing_line_start + 1)
+    assert transition_index != -1
+    assert transition_index > closing_line_start
+    assert not (opening_index < transition_index < closing_line_start)
+
+
+def test_ops_p46_docs_define_localhost_only_and_non_public_role_header_boundary() -> None:
+    staging_doc = _read("docs/operations/runtime/staging-server-deployment.md")
+    usage_doc = _read("docs/operations/api/usage_contract.md")
+    gate_doc = _read("docs/operations/runtime/paper-deployment-acceptance-gate.md")
+
+    assert "localhost-only" in staging_doc
+    assert "localhost-only" in usage_doc.lower() or "localhost-only" in gate_doc.lower()
+
+    expected_phrase = "public authentication model"
+    assert expected_phrase in staging_doc
+    assert expected_phrase in usage_doc
+    assert expected_phrase in gate_doc
+
+
+def test_ops_p46_docs_bound_remote_access_and_disallow_public_exposure() -> None:
+    staging_doc = _read("docs/operations/runtime/staging-server-deployment.md")
+    usage_doc = _read("docs/operations/api/usage_contract.md")
+    gate_doc = _read("docs/operations/runtime/paper-deployment-acceptance-gate.md")
+
+    assert "Remote access is out of default staging scope" in staging_doc
+    assert "Remote access is not part of the default API usage contract" in usage_doc
+    assert "Remote access is outside default staging scope" in gate_doc
+
+    disallow_phrase = "without an external trust boundary"
+    assert disallow_phrase in staging_doc
+    assert disallow_phrase in usage_doc
+    assert disallow_phrase in gate_doc
+
+
+def test_usage_contract_examples_have_closed_fences_and_valid_section_transitions() -> None:
+    content = _read("docs/operations/api/usage_contract.md")
+
+    assert "### Canonical request body" in content
+    assert "Canonical request example:" in content
+    assert "Request boundary notes:" in content
+    assert "### Canonical success response body" in content
+    assert "Canonical success response example:" in content
+    assert "### Canonical failure semantics" in content
+    assert "**Response:**" in content
+    assert "---\n\n## POST /watchlists" in content
+
+    fence_count = sum(1 for line in content.splitlines() if line.startswith("```"))
+    assert fence_count % 2 == 0
+
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker='"strategy_config": {',
+        expected_transition="Request boundary notes:",
+    )
+    _assert_fence_closes_to_transition(
+        content,
+        block_marker='"analysis_run_id": "e1f2d3c4-1111-2222-3333-444455556666"',
+        expected_transition="### Canonical failure semantics",
+    )
+    assert (
+        "Canonical request example:\n\n```json\n{\n"
+        in content
+    )
+    assert (
+        "}\n```\n\nRequest boundary notes:"
+        in content
+    )
+    assert (
+        "Canonical success response example:\n\n```json\n{\n"
+        in content
+    )
+    assert (
+        "}\n```\n\n### Canonical failure semantics"
+        in content
+    )
+    assert (
+        "### Example\n\n**Request:**\n\n```bash\n"
+        "curl -s -X POST http://localhost:8000/analysis/run \\\n"
+        in content
+    )
+    assert (
+        "  }'\n```\n\n**Response:**\n\n```json\n{\n"
+        '  "analysis_run_id": "e1f2d3c4-1111-2222-3333-444455556666",\n'
+        in content
+    )
+    assert (
+        '  "signals": []\n}\n```\n\n---\n\n## POST /watchlists'
+        in content
+    )

--- a/tests/test_paper_deployment_acceptance_gate_docs.py
+++ b/tests/test_paper_deployment_acceptance_gate_docs.py
@@ -21,6 +21,10 @@ def test_paper_acceptance_gate_doc_defines_bounded_binary_sequence() -> None:
     assert "`repository-runs-locally`" in content
     assert "`server-ready (staging)`" in content
     assert "`paper-install-ready`" in content
+    assert "## Operator Access and Exposure Boundary" in content
+    assert "Localhost-only is the default staging paper access posture." in content
+    assert "not a public authentication model." in content
+    assert "Public exposure without an external trust boundary is not allowed." in content
     assert "## Bounded Acceptance Sequence (Canonical and Reproducible)" in content
     assert "### Step 1 - Staging deployment validation" in content
     assert "### Step 2 - Explicit health/readiness evidence capture" in content
@@ -53,6 +57,7 @@ def test_paper_acceptance_gate_doc_names_required_evidence_outputs_and_markers()
     assert "## Pass/Fail Criteria (Binary)" in content
     assert "ACCEPTED: PAPER_INSTALL_READY" in content
     assert "NOT ACCEPTED: REMAIN STAGING" in content
+    assert "Remote access is outside default staging scope" in content
 
 
 def test_operator_checklist_matches_acceptance_gate_wording_and_evidence_contract() -> None:

--- a/tests/test_staging_deployment_docs.py
+++ b/tests/test_staging_deployment_docs.py
@@ -82,6 +82,11 @@ def test_staging_topology_doc_references_canonical_staging_artifacts() -> None:
     assert "`paper-install-ready`" in content
     assert "EVIDENCE_STAGING_VALIDATION_LOG" in content
     assert "## Test Gate" in content
+    assert "## Access and Trust Boundary (Staging Paper)" in content
+    assert "Default access posture for staging paper operation is localhost-only" in content
+    assert "public authentication model" in content
+    assert "Public or internet-exposed access without an external trust boundary is" in content
+    assert "explicitly disallowed." in content
 
 
 def test_staging_topology_doc_declares_single_canonical_first_deployment_path() -> None:
@@ -109,6 +114,8 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     assert "- `CILLY_STAGING_LOG_DIR`" in content
     assert "- `CILLY_STAGING_RUNTIME_STATE_DIR`" in content
     assert "Conditional provider secret requirements are explicit:" in content
+    assert "Remote access boundary:" in content
+    assert "Remote access is out of default staging scope" in content
     assert "Any local-run or local development installation guidance is non-canonical for" in content
     assert (
         "docker compose -f docker/staging/docker-compose.staging.yml up -d --build\n```\n\n"


### PR DESCRIPTION
﻿Closes #834

## What changed
- Added explicit localhost-only default and trust-boundary policy in staging deployment docs.
- Clarified that `X-Cilly-Role` headers are not a public authentication model.
- Bounded remote access as operator-owned external trust-boundary decision or unsupported.
- Explicitly disallowed public exposure without external trust boundary.
- Aligned wording across deployment, usage, and operator acceptance docs.
- Added/updated doc contract tests to enforce this wording.

## Files
- docs/operations/runtime/staging-server-deployment.md
- docs/operations/api/usage_contract.md
- docs/operations/runtime/paper-deployment-acceptance-gate.md
- docs/architecture/governance/external-readiness-checklist.md
- tests/test_staging_deployment_docs.py
- tests/test_paper_deployment_acceptance_gate_docs.py
- tests/test_ops_p46_trust_boundary_docs.py

## Validation
- `python -m pytest`

Pass
