### PR TITLE
P56-RISK: validate bounded risk guard behavior under adverse scenarios

### DIFF
--- a/docs/architecture/risk/p56-bounded-adverse-scenario-matrix.md
+++ b/docs/architecture/risk/p56-bounded-adverse-scenario-matrix.md
@@ -1,0 +1,45 @@
+# P56-RISK: Bounded Adverse Scenario Matrix (Current Framework Behavior)
+
+## Purpose
+This artifact validates currently implemented bounded risk behavior under explicit adverse scenarios.
+
+It does not introduce new risk architecture, does not redesign strategy behavior, and does not claim live-trading readiness.
+
+## Scope of Validation
+- Drawdown trigger behavior
+- Daily-loss trigger behavior
+- Kill-switch enforcement behavior
+- Blocked execution path after guard breach
+- Recovery/non-recovery behavior exactly as currently implemented
+
+## Bounded Adverse Scenario Matrix
+
+| Scenario ID | Adverse setup | Guard inputs | Expected execution outcome | Expected semantics |
+| --- | --- | --- | --- | --- |
+| `P56-S1` | Equity drawdown exceeds configured threshold (`peak=100000`, `current=85000`, threshold `0.10`) | `execution.drawdown.max_pct=0.10` | Blocked | `drawdown_shutdown_active`; adapter must not execute |
+| `P56-S2` | Daily loss exceeds configured limit (`start_of_day=100000`, `current=98800`, loss `1200`) | `execution.daily_loss.max_abs=1000` | Blocked | `daily_loss_guard_active`; adapter must not execute |
+| `P56-S3` | Kill switch active with no drawdown/daily-loss breach | `execution.kill_switch.active=true` | Blocked | `global_kill_switch_active`; adapter must not execute |
+| `P56-S4` | Guard breach occurs and execution path is attempted | Any blocking guard active | Blocked | Execution adapter path remains blocked (`adapter_called == false`) |
+| `P56-S5` | Drawdown breached then equity recovers below threshold breach | First: breached, then `current=95000` with same peak/threshold | First blocked, then allowed | Drawdown block can recover when current state no longer exceeds threshold |
+| `P56-S6` | Daily-loss breached then loss recovers within limit | First: loss breached, then `current=99500` with same day start/limit | First blocked, then allowed | Daily-loss block can recover when current state no longer breaches configured max loss |
+| `P56-S7` | Kill switch remains active across repeated attempts | `execution.kill_switch.active=true` | Repeatedly blocked | Non-recovery while switch remains true; recovery only after explicit config switch-off |
+
+## Explicit Expected Outcome Semantics
+- A trigger is considered breached only when the implemented guard predicate returns `True`.
+- When any guard breach blocks execution, the execution adapter path is not invoked.
+- Kill switch enforcement in runtime gate has explicit deterministic block semantics when runtime gate is reached.
+- Drawdown and daily-loss behavior are state-driven and can recover when later state no longer breaches configured limits.
+- Kill switch behavior is config-driven and remains blocked until switched off.
+
+## What Is Validated
+- Deterministic bounded guard behavior for drawdown, daily loss, and kill switch.
+- Deterministic blocked execution path after guard breach.
+- Recovery/non-recovery behavior only for currently implemented state/config semantics.
+
+## Out of Scope / Not Claimed
+- No new risk subsystem or architecture changes.
+- No strategy redesign.
+- No live trading behavior.
+- No broker integration behavior.
+- No production-readiness claim.
+- No claim of complete risk maturity beyond these bounded scenarios.

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,9 @@ Phase 44 reference links remain navigational and do not override the authoritati
 ### OPS-P61 Reference Materials
 - [OPS-P61 Practice and Analysis Article standards](phases/ops-p61-practice-analysis-article-standards.md)
 
+### P56-RISK Reference Materials
+- [P56 bounded adverse scenario matrix](architecture/risk/p56-bounded-adverse-scenario-matrix.md)
+
 ### DEC-P47 Reference Materials
 - [DEC-P47 qualification claim boundary](phases/dec-p47-qualification-claim-boundary.md)
 

--- a/tests/compliance/test_p56_bounded_adverse_scenarios.py
+++ b/tests/compliance/test_p56_bounded_adverse_scenarios.py
@@ -1,0 +1,245 @@
+"""P56 bounded adverse-scenario validation for current risk guard behavior.
+
+Acceptance criteria coverage:
+    - drawdown-trigger behavior
+    - daily-loss-trigger behavior
+    - kill-switch enforcement behavior
+    - blocked execution path after guard breach
+    - recovery/non-recovery behavior as currently implemented
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from cilly_trading.compliance.daily_loss_guard import should_block_execution_for_daily_loss
+from cilly_trading.compliance.drawdown_guard import should_block_execution_for_drawdown
+from cilly_trading.orchestrator.runtime import (
+    ExecutionBlockedError,
+    ExecutionRequest,
+    execute_request,
+)
+from cilly_trading.portfolio.state import PortfolioState
+
+
+def _request() -> ExecutionRequest:
+    return ExecutionRequest(strategy_id="strategy-p56", symbol="AAPL", quantity=1.0)
+
+
+def _execute_with_compliance_pipeline(
+    request: ExecutionRequest,
+    *,
+    execute_adapter: Callable[[ExecutionRequest], dict[str, Any]],
+    portfolio_state: PortfolioState,
+    config: dict[str, object] | None = None,
+) -> dict[str, Any]:
+    if should_block_execution_for_drawdown(portfolio_state=portfolio_state, config=config):
+        raise ExecutionBlockedError("blocked: drawdown_shutdown_active")
+
+    if should_block_execution_for_daily_loss(portfolio_state=portfolio_state, config=config):
+        raise ExecutionBlockedError("blocked: daily_loss_guard_active")
+
+    return execute_request(request, execute_adapter=execute_adapter, config=config)
+
+
+def _attempt(
+    *,
+    portfolio_state: PortfolioState,
+    config: dict[str, object] | None = None,
+) -> tuple[bool, bool, str | None]:
+    adapter_called = False
+
+    def _adapter(_: ExecutionRequest) -> dict[str, Any]:
+        nonlocal adapter_called
+        adapter_called = True
+        return {"status": "executed"}
+
+    try:
+        _execute_with_compliance_pipeline(
+            _request(),
+            execute_adapter=_adapter,
+            portfolio_state=portfolio_state,
+            config=config,
+        )
+        return False, adapter_called, None
+    except ExecutionBlockedError as exc:
+        return True, adapter_called, str(exc)
+
+
+def test_p56_drawdown_trigger_blocks_and_path_is_blocked() -> None:
+    blocked, adapter_called, reason = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=100_000.0,
+            current_equity=85_000.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config={
+            "execution.kill_switch.active": False,
+            "execution.emergency_block.active": False,
+            "execution.drawdown.max_pct": 0.10,
+            "execution.daily_loss.max_abs": 50_000.0,
+        },
+    )
+
+    assert blocked is True
+    assert adapter_called is False
+    assert reason == "blocked: drawdown_shutdown_active"
+
+
+def test_p56_daily_loss_trigger_blocks_and_path_is_blocked() -> None:
+    blocked, adapter_called, reason = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=110_000.0,
+            current_equity=98_800.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config={
+            "execution.kill_switch.active": False,
+            "execution.emergency_block.active": False,
+            "execution.drawdown.max_pct": 0.90,
+            "execution.daily_loss.max_abs": 1_000.0,
+        },
+    )
+
+    assert blocked is True
+    assert adapter_called is False
+    assert reason == "blocked: daily_loss_guard_active"
+
+
+def test_p56_kill_switch_enforcement_overrides_other_conditions() -> None:
+    blocked, adapter_called, reason = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=100_000.0,
+            current_equity=100_000.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config={
+            "execution.kill_switch.active": True,
+            "execution.emergency_block.active": False,
+            "execution.drawdown.max_pct": 0.50,
+            "execution.daily_loss.max_abs": 10_000.0,
+        },
+    )
+
+    assert blocked is True
+    assert adapter_called is False
+    assert reason == "blocked: global_kill_switch_active"
+
+
+def test_p56_drawdown_recovery_behavior_matches_current_implementation() -> None:
+    config = {
+        "execution.kill_switch.active": False,
+        "execution.emergency_block.active": False,
+        "execution.drawdown.max_pct": 0.10,
+        "execution.daily_loss.max_abs": 50_000.0,
+    }
+
+    blocked_first, adapter_called_first, reason_first = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=100_000.0,
+            current_equity=85_000.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config=config,
+    )
+    blocked_second, adapter_called_second, reason_second = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=100_000.0,
+            current_equity=95_000.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config=config,
+    )
+
+    assert blocked_first is True
+    assert adapter_called_first is False
+    assert reason_first == "blocked: drawdown_shutdown_active"
+    assert blocked_second is False
+    assert adapter_called_second is True
+    assert reason_second is None
+
+
+def test_p56_daily_loss_recovery_behavior_matches_current_implementation() -> None:
+    config = {
+        "execution.kill_switch.active": False,
+        "execution.emergency_block.active": False,
+        "execution.drawdown.max_pct": 0.90,
+        "execution.daily_loss.max_abs": 1_000.0,
+    }
+
+    blocked_first, adapter_called_first, reason_first = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=110_000.0,
+            current_equity=98_800.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config=config,
+    )
+    blocked_second, adapter_called_second, reason_second = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=110_000.0,
+            current_equity=99_500.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config=config,
+    )
+
+    assert blocked_first is True
+    assert adapter_called_first is False
+    assert reason_first == "blocked: daily_loss_guard_active"
+    assert blocked_second is False
+    assert adapter_called_second is True
+    assert reason_second is None
+
+
+def test_p56_kill_switch_non_recovery_until_config_switches_off() -> None:
+    blocked_first, adapter_called_first, reason_first = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=100_000.0,
+            current_equity=100_000.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config={
+            "execution.kill_switch.active": True,
+            "execution.emergency_block.active": False,
+            "execution.drawdown.max_pct": 0.50,
+            "execution.daily_loss.max_abs": 10_000.0,
+        },
+    )
+    blocked_second, adapter_called_second, reason_second = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=100_000.0,
+            current_equity=100_000.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config={
+            "execution.kill_switch.active": True,
+            "execution.emergency_block.active": False,
+            "execution.drawdown.max_pct": 0.50,
+            "execution.daily_loss.max_abs": 10_000.0,
+        },
+    )
+    blocked_third, adapter_called_third, reason_third = _attempt(
+        portfolio_state=PortfolioState(
+            peak_equity=100_000.0,
+            current_equity=100_000.0,
+            start_of_day_equity=100_000.0,
+        ),
+        config={
+            "execution.kill_switch.active": False,
+            "execution.emergency_block.active": False,
+            "execution.drawdown.max_pct": 0.50,
+            "execution.daily_loss.max_abs": 10_000.0,
+        },
+    )
+
+    assert blocked_first is True
+    assert adapter_called_first is False
+    assert reason_first == "blocked: global_kill_switch_active"
+    assert blocked_second is True
+    assert adapter_called_second is False
+    assert reason_second == "blocked: global_kill_switch_active"
+    assert blocked_third is False
+    assert adapter_called_third is True
+    assert reason_third is None

--- a/tests/test_p56_risk_bounded_adverse_scenario_matrix_docs.py
+++ b/tests/test_p56_risk_bounded_adverse_scenario_matrix_docs.py
@@ -1,0 +1,52 @@
+"""Contract tests for P56 bounded adverse scenario matrix documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+P56_DOC = "docs/architecture/risk/p56-bounded-adverse-scenario-matrix.md"
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_p56_doc_exists_and_has_required_sections() -> None:
+    content = _read(P56_DOC)
+
+    assert content.startswith("# P56-RISK: Bounded Adverse Scenario Matrix")
+    assert "## Scope of Validation" in content
+    assert "## Bounded Adverse Scenario Matrix" in content
+    assert "## Explicit Expected Outcome Semantics" in content
+    assert "## What Is Validated" in content
+    assert "## Out of Scope / Not Claimed" in content
+
+
+def test_p56_doc_covers_required_scenario_categories() -> None:
+    content = _read(P56_DOC)
+
+    assert "`P56-S1`" in content
+    assert "`P56-S2`" in content
+    assert "`P56-S3`" in content
+    assert "`P56-S4`" in content
+    assert "`P56-S5`" in content
+    assert "`P56-S6`" in content
+    assert "`P56-S7`" in content
+
+
+def test_p56_doc_defines_explicit_non_claim_boundaries() -> None:
+    content = _read(P56_DOC)
+
+    assert "No live trading behavior." in content
+    assert "No broker integration behavior." in content
+    assert "No production-readiness claim." in content
+    assert "No claim of complete risk maturity beyond these bounded scenarios." in content
+
+
+def test_docs_index_links_p56_reference() -> None:
+    content = _read("docs/index.md")
+
+    assert "### P56-RISK Reference Materials" in content
+    assert "architecture/risk/p56-bounded-adverse-scenario-matrix.md" in content


### PR DESCRIPTION
Closes #923

## Summary
- Added a bounded adverse scenario matrix for current risk guard behavior.
- Added explicit guard-behavior tests covering:
  - drawdown trigger
  - daily loss trigger
  - kill switch enforcement
  - blocked execution path after guard breach
  - recovery / non-recovery semantics as currently implemented
- Added documentation contract tests and linked P56 doc from docs index.

## Scope and Boundaries
- No architecture change.
- No new risk subsystem.
- No strategy redesign.
- No live trading or broker integration claims.
- No production-readiness claim added.

## Validation
`python -m pytest -q`

Result: `1013 passed, 4 warnings`