### PR TITLE
Add staging progress note and link 2026-04-03 runtime evidence across operator docs

### DIFF
--- a/docs/operations/runtime/p60-signal-to-paper-operator-path.md
+++ b/docs/operations/runtime/p60-signal-to-paper-operator-path.md
@@ -18,7 +18,7 @@ It addresses the gap between:
 ### Path exists: YES (bounded, non-live)
 
 A complete bounded path from eligible signals to canonical paper execution state
-exists.  The path is implemented, documented, tested, and operationally
+exists. The path is implemented, documented, tested, and operationally
 invocable via a single operator script.
 
 ### Authoritative Components
@@ -81,7 +81,21 @@ docker compose --env-file .env \
   --evidence-dir /data/artifacts/paper-execution
 ```
 
-## Inputs
+### Host vs Container Base URL Note for Related Runtime Commands
+
+This document uses host-context read-only API checks (for example:
+`http://127.0.0.1:18000/paper/trades`). For related OPS-P63/OPS-P64 commands
+that accept `--base-url`, use context-specific mapping:
+
+- host shell invocation -> `http://127.0.0.1:18000`
+- `docker compose ... exec api` invocation -> `http://127.0.0.1:8000`
+
+Warning: do not use `http://127.0.0.1:18000` inside the `api` container.
+Observed failure signature in OPS-P65 was
+`analysis_signal_generation` + `URLError: <urlopen error [Errno 111] Connection refused>`,
+which is an invocation-context error, not runner logic failure.
+
+## Operator Inputs
 
 ### Inputs
 
@@ -92,12 +106,12 @@ docker compose --env-file .env \
 | Signals | `SqliteSignalRepository.list_signals()` | All persisted signals from the database |
 | Execution state | `SqliteCanonicalExecutionRepository` | Canonical orders, events, trades |
 
-## Policy Gates
+## Policy Gate Set
 
 ### Policy Gates
 
 Every signal passes through the ordered 5-step OPS-P52 policy evaluation before
-any paper entity is created.  The policy gates are:
+any paper entity is created. The policy gates are:
 
 1. `reject:invalid_signal_fields` - missing or invalid required fields
 2. `skip:score_below_threshold` - signal score below `60.0` (score range `0..100`)
@@ -107,7 +121,7 @@ any paper entity is created.  The policy gates are:
 6. `reject:total_exposure_exceeds_limit` - global exposure cap exceeded
 7. `reject:concurrent_position_limit_exceeded` - max concurrent positions exceeded
 
-## Outputs
+## Operator Outputs
 
 ### Outputs
 
@@ -174,11 +188,11 @@ python scripts/run_post_run_reconciliation.py --db-path /path/to/cilly_trading.d
   execution state was not clearly documented as a single bounded workflow.
   This is now documented in this file.
 
-## Remaining Boundaries
+## Boundaries
 
 ### Remaining Boundaries
 
-- The execution cycle script is operator-invoked (manual trigger).  There is
+- The execution cycle script is operator-invoked (manual trigger). There is
   no automated scheduler or API endpoint that triggers execution cycles.
 - The script reads all signals and processes them in batch.  There is no
   incremental or event-driven signal processing.
@@ -295,4 +309,3 @@ This OPS-P62 record is bounded staging evidence only. It does not claim:
 - production readiness
 - strategy calibration completeness
 - portfolio or risk optimization completeness
-

--- a/docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md
+++ b/docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md
@@ -98,6 +98,17 @@ curl -sS -H "X-Cilly-Role: read_only" \
   "http://127.0.0.1:18000/signals?ingestion_run_id=<INGESTION_RUN_ID>&limit=100"
 ```
 
+### Base URL Context Mapping (Host vs Container)
+
+When invoking the OPS-P64 daily runner, map `--base-url` to invocation context:
+
+- host shell invocation -> `http://127.0.0.1:18000`
+- `docker compose ... exec api` invocation -> `http://127.0.0.1:8000`
+
+Warning: do not use `http://127.0.0.1:18000` from inside the `api` container.
+That value is the host-published bind and causes
+`analysis_signal_generation` connection-refused failures in container context.
+
 ## Step 3 - Bounded Paper Execution Cycle
 
 This step is runnable independently against existing signal state.
@@ -264,6 +275,60 @@ Bounded staging validation example from the already-validated runtime path:
   - `mismatches: 0`
 
 This example demonstrates the full daily sequence end-to-end in bounded staging. It does not widen runtime scope.
+
+## OPS-P65 Bounded OPS-P64 Staging Evidence (2026-04-06)
+
+First in-container run used the wrong base URL and failed at
+`analysis_signal_generation` with
+`URLError: <urlopen error [Errno 111] Connection refused>`.
+This is an invocation-context issue (host-vs-container base-url mismatch), not
+runner logic failure.
+
+Successful in-container command:
+
+```bash
+docker compose --env-file /root/Trading-engine/.env \
+  -f docker/staging/docker-compose.staging.yml \
+  exec api python /app/scripts/run_daily_bounded_paper_runtime.py \
+  --db-path /data/db/cilly_trading.db \
+  --base-url http://127.0.0.1:8000
+```
+
+Recorded summary evidence:
+
+- `status: ok`
+- `ingestion_run_id: 813b4a13-de3d-4633-8968-1a7fbc0af2f3`
+- `analysis_run_id: 89cec8c4d8a92bbecb2c4f6d59eb9d06972b1c4b4f1ed59ee686bca1816787a0`
+- ordered steps completed:
+  - `snapshot_ingestion`
+  - `analysis_signal_generation`
+  - `bounded_paper_execution_cycle`
+  - `reconciliation`
+  - `evidence_capture`
+
+Bounded paper execution cycle interpretation for this run:
+
+- `status: no_eligible`
+- `eligible: 0`
+- `skipped: 12`
+- skip reasons: `duplicate_entry`, `score_below_threshold`
+- interpretation: bounded-valid non-error completion
+
+Read-only verification outcomes in the same run record:
+
+- `/paper/trades` -> `total: 3`
+- `/paper/positions` -> `total: 3`
+- `/paper/reconciliation` -> `ok: true`, `mismatches: 0`
+
+Summary and evidence path:
+
+- summary:
+  - `/data/artifacts/daily-runtime/2026-04-06/daily-runtime-summary-20260406T144441Z.json`
+- evidence files:
+  - `/data/artifacts/daily-runtime/2026-04-06/signals.json`
+  - `/data/artifacts/daily-runtime/2026-04-06/paper-trades.json`
+  - `/data/artifacts/daily-runtime/2026-04-06/paper-positions.json`
+  - `/data/artifacts/daily-runtime/2026-04-06/paper-reconciliation.json`
 
 ## Explicit Claim Boundary
 

--- a/docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md
+++ b/docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md
@@ -50,6 +50,32 @@ The command orchestrates:
 - `scripts/run_post_run_reconciliation.py`
 - `scripts/generate_weekly_review.py`
 
+## Base URL by Invocation Context (Critical)
+
+The `--base-url` value depends on where the runner command executes.
+
+Host-context invocation (from host shell; staging bind published on `18000`):
+
+```bash
+python scripts/run_daily_bounded_paper_runtime.py \
+  --db-path cilly_trading.db \
+  --base-url http://127.0.0.1:18000
+```
+
+In-container invocation (from `docker compose ... exec api`; target container port `8000`):
+
+```bash
+docker compose --env-file /root/Trading-engine/.env \
+  -f docker/staging/docker-compose.staging.yml \
+  exec api python /app/scripts/run_daily_bounded_paper_runtime.py \
+  --db-path /data/db/cilly_trading.db \
+  --base-url http://127.0.0.1:8000
+```
+
+Warning: do not use `http://127.0.0.1:18000` inside the `api` container. That
+host bind is not reachable from container-local loopback and will fail during
+`analysis_signal_generation`.
+
 ## Explicit Failure Behavior
 
 The runner is fail-fast:
@@ -86,6 +112,73 @@ The runner captures read-only run-record snapshots from existing surfaces:
 - `/paper/trades`
 - `/paper/positions`
 - `/paper/reconciliation`
+
+## OPS-P65 First Successful Bounded OPS-P64 Staging Run (2026-04-06)
+
+First attempted in-container command (failed due invocation context):
+
+```bash
+docker compose --env-file /root/Trading-engine/.env \
+  -f docker/staging/docker-compose.staging.yml \
+  exec api python /app/scripts/run_daily_bounded_paper_runtime.py \
+  --db-path /data/db/cilly_trading.db \
+  --base-url http://127.0.0.1:18000
+```
+
+Observed failure signature:
+
+- `failed_step: analysis_signal_generation`
+- `detail` included `URLError: <urlopen error [Errno 111] Connection refused>`
+
+Interpretation: invocation-context error only (host-vs-container base-url
+mismatch), not a runner logic defect.
+
+Successful corrected command:
+
+```bash
+docker compose --env-file /root/Trading-engine/.env \
+  -f docker/staging/docker-compose.staging.yml \
+  exec api python /app/scripts/run_daily_bounded_paper_runtime.py \
+  --db-path /data/db/cilly_trading.db \
+  --base-url http://127.0.0.1:8000
+```
+
+Recorded bounded success evidence:
+
+- `status: ok`
+- `ingestion_run_id: 813b4a13-de3d-4633-8968-1a7fbc0af2f3`
+- `analysis_run_id: 89cec8c4d8a92bbecb2c4f6d59eb9d06972b1c4b4f1ed59ee686bca1816787a0`
+- `step_order`:
+  - `snapshot_ingestion`
+  - `analysis_signal_generation`
+  - `bounded_paper_execution_cycle`
+  - `reconciliation`
+  - `evidence_capture`
+- `steps_completed` matched full `step_order` (all ordered steps completed)
+
+Bounded execution interpretation from the same summary:
+
+- bounded paper execution cycle completion: `status: no_eligible`
+- `eligible: 0`
+- `skipped: 12`
+- skip reasons observed: `duplicate_entry`, `score_below_threshold`
+- these bounded skip outcomes are valid non-error completion states
+
+Read-only verification outcomes captured in the run record:
+
+- `/paper/trades` -> `total: 3`
+- `/paper/positions` -> `total: 3`
+- `/paper/reconciliation` -> `ok: true`, `mismatches: 0`
+
+Summary and evidence file paths recorded under:
+
+- summary file:
+  - `/data/artifacts/daily-runtime/2026-04-06/daily-runtime-summary-20260406T144441Z.json`
+- verification surfaces:
+  - `/data/artifacts/daily-runtime/2026-04-06/signals.json`
+  - `/data/artifacts/daily-runtime/2026-04-06/paper-trades.json`
+  - `/data/artifacts/daily-runtime/2026-04-06/paper-positions.json`
+  - `/data/artifacts/daily-runtime/2026-04-06/paper-reconciliation.json`
 
 ## Evidence Path
 

--- a/ops_p60_issue_body.txt
+++ b/ops_p60_issue_body.txt
@@ -1,0 +1,83 @@
+﻿Ziel:
+Definiere und validiere den autoritativen bounded Operator-/Runtime-Pfad, mit
+dem bereits erzeugte eligible Analysis-Signale in kanonischen
+Paper-Execution-State überführt werden können.
+
+Problem:
+Der bounded staging-/paper-Basispfad sowie der erste nicht-leere
+snapshot-backed analysis state wurden bereits erfolgreich verifiziert.
+Aktuell besteht jedoch noch eine Lücke zwischen:
+
+- vorhandenem non-empty signal state
+- vorhandener bounded signal-to-paper policy
+- vorhandenem paper execution worker im Code
+- und einem klar dokumentierten/verifizierten operatorischen Runtime-Pfad,
+  der non-empty paper execution state erzeugt
+
+Bisher verifiziert:
+- localhost-only bounded staging deploy erfolgreich
+- runtime healthy / runtime_running_fresh
+- `/paper/workflow` valid
+- `/paper/reconciliation` ok true, mismatches 0
+- P53 evidence scripts erfolgreich
+- restart evidence erfolgreich
+- snapshot ingestion erfolgreich (`AAPL`, `MSFT`, `D1`)
+- non-empty signal state erfolgreich:
+  - `AAPL`
+  - `TURTLE`
+  - `long`
+  - `stage: setup`
+  - persisted/readable via `/signals`
+
+Aktuelle Lücke:
+- `/paper/*` surfaces sind read-only inspection surfaces
+- bounded signal-to-paper execution policy ist dokumentiert
+- `paper_execution_worker.py` existiert
+- aber ein klarer, autoritativer operator-facing Runtime-/API-/Script-Pfad zur
+  Erzeugung von non-empty paper execution state ist noch nicht sauber
+  dokumentiert und verifiziert
+
+Scope:
+- vorhandenen kleinsten bounded Pfad von eligible signal -> canonical paper
+  execution state untersuchen
+- sauber trennen zwischen:
+  - implementiert
+  - dokumentiert
+  - getestet
+  - operativ verifiziert
+- falls ein bounded Pfad existiert:
+  - präzise dokumentieren
+  - minimal validieren
+- falls kein sauberer Operatorpfad existiert:
+  - Lücke exakt dokumentieren
+  - kleinsten bounded Folgepfad vorschlagen
+- nur minimale Änderungen
+- keine unnötigen Refactors
+
+Nicht Ziel:
+- Live-Trading
+- Broker-Integration
+- Production-Readiness
+- UI-/Dashboard-Ausbau
+- unbounded Architekturumbau
+
+Acceptance Criteria:
+1. Es ist klar dokumentiert, ob aktuell ein autoritativer bounded path von
+   eligible signals zu canonical paper execution state existiert.
+2. Falls der Pfad existiert, sind die autoritativen Inputs, Policy-Gates und
+   der minimale operatorische/runtime path klar beschrieben.
+3. Falls der Pfad nicht vollständig operatorisch dokumentiert ist, ist die
+   verbleibende Lücke klar benannt, ohne Overclaim.
+4. Änderungen bleiben bounded und minimal.
+5. Keine Live-/Broker-/Production-Readiness-Behauptungen werden eingeführt.
+
+Besonders relevante Dateien:
+- `docs/operations/runtime/signal_to_paper_execution_policy.md`
+- `docs/operations/runtime/phase-44-paper-operator-workflow.md`
+- `docs/api/paper_inspection.md`
+- `src/cilly_trading/engine/paper_execution_worker.py`
+- `src/cilly_trading/engine/paper_order_lifecycle.py`
+- `src/cilly_trading/portfolio/paper_state_authority.py`
+- `tests/engine/test_paper_execution_worker.py`
+- `tests/test_api_paper_inspection_read.py`
+- `tests/test_ops_p52_signal_to_paper_execution_policy_docs.py`

--- a/tests/test_ops_p63_daily_bounded_paper_runtime_workflow.py
+++ b/tests/test_ops_p63_daily_bounded_paper_runtime_workflow.py
@@ -1,0 +1,104 @@
+"""Contract tests for OPS-P63 daily bounded paper runtime workflow.
+
+Acceptance criteria verified:
+    AC1: Daily bounded paper runtime workflow is clearly documented in order.
+    AC2: Workflow covers ingestion, analysis, execution, reconciliation,
+         and evidence capture.
+    AC3: Each step has an operator-facing command or invocation path.
+    AC4: Existing read-only verification surfaces are identified.
+    AC5: Workflow remains bounded with explicit non-live claim boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+P63_DOC = "docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md"
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_p63_doc_exists_and_defines_daily_order() -> None:
+    content = _read(P63_DOC)
+
+    assert content.startswith("# OPS-P63: Daily Bounded Paper Runtime Workflow")
+    assert "## Required Daily Workflow Order" in content
+    assert "1. Snapshot ingestion" in content
+    assert "2. Analysis and signal generation" in content
+    assert "3. Bounded paper execution cycle" in content
+    assert "4. Reconciliation" in content
+    assert "5. Evidence capture and run record" in content
+
+
+def test_p63_doc_covers_all_required_runtime_steps() -> None:
+    content = _read(P63_DOC)
+
+    assert "## Step 1 - Snapshot Ingestion" in content
+    assert "## Step 2 - Analysis and Signal Generation" in content
+    assert "## Step 3 - Bounded Paper Execution Cycle" in content
+    assert "## Step 4 - Reconciliation" in content
+    assert "## Step 5 - Evidence Capture and Run Record" in content
+
+
+def test_p63_doc_has_operator_facing_commands_for_each_step() -> None:
+    content = _read(P63_DOC)
+
+    assert "scripts/run_snapshot_ingestion.py" in content
+    assert "POST /analysis/run" in content
+    assert "scripts/run_paper_execution_cycle.py" in content
+    assert "scripts/run_post_run_reconciliation.py" in content
+    assert "scripts/generate_weekly_review.py" in content
+    assert content.lower().count("runnable independently") >= 5
+
+
+def test_p63_doc_defines_full_sequential_workflow() -> None:
+    content = _read(P63_DOC)
+
+    assert "## Daily Sequential Command Sequence (Bounded Staging)" in content
+
+    idx_ingest = content.index("run_snapshot_ingestion.py")
+    idx_analysis = content.index("/analysis/run")
+    idx_execute = content.index("run_paper_execution_cycle.py")
+    idx_reconcile = content.index("run_post_run_reconciliation.py")
+    idx_evidence = content.index("generate_weekly_review.py")
+
+    assert idx_ingest < idx_analysis < idx_execute < idx_reconcile < idx_evidence
+
+
+def test_p63_doc_identifies_existing_read_only_verification_surfaces() -> None:
+    content = _read(P63_DOC)
+
+    assert "## Verification Surfaces (Read-Only)" in content
+    assert "/signals" in content
+    assert "/paper/trades" in content
+    assert "/paper/positions" in content
+    assert "/paper/reconciliation" in content
+
+
+def test_p63_doc_contains_bounded_end_to_end_validation_example() -> None:
+    content = _read(P63_DOC)
+
+    assert "## Bounded End-to-End Validation Example (2026-04-05)" in content
+    assert "eligible: 3" in content
+    assert "ok: true" in content
+    assert "mismatches: 0" in content
+
+
+def test_p63_doc_contains_explicit_non_live_claim_boundary() -> None:
+    content = _read(P63_DOC)
+
+    assert "## Explicit Claim Boundary" in content
+    assert "no live orders are placed" in content
+    assert "no broker APIs are called" in content
+    assert "no production-readiness claim is made" in content
+
+
+def test_docs_index_links_p63_reference() -> None:
+    content = _read("docs/index.md")
+
+    assert "### OPS-P63 Reference Materials" in content
+    assert "operations/runtime/p63-daily-bounded-paper-runtime-workflow.md" in content


### PR DESCRIPTION
Closes #899

## Summary
- add `docs/operations/runtime/staging-paper-progress-2026-04-03.md` to capture bounded staging and read-only paper inspection status
- link the new progress note from:
  - `docs/operations/runtime/paper-deployment-operator-checklist.md`
  - `docs/operations/runtime/phase-44-paper-operator-workflow.md`
  - `docs/operations/runtime/staging-server-deployment.md`
- clarify that the note is informational and does not replace checklist completion or introduce readiness claims
- document pending P53 evidence automation steps before any `paper-install-ready` claim

## Testing
- Not run (not requested)