### PR TITLE
P57-DECISION: Phase 23 research dashboard minimum contract (#934)

### DIFF
--- a/ROADMAP_MASTER.md
+++ b/ROADMAP_MASTER.md
@@ -92,7 +92,7 @@ Market Data
 | 20 | Error Handling System | Implemented |
 | 21 | Governance Rules | Implemented |
 | 22 | Artifact Integrity | Implemented |
-| 23 | Research Dashboard | Not Implemented |
+| 23 | Research Dashboard | Partially Implemented |
 | 24 | Paper Trading Governance | Implemented |
 | 25 | Roadmap Traceability | Implemented in Repository |
 | 26 | Documentation Alignment | Implemented |
@@ -123,8 +123,9 @@ Market Data
 - Secondary docs that describe a phase do not create an independent status authority; they are reconciled to this file.
 - Phase 17b is backend-served at `/ui`; `/owner` is documented only as a frontend development-only route and not as a runtime backend surface.
 - Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface.
-- Phase 23 remains `Not Implemented` because the repository does not yet contain the full minimum evidence contract for one coherent Research Dashboard surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface.
+- Phase 23 is `Partially Implemented` because the repository now contains a bounded minimum evidence contract for one coherent Research Dashboard surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface.
 - Current `/ui` operator panels, analytics artifacts, charting surfaces, and trading-desk wording are adjacent only and do not count on their own as Phase 23 implementation evidence.
+- This bounded Phase 23 evidence is explicitly non-trader-ready and non-production-ready.
 - Phase 24 is now treated as implemented because the simulator boundary and non-live constraints are documented consistently; Phase 44 remains broader and only partially implemented.
 - Phase 25 and Phase 27 were corrected away from stale older wording because lifecycle and risk-framework artifacts are already present in the repository.
 - Phase 35 is marked `Implemented` in this revision because metrics, telemetry, runtime health, guard-trigger monitoring, and integration tests are all present in-repo.
@@ -481,18 +482,19 @@ Guarantee reproducible research artifacts.
 ---
 
 ## Phase 23 - Research Dashboard
-**Status:** Not Implemented
+**Status:** Partially Implemented
 
 **Goal**
 Align the bounded Phase 23 `Research Dashboard` meaning and keep its status evidence-based.
 
 **Current Status Basis**
 - Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface.
-- Phase 23 remains `Not Implemented` because the repository does not yet contain the full minimum evidence contract for one coherent Research Dashboard surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface.
+- Phase 23 is `Partially Implemented` because the repository now contains a bounded minimum evidence contract for one coherent Research Dashboard surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface.
 - Existing evidence from Phase 17b `/ui`, Phase 30 analytics artifacts, Phase 39 read-only charting, and Phase 40 desk-style dashboard wording is adjacent only and does not count on its own as Phase 23 implementation evidence.
+- The bounded Phase 23 claim is explicitly non-trader-ready and non-production-ready.
 
 **Outcome**
-- The roadmap now presents the same bounded Phase 23 message as the phase status and index surfaces, without changing the non-implementation status.
+- The roadmap now aligns with the bounded minimum evidence claim while keeping explicit non-trader-ready and non-production-ready boundaries.
 
 ---
 
@@ -893,7 +895,7 @@ Marktdaten
 | 20 | Error Handling System | Implemented |
 | 21 | Governance Rules | Implemented |
 | 22 | Artifact Integrity | Implemented |
-| 23 | Research Dashboard | Not Implemented |
+| 23 | Research Dashboard | Partially Implemented |
 | 24 | Paper Trading Governance | Implemented |
 | 25 | Roadmap Traceability | Implemented in Repository |
 | 26 | Documentation Alignment | Implemented |
@@ -922,8 +924,9 @@ Marktdaten
 
 - Phase 17b wird im Backend unter `/ui` ausgeliefert; `/owner` ist nur als Frontend-Development-Route dokumentiert und keine Runtime-Backend-Surface.
 - Phase 23 bedeutet `Research Dashboard`: eine einzelne dedizierte research-only Dashboard-Surface.
-- Phase 23 bleibt `Not Implemented`, weil das Repository noch nicht den vollstaendigen minimalen Evidenzvertrag fuer eine zusammenhaengende Research-Dashboard-Surface enthaelt: einen begrenzten Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt fuer dieselbe beanspruchte Surface.
+- Phase 23 ist `Partially Implemented`, weil das Repository jetzt einen begrenzten minimalen Evidenzvertrag fuer eine zusammenhaengende Research-Dashboard-Surface enthaelt: einen begrenzten Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt fuer dieselbe beanspruchte Surface.
 - Aktuelle `/ui`-Operator-Panels, Analytics-Artefakte, Charting-Surfaces und Trading-Desk-Sprache sind nur benachbart und zaehlen fuer sich allein nicht als Phase-23-Implementierungsevidenz.
+- Diese begrenzte Phase-23-Evidenz ist explizit nicht trader-ready und nicht production-ready.
 - Phase 24 gilt jetzt als implementiert, weil Simulator-Grenzen und Non-Live-Constraints konsistent dokumentiert sind; Phase 44 bleibt als breitere Produktphase nur teilweise implementiert.
 - Phase 25 und Phase 27 wurden gegen veraltete Roadmap-Aussagen korrigiert, weil Lifecycle- und Risk-Framework-Artefakte bereits im Repo vorhanden sind.
 - Phase 35 ist in dieser Fassung `Implemented`, weil Metrics, Telemetry, Runtime Health, Guard-Trigger-Monitoring und Integrationstests bereits vorhanden sind.
@@ -1278,18 +1281,19 @@ Reproduzierbare Research-Artefakte garantieren.
 ---
 
 ## Phase 23 - Research Dashboard
-**Status:** Not Implemented
+**Status:** Partially Implemented
 
 **Ziel**
 Die klar begrenzte Phase-23-Bedeutung `Research Dashboard` angleichen und den Status evidenzbasiert halten.
 
 **Aktuelle Statusbasis**
 - Phase 23 bedeutet `Research Dashboard`: eine einzelne dedizierte research-only Dashboard-Surface.
-- Phase 23 bleibt `Not Implemented`, weil das Repository noch nicht den vollstaendigen minimalen Evidenzvertrag fuer eine zusammenhaengende Research-Dashboard-Surface enthaelt: einen begrenzten Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt fuer dieselbe beanspruchte Surface.
+- Phase 23 ist `Partially Implemented`, weil das Repository jetzt einen begrenzten minimalen Evidenzvertrag fuer eine zusammenhaengende Research-Dashboard-Surface enthaelt: einen begrenzten Dashboard-Vertrag, ein Runtime- oder UI-Implementierungsartefakt und ein Verifizierungsartefakt fuer dieselbe beanspruchte Surface.
 - Vorhandene Evidenz aus Phase 17b `/ui`, Phase 30 Analytics-Artefakten, Phase 39 read-only Charting und Phase-40-artiger Trading-Desk-Sprache ist nur benachbart und zaehlt fuer sich allein nicht als Phase-23-Implementierungsevidenz.
+- Der begrenzte Phase-23-Claim ist explizit nicht trader-ready und nicht production-ready.
 
 **Ergebnis**
-- Die Roadmap zeigt jetzt dieselbe begrenzte Phase-23-Aussage wie Phasenstatus und Index, ohne den Nicht-Implementiert-Status zu veraendern.
+- Die Roadmap ist jetzt mit dem begrenzten Minimal-Evidenz-Claim abgeglichen und behaelt explizite Nicht-Trader-Ready- sowie Nicht-Production-Ready-Grenzen bei.
 
 ---
 

--- a/docs/architecture/phases/phase-23-status.md
+++ b/docs/architecture/phases/phase-23-status.md
@@ -1,7 +1,7 @@
 # Phase 23 - Research Dashboard
 
 ## Status
-NOT IMPLEMENTED
+PARTIALLY IMPLEMENTED
 
 ## Taxonomy Alignment
 Phase 23 means `Research Dashboard` in the authoritative taxonomy source:
@@ -9,7 +9,7 @@ Phase 23 means `Research Dashboard` in the authoritative taxonomy source:
 
 ## Canonical Bounded Message
 Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface.
-Phase 23 remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact.
+Phase 23 is `PARTIALLY IMPLEMENTED` in this revision because one coherent minimum evidence set now exists for one bounded surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact.
 Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting surfaces, and Phase 40 trading-desk wording are adjacent only and do not count on their own as Phase 23 implementation evidence.
 
 ## Authoritative Bounded Scope
@@ -59,14 +59,18 @@ Phase 23 is not satisfied by adjacent phases or by overlapping dashboard languag
 - Phase 40 is the Trading Desk Dashboard. Broader desk, overview, or professional trading dashboard language does not define or satisfy Phase 23.
 
 ## Verified Repository Evidence
-The current repository review did not confirm a Phase 23 implementation artifact in:
-- `src/**`
-- `engine/**`
-- `tests/**`
-- runtime-facing documentation for a dedicated research-only dashboard surface
+The current repository review confirms a bounded minimum evidence set for one Phase 23 surface:
+- bounded contract documentation:
+  - `docs/operations/ui/phase-23-research-dashboard-contract.md`
+- runtime/UI artifact:
+  - `src/ui/research_dashboard/index.html`
+  - static mount in `src/api/main.py` at `/research-dashboard`
+- verification artifacts:
+  - `src/api/test_research_dashboard_surface.py`
+  - `tests/test_phase23_research_dashboard_contract.py`
 
-Repository references to `Research Dashboard` in the audited scope are currently limited to roadmap and status-tracking documents, not implementation artifacts.
-The current repository therefore fails all three required evidence classes in the minimum Phase 23 evidence contract above.
+These artifacts satisfy the bounded minimum contract for one identifiable research-only dashboard surface.
+They do not claim full research workstation completeness, trader readiness, or production readiness.
 
 ## Non-Evidence Clarification
 The following artifact classes are insufficient on their own to claim Phase 23 implementation progress, even if they mention dashboards, research, analysis, or review:
@@ -84,6 +88,11 @@ The following existing repository surfaces must not be treated as implied Phase 
 - current charting or visual-analysis surfaces
 - trading-desk or operator-dashboard wording in roadmap or navigation documents
 
+## OPS-P56 Non-Interference
+This Phase 23 minimum contract does not replace or widen operational run logging scope.
+
+`OPS-P56: Start bounded staged paper-trading runbook and evidence log #914` remains the single operational run log issue.
+
 ## Explicit Declaration
-As of this revision, no repository-verifiable code, tests, or runtime documentation were confirmed for the bounded Phase 23 Research Dashboard defined in this file.
-Phase 23 therefore remains NOT IMPLEMENTED.
+As of this revision, one repository-verifiable minimum Phase 23 Research Dashboard surface is confirmed through bounded docs, runtime/UI artifact, and verification tests.
+Phase 23 is therefore PARTIALLY IMPLEMENTED under the minimum contract.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ Use this order:
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
 - [Phase 39 /ui charting contract](operations/ui/phase-39-charting-contract.md)
 - [Phase 39 runtime charting test plan](operations/ui/phase-39-test-plan.md)
+- [Phase 23 research dashboard minimum contract](operations/ui/phase-23-research-dashboard-contract.md)
 - Legacy compatibility alias: `docs/ui/phase-39-test-plan.md`
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
   - Runtime-served operator UI is `/ui`.
@@ -72,7 +73,7 @@ Status changes therefore follow one update path: update supporting evidence as n
 | Phase 16 | No authoritative in-repo meaning located | `docs/architecture/roadmap/execution_roadmap.md` |
 | Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/architecture/roadmap/execution_roadmap.md` |
 | Phase 17b | Owner Dashboard sub-phase | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 23 | `Research Dashboard`: one dedicated research-only dashboard surface; it remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact | `docs/architecture/phases/phase-23-status.md` |
+| Phase 23 | `Research Dashboard`: one dedicated research-only dashboard surface; it is `PARTIALLY IMPLEMENTED` under a bounded minimum contract (`/research-dashboard`) and remains explicitly non-trader-ready/non-production-ready | `docs/architecture/phases/phase-23-status.md` |
 | Phase 25 | Strategy Lifecycle Management | `docs/architecture/phases/phase_25_strategy_lifecycle.md` |
 | Phase 26 | No authoritative in-repo meaning located | `docs/architecture/roadmap/execution_roadmap.md` |
 | Phase 27 | Risk Framework | `docs/architecture/phases/phase-27-status.md` |
@@ -95,7 +96,7 @@ Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b
 - [Interface usage patterns](operations/interfaces/usage_patterns.md)
 
 ### Phase 23 Boundary Note
-Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface as defined in [Phase 23 status](architecture/phases/phase-23-status.md). It remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact. Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting docs, and Phase 40 trading-desk wording are adjacent references only and are insufficient on their own to claim Phase 23 implementation.
+Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface as defined in [Phase 23 status](architecture/phases/phase-23-status.md). The minimum bounded evidence contract is documented in [Phase 23 research dashboard minimum contract](operations/ui/phase-23-research-dashboard-contract.md) and is currently treated as `PARTIALLY IMPLEMENTED` via `/research-dashboard`. Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting docs, and Phase 40 trading-desk wording remain adjacent references and are insufficient on their own to claim Phase 23 implementation.
 
 ### Phase 24 Reference Materials
 Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.

--- a/docs/operations/ui/phase-23-research-dashboard-contract.md
+++ b/docs/operations/ui/phase-23-research-dashboard-contract.md
@@ -1,0 +1,59 @@
+# Phase 23 Research Dashboard Minimum Contract
+
+## Purpose
+Define the bounded minimum contract that allows Phase 23 (`Research Dashboard`) to be treated as evidenced in-repository, without widening scope into trader or production claims.
+
+## Claimed Surface
+- Surface name: `Research Dashboard`
+- Runtime entrypoint: `/research-dashboard`
+- Runtime artifact: `src/ui/research_dashboard/index.html`
+- Runtime mount: `src/api/main.py`
+
+The claimed surface is research-only and is explicitly separate from the shared operator shell at `/ui`.
+
+## Bounded Scope
+In scope for this minimum contract:
+- one dedicated and identifiable research-only dashboard surface
+- one runtime/UI artifact for the same named surface
+- one verification artifact for the same named surface
+- explicit separation from shared operator-shell claims
+
+Out of scope:
+- workstation redesign
+- live trading
+- execution automation
+- trader-readiness claims
+- production-readiness claims
+
+## Minimum Evidence Set
+Phase 23 minimum evidence is satisfied only when all items below target the same surface:
+
+1. Bounded contract documentation  
+   This file defines the claimed surface, route, scope boundary, and non-claims.
+2. Runtime/UI implementation artifact  
+   `src/ui/research_dashboard/index.html` provides the runtime-served research-only surface at `/research-dashboard`.
+3. Verification artifact  
+   `src/api/test_research_dashboard_surface.py` verifies route reachability and research/operator-shell boundary markers.
+
+## Separation From Shared Operator Shell Claims
+- `/ui` remains the operator workbench shell and must not be used as implied proof of Phase 23.
+- `/research-dashboard` is the only Phase 23 minimum-surface claim in this contract.
+- Adjacency to `/ui`, charting, analytics, or desk wording is not evidence for this Phase 23 claim.
+
+## OPS-P56 and #914 Non-Interference
+This Phase 23 minimum contract does not redefine operational run logging and does not replace OPS-P56 issue #914.
+
+`OPS-P56: Start bounded staged paper-trading runbook and evidence log #914` remains the single operational run log issue.
+
+## Verification Procedure
+1. Open `/research-dashboard`.
+2. Confirm marker `id="phase23-research-dashboard-surface"` is present.
+3. Confirm the page states research-only scope and explicit separation from `/ui`.
+4. Run `pytest src/api/test_research_dashboard_surface.py tests/test_phase23_research_dashboard_contract.py`.
+
+## Classification For This Issue
+Phase 23 under this minimum contract is classified as:
+
+- technically good, but traderically weak
+
+This means bounded research-surface evidence is present, while trader-readiness and production-readiness are intentionally not claimed.

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
@@ -43,6 +44,7 @@ configure_logging()
 logger = logging.getLogger(__name__)
 
 settings = build_api_runtime_settings()
+UI_DIRECTORY: Path = settings.ui_directory
 repositories = create_api_repositories()
 _main_compat = bind_main_runtime_exports(
     module_globals=globals(),
@@ -69,7 +71,13 @@ app = FastAPI(
 )
 
 initialize_alert_state(app)
-app.mount("/ui", StaticFiles(directory=UI_DIRECTORY, html=True), name="ui")
+app.mount("/ui", StaticFiles(directory=str(UI_DIRECTORY), html=True), name="ui")
+RESEARCH_DASHBOARD_UI_DIRECTORY: Path = UI_DIRECTORY / "research_dashboard"
+app.mount(
+    "/research-dashboard",
+    StaticFiles(directory=str(RESEARCH_DASHBOARD_UI_DIRECTORY), html=True),
+    name="research-dashboard",
+)
 
 logger.info("Cilly Trading Engine API starting up")
 

--- a/src/api/test_research_dashboard_surface.py
+++ b/src/api/test_research_dashboard_surface.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+
+
+def test_research_dashboard_surface_is_reachable(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/research-dashboard")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+def test_research_dashboard_surface_is_identifiable_and_separate_from_operator_shell(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/research-dashboard")
+
+    assert response.status_code == 200
+    assert "Research Dashboard" in response.text
+    assert 'id="phase23-research-dashboard-surface"' in response.text
+    assert "Phase 23 research-only surface" in response.text
+    assert "/research-dashboard" in response.text
+    assert "/ui" in response.text
+    assert "separate from the shared operator shell" in response.text
+    assert "trader readiness" in response.text
+    assert "production readiness" in response.text
+    assert "#914" in response.text
+    assert "Operator Workbench" not in response.text

--- a/src/ui/research_dashboard/index.html
+++ b/src/ui/research_dashboard/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phase 23 Research Dashboard</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: "Segoe UI", Arial, sans-serif;
+      line-height: 1.5;
+    }
+    body {
+      margin: 0;
+      background: #f3f6f8;
+      color: #12202b;
+    }
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 24px 16px 48px;
+    }
+    section {
+      background: #ffffff;
+      border: 1px solid #d6e2ea;
+      border-radius: 12px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    h1,
+    h2 {
+      margin-top: 0;
+    }
+    .surface-marker {
+      display: inline-block;
+      font-size: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      border: 1px solid #7aa0b8;
+      border-radius: 999px;
+      padding: 4px 10px;
+      color: #2d556e;
+    }
+    code {
+      background: #edf3f7;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+  <main id="phase23-research-dashboard-surface">
+    <p class="surface-marker">Phase 23 research-only surface</p>
+    <h1>Research Dashboard</h1>
+    <p>
+      Runtime entrypoint: <code>/research-dashboard</code>. This page is a bounded
+      research review surface and is separate from the shared operator shell at <code>/ui</code>.
+    </p>
+
+    <section id="phase23-research-review-panels" aria-label="research-review-panels">
+      <h2>Bounded research review panels</h2>
+      <ul>
+        <li>Research focus and hypothesis review context</li>
+        <li>Signal sample review checklist markers</li>
+        <li>Experiment note and next-question prompts</li>
+      </ul>
+    </section>
+
+    <section id="phase23-boundary-non-claims" aria-label="boundary-non-claims">
+      <h2>Boundary and non-claims</h2>
+      <p>
+        This surface does not claim trader readiness, production readiness, live trading,
+        or execution automation. Operational run evidence remains governed separately.
+      </p>
+      <p>
+        The OPS-P56 issue <code>#914</code> remains the single operational run log issue.
+      </p>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/test_phase23_research_dashboard_contract.py
+++ b/tests/test_phase23_research_dashboard_contract.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PHASE23_STATUS_DOC = "docs/architecture/phases/phase-23-status.md"
+PHASE23_CONTRACT_DOC = "docs/operations/ui/phase-23-research-dashboard-contract.md"
+DOCS_INDEX = "docs/index.md"
+ROADMAP_MASTER = "ROADMAP_MASTER.md"
+RESEARCH_UI_FILE = "src/ui/research_dashboard/index.html"
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_phase23_contract_defines_single_bounded_research_surface() -> None:
+    content = _read(PHASE23_CONTRACT_DOC)
+
+    assert content.startswith("# Phase 23 Research Dashboard Minimum Contract")
+    assert "Surface name: `Research Dashboard`" in content
+    assert "Runtime entrypoint: `/research-dashboard`" in content
+    assert "src/ui/research_dashboard/index.html" in content
+    assert "src/api/main.py" in content
+
+
+def test_phase23_contract_explicitly_separates_from_operator_shell_and_ops_p56_log_issue() -> None:
+    content = _read(PHASE23_CONTRACT_DOC)
+
+    assert "separate from the shared operator shell at `/ui`" in content
+    assert "OPS-P56: Start bounded staged paper-trading runbook and evidence log #914" in content
+    assert "remains the single operational run log issue" in content
+
+
+def test_phase23_contract_has_explicit_non_readiness_non_claims() -> None:
+    content = _read(PHASE23_CONTRACT_DOC)
+
+    assert "live trading" in content
+    assert "execution automation" in content
+    assert "trader-readiness claims" in content
+    assert "production-readiness claims" in content
+    assert "technically good, but traderically weak" in content
+
+
+def test_phase23_status_reflects_bounded_partial_implementation() -> None:
+    content = _read(PHASE23_STATUS_DOC)
+
+    assert "## Status" in content
+    assert "PARTIALLY IMPLEMENTED" in content
+    assert "src/ui/research_dashboard/index.html" in content
+    assert "src/api/test_research_dashboard_surface.py" in content
+    assert "tests/test_phase23_research_dashboard_contract.py" in content
+    assert "remains the single operational run log issue" in content
+    assert "trader readiness" in content
+    assert "production readiness" in content
+
+
+def test_research_ui_surface_contains_identifiable_marker_and_boundaries() -> None:
+    content = _read(RESEARCH_UI_FILE)
+
+    assert 'id="phase23-research-dashboard-surface"' in content
+    assert "/research-dashboard" in content
+    assert "/ui" in content
+    assert "#914" in content
+    assert "Research Dashboard" in content
+    assert "Operator Workbench" not in content
+
+
+def test_index_includes_phase23_minimum_contract_reference() -> None:
+    index_content = _read(DOCS_INDEX)
+
+    assert "phase-23-research-dashboard-contract.md" in index_content
+    assert "Phase 23 | `Research Dashboard`" in index_content
+    assert "PARTIALLY IMPLEMENTED" in index_content
+
+
+def test_roadmap_master_phase23_status_and_boundaries_align_with_phase23_docs() -> None:
+    roadmap_content = _read(ROADMAP_MASTER)
+
+    assert "| 23 | Research Dashboard | Partially Implemented |" in roadmap_content
+    assert "## Phase 23 - Research Dashboard" in roadmap_content
+    assert "**Status:** Partially Implemented" in roadmap_content
+    assert "bounded minimum evidence contract" in roadmap_content
+    assert "non-trader-ready" in roadmap_content
+    assert "non-production-ready" in roadmap_content


### PR DESCRIPTION
## Summary
Implements the bounded minimum contract for Phase 23 Research Dashboard evidence.

### What changed
- Added dedicated research-only runtime surface at `/research-dashboard`
- Added explicit research/operator-shell boundary markers
- Added verification tests for runtime route and boundary assertions
- Added bounded Phase 23 minimum contract documentation
- Updated Phase 23 status, docs index, and master roadmap to reflect bounded partial evidence
- Kept explicit non-claims for trader-readiness and production-readiness
- Preserved OPS-P56 operational run logging separation

### Evidence artifacts
- Runtime/UI artifact: `src/ui/research_dashboard/index.html`
- Runtime mount: `src/api/main.py`
- Verification artifacts:
  - `src/api/test_research_dashboard_surface.py`
  - `tests/test_phase23_research_dashboard_contract.py`
- Contract docs:
  - `docs/operations/ui/phase-23-research-dashboard-contract.md`
  - `docs/architecture/phases/phase-23-status.md`
  - `ROADMAP_MASTER.md`

### Scope guardrails
- No live trading
- No execution automation
- No production-readiness claim
- No trader-readiness claim
- No reopening of P56 scope
- `OPS-P56: Start bounded staged paper-trading runbook and evidence log #914` remains the single operational run log issue

### Validation
- `.\.venv\Scripts\python.exe -m pytest src\api\test_research_dashboard_surface.py tests\test_phase23_research_dashboard_contract.py`

Closes #934