### PR TITLE
OPS-P56: Make P53 operator evidence scripts executable in bounded staging runtime

### DIFF
--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -10,6 +10,7 @@ RUN python -m pip install -U pip uv
 
 COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
+COPY scripts ./scripts
 
 RUN uv sync --frozen --no-dev
 RUN mkdir -p /data/db /data/artifacts /data/logs /data/runtime-state /app/runs/phase6

--- a/docs/api/paper_inspection.md
+++ b/docs/api/paper_inspection.md
@@ -176,9 +176,9 @@ This workflow is read-only and review-oriented. It does not introduce mutation e
 
 Post-run reconciliation, weekly review artifact generation, and restart/recovery evidence capture are automated by the P53 scripts:
 
-- `python scripts/run_post_run_reconciliation.py` — automated post-run reconciliation with evidence output.
-- `python scripts/generate_weekly_review.py` — deterministic R1–R7 weekly review bundle generation.
-- `python scripts/capture_restart_evidence.py` — restart/recovery evidence with optional baseline comparison.
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation` - automated post-run reconciliation with evidence output.
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review` - deterministic R1-R7 weekly review bundle generation.
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence` and `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json` - restart/recovery evidence with baseline comparison.
 
 All automation uses the same canonical state authority and derivation functions as the endpoints documented above. The full automation contract is in `docs/operations/runtime/p53-automated-review-operations.md`.
 

--- a/docs/operations/runtime/p53-automated-review-operations.md
+++ b/docs/operations/runtime/p53-automated-review-operations.md
@@ -22,17 +22,34 @@ Out of scope:
 
 ## Automated Scripts
 
+### Authoritative Bounded Staging Execution Path
+
+For bounded staging server operation, the authoritative execution path is to run
+the scripts inside the staging runtime container:
+
+`docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api ...`
+
+Use runtime paths:
+- DB path: `/data/db/cilly_trading.db`
+- Evidence output base: `/data/artifacts`
+
+This avoids host Python dependency drift and uses the packaged runtime
+dependencies and packaged script files at `/app/scripts`.
+
 ### Post-Run Reconciliation
 
 ```bash
-python scripts/run_post_run_reconciliation.py
-python scripts/run_post_run_reconciliation.py --db-path /path/to/cilly_trading.db
-python scripts/run_post_run_reconciliation.py --evidence-dir runs/reconciliation
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api \
+  python /app/scripts/run_post_run_reconciliation.py \
+  --db-path /data/db/cilly_trading.db \
+  --evidence-dir /data/artifacts/reconciliation
 ```
 
 Runs after each execution cycle. Loads canonical entities from the SQLite execution repository, derives positions and account state, validates cross-entity and account-equation consistency, and writes a timestamped evidence JSON file.
 
-Evidence output directory: `runs/reconciliation/`
+Evidence output directory (bounded staging runtime): `/data/artifacts/reconciliation`
+
+Local repository default output (non-staging usage): `runs/reconciliation/`
 
 Evidence markers:
 - `RECONCILIATION:PASS` — zero mismatches, reconciliation clean
@@ -47,14 +64,17 @@ Exit codes:
 ### Weekly Review Artifact Generation
 
 ```bash
-python scripts/generate_weekly_review.py
-python scripts/generate_weekly_review.py --db-path /path/to/cilly_trading.db
-python scripts/generate_weekly_review.py --evidence-dir runs/weekly-review
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api \
+  python /app/scripts/generate_weekly_review.py \
+  --db-path /data/db/cilly_trading.db \
+  --evidence-dir /data/artifacts/weekly-review
 ```
 
 Produces a deterministic weekly review evidence bundle containing the R1–R7 artifacts defined in the Phase 44 operator workflow. Each artifact is captured by reading canonical state and applying the same derivation logic used by the paper inspection API.
 
-Evidence output directory: `runs/weekly-review/`
+Evidence output directory (bounded staging runtime): `/data/artifacts/weekly-review`
+
+Local repository default output (non-staging usage): `runs/weekly-review/`
 
 Evidence markers:
 - `WEEKLY_REVIEW:PASS` — all R1–R7 artifacts valid
@@ -70,18 +90,26 @@ Exit codes:
 
 ```bash
 # Pre-restart baseline
-python scripts/capture_restart_evidence.py --phase pre-restart
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api \
+  python /app/scripts/capture_restart_evidence.py \
+  --phase pre-restart \
+  --db-path /data/db/cilly_trading.db \
+  --evidence-dir /data/artifacts/restart-evidence
 
 # Post-restart verification
-python scripts/capture_restart_evidence.py --phase post-restart
-
-# Post-restart with baseline comparison
-python scripts/capture_restart_evidence.py --phase post-restart --baseline runs/restart-evidence/pre-restart-pass-*.json
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api \
+  python /app/scripts/capture_restart_evidence.py \
+  --phase post-restart \
+  --db-path /data/db/cilly_trading.db \
+  --evidence-dir /data/artifacts/restart-evidence \
+  --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json
 ```
 
 Captures a deterministic evidence snapshot before or after a process restart. When a baseline file is provided, compares entity counts and reconciliation state to verify restart integrity.
 
-Evidence output directory: `runs/restart-evidence/`
+Evidence output directory (bounded staging runtime): `/data/artifacts/restart-evidence`
+
+Local repository default output (non-staging usage): `runs/restart-evidence/`
 
 Evidence markers:
 - `RESTART_EVIDENCE:PRE_RESTART:PASS` — pre-restart baseline captured clean

--- a/docs/operations/runtime/paper-deployment-operator-checklist.md
+++ b/docs/operations/runtime/paper-deployment-operator-checklist.md
@@ -28,10 +28,10 @@ Already validated:
 - persisted staging DB file at `/srv/cilly/staging/db/cilly_trading.db`
 
 Still open before final `paper-install-ready` acceptance:
-- `python3 scripts/run_post_run_reconciliation.py`
-- `python3 scripts/generate_weekly_review.py`
-- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
-- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
 
 Until these four commands are executed and linked with concrete evidence
 references, this checklist remains `NOT ACCEPTED: REMAIN STAGING`.
@@ -87,12 +87,12 @@ Use these exact evidence identifiers in the checklist references:
 
 The following scripts automate evidence capture for Section E items:
 
-- **Post-run reconciliation**: `python3 scripts/run_post_run_reconciliation.py` (supports E1, E4)
-- **Weekly review artifacts (R1–R7)**: `python3 scripts/generate_weekly_review.py` (supports E2)
-- **Pre-restart baseline**: `python3 scripts/capture_restart_evidence.py --phase pre-restart` (supports E3)
-- **Post-restart verification**: `python3 scripts/capture_restart_evidence.py --phase post-restart` (supports E4)
+- **Post-run reconciliation**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation` (supports E1, E4)
+- **Weekly review artifacts (R1-R7)**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review` (supports E2)
+- **Pre-restart baseline**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence` (supports E3)
+- **Post-restart verification**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json` (supports E4)
 
-Evidence output directories: `runs/reconciliation/`, `runs/weekly-review/`, `runs/restart-evidence/`
+Evidence output directories in bounded staging: `/data/artifacts/reconciliation`, `/data/artifacts/weekly-review`, `/data/artifacts/restart-evidence`
 
 See `docs/operations/runtime/p53-automated-review-operations.md` for the full automation contract.
 
@@ -112,4 +112,3 @@ Final decision (`ACCEPTED: PAPER_INSTALL_READY` or `NOT ACCEPTED: REMAIN STAGING
 Operator name:
 
 Date (UTC):
-

--- a/docs/operations/runtime/phase-44-paper-operator-workflow.md
+++ b/docs/operations/runtime/phase-44-paper-operator-workflow.md
@@ -170,9 +170,9 @@ The sole source of truth for paper execution state is `SqliteCanonicalExecutionR
 
 The manual operator steps defined above are automated by the following scripts introduced in P53:
 
-- **Post-run reconciliation**: `python scripts/run_post_run_reconciliation.py` — runs after each execution cycle to validate reconciliation automatically.
-- **Weekly review artifacts (R1–R7)**: `python scripts/generate_weekly_review.py` — produces deterministic weekly review evidence bundles.
-- **Restart/recovery evidence**: `python scripts/capture_restart_evidence.py` — captures pre-restart baselines and post-restart verification evidence.
+- **Post-run reconciliation**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation` - runs after each execution cycle to validate reconciliation automatically.
+- **Weekly review artifacts (R1-R7)**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review` - produces deterministic weekly review evidence bundles.
+- **Restart/recovery evidence**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence` and `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json` - captures pre-restart baselines and post-restart verification evidence.
 
 All automation scripts use the same canonical state authority and derivation functions as the paper inspection API. Evidence files are written to `runs/` subdirectories (excluded from version control).
 
@@ -190,10 +190,10 @@ Validated in bounded read-only scope:
 - bounded staging deployment and localhost-only access posture were validated
 
 Still open before any `paper-install-ready` claim:
-- `python3 scripts/run_post_run_reconciliation.py`
-- `python3 scripts/generate_weekly_review.py`
-- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
-- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
 
 This freeze note adds documentation clarity only and does not change runtime or
 API behavior.

--- a/docs/operations/runtime/staging-paper-progress-2026-04-03.md
+++ b/docs/operations/runtime/staging-paper-progress-2026-04-03.md
@@ -23,10 +23,10 @@ Status is frozen as documented evidence from the 2026-04-03 server session.
   initial state
 
 ### C) Final paper-install-ready evidence (open)
-- `python3 scripts/run_post_run_reconciliation.py`
-- `python3 scripts/generate_weekly_review.py`
-- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
-- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
 
 This freeze note is documentation-only and does not change runtime/API logic.
 
@@ -102,12 +102,11 @@ This freeze note is documentation-only and does not change runtime/API logic.
 - final paper-install-ready evidence capture still pending
 
 ## Not Completed Yet
-The following P53 evidence automation scripts were not fully executed in this
-session:
-- `python scripts/run_post_run_reconciliation.py`
-- `python scripts/generate_weekly_review.py`
-- `python scripts/capture_restart_evidence.py --phase pre-restart`
-- `python scripts/capture_restart_evidence.py --phase post-restart`
+The following bounded staging P53 evidence automation commands were not fully executed in this session:
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
 
 Therefore, the formal full paper-install-ready checklist remains incomplete as
 of 2026-04-03.

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -202,6 +202,20 @@ Validation stages:
 
 Expected success marker: `STAGING_VALIDATE:SUCCESS`.
 
+## P53 Operator Evidence Commands (Bounded Staging Runtime)
+Run these from repository root on the staging host:
+
+```bash
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence
+docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json
+```
+
+The `exec api` path is authoritative for bounded staging server evidence
+capture because runtime dependencies and script files are part of the container
+image.
+
 ## Conflicting Guidance Handling
 Any local-run or local development installation guidance is non-canonical for
 first-clean-server install. For first-clean-server install and startup, use this
@@ -237,10 +251,10 @@ Validated as read-only paper inspection (not paper-install-ready):
   empty initial state
 
 Still open before any `paper-install-ready` claim:
-- `python3 scripts/run_post_run_reconciliation.py`
-- `python3 scripts/generate_weekly_review.py`
-- `python3 scripts/capture_restart_evidence.py --phase pre-restart`
-- `python3 scripts/capture_restart_evidence.py --phase post-restart`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
+- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
 
 This freeze note is documentation-only and introduces no runtime/API behavior
 change.

--- a/tests/test_p53_automated_review_operations.py
+++ b/tests/test_p53_automated_review_operations.py
@@ -44,6 +44,22 @@ def test_p53_automation_doc_exists_and_defines_scope() -> None:
     assert "restart" in content.lower()
 
 
+def test_p53_automation_doc_defines_authoritative_bounded_staging_execution_path() -> None:
+    content = (
+        REPO_ROOT / "docs" / "operations" / "runtime" / "p53-automated-review-operations.md"
+    ).read_text(encoding="utf-8")
+
+    assert "### Authoritative Bounded Staging Execution Path" in content
+    assert "docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api" in content
+    assert "/app/scripts/run_post_run_reconciliation.py" in content
+    assert "/app/scripts/generate_weekly_review.py" in content
+    assert "/app/scripts/capture_restart_evidence.py" in content
+    assert "/data/db/cilly_trading.db" in content
+    assert "/data/artifacts/reconciliation" in content
+    assert "/data/artifacts/weekly-review" in content
+    assert "/data/artifacts/restart-evidence" in content
+
+
 def test_p53_automation_doc_defines_post_run_reconciliation_script() -> None:
     content = (
         REPO_ROOT / "docs" / "operations" / "runtime" / "p53-automated-review-operations.md"

--- a/tests/test_staging_deployment_validation.py
+++ b/tests/test_staging_deployment_validation.py
@@ -38,6 +38,7 @@ def test_staging_artifacts_define_canonical_runtime_contract() -> None:
     assert "FROM python:3.12.8-slim" in dockerfile_content
     assert "python -m pip install -U pip uv" in dockerfile_content
     assert "uv sync --frozen --no-dev" in dockerfile_content
+    assert "COPY scripts ./scripts" in dockerfile_content
     assert 'CILLY_DB_PATH="/data/db/cilly_trading.db"' in dockerfile_content
     assert "RUN mkdir -p /data/db /data/artifacts /data/logs /data/runtime-state /app/runs/phase6" in dockerfile_content
     assert "HEALTHCHECK" in dockerfile_content


### PR DESCRIPTION
## Summary
- package scripts/ into the bounded staging runtime image so P53 evidence scripts are present at /app/scripts
- define one authoritative bounded-staging execution path via:
  - docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/...
- align runtime/operator docs to the same DB/evidence paths:
  - /data/db/cilly_trading.db
  - /data/artifacts/reconciliation
  - /data/artifacts/weekly-review
  - /data/artifacts/restart-evidence
- update tests to enforce:
  - staging Dockerfile includes script packaging
  - P53 docs define the authoritative bounded-staging execution path

## Changed Files (9)
1. docker/staging/Dockerfile
2. docs/api/paper_inspection.md
3. docs/operations/runtime/p53-automated-review-operations.md
4. docs/operations/runtime/paper-deployment-operator-checklist.md
5. docs/operations/runtime/phase-44-paper-operator-workflow.md
6. docs/operations/runtime/staging-paper-progress-2026-04-03.md
7. docs/operations/runtime/staging-server-deployment.md
8. tests/test_p53_automated_review_operations.py
9. tests/test_staging_deployment_validation.py

## Validation
- python -m uv run -- python -m pytest --import-mode=importlib
- Result: 936 passed, 4 warnings

Closes #881