### PR TITLE
OPS-P55: Freeze bounded staging validation progress and remaining paper evidence steps in runtime docs

### DIFF
--- a/docs/operations/runtime/paper-deployment-operator-checklist.md
+++ b/docs/operations/runtime/paper-deployment-operator-checklist.md
@@ -13,6 +13,29 @@ on 2026-04-03, see:
 This note is informational only and does not replace a fully completed
 checklist.
 
+## OPS-P55 Freeze Snapshot (2026-04-03)
+The current runtime/operator documentation freeze separates the boundary status
+as follows:
+
+Already validated:
+- bounded staging deployment
+- localhost-only binding (`127.0.0.1:18000:8000`)
+- health readiness (`/health/engine`, `/health/data`, `/health/guards`)
+- read-only paper inspection validation (`/paper/workflow` with
+  `validation.ok: true`, `/paper/reconciliation` with `ok: true`,
+  `mismatches: 0`)
+- consistent empty-state inspection across `/trading-core/*` and `/paper/*`
+- persisted staging DB file at `/srv/cilly/staging/db/cilly_trading.db`
+
+Still open before final `paper-install-ready` acceptance:
+- `python3 scripts/run_post_run_reconciliation.py`
+- `python3 scripts/generate_weekly_review.py`
+- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
+- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+
+Until these four commands are executed and linked with concrete evidence
+references, this checklist remains `NOT ACCEPTED: REMAIN STAGING`.
+
 ## Required Evidence Output Names
 Use these exact evidence identifiers in the checklist references:
 - `EVIDENCE_STAGING_VALIDATION_LOG`
@@ -64,10 +87,10 @@ Use these exact evidence identifiers in the checklist references:
 
 The following scripts automate evidence capture for Section E items:
 
-- **Post-run reconciliation**: `python scripts/run_post_run_reconciliation.py` (supports E1, E4)
-- **Weekly review artifacts (R1–R7)**: `python scripts/generate_weekly_review.py` (supports E2)
-- **Pre-restart baseline**: `python scripts/capture_restart_evidence.py --phase pre-restart` (supports E3)
-- **Post-restart verification**: `python scripts/capture_restart_evidence.py --phase post-restart` (supports E4)
+- **Post-run reconciliation**: `python3 scripts/run_post_run_reconciliation.py` (supports E1, E4)
+- **Weekly review artifacts (R1–R7)**: `python3 scripts/generate_weekly_review.py` (supports E2)
+- **Pre-restart baseline**: `python3 scripts/capture_restart_evidence.py --phase pre-restart` (supports E3)
+- **Post-restart verification**: `python3 scripts/capture_restart_evidence.py --phase post-restart` (supports E4)
 
 Evidence output directories: `runs/reconciliation/`, `runs/weekly-review/`, `runs/restart-evidence/`
 
@@ -89,3 +112,4 @@ Final decision (`ACCEPTED: PAPER_INSTALL_READY` or `NOT ACCEPTED: REMAIN STAGING
 Operator name:
 
 Date (UTC):
+

--- a/docs/operations/runtime/phase-44-paper-operator-workflow.md
+++ b/docs/operations/runtime/phase-44-paper-operator-workflow.md
@@ -178,6 +178,26 @@ All automation scripts use the same canonical state authority and derivation fun
 
 The full automation contract is defined in `docs/operations/runtime/p53-automated-review-operations.md`.
 
+## OPS-P55 Freeze Status (2026-04-03)
+The runtime/operator documentation freeze separates status into validated
+bounded read-only workflow checks vs pending final evidence automation.
+
+Validated in bounded read-only scope:
+- `GET /paper/workflow` returned `validation.ok: true`
+- `GET /paper/reconciliation` returned `ok: true`, `summary.mismatches: 0`
+- `/paper/*` and `/trading-core/*` inspection surfaces were consistent in empty
+  initial state
+- bounded staging deployment and localhost-only access posture were validated
+
+Still open before any `paper-install-ready` claim:
+- `python3 scripts/run_post_run_reconciliation.py`
+- `python3 scripts/generate_weekly_review.py`
+- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
+- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+
+This freeze note adds documentation clarity only and does not change runtime or
+API behavior.
+
 ## Session Progress Note (2026-04-03)
 
 For the bounded runtime status verified on 2026-04-03, including:

--- a/docs/operations/runtime/staging-paper-progress-2026-04-03.md
+++ b/docs/operations/runtime/staging-paper-progress-2026-04-03.md
@@ -6,6 +6,30 @@ Capture the bounded, evidence-based status verified on 2026-04-03.
 This note documents observed staging and paper inspection status only. It does
 not claim live trading, broker readiness, or production readiness.
 
+## OPS-P55 Frozen Boundary Snapshot
+Status is frozen as documented evidence from the 2026-04-03 server session.
+
+### A) Bounded staging deployment (validated)
+- localhost-only exposure validated: `127.0.0.1:18000:8000`
+- `.env` and required host directories validated
+- `python3 scripts/validate_staging_deployment.py` validated
+- `/health/engine`, `/health/data`, `/health/guards` validated as ready
+- staging DB file validated at `/srv/cilly/staging/db/cilly_trading.db`
+
+### B) Read-only paper inspection (validated)
+- `/paper/workflow` validated with `validation.ok: true`
+- `/paper/reconciliation` validated with `ok: true`, `mismatches: 0`
+- `/paper/*` and `/trading-core/*` surfaces validated as consistent in empty
+  initial state
+
+### C) Final paper-install-ready evidence (open)
+- `python3 scripts/run_post_run_reconciliation.py`
+- `python3 scripts/generate_weekly_review.py`
+- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
+- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+
+This freeze note is documentation-only and does not change runtime/API logic.
+
 ## Verified Today
 
 ### 1) Server Foundation

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -218,6 +218,33 @@ Status interpretation:
 Required evidence output name used by the acceptance gate:
 - `EVIDENCE_STAGING_VALIDATION_LOG` (captures this runbook's validation output).
 
+## OPS-P55 Frozen Validation Status (2026-04-03)
+This runtime documentation freeze records bounded staging and read-only paper
+inspection status as verified on 2026-04-03.
+
+Validated in scope:
+- bounded staging deployment validated
+- localhost-only exposure validated (`127.0.0.1:18000:8000`)
+- `.env` and required host staging directories validated
+- `python3 scripts/validate_staging_deployment.py` validated
+- `/health/engine`, `/health/data`, `/health/guards` validated with ready state
+- database file validated at `/srv/cilly/staging/db/cilly_trading.db`
+
+Validated as read-only paper inspection (not paper-install-ready):
+- `/paper/workflow` validated with `validation.ok: true`
+- `/paper/reconciliation` validated with `ok: true`, `mismatches: 0`
+- trading-core and `/paper/*` inspection surfaces validated as consistent in
+  empty initial state
+
+Still open before any `paper-install-ready` claim:
+- `python3 scripts/run_post_run_reconciliation.py`
+- `python3 scripts/generate_weekly_review.py`
+- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
+- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+
+This freeze note is documentation-only and introduces no runtime/API behavior
+change.
+
 ## Session Progress Note (2026-04-03)
 For the bounded server session progress verified on 2026-04-03, including
 localhost binding correction, staging validation markers, and open follow-up


### PR DESCRIPTION
Closes #878

## Summary
- Freeze-documented the verified bounded staging state in runtime/operator docs.
- Added explicit status split between:
  - bounded staging validated
  - read-only paper inspection validated
  - final paper-install-ready evidence still open
- Listed remaining open P53 evidence automation commands explicitly.

## Scope
- Documentation-only updates under docs/operations/runtime/.
- No runtime/API logic changes.

## Validation
- No runtime tests executed.
- Docs-only change.
- Content checked via diff/review of touched runtime documentation files.