### PR TITLE
[QUEUED][3] P57-OPS — Bounded alert delivery MVP (#935)

### DIFF
--- a/src/api/alerts_api.py
+++ b/src/api/alerts_api.py
@@ -6,8 +6,13 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from cilly_trading.alerts.alert_models import AlertEvent
+from cilly_trading.alerts.alert_persistence_sqlite import BOUNDED_DELIVERY_MODE
 
-from .state import get_alert_configuration_store, get_alert_history_store
+from .state import (
+    get_alert_configuration_store,
+    get_alert_delivery_service,
+    get_alert_history_store,
+)
 
 
 class AlertConfigurationPayload(BaseModel):
@@ -80,6 +85,25 @@ class AlertHistoryListResponse(BaseModel):
     total: int
 
 
+class AlertDeliveryResultItemResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str
+    channel_name: str
+    delivered: bool
+    error: str | None
+    occurred_at: str
+    recorded_at: str
+    delivery_mode: str
+
+
+class AlertDeliveryResultListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: List[AlertDeliveryResultItemResponse]
+    total: int
+
+
 class AlertConfigurationDeleteResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -87,16 +111,118 @@ class AlertConfigurationDeleteResponse(BaseModel):
     deleted: Literal[True]
 
 
-def _get_store(request: Request) -> Dict[str, Dict[str, Any]]:
+class AlertDispatchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event: AlertEvent
+
+
+class ChannelDeliveryResultResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    channel_name: str
+    delivered: bool
+    error: str | None = None
+
+
+class AlertDispatchResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str
+    deliveries: List[ChannelDeliveryResultResponse]
+    delivery_mode: Literal["bounded_non_live"]
+    live_routing: Literal[False] = False
+
+
+def _get_store(request: Request) -> Any:
     return get_alert_configuration_store(request)
 
 
-def _get_alert_history_store(request: Request) -> List[Dict[str, Any]]:
+def _get_alert_history_store(request: Request) -> Any:
     return get_alert_history_store(request)
 
 
 def _sorted_items(store: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
     return [store[alert_id] for alert_id in sorted(store)]
+
+
+def _create_config_item(store: Any, payload: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(store, dict):
+        if payload["alert_id"] in store:
+            raise ValueError("alert_configuration_exists")
+        store[payload["alert_id"]] = payload
+        return payload
+    return store.create(payload)
+
+
+def _list_config_items(store: Any) -> list[dict[str, Any]]:
+    if isinstance(store, dict):
+        return _sorted_items(store)
+    return store.list()
+
+
+def _get_config_item(store: Any, alert_id: str) -> dict[str, Any] | None:
+    if isinstance(store, dict):
+        return store.get(alert_id)
+    return store.get(alert_id)
+
+
+def _update_config_item(store: Any, alert_id: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+    if isinstance(store, dict):
+        if alert_id not in store:
+            return None
+        store[alert_id] = payload
+        return payload
+    return store.update(alert_id, payload)
+
+
+def _delete_config_item(store: Any, alert_id: str) -> bool:
+    if isinstance(store, dict):
+        if alert_id not in store:
+            return False
+        del store[alert_id]
+        return True
+    return bool(store.delete(alert_id))
+
+
+def _list_history_events(store: Any, *, limit: int, offset: int) -> tuple[list[dict[str, Any]], int]:
+    if isinstance(store, list):
+        sorted_events = sorted(
+            store,
+            key=lambda event: (
+                event.get("occurred_at", ""),
+                event.get("event_id", ""),
+            ),
+            reverse=True,
+        )
+        return sorted_events[offset : offset + limit], len(store)
+    return store.list_events(limit=limit, offset=offset)
+
+
+def _list_delivery_results(store: Any, *, limit: int, offset: int) -> tuple[list[dict[str, Any]], int]:
+    if isinstance(store, list):
+        sorted_events = sorted(
+            store,
+            key=lambda event: (
+                event.get("occurred_at", ""),
+                event.get("event_id", ""),
+            ),
+            reverse=True,
+        )
+        items = [
+            {
+                "event_id": event.get("event_id", ""),
+                "channel_name": "bounded_non_live",
+                "delivered": True,
+                "error": None,
+                "occurred_at": event.get("occurred_at", ""),
+                "recorded_at": event.get("occurred_at", ""),
+                "delivery_mode": BOUNDED_DELIVERY_MODE,
+            }
+            for event in sorted_events[offset : offset + limit]
+        ]
+        return items, len(store)
+    return store.list_delivery_results(limit=limit, offset=offset)
 
 
 def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
@@ -113,12 +239,14 @@ def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
         _: str = Depends(require_role("operator")),
     ) -> AlertConfigurationResponse:
         store = _get_store(request)
-        if req.alert_id in store:
-            raise HTTPException(status_code=409, detail="alert_configuration_exists")
-
         payload = req.model_dump()
-        store[req.alert_id] = payload
-        return AlertConfigurationResponse(**payload)
+        try:
+            created = _create_config_item(store, payload)
+        except ValueError as exc:
+            if str(exc) == "alert_configuration_exists":
+                raise HTTPException(status_code=409, detail="alert_configuration_exists") from exc
+            raise
+        return AlertConfigurationResponse(**created)
 
     @router.get("/alerts/configurations", response_model=AlertConfigurationListResponse)
     def read_alert_configurations(
@@ -126,7 +254,7 @@ def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
         _: str = Depends(require_role("read_only")),
     ) -> AlertConfigurationListResponse:
         store = _get_store(request)
-        items = [AlertConfigurationResponse(**item) for item in _sorted_items(store)]
+        items = [AlertConfigurationResponse(**item) for item in _list_config_items(store)]
         return AlertConfigurationListResponse(items=items, total=len(items))
 
     @router.get(
@@ -139,7 +267,7 @@ def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
         _: str = Depends(require_role("read_only")),
     ) -> AlertConfigurationResponse:
         store = _get_store(request)
-        item = store.get(alert_id)
+        item = _get_config_item(store, alert_id)
         if item is None:
             raise HTTPException(status_code=404, detail="alert_configuration_not_found")
         return AlertConfigurationResponse(**item)
@@ -155,12 +283,11 @@ def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
         _: str = Depends(require_role("operator")),
     ) -> AlertConfigurationResponse:
         store = _get_store(request)
-        if alert_id not in store:
-            raise HTTPException(status_code=404, detail="alert_configuration_not_found")
-
         payload = {"alert_id": alert_id, **req.model_dump()}
-        store[alert_id] = payload
-        return AlertConfigurationResponse(**payload)
+        item = _update_config_item(store, alert_id, payload)
+        if item is None:
+            raise HTTPException(status_code=404, detail="alert_configuration_not_found")
+        return AlertConfigurationResponse(**item)
 
     @router.delete(
         "/alerts/configurations/{alert_id}",
@@ -172,10 +299,9 @@ def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
         _: str = Depends(require_role("operator")),
     ) -> AlertConfigurationDeleteResponse:
         store = _get_store(request)
-        if alert_id not in store:
+        deleted = _delete_config_item(store, alert_id)
+        if not deleted:
             raise HTTPException(status_code=404, detail="alert_configuration_not_found")
-
-        del store[alert_id]
         return AlertConfigurationDeleteResponse(alert_id=alert_id, deleted=True)
 
     @router.get("/alerts", response_model=AlertListResponse)
@@ -195,9 +321,31 @@ def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
                 operator=item["operator"],
                 threshold=item["threshold"],
             )
-            for item in _sorted_items(store)
+            for item in _list_config_items(store)
         ]
         return AlertListResponse(items=items, total=len(items))
+
+    @router.post("/alerts/dispatches", response_model=AlertDispatchResponse)
+    def dispatch_alert_event(
+        req: AlertDispatchRequest,
+        request: Request,
+        _: str = Depends(require_role("operator")),
+    ) -> AlertDispatchResponse:
+        delivery_service = get_alert_delivery_service(request)
+        result = delivery_service.dispatch_event(req.event)
+        return AlertDispatchResponse(
+            event_id=result.event_id,
+            deliveries=[
+                ChannelDeliveryResultResponse(
+                    channel_name=delivery.channel_name,
+                    delivered=delivery.delivered,
+                    error=delivery.error,
+                )
+                for delivery in result.deliveries
+            ],
+            delivery_mode=BOUNDED_DELIVERY_MODE,
+            live_routing=False,
+        )
 
     @router.get("/alerts/history", response_model=AlertHistoryListResponse)
     def read_alert_history(
@@ -207,15 +355,20 @@ def build_alerts_router(require_role: Callable[[str], Any]) -> APIRouter:
         _: str = Depends(require_role("read_only")),
     ) -> AlertHistoryListResponse:
         store = _get_alert_history_store(request)
-        sorted_events = sorted(
-            store,
-            key=lambda event: (
-                event.get("occurred_at", ""),
-                event.get("event_id", ""),
-            ),
-            reverse=True,
-        )
-        items = [AlertEvent(**event) for event in sorted_events[offset : offset + limit]]
-        return AlertHistoryListResponse(items=items, total=len(store))
+        events, total = _list_history_events(store, limit=limit, offset=offset)
+        items = [AlertEvent(**event) for event in events]
+        return AlertHistoryListResponse(items=items, total=total)
+
+    @router.get("/alerts/delivery-results", response_model=AlertDeliveryResultListResponse)
+    def read_alert_delivery_results(
+        request: Request,
+        limit: int = Query(default=20, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+        _: str = Depends(require_role("read_only")),
+    ) -> AlertDeliveryResultListResponse:
+        store = _get_alert_history_store(request)
+        rows, total = _list_delivery_results(store, limit=limit, offset=offset)
+        items = [AlertDeliveryResultItemResponse(**row) for row in rows]
+        return AlertDeliveryResultListResponse(items=items, total=total)
 
     return router

--- a/src/api/state/__init__.py
+++ b/src/api/state/__init__.py
@@ -1,16 +1,20 @@
 """Bounded mutable API state helpers."""
 
 from .alerts_state import (
+    ALERT_DELIVERY_SERVICE_ATTR,
     ALERT_CONFIGURATION_STORE_ATTR,
     ALERT_HISTORY_STORE_ATTR,
+    get_alert_delivery_service,
     get_alert_configuration_store,
     get_alert_history_store,
     initialize_alert_state,
 )
 
 __all__ = [
+    "ALERT_DELIVERY_SERVICE_ATTR",
     "ALERT_CONFIGURATION_STORE_ATTR",
     "ALERT_HISTORY_STORE_ATTR",
+    "get_alert_delivery_service",
     "get_alert_configuration_store",
     "get_alert_history_store",
     "initialize_alert_state",

--- a/src/api/state/alerts_state.py
+++ b/src/api/state/alerts_state.py
@@ -4,27 +4,53 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 
+from cilly_trading.alerts.alert_delivery_service import AlertDeliveryService
+from cilly_trading.alerts.alert_persistence_sqlite import (
+    SqliteAlertConfigurationRepository,
+    SqliteAlertDeliveryHistoryRepository,
+)
 
 ALERT_CONFIGURATION_STORE_ATTR = "alert_configuration_store"
 ALERT_HISTORY_STORE_ATTR = "alert_history_store"
+ALERT_DELIVERY_SERVICE_ATTR = "alert_delivery_service"
 
 
 def initialize_alert_state(app: FastAPI) -> None:
-    app.state.alert_configuration_store = {}
-    app.state.alert_history_store = []
+    app.state.alert_configuration_store = SqliteAlertConfigurationRepository()
+    app.state.alert_history_store = SqliteAlertDeliveryHistoryRepository()
+    app.state.alert_delivery_service = AlertDeliveryService(
+        history_store=app.state.alert_history_store
+    )
 
 
-def get_alert_configuration_store(request: Request) -> dict[str, dict[str, Any]]:
+def get_alert_configuration_store(
+    request: Request,
+) -> dict[str, dict[str, Any]] | SqliteAlertConfigurationRepository:
     store = getattr(request.app.state, ALERT_CONFIGURATION_STORE_ATTR, None)
     if store is None:
-        store = {}
+        store = SqliteAlertConfigurationRepository()
         setattr(request.app.state, ALERT_CONFIGURATION_STORE_ATTR, store)
     return store
 
 
-def get_alert_history_store(request: Request) -> list[dict[str, Any]]:
+def get_alert_history_store(
+    request: Request,
+) -> list[dict[str, Any]] | SqliteAlertDeliveryHistoryRepository:
     store = getattr(request.app.state, ALERT_HISTORY_STORE_ATTR, None)
     if store is None:
-        store = []
+        store = SqliteAlertDeliveryHistoryRepository()
         setattr(request.app.state, ALERT_HISTORY_STORE_ATTR, store)
     return store
+
+
+def get_alert_delivery_service(request: Request) -> AlertDeliveryService:
+    service = getattr(request.app.state, ALERT_DELIVERY_SERVICE_ATTR, None)
+    if service is None:
+        history_store = get_alert_history_store(request)
+        if isinstance(history_store, list):
+            # This branch is used by legacy tests that inject in-memory state directly.
+            history_store = SqliteAlertDeliveryHistoryRepository()
+            setattr(request.app.state, ALERT_HISTORY_STORE_ATTR, history_store)
+        service = AlertDeliveryService(history_store=history_store)
+        setattr(request.app.state, ALERT_DELIVERY_SERVICE_ATTR, service)
+    return service

--- a/src/cilly_trading/alerts/alert_delivery_service.py
+++ b/src/cilly_trading/alerts/alert_delivery_service.py
@@ -1,0 +1,40 @@
+"""Bounded alert delivery orchestrator."""
+
+from __future__ import annotations
+
+from .alert_dispatcher import AlertDispatchResult, AlertDispatcher
+from .alert_models import AlertEvent
+from .alert_persistence_sqlite import (
+    BOUNDED_DELIVERY_MODE,
+    SqliteAlertDeliveryHistoryRepository,
+)
+from .channels.bounded_non_live_channel import BoundedNonLiveChannel
+
+
+class AlertDeliveryService:
+    """Dispatch alert events through one bounded channel and persist results."""
+
+    def __init__(
+        self,
+        *,
+        history_store: SqliteAlertDeliveryHistoryRepository,
+        dispatcher: AlertDispatcher | None = None,
+    ) -> None:
+        self._history_store = history_store
+        self._dispatcher = dispatcher or AlertDispatcher(channels=[BoundedNonLiveChannel()])
+
+    @property
+    def channel_names(self) -> tuple[str, ...]:
+        return self._dispatcher.channel_names
+
+    def dispatch_event(self, event: AlertEvent) -> AlertDispatchResult:
+        dispatch_result = self._dispatcher.dispatch(event)
+        self._history_store.record_dispatch(
+            event=event,
+            dispatch_result=dispatch_result,
+            delivery_mode=BOUNDED_DELIVERY_MODE,
+        )
+        return dispatch_result
+
+
+__all__ = ["AlertDeliveryService"]

--- a/src/cilly_trading/alerts/alert_persistence_sqlite.py
+++ b/src/cilly_trading/alerts/alert_persistence_sqlite.py
@@ -1,0 +1,400 @@
+"""SQLite-backed persistence for bounded alert configuration and delivery history."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from cilly_trading.db import DEFAULT_DB_PATH, init_db
+
+from .alert_dispatcher import AlertDispatchResult
+from .alert_models import AlertEvent
+
+BOUNDED_DELIVERY_MODE = "bounded_non_live"
+
+
+class SqliteAlertConfigurationRepository:
+    """Persist alert configuration records in SQLite."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        if db_path is None:
+            db_path = DEFAULT_DB_PATH
+        self._db_path = Path(db_path)
+        init_db(self._db_path)
+        self._ensure_schema()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS alert_configurations (
+                alert_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                source TEXT NOT NULL,
+                metric TEXT NOT NULL,
+                operator TEXT NOT NULL,
+                threshold REAL NOT NULL,
+                severity TEXT NOT NULL,
+                enabled INTEGER NOT NULL,
+                tags_json TEXT NOT NULL
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_alert_configurations_name
+              ON alert_configurations(name, alert_id);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def create(self, payload: dict[str, Any]) -> dict[str, Any]:
+        conn = self._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                INSERT INTO alert_configurations (
+                    alert_id,
+                    name,
+                    description,
+                    source,
+                    metric,
+                    operator,
+                    threshold,
+                    severity,
+                    enabled,
+                    tags_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+                """,
+                self._to_row_payload(payload),
+            )
+            conn.commit()
+            return payload
+        except sqlite3.IntegrityError as exc:
+            raise ValueError("alert_configuration_exists") from exc
+        finally:
+            conn.close()
+
+    def update(self, alert_id: str, payload: dict[str, Any]) -> dict[str, Any] | None:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            UPDATE alert_configurations
+            SET
+                name = ?,
+                description = ?,
+                source = ?,
+                metric = ?,
+                operator = ?,
+                threshold = ?,
+                severity = ?,
+                enabled = ?,
+                tags_json = ?
+            WHERE alert_id = ?;
+            """,
+            (
+                payload["name"],
+                payload.get("description"),
+                payload["source"],
+                payload["metric"],
+                payload["operator"],
+                payload["threshold"],
+                payload["severity"],
+                1 if payload["enabled"] else 0,
+                _serialize_tags(payload.get("tags", [])),
+                alert_id,
+            ),
+        )
+        updated = cur.rowcount > 0
+        conn.commit()
+        conn.close()
+        if not updated:
+            return None
+        return payload
+
+    def get(self, alert_id: str) -> dict[str, Any] | None:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT
+                alert_id,
+                name,
+                description,
+                source,
+                metric,
+                operator,
+                threshold,
+                severity,
+                enabled,
+                tags_json
+            FROM alert_configurations
+            WHERE alert_id = ?
+            LIMIT 1;
+            """,
+            (alert_id,),
+        )
+        row = cur.fetchone()
+        conn.close()
+        if row is None:
+            return None
+        return self._from_row(row)
+
+    def list(self) -> list[dict[str, Any]]:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT
+                alert_id,
+                name,
+                description,
+                source,
+                metric,
+                operator,
+                threshold,
+                severity,
+                enabled,
+                tags_json
+            FROM alert_configurations
+            ORDER BY alert_id ASC;
+            """
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return [self._from_row(row) for row in rows]
+
+    def delete(self, alert_id: str) -> bool:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute("DELETE FROM alert_configurations WHERE alert_id = ?;", (alert_id,))
+        deleted = cur.rowcount > 0
+        conn.commit()
+        conn.close()
+        return deleted
+
+    @staticmethod
+    def _to_row_payload(payload: dict[str, Any]) -> tuple[Any, ...]:
+        return (
+            payload["alert_id"],
+            payload["name"],
+            payload.get("description"),
+            payload["source"],
+            payload["metric"],
+            payload["operator"],
+            payload["threshold"],
+            payload["severity"],
+            1 if payload["enabled"] else 0,
+            _serialize_tags(payload.get("tags", [])),
+        )
+
+    @staticmethod
+    def _from_row(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "alert_id": row["alert_id"],
+            "name": row["name"],
+            "description": row["description"],
+            "source": row["source"],
+            "metric": row["metric"],
+            "operator": row["operator"],
+            "threshold": row["threshold"],
+            "severity": row["severity"],
+            "enabled": bool(row["enabled"]),
+            "tags": _deserialize_tags(row["tags_json"]),
+        }
+
+
+class SqliteAlertDeliveryHistoryRepository:
+    """Persist bounded alert delivery attempts and expose deterministic reads."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        if db_path is None:
+            db_path = DEFAULT_DB_PATH
+        self._db_path = Path(db_path)
+        init_db(self._db_path)
+        self._ensure_schema()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _ensure_schema(self) -> None:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS alert_delivery_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL,
+                event_payload_json TEXT NOT NULL,
+                channel_name TEXT NOT NULL,
+                delivered INTEGER NOT NULL,
+                error TEXT,
+                occurred_at TEXT NOT NULL,
+                recorded_at TEXT NOT NULL,
+                delivery_mode TEXT NOT NULL
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_alert_delivery_history_ordering
+              ON alert_delivery_history(
+                  REPLACE(occurred_at, 'Z', '+00:00') DESC,
+                  event_id DESC,
+                  id DESC
+              );
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def record_dispatch(
+        self,
+        *,
+        event: AlertEvent,
+        dispatch_result: AlertDispatchResult,
+        delivery_mode: str = BOUNDED_DELIVERY_MODE,
+    ) -> None:
+        if not dispatch_result.deliveries:
+            return
+
+        now = datetime.now(timezone.utc).isoformat()
+        event_payload_json = event.model_dump_json()
+
+        rows = [
+            (
+                dispatch_result.event_id,
+                event_payload_json,
+                delivery.channel_name,
+                1 if delivery.delivered else 0,
+                delivery.error,
+                event.occurred_at,
+                now,
+                delivery_mode,
+            )
+            for delivery in dispatch_result.deliveries
+        ]
+
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.executemany(
+            """
+            INSERT INTO alert_delivery_history (
+                event_id,
+                event_payload_json,
+                channel_name,
+                delivered,
+                error,
+                occurred_at,
+                recorded_at,
+                delivery_mode
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            rows,
+        )
+        conn.commit()
+        conn.close()
+
+    def list_events(self, *, limit: int, offset: int) -> tuple[list[dict[str, Any]], int]:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM alert_delivery_history;")
+        total = int(cur.fetchone()[0])
+        cur.execute(
+            """
+            SELECT event_payload_json
+            FROM alert_delivery_history
+            ORDER BY
+                REPLACE(occurred_at, 'Z', '+00:00') DESC,
+                event_id DESC,
+                id DESC
+            LIMIT ?
+            OFFSET ?;
+            """,
+            (limit, offset),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        return ([json.loads(row["event_payload_json"]) for row in rows], total)
+
+    def list_delivery_results(
+        self,
+        *,
+        limit: int,
+        offset: int,
+    ) -> tuple[list[dict[str, Any]], int]:
+        conn = self._get_connection()
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM alert_delivery_history;")
+        total = int(cur.fetchone()[0])
+        cur.execute(
+            """
+            SELECT
+                event_id,
+                channel_name,
+                delivered,
+                error,
+                occurred_at,
+                recorded_at,
+                delivery_mode
+            FROM alert_delivery_history
+            ORDER BY
+                REPLACE(occurred_at, 'Z', '+00:00') DESC,
+                event_id DESC,
+                id DESC
+            LIMIT ?
+            OFFSET ?;
+            """,
+            (limit, offset),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        items = [
+            {
+                "event_id": row["event_id"],
+                "channel_name": row["channel_name"],
+                "delivered": bool(row["delivered"]),
+                "error": row["error"],
+                "occurred_at": row["occurred_at"],
+                "recorded_at": row["recorded_at"],
+                "delivery_mode": row["delivery_mode"],
+            }
+            for row in rows
+        ]
+        return items, total
+
+
+def _serialize_tags(tags: list[str]) -> str:
+    return json.dumps(tags, separators=(",", ":"), ensure_ascii=False)
+
+
+def _deserialize_tags(tags_json: str) -> list[str]:
+    try:
+        decoded = json.loads(tags_json)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return []
+    if not isinstance(decoded, list):
+        return []
+    return [str(item) for item in decoded]
+
+
+__all__ = [
+    "BOUNDED_DELIVERY_MODE",
+    "SqliteAlertConfigurationRepository",
+    "SqliteAlertDeliveryHistoryRepository",
+]

--- a/src/cilly_trading/alerts/channels/__init__.py
+++ b/src/cilly_trading/alerts/channels/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from cilly_trading.alerts.alert_models import AlertEvent
+from .bounded_non_live_channel import BoundedNonLiveChannel
 
 
 class NotificationChannel(Protocol):
@@ -16,4 +17,4 @@ class NotificationChannel(Protocol):
         """Deliver an alert event to an external notification destination."""
 
 
-__all__ = ["NotificationChannel"]
+__all__ = ["BoundedNonLiveChannel", "NotificationChannel"]

--- a/src/cilly_trading/alerts/channels/bounded_non_live_channel.py
+++ b/src/cilly_trading/alerts/channels/bounded_non_live_channel.py
@@ -1,0 +1,19 @@
+"""Single bounded, deterministic, explicitly non-live alert channel."""
+
+from __future__ import annotations
+
+from cilly_trading.alerts.alert_models import AlertEvent
+
+
+class BoundedNonLiveChannel:
+    """No-op channel that marks delivery as successful without external routing."""
+
+    channel_name = "bounded_non_live"
+
+    def deliver(self, event: AlertEvent) -> None:
+        # Explicitly bounded behavior: validate that event identity exists, then no-op.
+        if not event.event_id:
+            raise ValueError("alert event_id is required")
+
+
+__all__ = ["BoundedNonLiveChannel"]

--- a/tests/alerts/test_bounded_alert_delivery_mvp.py
+++ b/tests/alerts/test_bounded_alert_delivery_mvp.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from api.alerts_api import AlertConfigurationCreateRequest
+from cilly_trading.alerts.alert_delivery_service import AlertDeliveryService
+from cilly_trading.alerts.alert_models import create_alert_event
+from cilly_trading.alerts.alert_persistence_sqlite import (
+    BOUNDED_DELIVERY_MODE,
+    SqliteAlertConfigurationRepository,
+    SqliteAlertDeliveryHistoryRepository,
+)
+
+
+def _config_payload(alert_id: str = "drawdown-bounded") -> dict[str, object]:
+    return {
+        "alert_id": alert_id,
+        "name": "Drawdown Guard",
+        "description": "Bounded drawdown threshold alert",
+        "source": "risk",
+        "metric": "drawdown_pct",
+        "operator": "gte",
+        "threshold": 3.5,
+        "severity": "warning",
+        "enabled": True,
+        "tags": ["risk", "bounded"],
+    }
+
+
+def _event_payload() -> dict[str, object]:
+    return {
+        "event_type": "runtime.guard_triggered",
+        "source_type": "runtime",
+        "source_id": "guard-risk-1",
+        "severity": "warning",
+        "occurred_at": "2026-04-12T10:00:00Z",
+        "payload": {"guard": "drawdown", "value": 3.8},
+    }
+
+
+def test_bounded_dispatch_persists_delivery_result(tmp_path) -> None:
+    db_path = tmp_path / "alerts-mvp.db"
+    history_store = SqliteAlertDeliveryHistoryRepository(db_path=db_path)
+    service = AlertDeliveryService(history_store=history_store)
+    event = create_alert_event(**_event_payload())
+
+    result = service.dispatch_event(event)
+    stored_rows, total = history_store.list_delivery_results(limit=10, offset=0)
+
+    assert result.event_id == event.event_id
+    assert result.delivered_channels == ("bounded_non_live",)
+    assert result.failed_channels == ()
+    assert total == 1
+    assert stored_rows == [
+        {
+            "event_id": event.event_id,
+            "channel_name": "bounded_non_live",
+            "delivered": True,
+            "error": None,
+            "occurred_at": "2026-04-12T10:00:00Z",
+            "recorded_at": stored_rows[0]["recorded_at"],
+            "delivery_mode": BOUNDED_DELIVERY_MODE,
+        }
+    ]
+
+
+def test_restart_preserves_configuration_and_history(tmp_path) -> None:
+    db_path = tmp_path / "alerts-restart.db"
+    config_store = SqliteAlertConfigurationRepository(db_path=db_path)
+    history_store = SqliteAlertDeliveryHistoryRepository(db_path=db_path)
+    delivery_service = AlertDeliveryService(history_store=history_store)
+
+    config_store.create(_config_payload())
+    event = create_alert_event(**_event_payload())
+    delivery_service.dispatch_event(event)
+
+    restarted_config_store = SqliteAlertConfigurationRepository(db_path=db_path)
+    restarted_history_store = SqliteAlertDeliveryHistoryRepository(db_path=db_path)
+
+    config_item = restarted_config_store.get("drawdown-bounded")
+    events, total_events = restarted_history_store.list_events(limit=20, offset=0)
+
+    assert config_item is not None
+    assert config_item["name"] == "Drawdown Guard"
+    assert total_events == 1
+    assert events[0]["event_id"] == event.event_id
+
+
+def test_invalid_alert_configuration_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AlertConfigurationCreateRequest.model_validate(
+            {
+                "alert_id": "invalid-operator",
+                "name": "Invalid Operator",
+                "description": None,
+                "source": "risk",
+                "metric": "drawdown_pct",
+                "operator": "invalid",
+                "threshold": 2.0,
+                "severity": "warning",
+                "enabled": True,
+                "tags": ["risk"],
+            }
+        )

--- a/tests/integration/test_alert_delivery_lifecycle.py
+++ b/tests/integration/test_alert_delivery_lifecycle.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.alerts_api import build_alerts_router
+from cilly_trading.alerts.alert_delivery_service import AlertDeliveryService
+from cilly_trading.alerts.alert_persistence_sqlite import (
+    SqliteAlertConfigurationRepository,
+    SqliteAlertDeliveryHistoryRepository,
+)
+
+OPERATOR_HEADERS = {"X-Cilly-Role": "operator"}
+READ_ONLY_HEADERS = {"X-Cilly-Role": "read_only"}
+
+
+def _require_role(minimum_role: str):
+    def _dependency() -> str:
+        return minimum_role
+
+    return _dependency
+
+
+def _build_test_app(db_path) -> FastAPI:
+    app = FastAPI()
+    app.state.alert_configuration_store = SqliteAlertConfigurationRepository(db_path=db_path)
+    app.state.alert_history_store = SqliteAlertDeliveryHistoryRepository(db_path=db_path)
+    app.state.alert_delivery_service = AlertDeliveryService(history_store=app.state.alert_history_store)
+    app.include_router(build_alerts_router(_require_role))
+    return app
+
+
+def test_alert_event_dispatch_lifecycle_is_deterministic_and_restart_safe(tmp_path) -> None:
+    db_path = tmp_path / "alerts-lifecycle.db"
+    app = _build_test_app(db_path)
+
+    with TestClient(app) as client:
+        create_config_response = client.post(
+            "/alerts/configurations",
+            json={
+                "alert_id": "drawdown-life",
+                "name": "Drawdown Lifecycle",
+                "description": "Lifecycle verification",
+                "source": "risk",
+                "metric": "drawdown_pct",
+                "operator": "gte",
+                "threshold": 4.2,
+                "severity": "warning",
+                "enabled": True,
+                "tags": ["risk"],
+            },
+            headers=OPERATOR_HEADERS,
+        )
+        assert create_config_response.status_code == 201
+
+        dispatch_response = client.post(
+            "/alerts/dispatches",
+            json={
+                "event": {
+                    "schema_version": "1.0",
+                    "event_id": "alert_static_lifecycle_event",
+                    "event_type": "runtime.guard_triggered",
+                    "source_type": "runtime",
+                    "source_id": "guard-lifecycle",
+                    "severity": "warning",
+                    "occurred_at": "2026-04-12T12:00:00Z",
+                    "symbol": "AAPL",
+                    "strategy": "RSI2",
+                    "correlation_id": None,
+                    "payload": {"guard": "drawdown", "value": 4.2},
+                }
+            },
+            headers=OPERATOR_HEADERS,
+        )
+        assert dispatch_response.status_code == 200
+        assert dispatch_response.json() == {
+            "event_id": "alert_static_lifecycle_event",
+            "deliveries": [
+                {"channel_name": "bounded_non_live", "delivered": True, "error": None}
+            ],
+            "delivery_mode": "bounded_non_live",
+            "live_routing": False,
+        }
+
+        history_response = client.get("/alerts/history", headers=READ_ONLY_HEADERS)
+        assert history_response.status_code == 200
+        history_payload = history_response.json()
+        assert history_payload["total"] == 1
+        assert history_payload["items"][0]["event_id"] == "alert_static_lifecycle_event"
+
+        delivery_results_response = client.get(
+            "/alerts/delivery-results",
+            headers=READ_ONLY_HEADERS,
+        )
+        assert delivery_results_response.status_code == 200
+        delivery_results_payload = delivery_results_response.json()
+        assert delivery_results_payload["total"] == 1
+        assert delivery_results_payload["items"] == [
+            {
+                "event_id": "alert_static_lifecycle_event",
+                "channel_name": "bounded_non_live",
+                "delivered": True,
+                "error": None,
+                "occurred_at": "2026-04-12T12:00:00Z",
+                "recorded_at": delivery_results_payload["items"][0]["recorded_at"],
+                "delivery_mode": "bounded_non_live",
+            }
+        ]
+
+    restarted_app = _build_test_app(db_path)
+    with TestClient(restarted_app) as restarted_client:
+        configurations_response = restarted_client.get(
+            "/alerts/configurations",
+            headers=READ_ONLY_HEADERS,
+        )
+        assert configurations_response.status_code == 200
+        assert configurations_response.json()["total"] == 1
+        assert configurations_response.json()["items"][0]["alert_id"] == "drawdown-life"
+
+        history_response = restarted_client.get("/alerts/history", headers=READ_ONLY_HEADERS)
+        assert history_response.status_code == 200
+        assert history_response.json()["total"] == 1
+        assert history_response.json()["items"][0]["event_id"] == "alert_static_lifecycle_event"
+
+        restarted_delivery_results_response = restarted_client.get(
+            "/alerts/delivery-results",
+            headers=READ_ONLY_HEADERS,
+        )
+        assert restarted_delivery_results_response.status_code == 200
+        restarted_delivery_payload = restarted_delivery_results_response.json()
+        assert restarted_delivery_payload["total"] == 1
+        assert restarted_delivery_payload["items"] == [
+            {
+                "event_id": "alert_static_lifecycle_event",
+                "channel_name": "bounded_non_live",
+                "delivered": True,
+                "error": None,
+                "occurred_at": "2026-04-12T12:00:00Z",
+                "recorded_at": restarted_delivery_payload["items"][0]["recorded_at"],
+                "delivery_mode": "bounded_non_live",
+            }
+        ]


### PR DESCRIPTION
﻿Closes #935

## Scope
Implements a single deterministic, bounded, explicitly non-live alert delivery path with SQLite-backed persistence for alert configuration and delivery history.

## What changed
- Added bounded channel `bounded_non_live` with no external/live routing.
- Added `AlertDeliveryService` for deterministic event dispatch and persisted delivery results.
- Added SQLite repositories:
  - `SqliteAlertConfigurationRepository`
  - `SqliteAlertDeliveryHistoryRepository`
- Updated alert API/state wiring to use persistence-backed stores.
- Added bounded dispatch endpoint: `POST /alerts/dispatches`.
- Added bounded delivery-results read endpoint: `GET /alerts/delivery-results`.
- Added tests for:
  - deterministic event -> dispatch -> persisted delivery result
  - restart-safe persistence integrity
  - invalid alert configuration rejection
  - API lifecycle coverage for dispatch/history/config persistence

## Acceptance criteria mapping
- AC1: Single deterministic bounded channel implemented (`bounded_non_live`)
- AC2: E2E flow tested through API and persistence (`/alerts/dispatches` -> `/alerts/delivery-results`)
- AC3: Restart persistence tested for config/history/delivery results
- AC4: Delivery path explicitly non-live (`delivery_mode=bounded_non_live`, `live_routing=false`)
- AC5: No P56/runtime/engine/strategy scope impact

## Governance
- Codex A review decision: APPROVED
- Classification: technically good, but traderically weak
- Roadmap maintenance due after merge because Phase 41 should no longer remain pure `Planned`

## Test evidence
- Command: `python -m pytest`
- Result: `1029 passed, 4 warnings`
