### PR TITLE
P56-BT: define and validate bounded backtest realism assumptions

### DIFF
--- a/docs/testing/backtesting/README.md
+++ b/docs/testing/backtesting/README.md
@@ -19,6 +19,7 @@ python -m cilly_trading compare-strategies --snapshots <PATH> --strategy <NAME> 
 ## Comparable Harness
 - Detailed contract and workflow: `docs/testing/backtesting/strategy_comparison_harness.md`
 - Output artifact: `strategy-comparison.json` + `strategy-comparison.sha256`
+- Bounded realism assumptions contract: `docs/testing/backtesting/p56_bounded_backtest_realism_assumptions.md`
 
 ## Determinism Rules
 - Determinism guard is installed during backtest execution and uninstalled in a finally block.

--- a/docs/testing/backtesting/p56_bounded_backtest_realism_assumptions.md
+++ b/docs/testing/backtesting/p56_bounded_backtest_realism_assumptions.md
@@ -1,0 +1,60 @@
+# P56-BT Bounded Backtest Realism Assumptions
+
+## Goal
+Document and validate currently implemented realism-sensitive assumptions in the deterministic backtest path without introducing a new backtesting subsystem.
+
+## Scope Boundary
+This contract covers only the current deterministic backtest implementation.
+It does not define live-trading behavior, broker behavior, or a market-microstructure simulator.
+
+## Current Implemented Assumptions (Validated)
+
+### Fill assumptions
+- Fill model is fixed to `deterministic_market`.
+- Fill timing is configurable between `next_snapshot` and `same_snapshot`.
+- Price source is fixed to `open_then_price`:
+  - use `open` when present
+  - otherwise use `price`
+- Partial fills are not allowed (`partial_fills_allowed=false`).
+
+### Cost assumptions
+- Slippage model is fixed basis points by side:
+  - BUY adjusts price upward
+  - SELL adjusts price downward
+- Commission model is fixed per filled order (`commission_per_order`).
+
+### Execution assumptions
+- Signals are translated to deterministic market orders with deterministic ordering.
+- Snapshot processing and order processing are deterministic for identical inputs.
+
+## Explicit Realism Gaps (Not Modeled)
+- Market hours/session calendars, halts, auctions, and after-hours restrictions.
+- Broker routing, venue selection, rejects, cancels, and broker-specific policies.
+- Order-book depth, queue position, latency, fill probability, and market impact.
+
+## Evidence Interpretation Boundary
+- Backtest output is bounded evidence for deterministic replay under declared assumptions.
+- It supports controlled review of what the model did on supplied snapshots under fixed cost/fill rules.
+
+Unsupported claims:
+- live-trading readiness or approval
+- broker execution realism
+- market-hours compliance realism
+- liquidity or market microstructure realism
+- future profitability or out-of-sample robustness
+
+## Validation Evidence (Current Repository)
+- Engine contract tests validate assumptions and deterministic behavior:
+  - `tests/cilly_trading/engine/test_backtest_execution_contract.py`
+  - `tests/cilly_trading/engine/test_order_execution_model.py`
+  - `tests/cilly_trading/engine/test_backtest_realism_assumptions.py`
+- Documentation contract tests enforce bounded wording:
+  - `tests/test_backtest_evidence_docs.py`
+  - `tests/test_p56_bt_backtest_realism_docs.py`
+
+## Status Wording
+Classification: technically good, traderically weak.
+
+Rationale:
+- technically good: deterministic and test-validated for implemented assumptions
+- traderically weak: key market-realism dimensions are intentionally unmodeled

--- a/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
+++ b/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from cilly_trading.engine.backtest_execution_contract import (
+    BacktestExecutionAssumptions,
+    BacktestRunContract,
+    build_cost_slippage_metrics_baseline,
+    simulate_execution_flow,
+    sort_snapshots,
+)
+
+
+def _assumptions() -> BacktestExecutionAssumptions:
+    return BacktestExecutionAssumptions(
+        slippage_bps=10,
+        commission_per_order=Decimal("1.25"),
+        fill_timing="next_snapshot",
+    )
+
+
+def test_p56_bt_fill_timing_and_price_source_are_bounded_to_current_model() -> None:
+    snapshots = [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "100",
+            "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+        },
+        {
+            "id": "s2",
+            "timestamp": "2024-01-02T00:00:00Z",
+            "symbol": "AAPL",
+            "price": "101",
+            "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+        },
+        {
+            "id": "s3",
+            "timestamp": "2024-01-03T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "105",
+        },
+    ]
+    run_contract = BacktestRunContract(execution_assumptions=_assumptions())
+
+    flow = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="p56-bt-flow",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    assert len(flow.fills) == 2
+    assert [fill.occurred_at for fill in flow.fills] == ["2024-01-02T00:00:00Z", "2024-01-03T00:00:00Z"]
+    assert flow.fills[0].execution_price == Decimal("101.10100000")
+    assert flow.fills[1].execution_price == Decimal("104.89500000")
+
+
+def test_p56_bt_cost_assumptions_are_fixed_per_order_and_side_aware() -> None:
+    snapshots = sort_snapshots(
+        [
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {
+                "id": "s2",
+                "timestamp": "2024-01-02T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "101",
+                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {
+                "id": "s3",
+                "timestamp": "2024-01-03T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "102",
+            },
+        ]
+    )
+    assumptions = _assumptions()
+    run_contract = BacktestRunContract(execution_assumptions=assumptions)
+    flow = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="p56-bt-cost",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+    baseline = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=flow.fills,
+        execution_assumptions=assumptions,
+    )
+
+    assert [fill.commission for fill in flow.fills] == [Decimal("1.25"), Decimal("1.25")]
+    assert baseline["assumptions"] == assumptions.to_payload()
+    assert baseline["summary"]["total_commission"] == 2.5
+    assert baseline["summary"]["total_slippage_cost"] == 0.2
+    assert baseline["summary"]["total_transaction_cost"] == 2.7
+

--- a/tests/test_p56_bt_backtest_realism_docs.py
+++ b/tests/test_p56_bt_backtest_realism_docs.py
@@ -1,0 +1,40 @@
+"""Contract tests for P56-BT bounded backtest realism assumptions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_DOC = REPO_ROOT / "docs" / "testing" / "backtesting" / "p56_bounded_backtest_realism_assumptions.md"
+
+
+def test_p56_bt_doc_explicitly_documents_current_assumptions() -> None:
+    content = CONTRACT_DOC.read_text(encoding="utf-8")
+
+    assert content.startswith("# P56-BT Bounded Backtest Realism Assumptions")
+    assert "Current Implemented Assumptions (Validated)" in content
+    assert "Fill model is fixed to `deterministic_market`." in content
+    assert "Price source is fixed to `open_then_price`" in content
+    assert "Commission model is fixed per filled order (`commission_per_order`)." in content
+
+
+def test_p56_bt_doc_explicitly_states_realism_gaps_and_unsupported_claims() -> None:
+    content = CONTRACT_DOC.read_text(encoding="utf-8")
+
+    assert "Explicit Realism Gaps (Not Modeled)" in content
+    assert "Market hours/session calendars" in content
+    assert "Broker routing" in content
+    assert "Order-book depth, queue position" in content
+    assert "Unsupported claims:" in content
+    assert "live-trading readiness or approval" in content
+    assert "future profitability or out-of-sample robustness" in content
+
+
+def test_p56_bt_doc_status_wording_is_evidence_bounded() -> None:
+    content = CONTRACT_DOC.read_text(encoding="utf-8")
+
+    assert "Status Wording" in content
+    assert "Classification: technically good, traderically weak." in content
+    assert "deterministic and test-validated for implemented assumptions" in content
+    assert "key market-realism dimensions are intentionally unmodeled" in content


### PR DESCRIPTION
Closes #925

## Summary
- add explicit bounded contract doc for current deterministic backtest realism assumptions
- add bounded tests validating implemented fill/cost/execution assumptions
- add documentation contract tests enforcing explicit realism gaps and unsupported-claim exclusions
- link the new contract from backtesting README

## Scope Discipline
- no runtime semantics changed
- no new backtesting subsystem introduced
- documentation + validation only