### PR TITLE
Add read-only /signals/raw endpoint for undeduped signal observability

### DIFF
--- a/src/api/models/inspection_models.py
+++ b/src/api/models/inspection_models.py
@@ -18,13 +18,6 @@ class SignalsReadQuery(BaseModel):
     strategy: Optional[str] = Field(default=None)
     timeframe: Optional[str] = Field(default=None)
     ingestion_run_id: Optional[str] = Field(default=None)
-    dedupe: bool = Field(
-        default=True,
-        description=(
-            "If true (default), unfiltered reads dedupe identical signals across ingestion runs. "
-            "Set false for raw cross-ingestion visibility."
-        ),
-    )
     from_: Optional[datetime] = Field(default=None, alias="from")
     to: Optional[datetime] = Field(default=None, alias="to")
     sort: Literal["created_at_asc", "created_at_desc"] = Field(default="created_at_desc")

--- a/src/api/routers/inspection_router.py
+++ b/src/api/routers/inspection_router.py
@@ -71,13 +71,6 @@ def _get_signals_query(
     strategy: Optional[str] = Query(default=None),
     timeframe: Optional[str] = Query(default=None),
     ingestion_run_id: Optional[str] = Query(default=None),
-    dedupe: bool = Query(
-        default=True,
-        description=(
-            "When true (default), unfiltered reads dedupe identical signals across ingestion runs. "
-            "Set false for raw cross-ingestion visibility."
-        ),
-    ),
     from_: Optional[datetime] = Query(default=None, alias="from"),
     to: Optional[datetime] = Query(default=None, alias="to"),
     sort: Literal["created_at_asc", "created_at_desc"] = Query(default="created_at_desc"),
@@ -102,7 +95,6 @@ def _get_signals_query(
         strategy=strategy,
         timeframe=timeframe,
         ingestion_run_id=ingestion_run_id,
-        dedupe=dedupe,
         from_=resolved_from,
         to=resolved_to,
         sort=sort,
@@ -431,8 +423,8 @@ def build_inspection_router(
         response_model=SignalReadResponseDTO,
         summary="Read Signals",
         description=(
-            "Read stored signals with optional filters. By default, unfiltered reads are deduped "
-            "across ingestion runs; set dedupe=false for raw cross-ingestion visibility."
+            "Read stored signals with optional filters on the deduped consumer-facing view. "
+            "For undeduped raw cross-ingestion observability use /signals/raw."
         ),
     )
     def read_signals_handler(
@@ -440,6 +432,21 @@ def build_inspection_router(
         _: str = Depends(deps.require_role("read_only")),
     ) -> SignalReadResponseDTO:
         return inspection_service.read_signals(params=params, deps=_service_dependencies(deps))
+
+    @router.get(
+        "/signals/raw",
+        response_model=SignalReadResponseDTO,
+        summary="Read Raw Signals",
+        description=(
+            "Read stored signals with optional filters on the undeduped raw persisted view across "
+            "ingestion runs for debugging and observability."
+        ),
+    )
+    def read_raw_signals_handler(
+        params: SignalsReadQuery = Depends(_get_signals_query),
+        _: str = Depends(deps.require_role("read_only")),
+    ) -> SignalReadResponseDTO:
+        return inspection_service.read_signals_raw(params=params, deps=_service_dependencies(deps))
 
     @router.get(
         "/execution/orders",

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -398,7 +398,49 @@ def read_signals(
         strategy=params.strategy,
         timeframe=params.timeframe,
         ingestion_run_id=params.ingestion_run_id,
-        dedupe=params.dedupe,
+        from_=params.from_,
+        to=params.to,
+        sort=params.sort,
+        limit=params.limit,
+        offset=params.offset,
+    )
+
+    response_items: List[SignalReadItemDTO] = []
+    for signal in items:
+        response_items.append(
+            SignalReadItemDTO(
+                symbol=signal["symbol"],
+                strategy=signal["strategy"],
+                direction=signal["direction"],
+                score=signal["score"],
+                created_at=signal["timestamp"],
+                stage=signal["stage"],
+                entry_zone=signal.get("entry_zone"),
+                confirmation_rule=signal.get("confirmation_rule"),
+                timeframe=signal["timeframe"],
+                market_type=signal["market_type"],
+                data_source=signal["data_source"],
+            )
+        )
+
+    return SignalReadResponseDTO(
+        items=response_items,
+        limit=params.limit,
+        offset=params.offset,
+        total=total,
+    )
+
+
+def read_signals_raw(
+    *,
+    params: SignalsReadQuery,
+    deps: InspectionServiceDependencies,
+) -> SignalReadResponseDTO:
+    items, total = deps.signal_repo.read_signals_raw(
+        symbol=params.symbol,
+        strategy=params.strategy,
+        timeframe=params.timeframe,
+        ingestion_run_id=params.ingestion_run_id,
         from_=params.from_,
         to=params.to,
         sort=params.sort,

--- a/src/cilly_trading/repositories/signals_sqlite.py
+++ b/src/cilly_trading/repositories/signals_sqlite.py
@@ -264,14 +264,65 @@ class SqliteSignalRepository(SignalRepository):
         strategy: Optional[str] = None,
         timeframe: Optional[str] = None,
         ingestion_run_id: Optional[str] = None,
-        dedupe: bool = True,
         from_: Optional[datetime] = None,
         to: Optional[datetime] = None,
         sort: str = "created_at_desc",
         limit: int = 50,
         offset: int = 0,
     ) -> Tuple[List[Signal], int]:
-        dedupe_unfiltered_reads = dedupe and ingestion_run_id is None
+        return self._read_signals(
+            symbol=symbol,
+            strategy=strategy,
+            timeframe=timeframe,
+            ingestion_run_id=ingestion_run_id,
+            from_=from_,
+            to=to,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+            dedupe_unfiltered_reads=ingestion_run_id is None,
+        )
+
+    def read_signals_raw(
+        self,
+        *,
+        symbol: Optional[str] = None,
+        strategy: Optional[str] = None,
+        timeframe: Optional[str] = None,
+        ingestion_run_id: Optional[str] = None,
+        from_: Optional[datetime] = None,
+        to: Optional[datetime] = None,
+        sort: str = "created_at_desc",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Tuple[List[Signal], int]:
+        return self._read_signals(
+            symbol=symbol,
+            strategy=strategy,
+            timeframe=timeframe,
+            ingestion_run_id=ingestion_run_id,
+            from_=from_,
+            to=to,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+            dedupe_unfiltered_reads=False,
+        )
+
+    def _read_signals(
+        self,
+        *,
+        symbol: Optional[str],
+        strategy: Optional[str],
+        timeframe: Optional[str],
+        ingestion_run_id: Optional[str],
+        from_: Optional[datetime],
+        to: Optional[datetime],
+        sort: str,
+        limit: int,
+        offset: int,
+        dedupe_unfiltered_reads: bool,
+    ) -> Tuple[List[Signal], int]:
         where_clauses = []
         params: List[object] = []
 

--- a/tests/test_api_signals_read.py
+++ b/tests/test_api_signals_read.py
@@ -99,15 +99,16 @@ def test_read_signals_openapi_exposes_timeframe_not_legacy_filters(tmp_path: Pat
     parameter_names = {item["name"] for item in parameters}
 
     assert "timeframe" in parameter_names
-    assert "dedupe" in parameter_names
+    assert "dedupe" not in parameter_names
     assert "preset" not in parameter_names
     assert "start" not in parameter_names
     assert "end" not in parameter_names
-
-    dedupe_param = next(item for item in parameters if item["name"] == "dedupe")
-    assert dedupe_param["required"] is False
-    assert dedupe_param["schema"]["default"] is True
-    assert "raw cross-ingestion visibility" in dedupe_param["description"]
+    assert "/signals/raw" in response.json()["paths"]
+    assert "deduped consumer-facing view" in response.json()["paths"]["/signals"]["get"]["description"]
+    assert (
+        "undeduped raw persisted view across ingestion runs"
+        in response.json()["paths"]["/signals/raw"]["get"]["description"]
+    )
 
 
 def test_read_signals_empty_result(tmp_path: Path, monkeypatch) -> None:
@@ -133,7 +134,6 @@ def test_read_signals_invalid_params(tmp_path: Path, monkeypatch) -> None:
         {"sort": "foo"},
         {"limit": SIGNALS_READ_MAX_LIMIT + 1},
         {"limit": 0},
-        {"dedupe": "not-a-bool"},
         {"from": "2025-01-02T00:00:00+00:00", "to": "2025-01-01T00:00:00+00:00"},
         {"preset": "D1"},
         {"start": "2025-01-01T00:00:00+00:00"},
@@ -283,7 +283,7 @@ def test_read_signals_unfiltered_dedupes_same_signal_across_ingestion_runs(
     assert payload_second_run["items"][0]["symbol"] == "AAPL"
 
 
-def test_read_signals_dedupe_false_exposes_raw_cross_ingestion_rows(
+def test_read_signals_raw_exposes_undeduped_cross_ingestion_rows(
     tmp_path: Path, monkeypatch
 ) -> None:
     repo = _make_repo(tmp_path)
@@ -307,25 +307,86 @@ def test_read_signals_dedupe_false_exposes_raw_cross_ingestion_rows(
     monkeypatch.setattr(api_main, "signal_repo", repo)
     client = TestClient(api_main.app)
 
-    response_raw = client.get(
-        "/signals",
-        headers=READ_ONLY_HEADERS,
-        params={"dedupe": "false", "limit": 20},
-    )
+    response_raw = client.get("/signals/raw", headers=READ_ONLY_HEADERS, params={"limit": 20})
     assert response_raw.status_code == 200
     payload_raw = response_raw.json()
     assert payload_raw["total"] == 2
     assert len(payload_raw["items"]) == 2
 
     response_scoped_raw = client.get(
-        "/signals",
+        "/signals/raw",
         headers=READ_ONLY_HEADERS,
-        params={"ingestion_run_id": "ing-run-001", "dedupe": "false", "limit": 20},
+        params={"ingestion_run_id": "ing-run-001", "limit": 20},
     )
     assert response_scoped_raw.status_code == 200
     payload_scoped_raw = response_scoped_raw.json()
     assert payload_scoped_raw["total"] == 1
     assert payload_scoped_raw["items"][0]["symbol"] == "AAPL"
+
+
+def test_read_signals_raw_supports_filters_sort_and_pagination(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    repo.save_signals(
+        [
+            _base_signal(
+                ingestion_run_id="ing-run-001",
+                analysis_run_id="analysis-run-001",
+                symbol="AAPL",
+                strategy="RSI2",
+                timeframe="D1",
+                timestamp="2025-01-01T00:00:00+00:00",
+            ),
+            _base_signal(
+                ingestion_run_id="ing-run-002",
+                analysis_run_id="analysis-run-002",
+                symbol="AAPL",
+                strategy="RSI2",
+                timeframe="D1",
+                timestamp="2025-01-01T00:00:00+00:00",
+            ),
+            _base_signal(
+                ingestion_run_id="ing-run-003",
+                analysis_run_id="analysis-run-003",
+                symbol="AAPL",
+                strategy="RSI2",
+                timeframe="D1",
+                timestamp="2025-01-02T00:00:00+00:00",
+            ),
+            _base_signal(
+                ingestion_run_id="ing-run-004",
+                analysis_run_id="analysis-run-004",
+                symbol="MSFT",
+                strategy="TURTLE",
+                timeframe="H1",
+                timestamp="2025-01-03T00:00:00+00:00",
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(api_main, "signal_repo", repo)
+    client = TestClient(api_main.app)
+
+    response = client.get(
+        "/signals/raw",
+        headers=READ_ONLY_HEADERS,
+        params={
+            "symbol": "AAPL",
+            "strategy": "RSI2",
+            "timeframe": "D1",
+            "sort": "created_at_asc",
+            "limit": 1,
+            "offset": 1,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 3
+    assert payload["limit"] == 1
+    assert payload["offset"] == 1
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["symbol"] == "AAPL"
+    assert payload["items"][0]["created_at"] == "2025-01-01T00:00:00+00:00"
 
 
 def test_read_signals_default_limit_applied(tmp_path: Path, monkeypatch) -> None:
@@ -354,6 +415,17 @@ def test_read_signals_requires_authenticated_role(tmp_path: Path, monkeypatch) -
     client = TestClient(api_main.app)
 
     response = client.get("/signals")
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "unauthorized"}
+
+
+def test_read_signals_raw_requires_authenticated_role(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr(api_main, "signal_repo", repo)
+    client = TestClient(api_main.app)
+
+    response = client.get("/signals/raw")
 
     assert response.status_code == 401
     assert response.json() == {"detail": "unauthorized"}

--- a/tests/test_signal_repository_sqlite.py
+++ b/tests/test_signal_repository_sqlite.py
@@ -342,7 +342,7 @@ def test_read_signals_unfiltered_deduplicates_same_signal_across_ingestion_runs(
     assert ingestion_count == 2
 
 
-def test_read_signals_dedupe_false_unfiltered_returns_raw_cross_ingestion_rows(
+def test_read_signals_raw_unfiltered_returns_cross_ingestion_rows(
     tmp_path: Path,
 ) -> None:
     repo = _make_repo(tmp_path)
@@ -362,10 +362,9 @@ def test_read_signals_dedupe_false_unfiltered_returns_raw_cross_ingestion_rows(
     repo.save_signals([first])
     repo.save_signals([second])
 
-    all_items, all_total = repo.read_signals(dedupe=False, limit=20, offset=0)
-    scoped_items, scoped_total = repo.read_signals(
+    all_items, all_total = repo.read_signals_raw(limit=20, offset=0)
+    scoped_items, scoped_total = repo.read_signals_raw(
         ingestion_run_id="ing-run-001",
-        dedupe=False,
         limit=20,
         offset=0,
     )
@@ -377,6 +376,60 @@ def test_read_signals_dedupe_false_unfiltered_returns_raw_cross_ingestion_rows(
     assert scoped_total == 1
     assert len(scoped_items) == 1
     assert scoped_items[0]["ingestion_run_id"] == "ing-run-001"
+
+
+def test_read_signals_raw_supports_filters_sort_and_pagination(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    repo.save_signals(
+        [
+            _base_signal(
+                ingestion_run_id="ing-run-001",
+                analysis_run_id="analysis-run-001",
+                symbol="AAPL",
+                strategy="RSI2",
+                timeframe="D1",
+                timestamp="2025-01-01T00:00:00+00:00",
+            ),
+            _base_signal(
+                ingestion_run_id="ing-run-002",
+                analysis_run_id="analysis-run-002",
+                symbol="AAPL",
+                strategy="RSI2",
+                timeframe="D1",
+                timestamp="2025-01-01T00:00:00+00:00",
+            ),
+            _base_signal(
+                ingestion_run_id="ing-run-003",
+                analysis_run_id="analysis-run-003",
+                symbol="AAPL",
+                strategy="RSI2",
+                timeframe="D1",
+                timestamp="2025-01-02T00:00:00+00:00",
+            ),
+            _base_signal(
+                ingestion_run_id="ing-run-004",
+                analysis_run_id="analysis-run-004",
+                symbol="MSFT",
+                strategy="TURTLE",
+                timeframe="H1",
+                timestamp="2025-01-03T00:00:00+00:00",
+            ),
+        ]
+    )
+
+    items, total = repo.read_signals_raw(
+        symbol="AAPL",
+        strategy="RSI2",
+        timeframe="D1",
+        sort="created_at_asc",
+        limit=1,
+        offset=1,
+    )
+
+    assert total == 3
+    assert len(items) == 1
+    assert items[0]["symbol"] == "AAPL"
+    assert items[0]["timestamp"] == "2025-01-01T00:00:00+00:00"
 
 
 def test_repo_init_migrates_legacy_duplicate_ingestion_run_signal_rows(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a dedicated read-only GET /signals/raw endpoint for undeduped persisted signal visibility
- keep GET /signals as the deduped consumer-facing default surface
- remove hidden dual-behavior toggle on /signals (dedupe query param)
- add repository/service split for deduped vs raw read paths
- add targeted API/repository regression tests for:
  - raw cross-ingestion repeats
  - deduped /signals behavior
  - auth parity
  - filter/sort/pagination behavior on /signals/raw
- update OpenAPI-visible endpoint descriptions to make the semantic split explicit

## Scope
- bounded observability and API read-surface change only
- no persistence rule changes
- no architecture changes
- no live/broker/production-readiness claims

Closes #918