### PR TITLE
[AFTER SERVER TESTS][4] P56-PORT — Define bounded portfolio simulation acceptance contract

### DIFF
--- a/.github/pr-927-body.md
+++ b/.github/pr-927-body.md
@@ -1,0 +1,22 @@
+﻿Closes #927
+
+## Summary
+- strengthened bounded run-evidence interpretation rules for post-active server-test review
+- clarified decision-support review semantics: pass, pass-with-note, fail
+- added explicit follow-up issue triggers for reproducible bounded defects
+- aligned staging deployment runbook and operator checklist references to the new interpretation section
+
+## Scope
+- docs-only update
+- no automation changes
+- no production-readiness or live-trading claims
+- no architecture/runtime behavior changes
+
+## Files changed
+- docs/operations/runtime/p53-automated-review-operations.md
+- docs/operations/runtime/staging-server-deployment.md
+- docs/operations/runtime/paper-deployment-operator-checklist.md
+
+## Validation
+- Ran: python -m uv run -- python -m pytest --import-mode=importlib
+- Result: 1013 passed, 4 warnings

--- a/docs/architecture/phases/phase-43-portfolio-inspection-contract.md
+++ b/docs/architecture/phases/phase-43-portfolio-inspection-contract.md
@@ -1,36 +1,86 @@
-# Phase 43 Portfolio Inspection Contract
+# Phase 43 Bounded Portfolio Simulation Acceptance Contract
 
-This document defines the bounded Phase 43 contract for portfolio/paper inspection surfaces:
+This document formalizes the bounded acceptance contract for currently implemented
+Phase 43 portfolio-simulation primitives, without expanding into broader product
+workflow scope.
+
+## Contract Intent
+
+Phase 43 remains **Partially Implemented**.
+
+This contract defines only the deterministic portfolio-simulation primitives that
+are currently implemented and test-verified in repository code. It does not claim
+paper-trading readiness, live-capital readiness, or broader product workflow
+completeness.
+
+## Bounded Acceptance Surface
+
+### Capital Allocation Primitive
+
+- Authority module:
+  - `src/cilly_trading/portfolio_framework/capital_allocation_policy.py`
+- Contract operation:
+  - `assess_capital_allocation(state, rules)`
+- Accepted behavior:
+  - deterministic global-cap enforcement
+  - deterministic strategy-cap enforcement
+  - deterministic reason ordering for violations
+
+### Exposure Handling Primitive
+
+- Authority module:
+  - `src/cilly_trading/portfolio_framework/exposure_aggregator.py`
+- Contract operation:
+  - `aggregate_portfolio_exposure(state)`
+- Accepted behavior:
+  - deterministic strategy/symbol/position exposure aggregation
+  - explicit gross/net exposure math
+  - explicit zero-equity behavior (`inf`, `-inf`, or `0.0` as implemented)
+
+### Multi-Position Consistency Primitive
+
+- Authority modules:
+  - `src/cilly_trading/portfolio_framework/capital_allocation_policy.py`
+  - `src/api/services/paper_inspection_service.py`
+- Contract operations:
+  - `run_portfolio_decision_pipeline(...)`
+  - `build_portfolio_positions_from_trades(...)`
+  - `build_bounded_paper_simulation_state(...)`
+- Accepted behavior:
+  - deterministic ranked-signal decisions across competing positions
+  - state mutation only for approved outcomes in decision pipeline
+  - deterministic `(strategy_id, symbol)` aggregation for inspection positions
+  - bounded runtime snapshot validation via `validate_bounded_paper_simulation_state(...)`
+
+## Inspection Surfaces Covered by the Same Bounded State
 
 - `GET /portfolio/positions`
 - `GET /paper/account`
 - `GET /paper/reconciliation`
 
-## Scope
+Covered endpoints are read-only and derived from one bounded canonical snapshot.
+They do not execute orders or mutate portfolio state.
 
-- The covered endpoints are read-only inspection surfaces.
-- Covered state is derived from canonical simulation artifacts persisted by the trading-core execution repository.
-- Covered endpoints do not execute orders, mutate portfolio state, or expose live broker state.
+## Implemented Primitives vs Missing Broader Workflow
 
-## Source Of Truth
+### Implemented In Scope
 
-- `src/api/services/paper_inspection_service.py`
-- `build_bounded_paper_simulation_state(...)`
+- deterministic capital-allocation assessment
+- deterministic exposure aggregation and guardrail evaluation inputs
+- deterministic ranked portfolio decision pipeline semantics
+- deterministic portfolio/paper inspection derivation from canonical execution entities
+- bounded runtime validation of simulation snapshot integrity
 
-The source of truth is one bounded in-memory simulation snapshot built from canonical repository reads (`list_orders`, `list_execution_events`, `list_trades`) and reused for covered inspection derivations.
+### Not Implemented In This Phase Scope
 
-## Derivation Rules
-
-- Closed exposure (`remaining_quantity <= 0`) is excluded.
-- Positions are aggregated by `(strategy_id, symbol)`.
-- `size` is the sum of remaining quantities in the aggregate group.
-- `average_price` is a weighted entry average over remaining quantity.
-- `unrealized_pnl` is the sum of unrealized PnL values (missing values treated as `0`).
-- Output ordering is deterministic: `symbol`, `strategy_id`, `size`, `average_price`, `unrealized_pnl`.
-- Paper account and reconciliation summaries are derived from the same bounded snapshot used for portfolio inspection output.
+- broad portfolio product workflow expansion
+- live-capital claims or readiness
+- broker integration or broker-state synchronization workflow
+- broad execution-system redesign
+- complete paper-trading operational lifecycle as a Phase 43 claim
 
 ## Explicit Non-Claims
 
-- No live broker portfolio sync.
-- No mutation workflow for paper-trading state.
-- No execution-capability claim beyond deterministic inspection of bounded internal artifacts.
+- This contract does **not** upgrade Phase 43 from partial maturity.
+- Passing this contract does **not** imply Phase 44 paper readiness by itself.
+- Passing this contract does **not** imply any live-trading or broker-readiness claim.

--- a/tests/test_phase43_portfolio_simulation_contract.py
+++ b/tests/test_phase43_portfolio_simulation_contract.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from cilly_trading.models import Trade
+from cilly_trading.portfolio_framework import (
+    CapitalAllocationRules,
+    PortfolioGuardrailLimits,
+    PortfolioPosition,
+    PortfolioState,
+    PrioritizedAllocationConfig,
+    PrioritizedAllocationSignal,
+    StrategyAllocationRule,
+    aggregate_portfolio_exposure,
+    assess_capital_allocation,
+    run_portfolio_decision_pipeline,
+)
+from api.services.paper_inspection_service import build_portfolio_positions_from_trades
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_phase43_contract_doc_declares_bounded_partial_acceptance_surface() -> None:
+    content = (
+        REPO_ROOT
+        / "docs"
+        / "architecture"
+        / "phases"
+        / "phase-43-portfolio-inspection-contract.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Phase 43 remains **Partially Implemented**." in content
+    assert "Capital Allocation Primitive" in content
+    assert "Exposure Handling Primitive" in content
+    assert "Multi-Position Consistency Primitive" in content
+    assert "Implemented In Scope" in content
+    assert "Not Implemented In This Phase Scope" in content
+    assert "does **not** imply any live-trading or broker-readiness claim" in content
+
+
+def test_phase43_capital_allocation_contract_enforces_global_and_strategy_caps() -> None:
+    state = PortfolioState(
+        account_equity=1000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                quantity=2.0,
+                mark_price=100.0,
+            ),
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="ETHUSDT",
+                quantity=1.0,
+                mark_price=100.0,
+            ),
+        ),
+    )
+    rules = CapitalAllocationRules(
+        global_capital_cap_pct=0.25,
+        strategy_rules=(
+            StrategyAllocationRule(
+                strategy_id="alpha",
+                capital_cap_pct=0.15,
+                allocation_score=1.0,
+            ),
+            StrategyAllocationRule(
+                strategy_id="beta",
+                capital_cap_pct=0.25,
+                allocation_score=1.0,
+            ),
+        ),
+    )
+
+    assessment = assess_capital_allocation(state, rules)
+
+    assert assessment.approved is False
+    assert assessment.reasons == (
+        "global_cap_exceeded: total_absolute_notional=300.0 global_cap_notional=250.0",
+        "strategy_cap_exceeded: strategy_id=alpha",
+    )
+
+
+def test_phase43_exposure_handling_contract_reports_deterministic_multi_position_metrics() -> None:
+    state = PortfolioState(
+        account_equity=2000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="SOLUSDT",
+                quantity=5.0,
+                mark_price=20.0,
+            ),
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="ADAUSDT",
+                quantity=50.0,
+                mark_price=1.0,
+            ),
+            PortfolioPosition(
+                strategy_id="beta",
+                symbol="ADAUSDT",
+                quantity=-20.0,
+                mark_price=1.0,
+            ),
+        ),
+    )
+
+    summary = aggregate_portfolio_exposure(state)
+
+    assert summary.total_absolute_notional == 170.0
+    assert summary.net_notional == 130.0
+    assert summary.gross_exposure_pct == 0.085
+    assert summary.net_exposure_pct == 0.065
+    assert [item.symbol for item in summary.symbol_exposures] == ["ADAUSDT", "SOLUSDT"]
+    assert summary.symbol_exposures[0].net_notional == 30.0
+
+
+def test_phase43_multi_position_consistency_keeps_final_state_bounded_to_approved_signals() -> None:
+    initial_state = PortfolioState(
+        account_equity=1000.0,
+        positions=(
+            PortfolioPosition(
+                strategy_id="alpha",
+                symbol="BTCUSDT",
+                quantity=1.0,
+                mark_price=100.0,
+            ),
+        ),
+    )
+
+    result = run_portfolio_decision_pipeline(
+        state=initial_state,
+        signals=(
+            PrioritizedAllocationSignal(
+                signal_id="sig-1",
+                strategy_id="beta",
+                symbol="ETHUSDT",
+                priority_score=90.0,
+                requested_notional=100.0,
+                signal_timestamp="2026-04-10T08:00:00Z",
+                mark_price=100.0,
+            ),
+            PrioritizedAllocationSignal(
+                signal_id="sig-2",
+                strategy_id="beta",
+                symbol="SOLUSDT",
+                priority_score=80.0,
+                requested_notional=300.0,
+                signal_timestamp="2026-04-10T08:01:00Z",
+                mark_price=100.0,
+            ),
+        ),
+        allocation_config=PrioritizedAllocationConfig(
+            available_capital_notional=300.0,
+            max_positions=2,
+            default_position_cap_notional=300.0,
+            min_allocation_notional=10.0,
+        ),
+        allocation_rules=CapitalAllocationRules(
+            global_capital_cap_pct=0.25,
+            strategy_rules=(
+                StrategyAllocationRule(
+                    strategy_id="alpha",
+                    capital_cap_pct=0.25,
+                    allocation_score=1.0,
+                ),
+                StrategyAllocationRule(
+                    strategy_id="beta",
+                    capital_cap_pct=0.25,
+                    allocation_score=1.0,
+                ),
+            ),
+        ),
+        guardrail_limits=PortfolioGuardrailLimits(
+            max_gross_exposure_pct=1.0,
+            max_abs_net_exposure_pct=1.0,
+            max_offset_exposure_pct=1.0,
+            max_strategy_concentration_pct=1.0,
+            max_symbol_concentration_pct=1.0,
+            max_position_concentration_pct=1.0,
+        ),
+    )
+
+    assert result.approved_signal_ids == ("sig-1",)
+    assert result.constraint_hit_signal_ids == ("sig-2",)
+    assert len(result.final_state.positions) == 2
+    assert {(item.strategy_id, item.symbol) for item in result.final_state.positions} == {
+        ("alpha", "BTCUSDT"),
+        ("beta", "ETHUSDT"),
+    }
+
+
+def test_phase43_portfolio_positions_aggregate_open_trades_by_strategy_symbol_only() -> None:
+    trades = [
+        Trade.model_validate(
+            {
+                "trade_id": "t-1",
+                "position_id": "p-1",
+                "strategy_id": "alpha",
+                "symbol": "BTCUSDT",
+                "direction": "long",
+                "status": "open",
+                "opened_at": "2026-04-10T08:00:00Z",
+                "closed_at": None,
+                "quantity_opened": Decimal("2"),
+                "quantity_closed": Decimal("0"),
+                "average_entry_price": Decimal("100"),
+                "average_exit_price": None,
+                "realized_pnl": None,
+                "unrealized_pnl": Decimal("3"),
+                "opening_order_ids": ["o-1"],
+                "closing_order_ids": [],
+                "execution_event_ids": ["e-1"],
+            }
+        ),
+        Trade.model_validate(
+            {
+                "trade_id": "t-2",
+                "position_id": "p-2",
+                "strategy_id": "alpha",
+                "symbol": "BTCUSDT",
+                "direction": "long",
+                "status": "open",
+                "opened_at": "2026-04-10T08:01:00Z",
+                "closed_at": None,
+                "quantity_opened": Decimal("3"),
+                "quantity_closed": Decimal("0"),
+                "average_entry_price": Decimal("110"),
+                "average_exit_price": None,
+                "realized_pnl": None,
+                "unrealized_pnl": Decimal("4"),
+                "opening_order_ids": ["o-2"],
+                "closing_order_ids": [],
+                "execution_event_ids": ["e-2"],
+            }
+        ),
+        Trade.model_validate(
+            {
+                "trade_id": "t-closed",
+                "position_id": "p-3",
+                "strategy_id": "alpha",
+                "symbol": "BTCUSDT",
+                "direction": "long",
+                "status": "closed",
+                "opened_at": "2026-04-10T08:02:00Z",
+                "closed_at": "2026-04-10T08:03:00Z",
+                "quantity_opened": Decimal("1"),
+                "quantity_closed": Decimal("1"),
+                "average_entry_price": Decimal("95"),
+                "average_exit_price": Decimal("96"),
+                "realized_pnl": Decimal("1"),
+                "unrealized_pnl": None,
+                "opening_order_ids": ["o-3"],
+                "closing_order_ids": ["o-4"],
+                "execution_event_ids": ["e-3", "e-4"],
+            }
+        ),
+    ]
+
+    positions = build_portfolio_positions_from_trades(trades=trades)
+
+    assert len(positions) == 1
+    assert positions[0].strategy_id == "alpha"
+    assert positions[0].symbol == "BTCUSDT"
+    assert positions[0].size == Decimal("5")
+    assert positions[0].average_price == Decimal("106")
+    assert positions[0].unrealized_pnl == Decimal("7")


### PR DESCRIPTION
Closes #926

What changed
Formalized a bounded Phase 43 portfolio simulation acceptance contract in:
docs/architecture/phases/phase-43-portfolio-inspection-contract.md
Explicitly mapped currently implemented primitives:
capital allocation (assess_capital_allocation)
exposure handling (aggregate_portfolio_exposure)
multi-position consistency (run_portfolio_decision_pipeline, build_portfolio_positions_from_trades, build_bounded_paper_simulation_state, validate_bounded_paper_simulation_state)
Explicitly separated implemented primitives from broader incomplete workflow scope
Added contract-focused tests:
tests/test_phase43_portfolio_simulation_contract.py
Validation
Ran repository test command:
python -m pytest
Result:
1018 passed, 4 warnings
Governance Notes
Change is bounded to Phase 43 portfolio simulation contract documentation and contract validation tests
Phase 43 remains partially implemented
No Phase 44 paper-readiness claim
No live-trading or broker-readiness claim