### PR TITLE
OPS-P61: align signal score contract between analysis output and bounded paper execution

### DIFF
--- a/src/cilly_trading/engine/paper_execution_worker.py
+++ b/src/cilly_trading/engine/paper_execution_worker.py
@@ -49,8 +49,8 @@ from cilly_trading.repositories import CanonicalExecutionRepository
 # Policy constants (bounded paper simulation parameters — static defaults)
 # ---------------------------------------------------------------------------
 
-#: Minimum signal score required for paper entry (inclusive).
-MIN_SCORE_THRESHOLD: float = 0.6
+#: Minimum signal score required for paper entry (inclusive) on a 0..100 scale.
+MIN_SCORE_THRESHOLD: float = 60.0
 
 #: Maximum fraction of account equity for a single paper position.
 MAX_POSITION_PCT: Decimal = Decimal("0.10")
@@ -190,8 +190,8 @@ def _validate_signal_fields(signal: Signal) -> Optional[str]:
     except (TypeError, ValueError):
         return "score must be numeric"
 
-    if not (0.0 <= score <= 1.0):
-        return f"score={score} out of range [0.0, 1.0]"
+    if not (0.0 <= score <= 100.0):
+        return f"score={score} out of range [0.0, 100.0]"
 
     try:
         _parse_timestamp(signal["timestamp"])  # type: ignore[arg-type]

--- a/tests/engine/test_paper_execution_worker.py
+++ b/tests/engine/test_paper_execution_worker.py
@@ -54,7 +54,7 @@ def _make_signal(
     symbol: str = "AAPL",
     strategy: str = "rsi2",
     direction: str = "long",
-    score: float = 0.75,
+    score: float = 75.0,
     timestamp: str = "2024-01-15T10:00:00Z",
     stage: str = "setup",
     signal_id: str | None = None,
@@ -79,7 +79,7 @@ def _make_signal(
 
 def test_policy_constants_match_documented_defaults() -> None:
     """AC5: policy constants match the values declared in the policy doc."""
-    assert MIN_SCORE_THRESHOLD == 0.6
+    assert MIN_SCORE_THRESHOLD == 60.0
     assert MAX_POSITION_PCT == Decimal("0.10")
     assert MAX_TOTAL_EXPOSURE_PCT == Decimal("0.80")
     assert MAX_CONCURRENT_POSITIONS == 10
@@ -109,7 +109,7 @@ def test_missing_symbol_returns_reject(worker: BoundedPaperExecutionWorker) -> N
     signal: Signal = {
         "strategy": "rsi2",
         "direction": "long",  # type: ignore[typeddict-item]
-        "score": 0.8,
+        "score": 80.0,
         "timestamp": "2024-01-15T10:00:00Z",
         "stage": "setup",  # type: ignore[typeddict-item]
     }
@@ -123,7 +123,7 @@ def test_missing_strategy_returns_reject(worker: BoundedPaperExecutionWorker) ->
     signal: Signal = {
         "symbol": "AAPL",
         "direction": "long",  # type: ignore[typeddict-item]
-        "score": 0.8,
+        "score": 80.0,
         "timestamp": "2024-01-15T10:00:00Z",
         "stage": "setup",  # type: ignore[typeddict-item]
     }
@@ -132,7 +132,7 @@ def test_missing_strategy_returns_reject(worker: BoundedPaperExecutionWorker) ->
 
 
 def test_score_out_of_range_returns_reject(worker: BoundedPaperExecutionWorker) -> None:
-    result = worker.process_signal(_make_signal(score=1.5))
+    result = worker.process_signal(_make_signal(score=150.0))
     assert result.outcome == "reject:invalid_signal_fields"
     assert "out of range" in (result.reason or "")
 
@@ -150,7 +150,7 @@ def test_unparseable_timestamp_returns_reject(worker: BoundedPaperExecutionWorke
 
 
 def test_score_below_threshold_is_skipped(worker: BoundedPaperExecutionWorker) -> None:
-    result = worker.process_signal(_make_signal(score=0.59))
+    result = worker.process_signal(_make_signal(score=59.0))
     assert result.outcome == "skip:score_below_threshold"
     assert result.order_id is None
 
@@ -158,13 +158,23 @@ def test_score_below_threshold_is_skipped(worker: BoundedPaperExecutionWorker) -
 def test_score_exactly_at_threshold_is_eligible(
     worker: BoundedPaperExecutionWorker,
 ) -> None:
-    result = worker.process_signal(_make_signal(score=0.6))
+    result = worker.process_signal(_make_signal(score=60.0))
     assert result.outcome == "eligible"
 
 
 def test_score_above_threshold_is_eligible(worker: BoundedPaperExecutionWorker) -> None:
-    result = worker.process_signal(_make_signal(score=0.8))
+    result = worker.process_signal(_make_signal(score=80.0))
     assert result.outcome == "eligible"
+
+
+def test_midrange_score_is_not_rejected_as_invalid_field(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    """Score values in 0..100 must not be rejected by field validation."""
+    result = worker.process_signal(_make_signal(score=46.676762456528515))
+    assert result.outcome == "skip:score_below_threshold"
+    assert result.reason is not None
+    assert "min_score_threshold" in result.reason
 
 
 # ---------------------------------------------------------------------------
@@ -665,9 +675,9 @@ def test_batch_skips_ineligible_and_processes_eligible(
 ) -> None:
     """AC1+AC2: mixed batch — eligible and ineligible signals handled independently."""
     signals = [
-        _make_signal(signal_id="sig-mix-001", symbol="OK1", score=0.8),
-        _make_signal(signal_id="sig-mix-002", symbol="LOW", score=0.3),  # below threshold
-        _make_signal(signal_id="sig-mix-003", symbol="OK2", score=0.9),
+        _make_signal(signal_id="sig-mix-001", symbol="OK1", score=80.0),
+        _make_signal(signal_id="sig-mix-002", symbol="LOW", score=30.0),  # below threshold
+        _make_signal(signal_id="sig-mix-003", symbol="OK2", score=90.0),
     ]
     results = worker.process_batch(signals)
 


### PR DESCRIPTION
﻿The previous close of #890 was not the technical fix.
This PR is the actual technical follow-up.

## Problem
A real staging execution of the bounded paper execution operator path failed with:

- eject:invalid_signal_fields
- score=46.676762456528515 out of range [0.0, 1.0]

The operator/runtime path itself worked:
- the persisted signal was read from the DB
- the worker executed
- the signal was rejected only because of score-contract mismatch

## Fix
This PR aligns the bounded paper execution worker contract to the authoritative  ..100 signal score semantics already used by analysis/strategy output and persistence.

Bounded changes only:
- update worker score-range validation from  .0..1.0 to  .0..100.0
- update threshold semantics from  .6 to 60.0
- update targeted worker tests
- add targeted coverage for the reproduced mid-range score case

## Validation
- python -m pytest -q tests/engine/test_paper_execution_worker.py
- python -m pytest -q tests/test_ops_p60_signal_to_paper_operator_path.py
- python -m pytest -q tests/test_ops_p52_signal_to_paper_execution_policy_docs.py
- python -m pytest -q

Result:
- 955 passed, 4 warnings

## Scope Boundary
- bounded minimal technical fix only
- no live trading claims
- no broker integration
- no production-readiness claims
