### PR TITLE
OPS-P57: Record completed bounded staging paper evidence capture and acceptance status

### DIFF
--- a/docs/operations/runtime/paper-deployment-operator-checklist.md
+++ b/docs/operations/runtime/paper-deployment-operator-checklist.md
@@ -5,36 +5,41 @@
 2. Provide concrete evidence references (command output, artifact path, run id).
 3. If any item is `NO` or blank, the deployment is not paper-install-ready.
 
-## Current Session Status Note (2026-04-03)
-For the latest bounded staging and read-only paper inspection progress captured
-on 2026-04-03, see:
+## Current Session Status Note (2026-04-04)
+For the finalized bounded staging and paper evidence closure captured for
+OPS-P57, see:
 - `docs/operations/runtime/staging-paper-progress-2026-04-03.md`
 
 This note is informational only and does not replace a fully completed
 checklist.
 
-## OPS-P55 Freeze Snapshot (2026-04-03)
-The current runtime/operator documentation freeze separates the boundary status
-as follows:
+## OPS-P57 Final Verification Snapshot (2026-04-04)
+The runtime/operator status for bounded staging paper evidence is:
 
-Already validated:
+Validated and completed:
 - bounded staging deployment
 - localhost-only binding (`127.0.0.1:18000:8000`)
-- health readiness (`/health/engine`, `/health/data`, `/health/guards`)
+- successful staging validation output including `STAGING_VALIDATE:SUCCESS`
+- health readiness (`/health/engine`, `/health/data`, `/health/guards`) with
+  healthy engine runtime (`runtime_running_fresh`)
 - read-only paper inspection validation (`/paper/workflow` with
   `validation.ok: true`, `/paper/reconciliation` with `ok: true`,
   `mismatches: 0`)
 - consistent empty-state inspection across `/trading-core/*` and `/paper/*`
 - persisted staging DB file at `/srv/cilly/staging/db/cilly_trading.db`
+- P53 automation via authoritative bounded staging container path completed:
+  - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
+  - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
+  - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
+  - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
+- automation outcomes verified: post-run reconciliation `PASS`, weekly review
+  `PASS`, pre-restart evidence `PASS`, post-restart evidence `PASS`,
+  `baseline_match: true`
+- evidence artifacts persisted under `/srv/cilly/staging/artifacts/...`
 
-Still open before final `paper-install-ready` acceptance:
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
-
-Until these four commands are executed and linked with concrete evidence
-references, this checklist remains `NOT ACCEPTED: REMAIN STAGING`.
+Bounded acceptance status for this issue scope:
+- `ACCEPTED (BOUNDED_STAGING_PAPER_EVIDENCE_COMPLETE)`
+- no live-trading, broker, or production-readiness claim
 
 ## Required Evidence Output Names
 Use these exact evidence identifiers in the checklist references:
@@ -93,6 +98,7 @@ The following scripts automate evidence capture for Section E items:
 - **Post-restart verification**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json` (supports E4)
 
 Evidence output directories in bounded staging: `/data/artifacts/reconciliation`, `/data/artifacts/weekly-review`, `/data/artifacts/restart-evidence`
+Bound host persistence path: `/srv/cilly/staging/artifacts/...`
 
 See `docs/operations/runtime/p53-automated-review-operations.md` for the full automation contract.
 
@@ -107,7 +113,10 @@ Decision rule:
 - Any `NO` or blank -> `NOT ACCEPTED: REMAIN STAGING`
 - All `YES` -> `ACCEPTED: PAPER_INSTALL_READY`
 
-Final decision (`ACCEPTED: PAPER_INSTALL_READY` or `NOT ACCEPTED: REMAIN STAGING`):
+OPS-P57 bounded evidence status:
+`ACCEPTED (BOUNDED_STAGING_PAPER_EVIDENCE_COMPLETE)`
+
+Final decision (`ACCEPTED: PAPER_INSTALL_READY` or `NOT ACCEPTED: REMAIN STAGING`) if this checklist is executed as a full gate run:
 
 Operator name:
 

--- a/docs/operations/runtime/phase-44-paper-operator-workflow.md
+++ b/docs/operations/runtime/phase-44-paper-operator-workflow.md
@@ -174,13 +174,16 @@ The manual operator steps defined above are automated by the following scripts i
 - **Weekly review artifacts (R1-R7)**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review` - produces deterministic weekly review evidence bundles.
 - **Restart/recovery evidence**: `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence` and `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json` - captures pre-restart baselines and post-restart verification evidence.
 
-All automation scripts use the same canonical state authority and derivation functions as the paper inspection API. Evidence files are written to `runs/` subdirectories (excluded from version control).
+All automation scripts use the same canonical state authority and derivation
+functions as the paper inspection API. In bounded staging, evidence files are
+written under `/data/artifacts/...` in the container and persisted on the host
+under `/srv/cilly/staging/artifacts/...`.
 
 The full automation contract is defined in `docs/operations/runtime/p53-automated-review-operations.md`.
 
-## OPS-P55 Freeze Status (2026-04-03)
-The runtime/operator documentation freeze separates status into validated
-bounded read-only workflow checks vs pending final evidence automation.
+## OPS-P57 Final Verified Status (2026-04-04)
+The runtime/operator documentation status now records a completed bounded
+workflow evidence path.
 
 Validated in bounded read-only scope:
 - `GET /paper/workflow` returned `validation.ok: true`
@@ -189,21 +192,29 @@ Validated in bounded read-only scope:
   initial state
 - bounded staging deployment and localhost-only access posture were validated
 
-Still open before any `paper-install-ready` claim:
+Completed bounded evidence automation:
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
+- verified outcomes: post-run reconciliation `PASS`, weekly review `PASS`,
+  pre-restart evidence `PASS`, post-restart evidence `PASS`,
+  `baseline_match: true`
+- evidence persisted under `/srv/cilly/staging/artifacts/...`
 
-This freeze note adds documentation clarity only and does not change runtime or
+Bounded acceptance status:
+- `ACCEPTED (BOUNDED_STAGING_PAPER_EVIDENCE_COMPLETE)`
+- no live-trading, broker, or production-readiness claim
+
+This status note adds documentation clarity only and does not change runtime or
 API behavior.
 
-## Session Progress Note (2026-04-03)
+## Session Progress Note (2026-04-04)
 
-For the bounded runtime status verified on 2026-04-03, including:
+For the bounded runtime status finalized on 2026-04-04, including:
 - validated read-only inspection of `/paper/*` and `/trading-core/*` surfaces in
   empty-state form, and
-- pending P53 evidence automation steps required before any
-  `paper-install-ready` claim,
+- completed P53 evidence automation with persisted artifacts and acceptance
+  recording,
 
 see `docs/operations/runtime/staging-paper-progress-2026-04-03.md`.

--- a/docs/operations/runtime/staging-paper-progress-2026-04-03.md
+++ b/docs/operations/runtime/staging-paper-progress-2026-04-03.md
@@ -1,13 +1,15 @@
 # Staging and Paper Progress Note (2026-04-03)
 
 ## Purpose
-Capture the bounded, evidence-based status verified on 2026-04-03.
+Capture the bounded, evidence-based status first frozen on 2026-04-03 and
+finalized after full OPS-P57 verification on 2026-04-04.
 
 This note documents observed staging and paper inspection status only. It does
 not claim live trading, broker readiness, or production readiness.
 
-## OPS-P55 Frozen Boundary Snapshot
-Status is frozen as documented evidence from the 2026-04-03 server session.
+## OPS-P57 Final Verified Boundary Snapshot (2026-04-04)
+Status is now documented as finalized evidence from the bounded staging server
+session.
 
 ### A) Bounded staging deployment (validated)
 - localhost-only exposure validated: `127.0.0.1:18000:8000`
@@ -22,13 +24,19 @@ Status is frozen as documented evidence from the 2026-04-03 server session.
 - `/paper/*` and `/trading-core/*` surfaces validated as consistent in empty
   initial state
 
-### C) Final paper-install-ready evidence (open)
+### C) Final bounded evidence capture (completed)
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
+- post-run reconciliation result: `PASS`
+- weekly review result: `PASS`
+- pre-restart evidence capture result: `PASS`
+- post-restart evidence capture result: `PASS`
+- restart baseline comparison: `baseline_match: true`
+- evidence artifacts persisted under `/srv/cilly/staging/artifacts/...`
 
-This freeze note is documentation-only and does not change runtime/API logic.
+This status note is documentation-only and does not change runtime/API logic.
 
 ## Verified Today
 
@@ -51,7 +59,8 @@ This freeze note is documentation-only and does not change runtime/API logic.
 ### 3) Bounded Staging Runtime
 - Bounded staging container started successfully.
 - `docker compose ps` reported healthy status.
-- `GET /health/engine` verified with `read_only` role.
+- `GET /health/engine` verified with `read_only` role, healthy runtime, and
+  `runtime_running_fresh`.
 - `GET /health/data` verified with `ready=true`.
 - `GET /health/guards` verified with `ready=true`, `decision=allowing`,
   `blocking=false`.
@@ -99,19 +108,12 @@ This freeze note is documentation-only and does not change runtime/API logic.
 ## Current Boundary Status
 - bounded staging deployment validated
 - bounded paper inspection surfaces validated in empty-state/read-only form
-- final paper-install-ready evidence capture still pending
+- bounded P53 evidence automation path completed
+- bounded staging/paper acceptance status: `ACCEPTED
+  (BOUNDED_STAGING_PAPER_EVIDENCE_COMPLETE)`
 
-## Not Completed Yet
-The following bounded staging P53 evidence automation commands were not fully executed in this session:
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
-- `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
-
-Therefore, the formal full paper-install-ready checklist remains incomplete as
-of 2026-04-03.
-
-## Next Operator Step (Next Session)
-Execute the pending P53 evidence capture commands above, then complete
-`docs/operations/runtime/paper-deployment-operator-checklist.md` with concrete
-evidence references before any paper-install-ready claim.
+## Boundary and Claim Clarity
+- This document confirms bounded staging/paper acceptance only.
+- This document does not claim live trading readiness.
+- This document does not claim broker integration readiness.
+- This document does not claim production readiness.

--- a/docs/operations/runtime/staging-server-deployment.md
+++ b/docs/operations/runtime/staging-server-deployment.md
@@ -216,6 +216,10 @@ The `exec api` path is authoritative for bounded staging server evidence
 capture because runtime dependencies and script files are part of the container
 image.
 
+In bounded staging, `/data/artifacts/...` is bind-mounted to
+`/srv/cilly/staging/artifacts/...` on the host for persistent evidence
+retention.
+
 ## Conflicting Guidance Handling
 Any local-run or local development installation guidance is non-canonical for
 first-clean-server install. For first-clean-server install and startup, use this
@@ -232,37 +236,48 @@ Status interpretation:
 Required evidence output name used by the acceptance gate:
 - `EVIDENCE_STAGING_VALIDATION_LOG` (captures this runbook's validation output).
 
-## OPS-P55 Frozen Validation Status (2026-04-03)
-This runtime documentation freeze records bounded staging and read-only paper
-inspection status as verified on 2026-04-03.
+## OPS-P57 Final Validation Status (2026-04-04)
+This runtime documentation status records bounded staging and paper evidence
+closure as finally verified on 2026-04-04.
 
 Validated in scope:
 - bounded staging deployment validated
 - localhost-only exposure validated (`127.0.0.1:18000:8000`)
 - `.env` and required host staging directories validated
-- `python3 scripts/validate_staging_deployment.py` validated
-- `/health/engine`, `/health/data`, `/health/guards` validated with ready state
+- `python3 scripts/validate_staging_deployment.py` validated with all success
+  markers including `STAGING_VALIDATE:SUCCESS`
+- `/health/engine`, `/health/data`, `/health/guards` validated with ready
+  state, including healthy engine runtime (`runtime_running_fresh`) and
+  allowing guard decision
 - database file validated at `/srv/cilly/staging/db/cilly_trading.db`
 
-Validated as read-only paper inspection (not paper-install-ready):
+Validated as read-only paper inspection:
 - `/paper/workflow` validated with `validation.ok: true`
 - `/paper/reconciliation` validated with `ok: true`, `mismatches: 0`
 - trading-core and `/paper/*` inspection surfaces validated as consistent in
   empty initial state
 
-Still open before any `paper-install-ready` claim:
+Validated as completed bounded evidence automation:
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/run_post_run_reconciliation.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/reconciliation`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/generate_weekly_review.py --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/weekly-review`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase pre-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence`
 - `docker compose --env-file .env -f docker/staging/docker-compose.staging.yml exec api python /app/scripts/capture_restart_evidence.py --phase post-restart --db-path /data/db/cilly_trading.db --evidence-dir /data/artifacts/restart-evidence --baseline /data/artifacts/restart-evidence/pre-restart-pass-YYYYMMDDTHHMMSSZ.json`
+- results verified: post-run reconciliation `PASS`, weekly review `PASS`,
+  pre-restart evidence `PASS`, post-restart evidence `PASS`,
+  `baseline_match: true`
+- artifacts persisted under `/srv/cilly/staging/artifacts/...`
 
-This freeze note is documentation-only and introduces no runtime/API behavior
+Bounded acceptance status:
+- `ACCEPTED (BOUNDED_STAGING_PAPER_EVIDENCE_COMPLETE)`
+- no live-trading, broker-integration, or production-readiness claim
+
+This status note is documentation-only and introduces no runtime/API behavior
 change.
 
-## Session Progress Note (2026-04-03)
-For the bounded server session progress verified on 2026-04-03, including
-localhost binding correction, staging validation markers, and open follow-up
-evidence steps, see:
+## Session Progress Note (2026-04-04)
+For the finalized bounded server evidence status including localhost binding,
+staging validation markers, completed P53 automation results, and acceptance
+recording, see:
 - `docs/operations/runtime/staging-paper-progress-2026-04-03.md`
 
 ## Test Gate


### PR DESCRIPTION
## Summary
- updates runtime/operator docs from OPS-P55 pending/open wording to OPS-P57 final-verified status
- records completed bounded staging paper evidence path (validation markers, health/readiness, paper inspection consistency)
- records completed P53 automation evidence execution and persisted artifact path under /srv/cilly/staging/artifacts/...
- keeps boundaries explicit: bounded staging/paper acceptance only, no live-trading, broker, or production-readiness claim
- documentation-only change; no runtime/API/docker logic changes

## Validation
- python -m uv run -- python -m pytest --import-mode=importlib
- result: 936 passed, 4 warnings

Closes #883