### PR TITLE
fix(issue-917): add raw cross-ingestion signals read mode

### DIFF
--- a/src/api/models/inspection_models.py
+++ b/src/api/models/inspection_models.py
@@ -18,6 +18,13 @@ class SignalsReadQuery(BaseModel):
     strategy: Optional[str] = Field(default=None)
     timeframe: Optional[str] = Field(default=None)
     ingestion_run_id: Optional[str] = Field(default=None)
+    dedupe: bool = Field(
+        default=True,
+        description=(
+            "If true (default), unfiltered reads dedupe identical signals across ingestion runs. "
+            "Set false for raw cross-ingestion visibility."
+        ),
+    )
     from_: Optional[datetime] = Field(default=None, alias="from")
     to: Optional[datetime] = Field(default=None, alias="to")
     sort: Literal["created_at_asc", "created_at_desc"] = Field(default="created_at_desc")

--- a/src/api/routers/inspection_router.py
+++ b/src/api/routers/inspection_router.py
@@ -71,6 +71,13 @@ def _get_signals_query(
     strategy: Optional[str] = Query(default=None),
     timeframe: Optional[str] = Query(default=None),
     ingestion_run_id: Optional[str] = Query(default=None),
+    dedupe: bool = Query(
+        default=True,
+        description=(
+            "When true (default), unfiltered reads dedupe identical signals across ingestion runs. "
+            "Set false for raw cross-ingestion visibility."
+        ),
+    ),
     from_: Optional[datetime] = Query(default=None, alias="from"),
     to: Optional[datetime] = Query(default=None, alias="to"),
     sort: Literal["created_at_asc", "created_at_desc"] = Query(default="created_at_desc"),
@@ -95,6 +102,7 @@ def _get_signals_query(
         strategy=strategy,
         timeframe=timeframe,
         ingestion_run_id=ingestion_run_id,
+        dedupe=dedupe,
         from_=resolved_from,
         to=resolved_to,
         sort=sort,
@@ -421,6 +429,11 @@ def build_inspection_router(
     @router.get(
         "/signals",
         response_model=SignalReadResponseDTO,
+        summary="Read Signals",
+        description=(
+            "Read stored signals with optional filters. By default, unfiltered reads are deduped "
+            "across ingestion runs; set dedupe=false for raw cross-ingestion visibility."
+        ),
     )
     def read_signals_handler(
         params: SignalsReadQuery = Depends(_get_signals_query),

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -398,6 +398,7 @@ def read_signals(
         strategy=params.strategy,
         timeframe=params.timeframe,
         ingestion_run_id=params.ingestion_run_id,
+        dedupe=params.dedupe,
         from_=params.from_,
         to=params.to,
         sort=params.sort,

--- a/src/cilly_trading/repositories/signals_sqlite.py
+++ b/src/cilly_trading/repositories/signals_sqlite.py
@@ -264,13 +264,14 @@ class SqliteSignalRepository(SignalRepository):
         strategy: Optional[str] = None,
         timeframe: Optional[str] = None,
         ingestion_run_id: Optional[str] = None,
+        dedupe: bool = True,
         from_: Optional[datetime] = None,
         to: Optional[datetime] = None,
         sort: str = "created_at_desc",
         limit: int = 50,
         offset: int = 0,
     ) -> Tuple[List[Signal], int]:
-        dedupe_unfiltered_reads = ingestion_run_id is None
+        dedupe_unfiltered_reads = dedupe and ingestion_run_id is None
         where_clauses = []
         params: List[object] = []
 
@@ -307,8 +308,8 @@ class SqliteSignalRepository(SignalRepository):
         cur = conn.cursor()
 
         if dedupe_unfiltered_reads:
-            # Keep one row per deterministic signal identity when reads are not scoped
-            # to a single ingestion run. This prevents repeated entries caused by
+            # Keep one row per deterministic signal identity when reads are unscoped
+            # and dedupe is enabled. This prevents repeated entries caused by
             # reruns that persisted the same signal under a new ingestion_run_id.
             dedupe_identity_sql = (
                 "CASE "

--- a/tests/test_api_signals_read.py
+++ b/tests/test_api_signals_read.py
@@ -99,9 +99,15 @@ def test_read_signals_openapi_exposes_timeframe_not_legacy_filters(tmp_path: Pat
     parameter_names = {item["name"] for item in parameters}
 
     assert "timeframe" in parameter_names
+    assert "dedupe" in parameter_names
     assert "preset" not in parameter_names
     assert "start" not in parameter_names
     assert "end" not in parameter_names
+
+    dedupe_param = next(item for item in parameters if item["name"] == "dedupe")
+    assert dedupe_param["required"] is False
+    assert dedupe_param["schema"]["default"] is True
+    assert "raw cross-ingestion visibility" in dedupe_param["description"]
 
 
 def test_read_signals_empty_result(tmp_path: Path, monkeypatch) -> None:
@@ -127,6 +133,7 @@ def test_read_signals_invalid_params(tmp_path: Path, monkeypatch) -> None:
         {"sort": "foo"},
         {"limit": SIGNALS_READ_MAX_LIMIT + 1},
         {"limit": 0},
+        {"dedupe": "not-a-bool"},
         {"from": "2025-01-02T00:00:00+00:00", "to": "2025-01-01T00:00:00+00:00"},
         {"preset": "D1"},
         {"start": "2025-01-01T00:00:00+00:00"},
@@ -274,6 +281,51 @@ def test_read_signals_unfiltered_dedupes_same_signal_across_ingestion_runs(
     payload_second_run = response_second_run.json()
     assert payload_second_run["total"] == 1
     assert payload_second_run["items"][0]["symbol"] == "AAPL"
+
+
+def test_read_signals_dedupe_false_exposes_raw_cross_ingestion_rows(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo = _make_repo(tmp_path)
+    repo.save_signals(
+        [
+            _base_signal(
+                ingestion_run_id="ing-run-001",
+                analysis_run_id="analysis-run-001",
+                symbol="AAPL",
+                timestamp="2025-01-03T00:00:00+00:00",
+            ),
+            _base_signal(
+                ingestion_run_id="ing-run-002",
+                analysis_run_id="analysis-run-002",
+                symbol="AAPL",
+                timestamp="2025-01-03T00:00:00+00:00",
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(api_main, "signal_repo", repo)
+    client = TestClient(api_main.app)
+
+    response_raw = client.get(
+        "/signals",
+        headers=READ_ONLY_HEADERS,
+        params={"dedupe": "false", "limit": 20},
+    )
+    assert response_raw.status_code == 200
+    payload_raw = response_raw.json()
+    assert payload_raw["total"] == 2
+    assert len(payload_raw["items"]) == 2
+
+    response_scoped_raw = client.get(
+        "/signals",
+        headers=READ_ONLY_HEADERS,
+        params={"ingestion_run_id": "ing-run-001", "dedupe": "false", "limit": 20},
+    )
+    assert response_scoped_raw.status_code == 200
+    payload_scoped_raw = response_scoped_raw.json()
+    assert payload_scoped_raw["total"] == 1
+    assert payload_scoped_raw["items"][0]["symbol"] == "AAPL"
 
 
 def test_read_signals_default_limit_applied(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_signal_repository_sqlite.py
+++ b/tests/test_signal_repository_sqlite.py
@@ -342,6 +342,43 @@ def test_read_signals_unfiltered_deduplicates_same_signal_across_ingestion_runs(
     assert ingestion_count == 2
 
 
+def test_read_signals_dedupe_false_unfiltered_returns_raw_cross_ingestion_rows(
+    tmp_path: Path,
+) -> None:
+    repo = _make_repo(tmp_path)
+    first = _base_signal(
+        ingestion_run_id="ing-run-001",
+        analysis_run_id="analysis-run-001",
+        symbol="AAPL",
+        timestamp="2025-01-03T00:00:00+00:00",
+    )
+    second = _base_signal(
+        ingestion_run_id="ing-run-002",
+        analysis_run_id="analysis-run-002",
+        symbol="AAPL",
+        timestamp="2025-01-03T00:00:00+00:00",
+    )
+
+    repo.save_signals([first])
+    repo.save_signals([second])
+
+    all_items, all_total = repo.read_signals(dedupe=False, limit=20, offset=0)
+    scoped_items, scoped_total = repo.read_signals(
+        ingestion_run_id="ing-run-001",
+        dedupe=False,
+        limit=20,
+        offset=0,
+    )
+
+    assert all_total == 2
+    assert len(all_items) == 2
+    assert {item["ingestion_run_id"] for item in all_items} == {"ing-run-001", "ing-run-002"}
+
+    assert scoped_total == 1
+    assert len(scoped_items) == 1
+    assert scoped_items[0]["ingestion_run_id"] == "ing-run-001"
+
+
 def test_repo_init_migrates_legacy_duplicate_ingestion_run_signal_rows(tmp_path: Path) -> None:
     db_path = tmp_path / "legacy_dirty_signals.db"
     init_db(db_path)


### PR DESCRIPTION
## Summary
- add optional dedupe=false query mode for /signals
- preserve default deduped behavior for unfiltered reads
- keep ingestion-scoped behavior stable
- add repository and API coverage for deduped and raw modes

## Validation
- python -m pytest -q tests/test_api_signals_read.py tests/test_signal_repository_sqlite.py
- python -m pytest -q

## Scope
Issue #917