### PR TITLE
Codex/govern paper risk profile

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,4 @@
 ﻿# Codex project configuration
 
 approval_policy = "on-request"
-sandbox_mode = "workspace"
-
-# Prevent Codex from modifying files outside this repository
-# and require confirmation for risky commands.
+sandbox_mode = "workspace-write"

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,26 @@
-﻿__pycache__/
+﻿# Python caches / metadata
+__pycache__/
 *.pyc
+*.pyo
 .pytest_cache/
+*.egg-info/
+
+# Local environments / secrets
+.venv*/
+.env
+.env.*
+
+# Local databases / runtime files
+*.db
+runs/
+
+# Local editor settings
+.vscode/
 
 # Transient PR body artifacts at repository root
 /pr_body.md
 /pr_body_*.md
 /.pr-body-*.md
-*.db
-.venv*/
 
 # local scripts
 scripts/*
@@ -19,13 +32,4 @@ scripts/*
 !scripts/capture_restart_evidence.py
 !scripts/run_paper_execution_cycle.py
 !scripts/run_daily_bounded_paper_runtime.py
-
-# Local runtime artifacts (never commit)
-# runs/ stores local execution/test artifacts and must never be committed.
-runs/
-# Python build metadata
-*.egg-info/
-__pycache__/
-*.pyc
-*.pyo
-.pytest_cache/
+*.code-workspace

--- a/docs/operations/runtime/signal_to_paper_execution_policy.md
+++ b/docs/operations/runtime/signal_to_paper_execution_policy.md
@@ -55,6 +55,36 @@ A signal that fails any step produces an explicit outcome:
 - **reject**: signal violates a hard rule; it is blocked with an explicit reason
   code that must be logged.
 
+## Paper Execution Risk Profile Contract (P57-RISK)
+
+Bounded paper execution risk inputs are governed by one canonical validated
+contract:
+
+- `src/cilly_trading/engine/paper_execution_risk_profile.py`
+- contract id: `paper-execution-risk-profile-v1`
+
+The contract validates all bounded profile inputs fail-closed before execution
+begins. Invalid values raise explicit errors (for example, out-of-range
+percentages, non-positive limits, or non-finite numeric values), and execution
+does not proceed with implicit defaults.
+
+Validated by this contract:
+
+- score threshold bounds (`0.0..100.0`)
+- bounded exposure percentages (`(0, 1]`)
+- bounded concurrency/cooldown limits
+- bounded paper quantity, fallback entry price, and account equity (> `0`)
+
+Not claimed by this contract:
+
+- live-trading readiness
+- broker integration readiness
+- production-readiness approval
+
+P56 alignment note: this contract hardens paper-execution input governance for
+runtime determinism. It does not duplicate the existing P56 adverse-scenario
+matrix scope in `docs/architecture/risk/p56-bounded-adverse-scenario-matrix.md`.
+
 ## Eligibility Rules
 
 A signal is ineligible (rejected) if any required field is absent or invalid:
@@ -65,7 +95,7 @@ A signal is ineligible (rejected) if any required field is absent or invalid:
 | `strategy` | Non-empty string key matching a known governed strategy. |
 | `direction` | Must be `long` or `short`. |
 | `score` | Numeric value; must be present and within `[0.0, 100.0]`. |
-| `timestamp` | Parseable ISO-8601 datetime or Unix epoch milliseconds. |
+| `timestamp` | Parseable ISO-8601 datetime string. |
 | `stage` | Must be non-empty and a recognized stage value such as `setup`. |
 
 A signal missing any required field, or with a field value outside its allowed

--- a/scripts/run_paper_execution_cycle.py
+++ b/scripts/run_paper_execution_cycle.py
@@ -38,6 +38,7 @@ if str(SRC) not in sys.path:
 
 from cilly_trading.engine.paper_execution_worker import (  # noqa: E402
     BoundedPaperExecutionWorker,
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE,
     SignalEvaluationResult,
 )
 from cilly_trading.repositories.execution_core_sqlite import (  # noqa: E402
@@ -144,7 +145,11 @@ def run_paper_execution_cycle(
 
         signals = signal_repo.list_signals(limit=signal_limit)
 
-        worker = BoundedPaperExecutionWorker(repository=execution_repo)
+        risk_profile = DEFAULT_PAPER_EXECUTION_RISK_PROFILE
+        worker = BoundedPaperExecutionWorker(
+            repository=execution_repo,
+            risk_profile=risk_profile,
+        )
         results = worker.process_batch(signals)
     except Exception as exc:
         error_payload: dict[str, Any] = {
@@ -173,6 +178,7 @@ def run_paper_execution_cycle(
         "ran_at": ran_at.isoformat(),
         "rejected": len(rejected),
         "results": [_result_to_dict(r) for r in results],
+        "risk_profile": risk_profile.to_payload(),
         "signals_read": len(signals),
         "skipped": len(skipped),
         "status": "pass" if eligible else "no_eligible",

--- a/src/cilly_trading/engine/paper_execution_risk_profile.py
+++ b/src/cilly_trading/engine/paper_execution_risk_profile.py
@@ -1,0 +1,124 @@
+"""Canonical bounded paper execution risk profile contract (P57-RISK).
+
+This contract is the single authoritative input surface for bounded paper
+execution risk behavior. Every bounded paper execution path must source risk
+parameters from this profile.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from math import isfinite
+from typing import Any
+
+
+PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID = "paper-execution-risk-profile-v1"
+
+
+def _require_finite_pct(*, name: str, value: Decimal, allow_zero: bool = False) -> None:
+    if not value.is_finite():
+        raise ValueError(f"{name} must be finite")
+    if allow_zero:
+        if value < Decimal("0") or value > Decimal("1"):
+            raise ValueError(f"{name} must be in range [0, 1]")
+        return
+    if value <= Decimal("0") or value > Decimal("1"):
+        raise ValueError(f"{name} must be in range (0, 1]")
+
+
+def _require_finite_positive_decimal(*, name: str, value: Decimal) -> None:
+    if not value.is_finite():
+        raise ValueError(f"{name} must be finite")
+    if value <= Decimal("0"):
+        raise ValueError(f"{name} must be > 0")
+
+
+def _require_finite_score(*, name: str, value: float) -> None:
+    if not isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    if value < 0.0 or value > 100.0:
+        raise ValueError(f"{name} must be in range [0.0, 100.0]")
+
+
+@dataclass(frozen=True)
+class PaperExecutionRiskProfile:
+    """Validated bounded risk profile for paper execution."""
+
+    contract_id: str = PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID
+    min_score_threshold: float = 60.0
+    max_position_pct: Decimal = Decimal("0.10")
+    max_total_exposure_pct: Decimal = Decimal("0.80")
+    max_strategy_exposure_pct: Decimal = Decimal("0.80")
+    max_symbol_exposure_pct: Decimal = Decimal("0.80")
+    max_concurrent_positions: int = 10
+    cooldown_hours: int = 24
+    account_equity: Decimal = Decimal("100000")
+    default_paper_quantity: Decimal = Decimal("1")
+    default_paper_entry_price: Decimal = Decimal("100")
+
+    def __post_init__(self) -> None:
+        if self.contract_id != PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID:
+            raise ValueError(
+                "unsupported paper execution risk profile contract_id: "
+                f"{self.contract_id!r}"
+            )
+        _require_finite_score(
+            name="min_score_threshold",
+            value=self.min_score_threshold,
+        )
+        _require_finite_pct(name="max_position_pct", value=self.max_position_pct)
+        _require_finite_pct(
+            name="max_total_exposure_pct",
+            value=self.max_total_exposure_pct,
+        )
+        _require_finite_pct(
+            name="max_strategy_exposure_pct",
+            value=self.max_strategy_exposure_pct,
+        )
+        _require_finite_pct(
+            name="max_symbol_exposure_pct",
+            value=self.max_symbol_exposure_pct,
+        )
+        if self.max_concurrent_positions <= 0:
+            raise ValueError("max_concurrent_positions must be > 0")
+        if self.cooldown_hours < 0:
+            raise ValueError("cooldown_hours must be >= 0")
+        _require_finite_positive_decimal(
+            name="account_equity",
+            value=self.account_equity,
+        )
+        _require_finite_positive_decimal(
+            name="default_paper_quantity",
+            value=self.default_paper_quantity,
+        )
+        _require_finite_positive_decimal(
+            name="default_paper_entry_price",
+            value=self.default_paper_entry_price,
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a deterministic JSON-safe payload for evidence/logging."""
+        return {
+            "contract_id": self.contract_id,
+            "min_score_threshold": self.min_score_threshold,
+            "max_position_pct": str(self.max_position_pct),
+            "max_total_exposure_pct": str(self.max_total_exposure_pct),
+            "max_strategy_exposure_pct": str(self.max_strategy_exposure_pct),
+            "max_symbol_exposure_pct": str(self.max_symbol_exposure_pct),
+            "max_concurrent_positions": self.max_concurrent_positions,
+            "cooldown_hours": self.cooldown_hours,
+            "account_equity": str(self.account_equity),
+            "default_paper_quantity": str(self.default_paper_quantity),
+            "default_paper_entry_price": str(self.default_paper_entry_price),
+        }
+
+
+DEFAULT_PAPER_EXECUTION_RISK_PROFILE = PaperExecutionRiskProfile()
+
+
+__all__ = [
+    "DEFAULT_PAPER_EXECUTION_RISK_PROFILE",
+    "PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID",
+    "PaperExecutionRiskProfile",
+]

--- a/src/cilly_trading/engine/paper_execution_worker.py
+++ b/src/cilly_trading/engine/paper_execution_worker.py
@@ -32,6 +32,10 @@ from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Literal, Optional, Sequence
 
+from cilly_trading.engine.paper_execution_risk_profile import (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE,
+    PaperExecutionRiskProfile,
+)
 from cilly_trading.engine.risk import evaluate_risk_framework_execution_decision
 from cilly_trading.models import (
     ExecutionEvent,
@@ -52,32 +56,44 @@ from cilly_trading.risk_framework.allocation_rules import RiskLimits
 # ---------------------------------------------------------------------------
 
 #: Minimum signal score required for paper entry (inclusive) on a 0..100 scale.
-MIN_SCORE_THRESHOLD: float = 60.0
+MIN_SCORE_THRESHOLD: float = DEFAULT_PAPER_EXECUTION_RISK_PROFILE.min_score_threshold
 
 #: Maximum fraction of account equity for a single paper position.
-MAX_POSITION_PCT: Decimal = Decimal("0.10")
+MAX_POSITION_PCT: Decimal = DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_position_pct
 
 #: Maximum fraction of account equity across all open paper positions.
-MAX_TOTAL_EXPOSURE_PCT: Decimal = Decimal("0.80")
+MAX_TOTAL_EXPOSURE_PCT: Decimal = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_total_exposure_pct
+)
 
 #: Maximum number of concurrent open paper positions.
-MAX_CONCURRENT_POSITIONS: int = 10
+MAX_CONCURRENT_POSITIONS: int = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_concurrent_positions
+)
 
 #: Maximum fraction of account equity for a strategy aggregate.
-MAX_STRATEGY_EXPOSURE_PCT: Decimal = Decimal("0.80")
+MAX_STRATEGY_EXPOSURE_PCT: Decimal = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_strategy_exposure_pct
+)
 
 #: Maximum fraction of account equity for a symbol aggregate.
-MAX_SYMBOL_EXPOSURE_PCT: Decimal = Decimal("0.80")
+MAX_SYMBOL_EXPOSURE_PCT: Decimal = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_symbol_exposure_pct
+)
 
 #: Minimum cooldown in hours between accepted entries for the same
 #: ``(symbol, strategy)`` pair.
-COOLDOWN_HOURS: int = 24
+COOLDOWN_HOURS: int = DEFAULT_PAPER_EXECUTION_RISK_PROFILE.cooldown_hours
 
 #: Default paper quantity (one unit per entry).
-DEFAULT_PAPER_QUANTITY: Decimal = Decimal("1")
+DEFAULT_PAPER_QUANTITY: Decimal = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.default_paper_quantity
+)
 
 #: Fallback entry price used when the signal provides no price or entry_zone.
-DEFAULT_PAPER_ENTRY_PRICE: Decimal = Decimal("100")
+DEFAULT_PAPER_ENTRY_PRICE: Decimal = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.default_paper_entry_price
+)
 
 _PRICE_SCALE: Decimal = Decimal("0.0001")
 
@@ -171,17 +187,21 @@ def _parse_timestamp(ts: str) -> datetime.datetime:
     return datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
 
 
-def _extract_entry_price(signal: Signal) -> Decimal:
+def _extract_entry_price(
+    signal: Signal,
+    *,
+    fallback_entry_price: Decimal,
+) -> Decimal:
     """Extract a representative entry price from the signal.
 
     Uses the entry_zone midpoint when available; falls back to
-    ``DEFAULT_PAPER_ENTRY_PRICE`` otherwise.
+    ``fallback_entry_price`` otherwise.
     """
     entry_zone = signal.get("entry_zone")
     if entry_zone is not None:
         mid = Decimal(str(entry_zone["from_"] + entry_zone["to"])) / Decimal("2")
         return mid.quantize(_PRICE_SCALE, rounding=ROUND_HALF_UP)
-    return DEFAULT_PAPER_ENTRY_PRICE
+    return fallback_entry_price
 
 
 _DIRECTION_TO_SIDE: dict[str, str] = {
@@ -260,24 +280,10 @@ class BoundedPaperExecutionWorker:
         self,
         repository: CanonicalExecutionRepository,
         *,
-        min_score_threshold: float = MIN_SCORE_THRESHOLD,
-        max_position_pct: Decimal = MAX_POSITION_PCT,
-        max_total_exposure_pct: Decimal = MAX_TOTAL_EXPOSURE_PCT,
-        max_strategy_exposure_pct: Decimal = MAX_STRATEGY_EXPOSURE_PCT,
-        max_symbol_exposure_pct: Decimal = MAX_SYMBOL_EXPOSURE_PCT,
-        max_concurrent_positions: int = MAX_CONCURRENT_POSITIONS,
-        cooldown_hours: int = COOLDOWN_HOURS,
-        account_equity: Decimal = Decimal("100000"),
+        risk_profile: PaperExecutionRiskProfile = DEFAULT_PAPER_EXECUTION_RISK_PROFILE,
     ) -> None:
         self._repo = repository
-        self._min_score = min_score_threshold
-        self._max_position_pct = max_position_pct
-        self._max_total_exposure_pct = max_total_exposure_pct
-        self._max_strategy_exposure_pct = max_strategy_exposure_pct
-        self._max_symbol_exposure_pct = max_symbol_exposure_pct
-        self._max_concurrent_positions = max_concurrent_positions
-        self._cooldown_hours = cooldown_hours
-        self._account_equity = account_equity
+        self._risk_profile = risk_profile
         self._risk_limits = self._build_risk_limits()
 
     # ------------------------------------------------------------------
@@ -303,13 +309,22 @@ class BoundedPaperExecutionWorker:
         """
         return [self.process_signal(signal) for signal in signals]
 
+    @property
+    def risk_profile(self) -> PaperExecutionRiskProfile:
+        """Return the canonical validated risk profile used by this worker."""
+        return self._risk_profile
+
     def _build_risk_limits(self) -> RiskLimits:
         """Build deterministic risk-framework limits for paper execution."""
         return RiskLimits(
-            max_account_exposure_pct=float(self._max_total_exposure_pct),
-            max_position_size=float(self._account_equity * self._max_position_pct),
-            max_strategy_exposure_pct=float(self._max_strategy_exposure_pct),
-            max_symbol_exposure_pct=float(self._max_symbol_exposure_pct),
+            max_account_exposure_pct=float(self._risk_profile.max_total_exposure_pct),
+            max_position_size=float(
+                self._risk_profile.account_equity * self._risk_profile.max_position_pct
+            ),
+            max_strategy_exposure_pct=float(
+                self._risk_profile.max_strategy_exposure_pct
+            ),
+            max_symbol_exposure_pct=float(self._risk_profile.max_symbol_exposure_pct),
         )
 
     # ------------------------------------------------------------------
@@ -340,11 +355,11 @@ class BoundedPaperExecutionWorker:
         score = float(signal["score"])  # type: ignore[arg-type]
 
         # Step 2: score threshold
-        if score < self._min_score:
+        if score < self._risk_profile.min_score_threshold:
             return SignalEvaluationResult(
                 outcome="skip:score_below_threshold",
                 reason=(
-                    f"score={score} < min_score_threshold={self._min_score}"
+                    f"score={score} < min_score_threshold={self._risk_profile.min_score_threshold}"
                 ),
             )
 
@@ -375,7 +390,7 @@ class BoundedPaperExecutionWorker:
             signal_ts = _parse_timestamp(signal["timestamp"])  # type: ignore[arg-type]
             last_entry_ts = _parse_timestamp(most_recent_opened_at)
             elapsed = signal_ts - last_entry_ts
-            cooldown_window = datetime.timedelta(hours=self._cooldown_hours)
+            cooldown_window = datetime.timedelta(hours=self._risk_profile.cooldown_hours)
             if elapsed < cooldown_window:
                 return SignalEvaluationResult(
                     outcome="skip:cooldown_active",
@@ -386,8 +401,11 @@ class BoundedPaperExecutionWorker:
                 )
 
         # Step 5: exposure and position-limit checks
-        entry_price = _extract_entry_price(signal)
-        proposed_notional = DEFAULT_PAPER_QUANTITY * entry_price
+        entry_price = _extract_entry_price(
+            signal,
+            fallback_entry_price=self._risk_profile.default_paper_entry_price,
+        )
+        proposed_notional = self._risk_profile.default_paper_quantity * entry_price
 
         # Load all open trades for canonical exposure/concurrent-position checks.
         # The limit of 1000 reflects the bounded paper simulation scope
@@ -397,12 +415,12 @@ class BoundedPaperExecutionWorker:
         all_open_trades = [t for t in all_trades if t.status == "open"]
 
         # Concurrent position limit
-        if len(all_open_trades) >= self._max_concurrent_positions:
+        if len(all_open_trades) >= self._risk_profile.max_concurrent_positions:
             return SignalEvaluationResult(
                 outcome="reject:concurrent_position_limit_exceeded",
                 reason=(
                     f"concurrent_positions={len(all_open_trades)} >= "
-                    f"limit={self._max_concurrent_positions}"
+                    f"limit={self._risk_profile.max_concurrent_positions}"
                 ),
             )
 
@@ -425,7 +443,7 @@ class BoundedPaperExecutionWorker:
             strategy_id=strategy,
             symbol=symbol,
             proposed_position_size=float(proposed_notional),
-            account_equity=float(self._account_equity),
+            account_equity=float(self._risk_profile.account_equity),
             current_exposure=float(current_exposure),
             strategy_exposure=float(strategy_exposure),
             symbol_exposure=float(symbol_exposure),
@@ -461,8 +479,11 @@ class BoundedPaperExecutionWorker:
         strategy: str = signal["strategy"]  # type: ignore[assignment]
         direction: str = signal["direction"]  # type: ignore[assignment]
         occurred_at: str = signal["timestamp"]  # type: ignore[assignment]
-        entry_price = _extract_entry_price(signal)
-        quantity = DEFAULT_PAPER_QUANTITY
+        entry_price = _extract_entry_price(
+            signal,
+            fallback_entry_price=self._risk_profile.default_paper_entry_price,
+        )
+        quantity = self._risk_profile.default_paper_quantity
         side = _direction_to_order_side(direction)
 
         # --- Execution events ------------------------------------------
@@ -588,6 +609,7 @@ class BoundedPaperExecutionWorker:
 
 __all__ = [
     "BoundedPaperExecutionWorker",
+    "DEFAULT_PAPER_EXECUTION_RISK_PROFILE",
     "SignalEvaluationResult",
     "MIN_SCORE_THRESHOLD",
     "MAX_POSITION_PCT",
@@ -598,5 +620,6 @@ __all__ = [
     "COOLDOWN_HOURS",
     "DEFAULT_PAPER_QUANTITY",
     "DEFAULT_PAPER_ENTRY_PRICE",
+    "PaperExecutionRiskProfile",
     "_direction_to_order_side",
 ]

--- a/tests/cilly_trading/engine/test_paper_execution_risk_alignment.py
+++ b/tests/cilly_trading/engine/test_paper_execution_risk_alignment.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from cilly_trading.engine.paper_execution_risk_profile import PaperExecutionRiskProfile
 from cilly_trading.engine.paper_execution_worker import BoundedPaperExecutionWorker
 from cilly_trading.models import Signal
 from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
@@ -38,12 +39,14 @@ def test_paper_execution_account_exposure_rejection_uses_canonical_reason(
 ) -> None:
     worker = BoundedPaperExecutionWorker(
         repository=repo,
-        account_equity=Decimal("1000"),
-        max_position_pct=Decimal("0.20"),
-        max_total_exposure_pct=Decimal("0.80"),
-        max_strategy_exposure_pct=Decimal("1.00"),
-        max_symbol_exposure_pct=Decimal("1.00"),
-        max_concurrent_positions=20,
+        risk_profile=PaperExecutionRiskProfile(
+            account_equity=Decimal("1000"),
+            max_position_pct=Decimal("0.20"),
+            max_total_exposure_pct=Decimal("0.80"),
+            max_strategy_exposure_pct=Decimal("1.00"),
+            max_symbol_exposure_pct=Decimal("1.00"),
+            max_concurrent_positions=20,
+        ),
     )
 
     for index in range(8):
@@ -68,12 +71,14 @@ def test_paper_execution_strategy_exposure_rejection_uses_canonical_reason(
 ) -> None:
     worker = BoundedPaperExecutionWorker(
         repository=repo,
-        account_equity=Decimal("1000"),
-        max_position_pct=Decimal("0.20"),
-        max_total_exposure_pct=Decimal("1.00"),
-        max_strategy_exposure_pct=Decimal("0.20"),
-        max_symbol_exposure_pct=Decimal("1.00"),
-        max_concurrent_positions=20,
+        risk_profile=PaperExecutionRiskProfile(
+            account_equity=Decimal("1000"),
+            max_position_pct=Decimal("0.20"),
+            max_total_exposure_pct=Decimal("1.00"),
+            max_strategy_exposure_pct=Decimal("0.20"),
+            max_symbol_exposure_pct=Decimal("1.00"),
+            max_concurrent_positions=20,
+        ),
     )
 
     first = worker.process_signal(_signal(symbol="AAPL", strategy="strategy-a", signal_id="sig-s-1"))
@@ -91,12 +96,14 @@ def test_paper_execution_symbol_exposure_rejection_uses_canonical_reason(
 ) -> None:
     worker = BoundedPaperExecutionWorker(
         repository=repo,
-        account_equity=Decimal("1000"),
-        max_position_pct=Decimal("0.20"),
-        max_total_exposure_pct=Decimal("1.00"),
-        max_strategy_exposure_pct=Decimal("1.00"),
-        max_symbol_exposure_pct=Decimal("0.20"),
-        max_concurrent_positions=20,
+        risk_profile=PaperExecutionRiskProfile(
+            account_equity=Decimal("1000"),
+            max_position_pct=Decimal("0.20"),
+            max_total_exposure_pct=Decimal("1.00"),
+            max_strategy_exposure_pct=Decimal("1.00"),
+            max_symbol_exposure_pct=Decimal("0.20"),
+            max_concurrent_positions=20,
+        ),
     )
 
     first = worker.process_signal(_signal(symbol="AAPL", strategy="strategy-a", signal_id="sig-y-1"))

--- a/tests/engine/test_paper_execution_risk_profile_contract.py
+++ b/tests/engine/test_paper_execution_risk_profile_contract.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.engine.paper_execution_risk_profile import (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE,
+    PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID,
+    PaperExecutionRiskProfile,
+)
+from cilly_trading.engine.paper_execution_worker import BoundedPaperExecutionWorker
+from cilly_trading.models import Signal
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
+
+
+def _signal(*, signal_id: str, score: float = 90.0) -> Signal:
+    return {
+        "symbol": "AAPL",
+        "strategy": "rsi2",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": score,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "signal_id": signal_id,
+    }
+
+
+def test_default_profile_uses_canonical_contract_id() -> None:
+    assert (
+        DEFAULT_PAPER_EXECUTION_RISK_PROFILE.contract_id
+        == PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID
+    )
+
+
+def test_invalid_profile_values_fail_closed() -> None:
+    with pytest.raises(ValueError, match="max_position_pct must be in range"):
+        PaperExecutionRiskProfile(max_position_pct=Decimal("1.50"))
+
+    with pytest.raises(ValueError, match="max_concurrent_positions must be > 0"):
+        PaperExecutionRiskProfile(max_concurrent_positions=0)
+
+    with pytest.raises(ValueError, match="min_score_threshold must be in range"):
+        PaperExecutionRiskProfile(min_score_threshold=101.0)
+
+
+def test_same_profile_and_same_input_produce_same_outcome(tmp_path: Path) -> None:
+    profile = PaperExecutionRiskProfile(min_score_threshold=95.0)
+    signal = _signal(signal_id="sig-same-profile-input", score=90.0)
+
+    repo_a = SqliteCanonicalExecutionRepository(db_path=tmp_path / "profile-a.db")
+    repo_b = SqliteCanonicalExecutionRepository(db_path=tmp_path / "profile-b.db")
+
+    worker_a = BoundedPaperExecutionWorker(repository=repo_a, risk_profile=profile)
+    worker_b = BoundedPaperExecutionWorker(repository=repo_b, risk_profile=profile)
+
+    result_a = worker_a.process_signal(signal)
+    result_b = worker_b.process_signal(signal)
+
+    assert result_a.outcome == "skip:score_below_threshold"
+    assert result_b.outcome == "skip:score_below_threshold"
+    assert result_a.reason == result_b.reason

--- a/tests/engine/test_paper_execution_worker.py
+++ b/tests/engine/test_paper_execution_worker.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from cilly_trading.engine.paper_execution_risk_profile import PaperExecutionRiskProfile
 from cilly_trading.engine.paper_execution_worker import (
     BoundedPaperExecutionWorker,
     COOLDOWN_HOURS,
@@ -474,7 +475,7 @@ def test_concurrent_position_limit_enforced(
     """AC5: exceeding concurrent position limit → reject:concurrent_position_limit_exceeded."""
     worker = BoundedPaperExecutionWorker(
         repository=repo,
-        max_concurrent_positions=2,
+        risk_profile=PaperExecutionRiskProfile(max_concurrent_positions=2),
     )
 
     symbols = ["SYM1", "SYM2", "SYM3"]
@@ -501,10 +502,12 @@ def test_total_exposure_limit_enforced(
     # after 8 positions exposure=800 → 9th should reject
     worker = BoundedPaperExecutionWorker(
         repository=repo,
-        account_equity=Decimal("1000"),
-        max_total_exposure_pct=Decimal("0.80"),
-        max_concurrent_positions=20,
-        max_position_pct=Decimal("0.20"),  # 20% of 1000 = 200 > 100 ✓
+        risk_profile=PaperExecutionRiskProfile(
+            account_equity=Decimal("1000"),
+            max_total_exposure_pct=Decimal("0.80"),
+            max_concurrent_positions=20,
+            max_position_pct=Decimal("0.20"),  # 20% of 1000 = 200 > 100 ✓
+        ),
     )
 
     eligible_count = 0
@@ -533,8 +536,10 @@ def test_position_size_limit_enforced(
     # DEFAULT_PAPER_ENTRY_PRICE=100 → proposed_notional=100 > 50 → reject
     worker = BoundedPaperExecutionWorker(
         repository=repo,
-        account_equity=Decimal("500"),
-        max_position_pct=Decimal("0.10"),
+        risk_profile=PaperExecutionRiskProfile(
+            account_equity=Decimal("500"),
+            max_position_pct=Decimal("0.10"),
+        ),
     )
     result = worker.process_signal(_make_signal(signal_id="sig-pos-001"))
     assert result.outcome == "reject:position_size_exceeds_limit"

--- a/tests/test_ops_p52_signal_to_paper_execution_policy_docs.py
+++ b/tests/test_ops_p52_signal_to_paper_execution_policy_docs.py
@@ -73,6 +73,13 @@ def test_ops_p52_eligibility_rules_define_required_signal_fields() -> None:
     assert "`reject:invalid_signal_fields`" in content
 
 
+def test_ops_p52_timestamp_requirement_matches_iso8601_only_implementation_claim() -> None:
+    content = _read(POLICY_DOC_PATH)
+
+    assert "| `timestamp` | Parseable ISO-8601 datetime string. |" in content
+    assert "Unix epoch milliseconds" not in content
+
+
 def test_ops_p52_skip_and_reject_outcomes_are_explicit_with_codes() -> None:
     content = _read(POLICY_DOC_PATH)
 

--- a/tests/test_p57_risk_profile_contract_docs.py
+++ b/tests/test_p57_risk_profile_contract_docs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_DOC_PATH = "docs/operations/runtime/signal_to_paper_execution_policy.md"
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_p57_risk_profile_contract_is_documented_with_validation_boundary() -> None:
+    content = _read(POLICY_DOC_PATH)
+
+    assert "## Paper Execution Risk Profile Contract (P57-RISK)" in content
+    assert "paper_execution_risk_profile.py" in content
+    assert "paper-execution-risk-profile-v1" in content
+    assert "validates all bounded profile inputs fail-closed" in content
+    assert "Invalid values raise explicit errors" in content
+
+
+def test_p57_docs_state_what_is_not_claimed_and_no_p56_duplication() -> None:
+    content = _read(POLICY_DOC_PATH)
+
+    assert "Not claimed by this contract" in content
+    assert "live-trading readiness" in content
+    assert "broker integration readiness" in content
+    assert "production-readiness approval" in content
+    assert "does not duplicate the existing P56 adverse-scenario" in content

--- a/tests/test_run_paper_execution_cycle_script.py
+++ b/tests/test_run_paper_execution_cycle_script.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cilly_trading.engine.paper_execution_risk_profile import (
+    PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script_module():
+    module_path = REPO_ROOT / "scripts" / "run_paper_execution_cycle.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_run_paper_execution_cycle_script_module",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load run_paper_execution_cycle.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_run_paper_execution_cycle_includes_canonical_risk_profile(
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    db_path = tmp_path / "paper_execution.db"
+    evidence_dir = tmp_path / "evidence"
+
+    exit_code = module.run_paper_execution_cycle(
+        db_path=str(db_path),
+        evidence_dir=str(evidence_dir),
+        signal_limit=10,
+        ran_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+    )
+    assert exit_code == module.EXIT_CYCLE_NO_ELIGIBLE
+
+    evidence_files = sorted(evidence_dir.glob("paper-execution-no-eligible-*.json"))
+    assert len(evidence_files) == 1
+
+    payload = json.loads(evidence_files[0].read_text(encoding="utf-8"))
+    assert payload["risk_profile"]["contract_id"] == PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID


### PR DESCRIPTION
Closes #933

## What Changed
- Added canonical bounded risk profile contract:
  - `src/cilly_trading/engine/paper_execution_risk_profile.py`
  - contract id: `paper-execution-risk-profile-v1`
  - strict fail-closed validation for invalid values
- Updated bounded paper worker to source risk parameters from one profile contract:
  - `src/cilly_trading/engine/paper_execution_worker.py`
- Updated `scripts/run_paper_execution_cycle.py` to:
  - instantiate worker with canonical risk profile
  - emit `risk_profile` payload in execution evidence for reviewability
- Added focused tests for:
  - fail-closed validation
  - deterministic same profile + same input => same outcome
  - script evidence includes canonical risk profile contract id
  - OPS-P52 doc wording aligned to ISO-8601 timestamp support only
- Updated policy documentation with bounded validation and claim boundary, including explicit note that P57 does not duplicate P56 scenario-matrix scope.

## Acceptance Criteria Mapping
- Paper execution risk parameters sourced from one validated profile contract: implemented.
- Invalid profile values fail closed with explicit errors: implemented + tested.
- Deterministic tests for same profile + same input => same outcome: implemented + tested.
- Documentation states validated scope and non-claims: implemented.
- Existing P56 scope not duplicated: documented explicitly.
- OPS-P52 doc wording aligned to implementation for timestamp validation: implemented + tested.

## Test Evidence
- Repository command run locally:
  - `.\.venv\Scripts\python.exe -m pytest`
- Result:
  - `1024 passed, 4 warnings`

## Focused Fix Evidence
- `.\.venv\Scripts\python.exe -m pytest tests/test_ops_p52_signal_to_paper_execution_policy_docs.py tests/test_p57_risk_profile_contract_docs.py -q`
- `15 passed in 0.15s`

Note: existing unrelated local modifications were already present in `.codex/config.toml` and `.gitignore` before this implementation and were not changed by this issue work.