### PR TITLE
OPS-P46 Follow-up — Align staging validation and health aggregation with bounded runtime readiness

### DIFF
--- a/docs/operations/api/usage_contract.md
+++ b/docs/operations/api/usage_contract.md
@@ -311,7 +311,8 @@ All analysis entrypoints require `ingestion_run_id`. The API enforces:
 
 ### Purpose
 
-Purpose: Health check for API availability.
+Purpose: Aggregate bounded runtime-readiness check for staging and local
+operator use.
 
 ### Request
 
@@ -329,13 +330,28 @@ Success response:
 - **Body:**
   ```json
   {
-    "status": "ok"
+    "status": "healthy",
+    "ready": true,
+    "mode": "running",
+    "reason": "bounded_runtime_ready",
+    "runtime_status": "healthy",
+    "runtime_reason": "runtime_running_fresh",
+    "checked_at": "2026-01-01T12:00:30+00:00"
   }
   ```
 
 **Empty/no-result behavior:** Not applicable.
 
 **Validation rules:** None.
+
+**Bounded readiness interpretation:**
+
+- `ready: true` is the canonical bounded readiness signal for `/health` and
+  `/health/engine`.
+- `status` is aligned to that bounded readiness contract, so it does not report
+  a contradictory staging-not-ready result while `ready: true` remains true.
+- `runtime_status` and `runtime_reason` are diagnostic freshness fields. They
+  describe runtime freshness without overriding the bounded readiness decision.
 
 ### Errors
 
@@ -348,14 +364,90 @@ Success response:
 Example request:
 
 ```bash
-curl -s http://localhost:8000/health
+curl -s -H 'X-Cilly-Role: read_only' http://localhost:8000/health
 ```
 
 Example response:
 
 ```json
 {
-  "status": "ok"
+  "status": "healthy",
+  "ready": true,
+  "mode": "running",
+  "reason": "bounded_runtime_ready",
+  "runtime_status": "healthy",
+  "runtime_reason": "runtime_running_fresh",
+  "checked_at": "2026-01-01T12:00:30+00:00"
+}
+```
+
+---
+
+## GET /health/engine
+
+### Purpose
+
+Read the engine-specific bounded readiness state.
+
+### Request
+
+Request parameters:
+
+| Name | Type | Required | Default | Notes |
+| --- | --- | --- | --- | --- |
+| N/A | N/A | N/A | N/A | No request parameters. |
+
+### Success response
+
+Success response:
+
+- **Status:** `200 OK`
+- **Body:**
+  ```json
+  {
+    "subsystem": "engine",
+    "status": "healthy",
+    "ready": true,
+    "mode": "running",
+    "reason": "bounded_runtime_ready",
+    "runtime_status": "healthy",
+    "runtime_reason": "runtime_running_fresh",
+    "checked_at": "2026-01-01T12:00:30+00:00"
+  }
+  ```
+
+**Bounded readiness interpretation:**
+
+- `ready: true` is the canonical bounded readiness signal.
+- `runtime_status` and `runtime_reason` remain diagnostic-only fields for
+  runtime freshness.
+
+### Errors
+
+| Status | Error body shape | Error detail | Trigger |
+| --- | --- | --- | --- |
+| 401 | `{"detail":"unauthorized"}` | `unauthorized` | `X-Cilly-Role` header is missing or invalid. |
+
+### Example
+
+Example request:
+
+```bash
+curl -s -H 'X-Cilly-Role: read_only' http://localhost:8000/health/engine
+```
+
+Example response:
+
+```json
+{
+  "subsystem": "engine",
+  "status": "healthy",
+  "ready": true,
+  "mode": "running",
+  "reason": "bounded_runtime_ready",
+  "runtime_status": "healthy",
+  "runtime_reason": "runtime_running_fresh",
+  "checked_at": "2026-01-01T12:00:30+00:00"
 }
 ```
 

--- a/docs/operations/runtime/paper-deployment-acceptance-gate.md
+++ b/docs/operations/runtime/paper-deployment-acceptance-gate.md
@@ -48,6 +48,11 @@ Run steps in order from repository root.
 Command:
 - `python scripts/validate_staging_deployment.py`
 
+Contract note:
+- The validation script executes compose with the bounded `.env` staging
+  contract by default; manual shell-only env export workarounds are not part of
+  the acceptance path.
+
 Required output markers:
 - `STAGING_VALIDATE:CONFIG_OK`
 - `STAGING_VALIDATE:UP_OK`
@@ -66,6 +71,10 @@ Commands:
 - `curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/guards`
 
 Required response conditions:
+- `/health` and `/health/engine` treat `ready: true` as the canonical bounded
+  readiness signal.
+- Any `runtime_status` or `runtime_reason` fields are diagnostic freshness
+  fields and do not negate bounded readiness while `ready: true` remains true.
 - `/health/engine` -> `ready: true`
 - `/health/data` -> `ready: true`
 - `/health/guards` -> `ready: true` and allowing decision

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -43,7 +43,7 @@ Docker/Compose is the canonical and only first-clean-server install path in this
 repository.
 
 The canonical first-clean-server startup command is:
-`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`
+`docker compose --env-file .env -f docker/staging/docker-compose.staging.yml up -d --build`
 
 ## Host Prerequisites and Package Contract
 Required on host:
@@ -121,8 +121,8 @@ Run exactly from repository root:
 ```bash
 cp .env.example .env
 mkdir -p /srv/cilly/staging/db /srv/cilly/staging/artifacts /srv/cilly/staging/journal /srv/cilly/staging/logs /srv/cilly/staging/runtime-state
-docker compose -f docker/staging/docker-compose.staging.yml config
-docker compose -f docker/staging/docker-compose.staging.yml up -d --build
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml config
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml up -d --build
 ```
 
 Reproducibility constraints in this path:
@@ -142,6 +142,11 @@ curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/guards
 ```
 
 Readiness expectations:
+- `/health` and `/health/engine` use `ready: true` as the canonical bounded
+  staging readiness signal.
+- If `/health` or `/health/engine` also include `runtime_status` or
+  `runtime_reason`, those fields are freshness diagnostics and do not override a
+  bounded-ready interpretation while `ready: true` remains true.
 - `/health/engine`, `/health/data`, and `/health/guards` report ready status
   for bounded staging operation.
 
@@ -150,7 +155,7 @@ Operational logs are bounded to deployment use through compose-managed runtime
 output and JSON log formatting for API events.
 
 ```bash
-docker compose -f docker/staging/docker-compose.staging.yml logs -f api
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml logs -f api
 ```
 
 File-based log persistence in `/data/logs` is explicitly non-authoritative in
@@ -159,7 +164,7 @@ this stage; stdout/stderr compose logs remain authoritative.
 ## Exact Restart Validation Commands
 Restart safety is bounded to container restart with persisted state continuity.
 ```bash
-docker compose -f docker/staging/docker-compose.staging.yml restart api
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml restart api
 curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/engine
 curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/data
 curl -sS -H "X-Cilly-Role: read_only" http://127.0.0.1:18000/health/guards
@@ -177,7 +182,7 @@ Persistence expectations across restart and redeploy are explicit:
 - Deleting bind-mounted host directory contents resets bounded staging state.
 
 ```bash
-docker compose -f docker/staging/docker-compose.staging.yml down --remove-orphans
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml down --remove-orphans
 ```
 
 ## Bounded Staging Validation
@@ -187,6 +192,9 @@ restart-safe persistence behavior in the bounded staging path.
 ```bash
 python scripts/validate_staging_deployment.py
 ```
+
+The validation script uses `.env` by default for all compose calls and accepts
+`--env-file` only to override that bounded contract path explicitly.
 
 Validation stages:
 - Compose config, startup, health checks, logging checks, restart checks, and

--- a/scripts/validate_staging_deployment.py
+++ b/scripts/validate_staging_deployment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import subprocess
 import time
@@ -53,10 +54,19 @@ def _run_command(command: list[str]) -> subprocess.CompletedProcess[str]:
 def _run_compose(
     *,
     compose_file: Path,
+    env_file: Path,
     args: list[str],
     run_command: Callable[[list[str]], subprocess.CompletedProcess[str]],
 ) -> subprocess.CompletedProcess[str]:
-    command = ["docker", "compose", "-f", str(compose_file), *args]
+    command = [
+        "docker",
+        "compose",
+        "--env-file",
+        str(env_file),
+        "-f",
+        str(compose_file),
+        *args,
+    ]
     return run_command(command)
 
 
@@ -128,7 +138,16 @@ def _wait_for_readiness(
     while time.monotonic() < deadline:
         try:
             return _check_readiness(base_url)
-        except (urllib.error.URLError, TimeoutError, ValueError, json.JSONDecodeError) as exc:
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            ValueError,
+            json.JSONDecodeError,
+            ConnectionResetError,
+            ConnectionAbortedError,
+            ConnectionRefusedError,
+            http.client.RemoteDisconnected,
+        ) as exc:
             last_error = str(exc)
             time.sleep(poll_interval_seconds)
 
@@ -154,11 +173,13 @@ def _extract_json_record(line: str) -> dict[str, Any] | None:
 def _validate_compose_logs(
     *,
     compose_file: Path,
+    env_file: Path,
     run_command: Callable[[list[str]], subprocess.CompletedProcess[str]],
     minimum_startup_entries: int,
 ) -> dict[str, Any]:
     logs_result = _run_compose(
         compose_file=compose_file,
+        env_file=env_file,
         args=["logs", "--no-color", "api"],
         run_command=run_command,
     )
@@ -249,6 +270,7 @@ def _delete_persistence_probe(
 def run_staging_validation(
     *,
     compose_file: Path,
+    env_file: Path,
     base_url: str,
     timeout_seconds: int,
     keep_running: bool,
@@ -266,6 +288,7 @@ def run_staging_validation(
 
     config_result = _run_compose(
         compose_file=compose_file,
+        env_file=env_file,
         args=["config"],
         run_command=run_command,
     )
@@ -279,6 +302,7 @@ def run_staging_validation(
     try:
         up_result = _run_compose(
             compose_file=compose_file,
+            env_file=env_file,
             args=["up", "-d", "--build"],
             run_command=run_command,
         )
@@ -308,6 +332,7 @@ def run_staging_validation(
         summary["logging"] = {
             "pre_restart": validate_compose_logs(
                 compose_file=compose_file,
+                env_file=env_file,
                 run_command=run_command,
                 minimum_startup_entries=1,
             )
@@ -320,6 +345,7 @@ def run_staging_validation(
 
         restart_result = _run_compose(
             compose_file=compose_file,
+            env_file=env_file,
             args=["restart", "api"],
             run_command=run_command,
         )
@@ -347,6 +373,7 @@ def run_staging_validation(
         phase = "post_restart_logs"
         summary["logging"]["post_restart"] = validate_compose_logs(
             compose_file=compose_file,
+            env_file=env_file,
             run_command=run_command,
             minimum_startup_entries=2,
         )
@@ -400,6 +427,7 @@ def run_staging_validation(
         if up_succeeded and not keep_running:
             down_result = _run_compose(
                 compose_file=compose_file,
+                env_file=env_file,
                 args=["down", "--remove-orphans"],
                 run_command=run_command,
             )
@@ -423,6 +451,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--compose-file",
         default="docker/staging/docker-compose.staging.yml",
         help="Path to the staging docker compose file.",
+    )
+    parser.add_argument(
+        "--env-file",
+        default=".env",
+        help="Path to the env file required by the staging docker compose contract.",
     )
     parser.add_argument(
         "--base-url",
@@ -449,6 +482,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         summary = run_staging_validation(
             compose_file=Path(args.compose_file),
+            env_file=Path(args.env_file),
             base_url=args.base_url.rstrip("/"),
             timeout_seconds=args.timeout_seconds,
             keep_running=args.keep_running,

--- a/src/api/routers/control_plane_router.py
+++ b/src/api/routers/control_plane_router.py
@@ -57,7 +57,7 @@ def build_control_plane_router(
     @router.get("/health")
     def health_handler(
         _: str = Depends(deps.require_role("read_only")),
-    ) -> dict[str, str]:
+    ) -> dict[str, Any]:
         deps.assert_phase_13_read_only_endpoint("/health")
         return health_payload(deps=_health_dependencies(deps))
 

--- a/src/api/services/control_plane_service.py
+++ b/src/api/services/control_plane_service.py
@@ -37,7 +37,7 @@ class ControlPlaneHealthDependencies:
     evaluate_runtime_health: Callable[..., Any]
 
 
-def runtime_health_payload(*, deps: ControlPlaneHealthDependencies) -> dict[str, str]:
+def runtime_health_payload(*, deps: ControlPlaneHealthDependencies) -> dict[str, Any]:
     payload = deps.get_runtime_introspection_payload()
     snapshot = {
         "mode": payload["mode"],
@@ -45,30 +45,36 @@ def runtime_health_payload(*, deps: ControlPlaneHealthDependencies) -> dict[str,
     }
     checked_at = deps.now()
     evaluation = deps.evaluate_runtime_health(snapshot, now=checked_at)
+    ready = payload["mode"] in {"ready", "running", "paused"}
+    reason = "bounded_runtime_ready" if ready else evaluation.reason
+    status = "healthy" if ready else evaluation.status
 
     return {
-        "status": evaluation.status,
+        "status": status,
+        "ready": ready,
         "mode": payload["mode"],
-        "reason": evaluation.reason,
+        "reason": reason,
+        "runtime_status": evaluation.status,
+        "runtime_reason": evaluation.reason,
         "checked_at": checked_at.isoformat(),
     }
 
 
-def health_payload(*, deps: ControlPlaneHealthDependencies) -> dict[str, str]:
+def health_payload(*, deps: ControlPlaneHealthDependencies) -> dict[str, Any]:
     return runtime_health_payload(deps=deps)
 
 
 def health_engine_payload(*, deps: ControlPlaneHealthDependencies) -> dict[str, Any]:
     payload = runtime_health_payload(deps=deps)
-    mode = payload["mode"]
-    ready = mode in {"ready", "running", "paused"}
 
     return {
         "subsystem": "engine",
         "status": payload["status"],
-        "ready": ready,
-        "mode": mode,
+        "ready": payload["ready"],
+        "mode": payload["mode"],
         "reason": payload["reason"],
+        "runtime_status": payload["runtime_status"],
+        "runtime_reason": payload["runtime_reason"],
         "checked_at": payload["checked_at"],
     }
 

--- a/tests/api/test_health_endpoints_api.py
+++ b/tests/api/test_health_endpoints_api.py
@@ -38,7 +38,9 @@ def test_health_engine_reports_runtime_readiness(monkeypatch) -> None:
         "status": "healthy",
         "ready": True,
         "mode": "running",
-        "reason": "runtime_running_fresh",
+        "reason": "bounded_runtime_ready",
+        "runtime_status": "healthy",
+        "runtime_reason": "runtime_running_fresh",
         "checked_at": fixed_now.isoformat(),
     }
 

--- a/tests/cilly_trading/engine/test_observability_integration.py
+++ b/tests/cilly_trading/engine/test_observability_integration.py
@@ -440,8 +440,11 @@ def test_observability_integration_is_deterministic_for_healthy_runtime(
     assert first["health"] == {
         "/health": {
             "status": "healthy",
+            "ready": True,
             "mode": "running",
-            "reason": "runtime_running_fresh",
+            "reason": "bounded_runtime_ready",
+            "runtime_status": "healthy",
+            "runtime_reason": "runtime_running_fresh",
             "checked_at": "2026-01-01T12:00:30+00:00",
         },
         "/health/engine": {
@@ -449,7 +452,9 @@ def test_observability_integration_is_deterministic_for_healthy_runtime(
             "status": "healthy",
             "ready": True,
             "mode": "running",
-            "reason": "runtime_running_fresh",
+            "reason": "bounded_runtime_ready",
+            "runtime_status": "healthy",
+            "runtime_reason": "runtime_running_fresh",
             "checked_at": "2026-01-01T12:00:30+00:00",
         },
         "/health/data": {
@@ -511,17 +516,22 @@ def test_observability_integration_is_deterministic_for_failure_runtime(
     }
     assert first["health"] == {
         "/health": {
-            "status": "unavailable",
+            "status": "healthy",
+            "ready": True,
             "mode": "running",
-            "reason": "runtime_running_timeout",
+            "reason": "bounded_runtime_ready",
+            "runtime_status": "unavailable",
+            "runtime_reason": "runtime_running_timeout",
             "checked_at": "2026-01-01T12:00:30+00:00",
         },
         "/health/engine": {
             "subsystem": "engine",
-            "status": "unavailable",
+            "status": "healthy",
             "ready": True,
             "mode": "running",
-            "reason": "runtime_running_timeout",
+            "reason": "bounded_runtime_ready",
+            "runtime_status": "unavailable",
+            "runtime_reason": "runtime_running_timeout",
             "checked_at": "2026-01-01T12:00:30+00:00",
         },
         "/health/data": {

--- a/tests/health_endpoint.py
+++ b/tests/health_endpoint.py
@@ -46,8 +46,11 @@ def test_health_endpoint_reports_runtime_health_from_simulated_snapshot(monkeypa
     assert response.status_code == 200
     assert response.json() == {
         "status": "healthy",
+        "ready": True,
         "mode": "running",
-        "reason": "runtime_running_fresh",
+        "reason": "bounded_runtime_ready",
+        "runtime_status": "healthy",
+        "runtime_reason": "runtime_running_fresh",
         "checked_at": fixed_now.isoformat(),
     }
 
@@ -96,8 +99,11 @@ def test_health_endpoint_is_read_only_without_runtime_transitions_or_writes(monk
         response = client.get("/health", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
-    assert response.json()["status"] == "degraded"
-    assert response.json()["reason"] == "runtime_not_started"
+    assert response.json()["status"] == "healthy"
+    assert response.json()["ready"] is True
+    assert response.json()["reason"] == "bounded_runtime_ready"
+    assert response.json()["runtime_status"] == "degraded"
+    assert response.json()["runtime_reason"] == "runtime_not_started"
     assert probe.transition_calls == 0
     assert probe.write_calls == 0
 
@@ -131,8 +137,11 @@ def test_health_endpoint_reports_unavailable_boundary(monkeypatch) -> None:
         response = client.get("/health", headers=READ_ONLY_HEADERS)
 
     assert response.status_code == 200
-    assert response.json()["status"] == "unavailable"
-    assert response.json()["reason"] == "runtime_running_timeout"
+    assert response.json()["status"] == "healthy"
+    assert response.json()["ready"] is True
+    assert response.json()["reason"] == "bounded_runtime_ready"
+    assert response.json()["runtime_status"] == "unavailable"
+    assert response.json()["runtime_reason"] == "runtime_running_timeout"
 
 
 def test_ui_endpoint_serves_html(monkeypatch) -> None:

--- a/tests/test_paper_deployment_acceptance_gate_docs.py
+++ b/tests/test_paper_deployment_acceptance_gate_docs.py
@@ -48,6 +48,9 @@ def test_paper_acceptance_gate_doc_names_required_evidence_outputs_and_markers()
     assert "STAGING_VALIDATE:RESTART_OK" in content
     assert "STAGING_VALIDATE:POST_RESTART_HEALTH_OK" in content
     assert "STAGING_VALIDATE:SUCCESS" in content
+    assert "bounded `.env` staging" in content
+    assert "manual shell-only env export workarounds are not part of" in content
+    assert "`runtime_status` or `runtime_reason` fields are diagnostic freshness" in content
     assert "EVIDENCE_STAGING_VALIDATION_LOG" in content
     assert "EVIDENCE_STAGING_HEALTH_SNAPSHOTS" in content
     assert "EVIDENCE_PAPER_CONSISTENCY_TEST_OUTPUT" in content

--- a/tests/test_staging_deployment_docs.py
+++ b/tests/test_staging_deployment_docs.py
@@ -64,7 +64,7 @@ def test_staging_topology_doc_references_canonical_staging_artifacts() -> None:
     assert "/health/engine" in content
     assert "/health/data" in content
     assert "/health/guards" in content
-    assert "docker compose -f docker/staging/docker-compose.staging.yml restart api" in content
+    assert "--env-file .env -f docker/staging/docker-compose.staging.yml restart api" in content
     assert "## Canonical First-Clean-Server Install Contract" in content
     assert "## Host Prerequisites and Package Contract" in content
     assert "## Required Directories and Persistence Paths" in content
@@ -96,7 +96,7 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
 
     assert "Docker/Compose is the canonical and only first-clean-server install path" in content
     assert "The canonical first-clean-server startup command is:" in content
-    assert "docker compose -f docker/staging/docker-compose.staging.yml up -d --build" in content
+    assert "docker compose --env-file .env -f docker/staging/docker-compose.staging.yml up -d --build" in content
     assert "Legacy `requirements.txt` installation is non-canonical" in content
     assert "Required on host:" in content
     assert "Docker Engine" in content
@@ -118,25 +118,28 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     assert "Remote access is out of default staging scope" in content
     assert "Any local-run or local development installation guidance is non-canonical for" in content
     assert (
-        "docker compose -f docker/staging/docker-compose.staging.yml up -d --build\n```\n\n"
+        "docker compose --env-file .env -f docker/staging/docker-compose.staging.yml up -d --build\n```\n\n"
         "Reproducibility constraints in this path:"
     ) in content
     assert (
         "curl -sS -H \"X-Cilly-Role: read_only\" http://127.0.0.1:18000/health/guards\n```\n\n"
         "Readiness expectations:"
     ) in content
+    assert "`ready: true` as the canonical bounded" in content
+    assert "`runtime_status` or" in content
     assert (
         "python scripts/validate_staging_deployment.py\n```\n\n"
-        "Validation stages:"
+        "The validation script uses `.env` by default"
     ) in content
+    assert "uses `.env` by default for all compose calls" in content
     _assert_fence_closes_to_transition(
         content,
-        block_marker="docker compose -f docker/staging/docker-compose.staging.yml config",
+        block_marker="docker compose --env-file .env -f docker/staging/docker-compose.staging.yml config",
         expected_transition="Reproducibility constraints in this path:",
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="docker compose -f docker/staging/docker-compose.staging.yml config",
+        block_marker="docker compose --env-file .env -f docker/staging/docker-compose.staging.yml config",
         expected_transition="## Exact Smoke Commands",
     )
     _assert_fence_closes_to_transition(
@@ -146,22 +149,22 @@ def test_staging_topology_doc_declares_single_canonical_first_deployment_path() 
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="docker compose -f docker/staging/docker-compose.staging.yml logs -f api",
+        block_marker="docker compose --env-file .env -f docker/staging/docker-compose.staging.yml logs -f api",
         expected_transition="## Exact Restart Validation Commands",
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="docker compose -f docker/staging/docker-compose.staging.yml restart api",
+        block_marker="docker compose --env-file .env -f docker/staging/docker-compose.staging.yml restart api",
         expected_transition="Expected result:",
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="docker compose -f docker/staging/docker-compose.staging.yml restart api",
+        block_marker="docker compose --env-file .env -f docker/staging/docker-compose.staging.yml restart api",
         expected_transition="## Storage and Persistence Expectations",
     )
     _assert_fence_closes_to_transition(
         content,
-        block_marker="docker compose -f docker/staging/docker-compose.staging.yml down --remove-orphans",
+        block_marker="docker compose --env-file .env -f docker/staging/docker-compose.staging.yml down --remove-orphans",
         expected_transition="## Bounded Staging Validation",
     )
     _assert_fence_closes_to_transition(

--- a/tests/test_staging_deployment_validation.py
+++ b/tests/test_staging_deployment_validation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import scripts.validate_staging_deployment as staging_validation
 from scripts.validate_staging_deployment import (
     EXIT_CODE_LOGGING_CHECK_FAILED,
     HealthSnapshot,
@@ -99,6 +100,7 @@ def test_run_staging_validation_includes_logging_and_persistence_checks() -> Non
 
     summary = run_staging_validation(
         compose_file=compose_file,
+        env_file=Path(".env"),
         base_url="http://127.0.0.1:18000",
         timeout_seconds=5,
         keep_running=False,
@@ -111,10 +113,10 @@ def test_run_staging_validation_includes_logging_and_persistence_checks() -> Non
     )
 
     assert commands == [
-        ["docker", "compose", "-f", str(compose_file), "config"],
-        ["docker", "compose", "-f", str(compose_file), "up", "-d", "--build"],
-        ["docker", "compose", "-f", str(compose_file), "restart", "api"],
-        ["docker", "compose", "-f", str(compose_file), "down", "--remove-orphans"],
+        ["docker", "compose", "--env-file", ".env", "-f", str(compose_file), "config"],
+        ["docker", "compose", "--env-file", ".env", "-f", str(compose_file), "up", "-d", "--build"],
+        ["docker", "compose", "--env-file", ".env", "-f", str(compose_file), "restart", "api"],
+        ["docker", "compose", "--env-file", ".env", "-f", str(compose_file), "down", "--remove-orphans"],
     ]
     assert log_checks == [1, 2]
     assert deleted_probes == ["ops-p46-probe"]
@@ -138,6 +140,7 @@ def test_run_staging_validation_raises_logging_exit_code_when_log_validation_fai
     with pytest.raises(StagingValidationError) as exc_info:
         run_staging_validation(
             compose_file=Path("docker/staging/docker-compose.staging.yml"),
+            env_file=Path(".env"),
             base_url="http://127.0.0.1:18000",
             timeout_seconds=5,
             keep_running=True,
@@ -149,3 +152,27 @@ def test_run_staging_validation_raises_logging_exit_code_when_log_validation_fai
         )
 
     assert exc_info.value.exit_code == EXIT_CODE_LOGGING_CHECK_FAILED
+
+
+def test_wait_for_readiness_retries_after_transient_connection_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = {"count": 0}
+
+    def _check_readiness(_base_url: str) -> HealthSnapshot:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise ConnectionResetError(104, "Connection reset by peer")
+        return _healthy_snapshot()
+
+    monkeypatch.setattr(staging_validation, "_check_readiness", _check_readiness)
+    monkeypatch.setattr(staging_validation.time, "sleep", lambda _seconds: None)
+
+    snapshot = staging_validation._wait_for_readiness(
+        base_url="http://127.0.0.1:18000",
+        timeout_seconds=1,
+        poll_interval_seconds=0.0,
+    )
+
+    assert attempts["count"] == 2
+    assert snapshot == _healthy_snapshot()


### PR DESCRIPTION
## Summary
Closes #846.

Aligns bounded staging validation and health semantics with the current bounded runtime readiness contract by:
- making scripts/validate_staging_deployment.py env-file aware for compose execution
- making readiness polling retry-safe against transient startup and restart connection-reset behavior
- aligning /health and /health/engine semantics with bounded readiness while preserving runtime diagnostics
- aligning staging deployment and acceptance docs with the implemented validation path
- adding and updating targeted validation, health, and doc tests

## Changes
- Updated scripts/validate_staging_deployment.py to use the bounded .env contract by default and support explicit env-file override.
- Updated src/api/services/control_plane_service.py and src/api/routers/control_plane_router.py to align bounded readiness and runtime diagnostic semantics.
- Updated staging deployment and acceptance documentation:
  - docs/operations/runtime/staging-server-deployment.md
  - docs/operations/runtime/paper-deployment-acceptance-gate.md
  - docs/operations/api/usage_contract.md
- Added or adjusted targeted tests for:
  - env-aware compose execution
  - transient readiness retry behavior
  - health endpoint semantics
  - staging and acceptance doc alignment

## Validation
- python -m compileall scripts/validate_staging_deployment.py src/api/services/control_plane_service.py tests/test_staging_deployment_validation.py tests/api/test_health_endpoints_api.py tests/health_endpoint.py tests/cilly_trading/engine/test_observability_integration.py
- python -m pytest tests/test_staging_deployment_validation.py tests/test_staging_deployment_docs.py tests/test_paper_deployment_acceptance_gate_docs.py tests/test_ops_p46_trust_boundary_docs.py tests/api/test_health_endpoints_api.py tests/health_endpoint.py tests/cilly_trading/engine/test_observability_integration.py
- python -m pytest

## Scope check
This PR remains bounded to OPS-P46 staging validation and health-contract consistency.
It does not expand into P48, P47, P49, live trading, broker integrations, reverse proxy, auth redesign, or unrelated UI work.