### PR TITLE
OPS-P51 Limit evidence artifacts to canonical persistence writes

### DIFF
--- a/docs/operations/api/usage_contract.md
+++ b/docs/operations/api/usage_contract.md
@@ -180,7 +180,49 @@ For scheduled analysis, the minimum attributable run evidence is the exact reque
 - workflow scope fields (`symbol` and `strategy` for `/analysis/run`; `watchlist_id` and `watchlist_name` for watchlist execution)
 - outcome classification: empty success, populated success, isolated symbol failure, or request-level snapshot failure
 
-The repository's implemented persistence path stores request and result payloads keyed by `analysis_run_id` for both `POST /analysis/run` and `POST /watchlists/{watchlist_id}/execute`. That persisted pair is the canonical server-side evidence for the exact `ingestion_run_id`-bound execution.
+The repository's implemented persistence path stores request and result payloads keyed by `analysis_run_id` for both `POST /analysis/run` and `POST /watchlists/{watchlist_id}/execute`. That persisted pair remains the canonical server-side evidence for the exact `ingestion_run_id`-bound execution.
+
+The repository now also emits one deterministic bounded artifact bundle at canonical persistence time for each completed persisted run under:
+
+- default root: `runs/analysis_run_evidence`
+- overridable root: `CILLY_ANALYSIS_EVIDENCE_DIR`
+- storage bucket: `runs/analysis_run_evidence/<YYYY-Www>/<analysis_run_id>/`
+
+The bounded artifact set is:
+
+- `analysis-run-evidence.json`
+- `analysis-run-evidence.sha256`
+- `operator-review.json`
+- `operator-review.sha256`
+
+`analysis-run-evidence.json` must include:
+
+- exact persisted request payload
+- exact persisted response payload
+- `analysis_run_id`
+- `ingestion_run_id`
+- snapshot metadata when available from `ingestion_runs` (`created_at`, `timeframe`, `source`, `symbols`, `fingerprint_hash`)
+- workflow kind and authoritative endpoint
+- workflow scope fields
+- outcome classification
+- comparison-ready hashes for the request and response payloads
+- one deterministic `comparison_key` derived from the execution inputs excluding the bound `ingestion_run_id`
+- one `review_week` bucket label in `YYYY-Www` form
+
+`operator-review.json` is intentionally bounded to later comparison and weekly review. It must include:
+
+- `analysis_run_id`
+- `ingestion_run_id`
+- `workflow_kind`
+- scope fields
+- outcome classification
+- bounded output counts (`signals`, or `ranked_results` plus `failures`)
+- `comparison_key`
+- `review_week`
+- references to the exact evidence artifact filenames in the same run directory
+
+Weekly review is supported by scanning one ISO-week bucket at a time rather than by introducing a reporting platform or public dashboard.
+Later repository reads may derive the same deterministic evidence metadata, but they must not create, refresh, or rewrite the artifact files.
 
 ## Phase 37 Watchlist Workflow
 

--- a/docs/operations/runtime/snapshot_runtime.md
+++ b/docs/operations/runtime/snapshot_runtime.md
@@ -26,6 +26,35 @@ The runner does not provide:
 - distributed scheduling, leader election, or cross-host coordination
 - general-purpose job orchestration
 
+## Scheduled Evidence Artifacts
+
+Every completed scheduled analysis or watchlist execution reuses the repository's
+canonical `analysis_runs` persistence and emits one bounded review artifact
+bundle at persistence time for the resulting `analysis_run_id`.
+
+Storage is deterministic:
+
+- default root: `runs/analysis_run_evidence`
+- environment override: `CILLY_ANALYSIS_EVIDENCE_DIR`
+- review bucket: `<YYYY-Www>/<analysis_run_id>/`
+
+Each persisted run directory contains exactly:
+
+- `analysis-run-evidence.json`
+- `analysis-run-evidence.sha256`
+- `operator-review.json`
+- `operator-review.sha256`
+
+The evidence artifact captures the exact persisted request/response pair plus
+snapshot metadata from `ingestion_runs` when available. The operator review
+artifact is smaller and bounded to comparison keys, outcome classification, and
+review counts for later weekly review.
+
+This artifact set is operational evidence only. It does not create a reporting
+platform, decision dashboard, or public review surface.
+Later read paths may reconstruct deterministic metadata for those artifacts, but
+they do not emit, refresh, or rewrite the files.
+
 ## Deterministic Snapshot Selection
 
 The in-repository runner does not use an implicit "latest snapshot" shortcut.
@@ -75,6 +104,7 @@ The repository provides:
 - deterministic scheduled analysis execution on the server
 - deterministic snapshot selection rules
 - reuse of existing attributable persistence for analysis and watchlist runs
+- deterministic weekly review buckets and bounded operator review artifacts
 
 The repository does not provide:
 

--- a/src/cilly_trading/repositories/analysis_run_evidence.py
+++ b/src/cilly_trading/repositories/analysis_run_evidence.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from cilly_trading.engine.result_artifact import canonical_json_bytes
+
+DEFAULT_ANALYSIS_EVIDENCE_DIR_ENV_VAR = "CILLY_ANALYSIS_EVIDENCE_DIR"
+DEFAULT_ANALYSIS_EVIDENCE_ROOT = (
+    Path(__file__).resolve().parents[3] / "runs" / "analysis_run_evidence"
+)
+
+EVIDENCE_ARTIFACT_NAME = "analysis-run-evidence.json"
+EVIDENCE_HASH_NAME = "analysis-run-evidence.sha256"
+OPERATOR_REVIEW_ARTIFACT_NAME = "operator-review.json"
+OPERATOR_REVIEW_HASH_NAME = "operator-review.sha256"
+
+
+def resolve_analysis_evidence_root() -> Path:
+    configured_path = os.getenv(DEFAULT_ANALYSIS_EVIDENCE_DIR_ENV_VAR)
+    if configured_path:
+        return Path(configured_path).expanduser()
+    return DEFAULT_ANALYSIS_EVIDENCE_ROOT
+
+
+def _parse_iso8601_utc(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _review_week_label(snapshot_created_at: str | None, persisted_created_at: str) -> str:
+    reference = _parse_iso8601_utc(snapshot_created_at) or _parse_iso8601_utc(persisted_created_at)
+    if reference is None:
+        return "unknown-week"
+    iso_year, iso_week, _ = reference.isocalendar()
+    return f"{iso_year}-W{iso_week:02d}"
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write_artifact(
+    artifact_dir: Path,
+    *,
+    artifact_name: str,
+    hash_name: str,
+    payload: Mapping[str, Any],
+) -> tuple[Path, Path, str]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_bytes = canonical_json_bytes(payload)
+    artifact_path = artifact_dir / artifact_name
+    artifact_path.write_bytes(artifact_bytes)
+
+    artifact_sha256 = _sha256_bytes(artifact_bytes)
+    hash_path = artifact_dir / hash_name
+    hash_path.write_text(f"{artifact_sha256}\n", encoding="utf-8")
+    return artifact_path, hash_path, artifact_sha256
+
+
+def _normalize_symbols(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for item in value:
+        if isinstance(item, str) and item.strip():
+            normalized.append(item.strip())
+    return normalized
+
+
+def _classify_outcome(result_payload: Mapping[str, Any]) -> str:
+    if "ranked_results" in result_payload:
+        failures = result_payload.get("failures")
+        ranked_results = result_payload.get("ranked_results")
+        failure_count = len(failures) if isinstance(failures, list) else 0
+        ranked_count = len(ranked_results) if isinstance(ranked_results, list) else 0
+        if failure_count > 0:
+            return "isolated_symbol_failure"
+        if ranked_count == 0:
+            return "empty_success"
+        return "populated_success"
+
+    signals = result_payload.get("signals")
+    signal_count = len(signals) if isinstance(signals, list) else 0
+    if signal_count == 0:
+        return "empty_success"
+    return "populated_success"
+
+
+def _workflow_details(
+    request_payload: Mapping[str, Any],
+    result_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if request_payload.get("workflow") == "watchlist_execution":
+        watchlist_id = request_payload.get("watchlist_id") or result_payload.get("watchlist_id")
+        watchlist_name = result_payload.get("watchlist_name")
+        comparison_payload = {
+            key: value
+            for key, value in request_payload.items()
+            if key != "ingestion_run_id"
+        }
+        return {
+            "kind": "watchlist_execution",
+            "endpoint": "POST /watchlists/{watchlist_id}/execute",
+            "scope": {
+                "watchlist_id": watchlist_id,
+                "watchlist_name": watchlist_name,
+            },
+            "comparison_payload": comparison_payload,
+            "comparison_scope": f"watchlist:{watchlist_id}",
+        }
+
+    symbol = request_payload.get("symbol") or result_payload.get("symbol")
+    strategy = request_payload.get("strategy") or result_payload.get("strategy")
+    comparison_payload = {
+        key: value
+        for key, value in request_payload.items()
+        if key != "ingestion_run_id"
+    }
+    return {
+        "kind": "single_symbol_analysis",
+        "endpoint": "POST /analysis/run",
+        "scope": {
+            "symbol": symbol,
+            "strategy": strategy,
+        },
+        "comparison_payload": comparison_payload,
+        "comparison_scope": f"analysis:{symbol}:{strategy}",
+    }
+
+
+def _result_counts(result_payload: Mapping[str, Any]) -> dict[str, int]:
+    if "ranked_results" in result_payload:
+        ranked_results = result_payload.get("ranked_results")
+        failures = result_payload.get("failures")
+        return {
+            "ranked_results": len(ranked_results) if isinstance(ranked_results, list) else 0,
+            "failures": len(failures) if isinstance(failures, list) else 0,
+        }
+
+    signals = result_payload.get("signals")
+    return {
+        "signals": len(signals) if isinstance(signals, list) else 0,
+    }
+
+
+def _build_analysis_run_evidence_bundle(
+    *,
+    analysis_run_id: str,
+    ingestion_run_id: str,
+    request_payload: Mapping[str, Any],
+    result_payload: Mapping[str, Any],
+    persisted_created_at: str,
+    ingestion_metadata: Mapping[str, Any] | None,
+    evidence_root: Path | None = None,
+) -> dict[str, Any]:
+    root = evidence_root or resolve_analysis_evidence_root()
+    snapshot_created_at = None
+    snapshot_symbols: list[str] = []
+    if ingestion_metadata is not None:
+        raw_snapshot_created_at = ingestion_metadata.get("created_at")
+        snapshot_created_at = (
+            str(raw_snapshot_created_at) if isinstance(raw_snapshot_created_at, str) else None
+        )
+        snapshot_symbols = _normalize_symbols(ingestion_metadata.get("symbols"))
+
+    review_week = _review_week_label(snapshot_created_at, persisted_created_at)
+    artifact_dir = root / review_week / analysis_run_id
+
+    workflow = _workflow_details(request_payload, result_payload)
+    comparison_payload = workflow["comparison_payload"]
+    comparison_json = json.dumps(
+        comparison_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    request_json = json.dumps(
+        request_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    result_json = json.dumps(
+        result_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+    evidence_payload = {
+        "analysis_run_id": analysis_run_id,
+        "artifact": "analysis_run_evidence",
+        "artifact_version": "1",
+        "comparison": {
+            "comparison_key": hashlib.sha256(comparison_json.encode("utf-8")).hexdigest(),
+            "comparison_payload": comparison_payload,
+            "comparison_scope": workflow["comparison_scope"],
+            "request_sha256": hashlib.sha256(request_json.encode("utf-8")).hexdigest(),
+            "result_sha256": hashlib.sha256(result_json.encode("utf-8")).hexdigest(),
+            "review_week": review_week,
+        },
+        "ingestion_run_id": ingestion_run_id,
+        "persisted_created_at": persisted_created_at,
+        "request": dict(request_payload),
+        "result": dict(result_payload),
+        "snapshot": {
+            "created_at": snapshot_created_at,
+            "fingerprint_hash": (
+                ingestion_metadata.get("fingerprint_hash") if ingestion_metadata else None
+            ),
+            "ingestion_run_id": ingestion_run_id,
+            "source": ingestion_metadata.get("source") if ingestion_metadata else None,
+            "symbols": snapshot_symbols,
+            "symbols_count": len(snapshot_symbols),
+            "timeframe": ingestion_metadata.get("timeframe") if ingestion_metadata else None,
+        },
+        "workflow": {
+            "endpoint": workflow["endpoint"],
+            "kind": workflow["kind"],
+            "outcome_classification": _classify_outcome(result_payload),
+            "scope": workflow["scope"],
+        },
+    }
+    evidence_sha256 = _sha256_bytes(canonical_json_bytes(evidence_payload))
+
+    operator_review_payload = {
+        "analysis_run_id": analysis_run_id,
+        "artifact": "operator_review",
+        "artifact_version": "1",
+        "artifacts": {
+            "evidence_file": EVIDENCE_ARTIFACT_NAME,
+            "evidence_sha256_file": EVIDENCE_HASH_NAME,
+        },
+        "comparison": {
+            "comparison_key": evidence_payload["comparison"]["comparison_key"],
+            "comparison_scope": workflow["comparison_scope"],
+            "request_sha256": evidence_payload["comparison"]["request_sha256"],
+            "result_sha256": evidence_payload["comparison"]["result_sha256"],
+            "review_week": review_week,
+        },
+        "counts": _result_counts(result_payload),
+        "ingestion_run_id": ingestion_run_id,
+        "outcome_classification": evidence_payload["workflow"]["outcome_classification"],
+        "persisted_created_at": persisted_created_at,
+        "scope": workflow["scope"],
+        "snapshot": {
+            "created_at": snapshot_created_at,
+            "fingerprint_hash": (
+                ingestion_metadata.get("fingerprint_hash") if ingestion_metadata else None
+            ),
+            "timeframe": ingestion_metadata.get("timeframe") if ingestion_metadata else None,
+        },
+        "workflow_kind": workflow["kind"],
+    }
+
+    public_metadata = {
+        "artifact_dir": str(artifact_dir),
+        "evidence_file": str(artifact_dir / EVIDENCE_ARTIFACT_NAME),
+        "evidence_sha256": evidence_sha256,
+        "evidence_sha256_file": str(artifact_dir / EVIDENCE_HASH_NAME),
+        "operator_review_file": str(artifact_dir / OPERATOR_REVIEW_ARTIFACT_NAME),
+        "operator_review_sha256": _sha256_bytes(canonical_json_bytes(operator_review_payload)),
+        "operator_review_sha256_file": str(artifact_dir / OPERATOR_REVIEW_HASH_NAME),
+        "review_week": review_week,
+    }
+    return {
+        "metadata": public_metadata,
+        "evidence_payload": evidence_payload,
+        "operator_review_payload": operator_review_payload,
+    }
+
+
+def build_analysis_run_evidence_metadata(
+    *,
+    analysis_run_id: str,
+    ingestion_run_id: str,
+    request_payload: Mapping[str, Any],
+    result_payload: Mapping[str, Any],
+    persisted_created_at: str,
+    ingestion_metadata: Mapping[str, Any] | None,
+    evidence_root: Path | None = None,
+) -> dict[str, Any]:
+    bundle = _build_analysis_run_evidence_bundle(
+        analysis_run_id=analysis_run_id,
+        ingestion_run_id=ingestion_run_id,
+        request_payload=request_payload,
+        result_payload=result_payload,
+        persisted_created_at=persisted_created_at,
+        ingestion_metadata=ingestion_metadata,
+        evidence_root=evidence_root,
+    )
+    return dict(bundle["metadata"])
+
+
+def write_analysis_run_evidence_artifacts(
+    *,
+    analysis_run_id: str,
+    ingestion_run_id: str,
+    request_payload: Mapping[str, Any],
+    result_payload: Mapping[str, Any],
+    persisted_created_at: str,
+    ingestion_metadata: Mapping[str, Any] | None,
+    evidence_root: Path | None = None,
+) -> dict[str, Any]:
+    bundle = _build_analysis_run_evidence_bundle(
+        analysis_run_id=analysis_run_id,
+        ingestion_run_id=ingestion_run_id,
+        request_payload=request_payload,
+        result_payload=result_payload,
+        persisted_created_at=persisted_created_at,
+        ingestion_metadata=ingestion_metadata,
+        evidence_root=evidence_root,
+    )
+    artifact_dir = Path(bundle["metadata"]["artifact_dir"])
+    _write_artifact(
+        artifact_dir,
+        artifact_name=EVIDENCE_ARTIFACT_NAME,
+        hash_name=EVIDENCE_HASH_NAME,
+        payload=bundle["evidence_payload"],
+    )
+    _write_artifact(
+        artifact_dir,
+        artifact_name=OPERATOR_REVIEW_ARTIFACT_NAME,
+        hash_name=OPERATOR_REVIEW_HASH_NAME,
+        payload=bundle["operator_review_payload"],
+    )
+    return dict(bundle["metadata"])

--- a/src/cilly_trading/repositories/analysis_runs_sqlite.py
+++ b/src/cilly_trading/repositories/analysis_runs_sqlite.py
@@ -12,6 +12,10 @@ from typing import Any, Dict, Optional
 
 from cilly_trading.db import DEFAULT_DB_PATH, init_db
 from cilly_trading.engine.core import AnalysisRun
+from cilly_trading.repositories.analysis_run_evidence import (
+    build_analysis_run_evidence_metadata,
+    write_analysis_run_evidence_artifacts,
+)
 
 
 class SqliteAnalysisRunRepository:
@@ -41,6 +45,87 @@ class SqliteAnalysisRunRepository:
             "result": json.loads(row["result_payload"]),
             "created_at": row["created_at"],
         }
+
+    def _load_ingestion_run_metadata(
+        self,
+        *,
+        ingestion_run_id: str,
+    ) -> Dict[str, Any] | None:
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT
+                    ingestion_run_id,
+                    created_at,
+                    source,
+                    symbols_json,
+                    timeframe,
+                    fingerprint_hash
+                FROM ingestion_runs
+                WHERE ingestion_run_id = ?
+                LIMIT 1;
+                """,
+                (ingestion_run_id,),
+            )
+            row = cur.fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            return None
+
+        symbols: list[str] = []
+        try:
+            parsed_symbols = json.loads(row["symbols_json"])
+            if isinstance(parsed_symbols, list):
+                symbols = [str(item) for item in parsed_symbols]
+        except (TypeError, ValueError, json.JSONDecodeError):
+            symbols = []
+
+        return {
+            "ingestion_run_id": row["ingestion_run_id"],
+            "created_at": row["created_at"],
+            "source": row["source"],
+            "symbols": symbols,
+            "timeframe": row["timeframe"],
+            "fingerprint_hash": row["fingerprint_hash"],
+        }
+
+    def _build_evidence_metadata(self, run_data: Dict[str, Any]) -> Dict[str, Any]:
+        return build_analysis_run_evidence_metadata(
+            analysis_run_id=run_data["analysis_run_id"],
+            ingestion_run_id=run_data["ingestion_run_id"],
+            request_payload=run_data["request"],
+            result_payload=run_data["result"],
+            persisted_created_at=run_data["created_at"],
+            ingestion_metadata=self._load_ingestion_run_metadata(
+                ingestion_run_id=run_data["ingestion_run_id"]
+            ),
+        )
+    def _attach_evidence(
+        self,
+        run_data: Dict[str, Any],
+        *,
+        write_artifacts: bool,
+    ) -> Dict[str, Any]:
+        if write_artifacts:
+            evidence = write_analysis_run_evidence_artifacts(
+                analysis_run_id=run_data["analysis_run_id"],
+                ingestion_run_id=run_data["ingestion_run_id"],
+                request_payload=run_data["request"],
+                result_payload=run_data["result"],
+                persisted_created_at=run_data["created_at"],
+                ingestion_metadata=self._load_ingestion_run_metadata(
+                    ingestion_run_id=run_data["ingestion_run_id"]
+                ),
+            )
+        else:
+            evidence = self._build_evidence_metadata(run_data)
+        enriched = dict(run_data)
+        enriched["evidence"] = evidence
+        return enriched
 
     def ingestion_run_exists(self, ingestion_run_id: str) -> bool:
         conn = self._get_connection()
@@ -135,7 +220,7 @@ class SqliteAnalysisRunRepository:
         if row is None:
             return None
 
-        return self._deserialize_run_row(row)
+        return self._attach_evidence(self._deserialize_run_row(row), write_artifacts=False)
 
     def save_run(
         self,
@@ -195,7 +280,7 @@ class SqliteAnalysisRunRepository:
             row = cur.fetchone()
             if row is None:
                 raise RuntimeError("persisted analysis run could not be reloaded")
-            return self._deserialize_run_row(row)
+            return self._attach_evidence(self._deserialize_run_row(row), write_artifacts=True)
         except sqlite3.IntegrityError:
             conn.rollback()
             cur = conn.cursor()
@@ -216,7 +301,7 @@ class SqliteAnalysisRunRepository:
             if row is None:
                 raise
             if row["request_payload"] == serialized_request:
-                return self._deserialize_run_row(row)
+                return self._attach_evidence(self._deserialize_run_row(row), write_artifacts=False)
             raise ValueError("analysis_run_id already exists with different persisted payload")
         finally:
             conn.close()

--- a/tests/test_analysis_run_evidence_persistence.py
+++ b/tests/test_analysis_run_evidence_persistence.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRepository
+
+
+def _insert_ingestion_run(
+    db_path: Path,
+    ingestion_run_id: str,
+    *,
+    created_at: str,
+    symbols: list[str],
+    timeframe: str = "D1",
+    source: str = "test",
+    fingerprint_hash: str | None = None,
+) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO ingestion_runs (
+            ingestion_run_id,
+            created_at,
+            source,
+            symbols_json,
+            timeframe,
+            fingerprint_hash
+        )
+        VALUES (?, ?, ?, ?, ?, ?);
+        """,
+        (
+            ingestion_run_id,
+            created_at,
+            source,
+            json.dumps(symbols),
+            timeframe,
+            fingerprint_hash,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_analysis_run_repository_writes_deterministic_evidence_bundle(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    evidence_dir = tmp_path / "evidence"
+    monkeypatch.setenv("CILLY_ANALYSIS_EVIDENCE_DIR", str(evidence_dir))
+
+    db_path = tmp_path / "analysis.db"
+    repo = SqliteAnalysisRunRepository(db_path=db_path)
+    _insert_ingestion_run(
+        db_path,
+        "ingestion-001",
+        created_at="2026-03-31T06:05:00+00:00",
+        symbols=["AAPL"],
+        fingerprint_hash="snapshot-fingerprint-001",
+    )
+
+    saved = repo.save_run(
+        analysis_run_id="run-001",
+        ingestion_run_id="ingestion-001",
+        request_payload={
+            "ingestion_run_id": "ingestion-001",
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "market_type": "stock",
+            "lookback_days": 200,
+        },
+        result_payload={
+            "analysis_run_id": "run-001",
+            "ingestion_run_id": "ingestion-001",
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "signals": [],
+        },
+    )
+
+    evidence = saved["evidence"]
+    assert evidence["review_week"] == "2026-W14"
+
+    artifact_dir = Path(evidence["artifact_dir"])
+    assert artifact_dir == evidence_dir / "2026-W14" / "run-001"
+
+    evidence_payload = json.loads(Path(evidence["evidence_file"]).read_text(encoding="utf-8"))
+    assert evidence_payload["artifact"] == "analysis_run_evidence"
+    assert evidence_payload["workflow"]["endpoint"] == "POST /analysis/run"
+    assert evidence_payload["workflow"]["kind"] == "single_symbol_analysis"
+    assert evidence_payload["workflow"]["outcome_classification"] == "empty_success"
+    assert evidence_payload["workflow"]["scope"] == {
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+    }
+    assert evidence_payload["snapshot"]["ingestion_run_id"] == "ingestion-001"
+    assert evidence_payload["snapshot"]["fingerprint_hash"] == "snapshot-fingerprint-001"
+    assert evidence_payload["snapshot"]["symbols"] == ["AAPL"]
+    assert evidence_payload["comparison"]["comparison_scope"] == "analysis:AAPL:RSI2"
+    assert evidence_payload["comparison"]["request_sha256"]
+    assert evidence_payload["comparison"]["result_sha256"]
+
+    operator_review_payload = json.loads(
+        Path(evidence["operator_review_file"]).read_text(encoding="utf-8")
+    )
+    assert operator_review_payload["artifact"] == "operator_review"
+    assert operator_review_payload["workflow_kind"] == "single_symbol_analysis"
+    assert operator_review_payload["outcome_classification"] == "empty_success"
+    assert operator_review_payload["counts"] == {"signals": 0}
+    assert operator_review_payload["comparison"]["review_week"] == "2026-W14"
+
+    assert Path(evidence["evidence_sha256_file"]).read_text(encoding="utf-8").strip()
+    assert Path(evidence["operator_review_sha256_file"]).read_text(encoding="utf-8").strip()
+
+
+def test_analysis_run_repository_duplicate_save_reuses_same_evidence_artifacts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    evidence_dir = tmp_path / "evidence"
+    monkeypatch.setenv("CILLY_ANALYSIS_EVIDENCE_DIR", str(evidence_dir))
+
+    db_path = tmp_path / "analysis.db"
+    repo = SqliteAnalysisRunRepository(db_path=db_path)
+    _insert_ingestion_run(
+        db_path,
+        "ingestion-001",
+        created_at="2026-03-31T06:05:00+00:00",
+        symbols=["AAPL", "MSFT"],
+        fingerprint_hash="snapshot-fingerprint-001",
+    )
+
+    request_payload = {
+        "workflow": "watchlist_execution",
+        "ingestion_run_id": "ingestion-001",
+        "watchlist_id": "core-tech",
+        "symbols": ["AAPL", "MSFT"],
+        "strategies": ["RSI2", "TURTLE"],
+        "market_type": "stock",
+        "lookback_days": 200,
+        "min_score": "30",
+    }
+    result_payload = {
+        "analysis_run_id": "run-002",
+        "ingestion_run_id": "ingestion-001",
+        "watchlist_id": "core-tech",
+        "watchlist_name": "Core Tech",
+        "market_type": "stock",
+        "ranked_results": [
+            {
+                "rank": 1,
+                "symbol": "AAPL",
+                "score": 88.0,
+                "signal_strength": 0.9,
+                "setups": [],
+            }
+        ],
+        "failures": [
+            {
+                "symbol": "MSFT",
+                "code": "snapshot_data_invalid",
+                "detail": "snapshot data unavailable or invalid for symbol",
+            }
+        ],
+    }
+
+    first = repo.save_run(
+        analysis_run_id="run-002",
+        ingestion_run_id="ingestion-001",
+        request_payload=request_payload,
+        result_payload=result_payload,
+    )
+    second = repo.save_run(
+        analysis_run_id="run-002",
+        ingestion_run_id="ingestion-001",
+        request_payload=request_payload,
+        result_payload=result_payload,
+    )
+
+    assert first["evidence"] == second["evidence"]
+    evidence_path = Path(first["evidence"]["evidence_file"])
+    review_path = Path(first["evidence"]["operator_review_file"])
+    evidence_hash_path = Path(first["evidence"]["evidence_sha256_file"])
+    review_hash_path = Path(first["evidence"]["operator_review_sha256_file"])
+
+    first_evidence_mtime = evidence_path.stat().st_mtime_ns
+    first_review_mtime = review_path.stat().st_mtime_ns
+    first_evidence_hash_mtime = evidence_hash_path.stat().st_mtime_ns
+    first_review_hash_mtime = review_hash_path.stat().st_mtime_ns
+    first_evidence_bytes = evidence_path.read_bytes()
+    first_review_bytes = review_path.read_bytes()
+    first_evidence_hash_bytes = evidence_hash_path.read_bytes()
+    first_review_hash_bytes = review_hash_path.read_bytes()
+
+    reloaded_once = repo.get_run("run-002")
+    reloaded_twice = repo.get_run("run-002")
+
+    assert reloaded_once is not None
+    assert reloaded_twice is not None
+    assert reloaded_once["evidence"] == first["evidence"]
+    assert reloaded_twice["evidence"] == first["evidence"]
+    assert evidence_path.stat().st_mtime_ns == first_evidence_mtime
+    assert review_path.stat().st_mtime_ns == first_review_mtime
+    assert evidence_hash_path.stat().st_mtime_ns == first_evidence_hash_mtime
+    assert review_hash_path.stat().st_mtime_ns == first_review_hash_mtime
+    assert evidence_path.read_bytes() == first_evidence_bytes
+    assert review_path.read_bytes() == first_review_bytes
+    assert evidence_hash_path.read_bytes() == first_evidence_hash_bytes
+    assert review_hash_path.read_bytes() == first_review_hash_bytes
+
+    evidence_payload = json.loads(
+        Path(first["evidence"]["evidence_file"]).read_text(encoding="utf-8")
+    )
+    operator_review_payload = json.loads(
+        Path(first["evidence"]["operator_review_file"]).read_text(encoding="utf-8")
+    )
+
+    assert evidence_payload["workflow"]["kind"] == "watchlist_execution"
+    assert evidence_payload["workflow"]["outcome_classification"] == "isolated_symbol_failure"
+    assert evidence_payload["workflow"]["scope"] == {
+        "watchlist_id": "core-tech",
+        "watchlist_name": "Core Tech",
+    }
+    assert evidence_payload["comparison"]["comparison_scope"] == "watchlist:core-tech"
+
+    assert operator_review_payload["workflow_kind"] == "watchlist_execution"
+    assert operator_review_payload["outcome_classification"] == "isolated_symbol_failure"
+    assert operator_review_payload["counts"] == {
+        "ranked_results": 1,
+        "failures": 1,
+    }


### PR DESCRIPTION
﻿Closes #860

## What changed
- make analysis run evidence metadata derivation pure for read paths
- limit filesystem artifact emission to the canonical save_run persistence path
- prevent duplicate-save and get_run reloads from rewriting evidence artifacts
- add regression coverage that repeated reads preserve artifact mtimes, contents, and hashes
- update scheduled-analysis docs to state artifacts are emitted at persistence time only

## Validation
- python -m pytest tests\test_analysis_run_evidence_persistence.py tests\test_scheduled_analysis_runner.py tests\test_ops_p51_scheduled_analysis_contract_docs.py
