### PR TITLE
P56-SIGNAL: Add bounded signal quality validation contract

### DIFF
--- a/docs/governance/signal-quality-bounded-contract.md
+++ b/docs/governance/signal-quality-bounded-contract.md
@@ -1,0 +1,85 @@
+# P56 Signal Quality - Bounded Validation Contract
+
+## Purpose
+
+This contract defines signal-quality validation boundaries for current repository behavior.
+It validates deterministic ranking and filtering behavior for decision-support inspection
+without expanding strategy scope or changing runtime architecture.
+
+## Scope
+
+In scope:
+
+- deterministic ranking behavior under fixed fixtures
+- selectivity behavior via `min_score` filtering where score data is numeric
+- bounded handling for weak or low-information cases where current implementation supports it
+- wording discipline aligned to available repository evidence only
+
+Out of scope:
+
+- new strategies
+- ML scoring
+- external data expansion
+- broad scoring redesign
+- trader-readiness claims
+
+## Bounded Signal-Quality Meaning
+
+Within this repository, "signal quality" is bounded to three implementation-level properties:
+
+1. Deterministic ranking behavior under defined fixtures.
+2. Selectivity boundary for low-information candidates.
+3. Stability boundary under equivalent fixture content.
+
+This contract evaluates ordering and filtering consistency only. It does not evaluate
+market edge, profitability, or production trading outcomes.
+
+## Deterministic Ranking Boundary
+
+For setup-stage candidates that meet the configured score floor, ranking is deterministic:
+
+- primary key: `score` descending
+- secondary key: `signal_strength` descending (when present)
+- tiebreaker: `symbol` ascending
+
+This boundary is implemented by the ranking key in
+`src/api/services/analysis_service.py` (`build_ranked_symbol_results`).
+
+## Selectivity Boundary
+
+Selectivity is bounded to currently supported filtering behavior:
+
+- only `stage == "setup"` is considered
+- candidate score must meet `min_score` (inclusive)
+- scores that cannot be coerced to numeric are treated as low-information and filtered
+  out when `min_score > 0`
+
+The filter is bounded to available signal fields and does not infer missing external context.
+
+## Weak/Low-Information Handling Boundary
+
+Current bounded behavior for weak or low-information signals:
+
+- missing/empty `symbol` is excluded from ranked output
+- non-setup stage is excluded from ranked output
+- non-numeric or missing scores are not promoted above valid numeric setups
+
+These are implementation boundaries, not trader-value guarantees.
+
+## Stability Boundary
+
+Given equivalent fixture content, ranked output remains stable independent of input list order.
+Determinism is asserted through contract tests with permuted fixture ordering.
+
+## Evidence and Claim Boundary
+
+This contract supports only bounded implementation claims. It explicitly supports
+"Classification: technically good, traderically weak" for current state.
+
+It does not claim trader readiness, and it provides no live-trading readiness, execution approval, or profitability guarantee.
+
+## Validation Surfaces
+
+- Tests: `tests/test_sig_p56_signal_quality_contract.py`
+- Runtime ranking surface: `src/api/services/analysis_service.py`
+- Read-model ranking surface: `src/cilly_trading/repositories/signals_sqlite.py`

--- a/tests/test_sig_p56_signal_quality_contract.py
+++ b/tests/test_sig_p56_signal_quality_contract.py
@@ -1,0 +1,93 @@
+"""Contract tests for P56: bounded signal-quality validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from api.services.analysis_service import build_ranked_symbol_results
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_DOC = REPO_ROOT / "docs" / "governance" / "signal-quality-bounded-contract.md"
+
+
+def _signal(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "symbol": "AAPL",
+        "strategy": "RSI2",
+        "stage": "setup",
+        "score": 50.0,
+        "signal_strength": 0.5,
+        "timeframe": "D1",
+        "market_type": "stock",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_p56_ranking_is_deterministic_for_defined_fixture_ordering() -> None:
+    signals = [
+        _signal(symbol="BBB", score=60.0, signal_strength=0.4),
+        _signal(symbol="AAA", score=60.0, signal_strength=0.7),
+        _signal(symbol="AAC", score=60.0, signal_strength=0.7),
+        _signal(symbol="DDD", score=95.0, signal_strength=0.2),
+        _signal(symbol="EEE", score=20.0, signal_strength=0.9),
+    ]
+
+    ranked = build_ranked_symbol_results(signals, min_score=30.0)
+    assert [item.symbol for item in ranked] == ["DDD", "AAA", "AAC", "BBB"]
+
+
+def test_p56_ranking_is_stable_for_permuted_input_fixture() -> None:
+    fixture_a = [
+        _signal(symbol="BBB", score=60.0, signal_strength=0.4),
+        _signal(symbol="AAA", score=60.0, signal_strength=0.7),
+        _signal(symbol="AAC", score=60.0, signal_strength=0.7),
+        _signal(symbol="DDD", score=95.0, signal_strength=0.2),
+    ]
+    fixture_b = list(reversed(fixture_a))
+
+    ranked_a = build_ranked_symbol_results(fixture_a, min_score=30.0)
+    ranked_b = build_ranked_symbol_results(fixture_b, min_score=30.0)
+
+    assert [item.symbol for item in ranked_a] == [item.symbol for item in ranked_b]
+    assert [item.score for item in ranked_a] == [item.score for item in ranked_b]
+    assert [item.signal_strength for item in ranked_a] == [item.signal_strength for item in ranked_b]
+
+
+def test_p56_selectivity_respects_min_score_boundary_for_supported_numeric_scores() -> None:
+    signals = [
+        _signal(symbol="A", score=44.9),
+        _signal(symbol="B", score=45.0),
+        _signal(symbol="C", score=80.0),
+    ]
+
+    ranked = build_ranked_symbol_results(signals, min_score=45.0)
+
+    assert [item.symbol for item in ranked] == ["C", "B"]
+
+
+def test_p56_weak_or_low_information_cases_are_bounded_where_supported() -> None:
+    signals = [
+        _signal(symbol="", score=99.0, signal_strength=1.0),
+        _signal(symbol="NO_SETUP", stage="entry", score=99.0, signal_strength=1.0),
+        _signal(symbol="NO_SCORE", score=None, signal_strength=0.4),
+        _signal(symbol="TEXT_SCORE", score="n/a", signal_strength=0.4),
+        _signal(symbol="VALID", score=55.0, signal_strength=0.2),
+    ]
+
+    ranked = build_ranked_symbol_results(signals, min_score=30.0)
+
+    assert [item.symbol for item in ranked] == ["VALID"]
+
+
+def test_p56_contract_doc_is_bounded_and_no_trader_readiness_claim() -> None:
+    content = CONTRACT_DOC.read_text(encoding="utf-8")
+
+    assert content.startswith("# P56 Signal Quality - Bounded Validation Contract")
+    assert "Deterministic ranking behavior under defined fixtures" in content
+    assert "Selectivity boundary for low-information candidates" in content
+    assert "Stability boundary under equivalent fixture content" in content
+    assert "Classification: technically good, traderically weak" in content
+    assert "does not claim trader readiness" in content
+    assert "no live-trading readiness, execution approval, or profitability guarantee" in content


### PR DESCRIPTION
Closes #924

## Summary
- Add a bounded signal-quality governance contract for current repository behavior.
- Add contract tests for deterministic ranking, selectivity, and stability.
- Add bounded weak/low-information handling tests where current implementation supports it.
- Keep wording evidence-aligned and explicitly non-claiming for trader readiness.

## Scope Guard
- No new strategies
- No ML scoring
- No external data expansion
- No architecture change
- No runtime path expansion