### PR TITLE
OPS-P54: Bound runtime freshness to healthy running state in staging

### DIFF
--- a/src/cilly_trading/engine/runtime_introspection.py
+++ b/src/cilly_trading/engine/runtime_introspection.py
@@ -50,6 +50,7 @@ def get_runtime_introspection_payload() -> RuntimeIntrospectionPayload:
 
     runtime_controller = get_runtime_controller()
     started_at_iso = _RUNTIME_INTROSPECTION_STARTED_AT.isoformat()
+    updated_at_iso = _runtime_updated_at().isoformat()
 
     return {
         "schema_version": _RUNTIME_INTROSPECTION_SCHEMA_VERSION,
@@ -57,7 +58,7 @@ def get_runtime_introspection_payload() -> RuntimeIntrospectionPayload:
         "mode": runtime_controller.state,
         "timestamps": {
             "started_at": started_at_iso,
-            "updated_at": started_at_iso,
+            "updated_at": updated_at_iso,
         },
         "ownership": {
             "owner_tag": _RUNTIME_OWNERSHIP_TAG,
@@ -72,6 +73,10 @@ def get_runtime_introspection_payload() -> RuntimeIntrospectionPayload:
             for metadata in _RUNTIME_OBSERVABILITY_REGISTRY.list_extensions_metadata()
         ],
     }
+
+
+def _runtime_updated_at() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 def get_runtime_observability_registry() -> RuntimeObservabilityRegistry:

--- a/tests/health_endpoint.py
+++ b/tests/health_endpoint.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
 
 import api.main as api_main
+import cilly_trading.engine.runtime_introspection as runtime_introspection
 
 READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
 
@@ -142,6 +143,35 @@ def test_health_endpoint_reports_unavailable_boundary(monkeypatch) -> None:
     assert response.json()["reason"] == "bounded_runtime_ready"
     assert response.json()["runtime_status"] == "unavailable"
     assert response.json()["runtime_reason"] == "runtime_running_timeout"
+
+
+def test_health_endpoints_keep_running_runtime_fresh_during_idle_longrun(monkeypatch) -> None:
+    class _RuntimeStateStub:
+        state = "running"
+
+    fixed_now = datetime(2026, 1, 1, 14, 0, 0, tzinfo=timezone.utc)
+    started_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "_health_now", lambda: fixed_now)
+    monkeypatch.setattr(runtime_introspection, "get_runtime_controller", lambda: _RuntimeStateStub())
+    monkeypatch.setattr(runtime_introspection, "_RUNTIME_INTROSPECTION_STARTED_AT", started_at)
+    monkeypatch.setattr(
+        runtime_introspection,
+        "_runtime_updated_at",
+        lambda: fixed_now - timedelta(seconds=2),
+    )
+
+    with TestClient(api_main.app) as client:
+        health = client.get("/health", headers=READ_ONLY_HEADERS)
+        engine = client.get("/health/engine", headers=READ_ONLY_HEADERS)
+
+    assert health.status_code == 200
+    assert health.json()["runtime_status"] == "healthy"
+    assert health.json()["runtime_reason"] == "runtime_running_fresh"
+    assert engine.status_code == 200
+    assert engine.json()["runtime_status"] == "healthy"
+    assert engine.json()["runtime_reason"] == "runtime_running_fresh"
 
 
 def test_ui_endpoint_serves_html(monkeypatch) -> None:

--- a/tests/test_runtime_introspection.py
+++ b/tests/test_runtime_introspection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from fastapi.testclient import TestClient
 import api.main as api_main
 from cilly_trading.engine.observability_extensions import RuntimeObservabilityRegistry
@@ -23,6 +25,7 @@ def _build_registry_for_tests() -> RuntimeObservabilityRegistry:
 
 def test_runtime_introspection_contract_is_explicit_and_stable(monkeypatch) -> None:
     runtime = _RuntimeStateStub("running")
+    fixed_updated_at = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
 
     def _start() -> str:
         return "running"
@@ -34,6 +37,7 @@ def test_runtime_introspection_contract_is_explicit_and_stable(monkeypatch) -> N
     monkeypatch.setattr(api_main, "get_runtime_controller", _runtime)
     monkeypatch.setattr(runtime_introspection, "get_runtime_controller", _runtime)
     monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
+    monkeypatch.setattr(runtime_introspection, "_runtime_updated_at", lambda: fixed_updated_at)
 
     with TestClient(api_main.app) as client:
         first = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
@@ -50,7 +54,10 @@ def test_runtime_introspection_contract_is_explicit_and_stable(monkeypatch) -> N
         "schema_version": "v1",
         "runtime_id": first_payload["runtime_id"],
         "mode": "running",
-        "timestamps": first_payload["timestamps"],
+        "timestamps": {
+            "started_at": first_payload["timestamps"]["started_at"],
+            "updated_at": "2026-01-01T12:00:05+00:00",
+        },
         "ownership": {"owner_tag": "engine"},
         "extensions": [
             {
@@ -78,6 +85,7 @@ def test_runtime_introspection_contract_is_explicit_and_stable(monkeypatch) -> N
 
 def test_runtime_introspection_triggers_no_persistence_writes(monkeypatch) -> None:
     runtime = _RuntimeStateStub("running")
+    fixed_updated_at = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
 
     def _start() -> str:
         return "running"
@@ -97,6 +105,7 @@ def test_runtime_introspection_triggers_no_persistence_writes(monkeypatch) -> No
     monkeypatch.setattr(api_main.analysis_run_repo, "save_run", _unexpected_save_run)
     monkeypatch.setattr(api_main.signal_repo, "save_signals", _unexpected_save_signals)
     monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
+    monkeypatch.setattr(runtime_introspection, "_runtime_updated_at", lambda: fixed_updated_at)
 
     with TestClient(api_main.app) as client:
         response = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS)
@@ -106,11 +115,13 @@ def test_runtime_introspection_triggers_no_persistence_writes(monkeypatch) -> No
 
 def test_runtime_introspection_rejects_missing_and_invalid_roles(monkeypatch) -> None:
     runtime = _RuntimeStateStub("running")
+    fixed_updated_at = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
 
     monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
     monkeypatch.setattr(api_main, "get_runtime_controller", lambda: runtime)
     monkeypatch.setattr(runtime_introspection, "get_runtime_controller", lambda: runtime)
     monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
+    monkeypatch.setattr(runtime_introspection, "_runtime_updated_at", lambda: fixed_updated_at)
 
     with TestClient(api_main.app) as client:
         missing = client.get("/runtime/introspection")
@@ -163,13 +174,39 @@ def test_system_state_uses_internal_helper_not_runtime_route_handler(monkeypatch
 
 def test_runtime_introspection_is_deterministic_across_repeated_calls(monkeypatch) -> None:
     runtime = _RuntimeStateStub("running")
+    fixed_updated_at = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
 
     monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
     monkeypatch.setattr(api_main, "get_runtime_controller", lambda: runtime)
     monkeypatch.setattr(runtime_introspection, "get_runtime_controller", lambda: runtime)
     monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
+    monkeypatch.setattr(runtime_introspection, "_runtime_updated_at", lambda: fixed_updated_at)
 
     with TestClient(api_main.app) as client:
         payloads = [client.get("/runtime/introspection", headers=READ_ONLY_HEADERS).json() for _ in range(5)]
 
     assert payloads[0] == payloads[1] == payloads[2] == payloads[3] == payloads[4]
+
+
+def test_runtime_introspection_advances_updated_at_across_calls(monkeypatch) -> None:
+    runtime = _RuntimeStateStub("running")
+    updated_values = iter(
+        [
+            datetime(2026, 1, 1, 12, 0, 1, tzinfo=timezone.utc),
+            datetime(2026, 1, 1, 12, 0, 2, tzinfo=timezone.utc),
+        ]
+    )
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "get_runtime_controller", lambda: runtime)
+    monkeypatch.setattr(runtime_introspection, "get_runtime_controller", lambda: runtime)
+    monkeypatch.setattr(runtime_introspection, "_RUNTIME_OBSERVABILITY_REGISTRY", _build_registry_for_tests())
+    monkeypatch.setattr(runtime_introspection, "_runtime_updated_at", lambda: next(updated_values))
+
+    with TestClient(api_main.app) as client:
+        first = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS).json()
+        second = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS).json()
+
+    assert first["timestamps"]["started_at"] == second["timestamps"]["started_at"]
+    assert first["timestamps"]["updated_at"] == "2026-01-01T12:00:01+00:00"
+    assert second["timestamps"]["updated_at"] == "2026-01-01T12:00:02+00:00"

--- a/tests/test_runtime_introspection_snapshot.py
+++ b/tests/test_runtime_introspection_snapshot.py
@@ -37,6 +37,11 @@ def test_runtime_introspection_snapshot_with_extensions(monkeypatch) -> None:
         "_RUNTIME_INTROSPECTION_STARTED_AT",
         datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc),
     )
+    monkeypatch.setattr(
+        runtime_introspection,
+        "_runtime_updated_at",
+        lambda: datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc),
+    )
 
     with TestClient(api_main.app) as client:
         payload = client.get("/runtime/introspection", headers=READ_ONLY_HEADERS).json()


### PR DESCRIPTION
## Summary
- Fix runtime introspection timestamp behavior so 	imestamps.updated_at advances at read time instead of staying pinned to process start.
- Keep health freshness evaluation intact while preventing false untime_running_timeout for healthy idle running runtime.
- Add regression coverage for long-running idle /health and /health/engine behavior.
- Adjust runtime introspection tests/snapshot setup for deterministic expectations with the new updated-at heartbeat.

## Scope
- Minimal fix in runtime introspection timestamp generation
- Targeted runtime/health tests only
- No architecture change, no broker/live-trading scope expansion

Closes #877