### PR TITLE
[REPO-RATIONALIZATION][01] Resolve canonical roadmap status authority conflict #939

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The current repository state supports local runtime, deterministic smoke-run and
 `README.md` is an entry point only. It provides navigation into the canonical
 documentation structure and does not act as the source of truth for setup,
 local run, testing, or architecture topics.
+It also does not act as a source of authority for roadmap phase maturity/status.
 
 Start from these documents:
 
@@ -19,6 +20,7 @@ Start from these documents:
 - Local run authority: `docs/getting-started/local-run.md`
 - Testing authority: `docs/testing/index.md`
 - Architecture authority root: `docs/architecture/`
+- Roadmap phase maturity/status authority: `ROADMAP_MASTER.md`
 - Server-ready release governance contract:
   `docs/releases/release_governance_contract.md`
 

--- a/ROADMAP_MASTER.md
+++ b/ROADMAP_MASTER.md
@@ -29,6 +29,7 @@ Authority model used in this file:
 Status update path:
 - Update supporting evidence first, as needed, in the relevant per-phase or audit artifact.
 - Update this file to record the canonical phase maturity/status change.
+- PR review rule: reject status-changing roadmap/doc updates unless `ROADMAP_MASTER.md` is updated in the same change (or the PR explicitly proves no maturity/status change occurred).
 - Treat any secondary document that has not yet been reconciled to this file as stale derived documentation rather than as a competing status source.
 
 Status policy used in this file:

--- a/docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md
+++ b/docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md
@@ -1,9 +1,11 @@
 # Cilly Trading Engine - Complete Master Roadmap
 Version: Bilingual (English -> Deutsch)
 Status Basis Date: 2026-04-09
+Status Authority: Derived Snapshot (Non-Authoritative for phase maturity/status)
 Purpose: Repo-based roadmap aligned to the uploaded 45-phase master reference.
 
 This roadmap replaces the prior working copy at this path.
+Canonical phase maturity/status authority is `ROADMAP_MASTER.md`.
 
 Reference input:
 - `C:\Users\Serdar Cil\Downloads\cilly_trading_execution_roadmap.md`
@@ -26,15 +28,15 @@ Primary status sources:
 
 Authority model used in this file:
 - `docs/architecture/roadmap/execution_roadmap.md` is the authoritative in-repo source for audited phase meaning and taxonomy.
-- This master roadmap is the single authoritative in-repo source for phase maturity/status across the 45-phase reference set.
-- Per-phase status artifacts, audit reports, indexes, and other roadmap/navigation documents are evidence-bearing or explanatory surfaces only; they do not set canonical phase maturity/status unless their change is also reflected in this file.
+- `ROADMAP_MASTER.md` is the single authoritative in-repo source for phase maturity/status across the 45-phase reference set.
+- This file is a derived roadmap snapshot for context/navigation only. Per-phase status artifacts, audit reports, indexes, and other roadmap/navigation documents (including this file) do not set canonical phase maturity/status unless their change is also reflected in `ROADMAP_MASTER.md`.
 - This file does not redefine audited phase meanings that are governed by the authoritative execution roadmap.
 - Where this file references an audited phase that is covered by the authoritative execution roadmap, phase meaning must defer to that file and any conflicting wording here should be read as non-authoritative for taxonomy.
 
 Status update path:
 - Update supporting evidence first, as needed, in the relevant per-phase or audit artifact.
-- Update this file to record the canonical phase maturity/status change.
-- Treat any secondary document that has not yet been reconciled to this file as stale derived documentation rather than as a competing status source.
+- Update `ROADMAP_MASTER.md` to record the canonical phase maturity/status change.
+- Treat this file and any other secondary document that has not yet been reconciled to `ROADMAP_MASTER.md` as stale derived documentation rather than as a competing status source.
 
 Status policy used in this file:
 - `Implemented`: repo-verifiable implementation exists without a documented material completion gap for this phase scope.
@@ -52,8 +54,9 @@ Status policy used in this file:
 ## Authority Relationship
 
 - `docs/architecture/roadmap/execution_roadmap.md` governs audited phase meaning.
-- This document governs the broader master-roadmap view, sequencing, and the canonical phase maturity/status labels for the 45-phase reference set.
-- Per-phase status files, audit artifacts, and index/navigation pages may explain or evidence a phase, but they remain derived surfaces for status and must defer to this document for the canonical maturity/status label.
+- `ROADMAP_MASTER.md` governs the broader master-roadmap view, sequencing, and the canonical phase maturity/status labels for the 45-phase reference set.
+- This document is derived/non-authoritative for status and is retained for compatibility and navigation only.
+- Per-phase status files, audit artifacts, and index/navigation pages may explain or evidence a phase, but they remain derived surfaces for status and must defer to `ROADMAP_MASTER.md` for the canonical maturity/status label.
 - For audited phases, this document must defer to the authoritative execution roadmap for taxonomy and phase-name interpretation.
 
 ## System Workflow
@@ -124,8 +127,8 @@ Market Data
 
 ## Status Notes
 
-- Status changes follow one update path: update evidence as needed, then update this master roadmap to change the canonical phase maturity/status label.
-- Secondary docs that describe a phase do not create an independent status authority; they are reconciled to this file.
+- Status changes follow one update path: update evidence as needed, then update `ROADMAP_MASTER.md` to change the canonical phase maturity/status label.
+- Secondary docs that describe a phase do not create an independent status authority; they are reconciled to `ROADMAP_MASTER.md`.
 - Phase 17b is backend-served at `/ui`; `/owner` is documented only as a frontend development-only route and not as a runtime backend surface.
 - Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface.
 - Phase 23 remains `Not Implemented` because the repository does not yet contain the full minimum evidence contract for one coherent Research Dashboard surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact for the same claimed surface.

--- a/docs/architecture/roadmap/execution_roadmap.md
+++ b/docs/architecture/roadmap/execution_roadmap.md
@@ -9,14 +9,14 @@ This file is the single authoritative in-repo source for audited phase-number me
 
 ## Authority Relationship
 - This file governs the meaning of the audited phase numbers listed below.
-- The master roadmap at `docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md` is the single authoritative in-repo source for phase maturity/status labels and status-change decisions.
+- `ROADMAP_MASTER.md` is the single authoritative in-repo source for phase maturity/status labels and status-change decisions.
 - This file does not authoritatively set phase maturity/status labels. Any status wording here, in a per-phase artifact, or in an index must defer to the master roadmap for canonical maturity/status.
 - The master roadmap may summarize broader sequencing and implementation-status context, but it must defer to this file for audited phase meaning.
 - If wording in a secondary roadmap, index, or audit artifact conflicts with the audited phase meanings defined here, this file controls the taxonomy interpretation.
 
 ## Status Update Rule
 - Taxonomy updates follow this file.
-- Phase maturity/status updates follow `docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md`.
+- Phase maturity/status updates follow `ROADMAP_MASTER.md`.
 - Per-phase status artifacts, audit reports, and index/navigation documents may provide evidence, scoped detail, or traceability, but they do not become canonical status sources unless the master roadmap is updated to reflect the change.
 - Reviewers should reject status changes that update a secondary document without also updating the master roadmap.
 
@@ -46,7 +46,7 @@ This file is the single authoritative in-repo source for audited phase-number me
 - Phase 17 and Phase 17b are not interchangeable: Phase 17 is the umbrella phase, and Phase 17b is the Owner Dashboard sub-phase.
 - Phase 27 and Phase 27b are not interchangeable: Phase 27 is Risk Framework taxonomy; Phase 27b remains a distinct Pipeline Enforcement Layer artifact.
 - Phase 25 and Phase 26 must not be grouped into a shared replacement meaning. Phase 25 is defined above, while Phase 26 remains unmapped in current authoritative in-repo taxonomy.
-- This document establishes taxonomy only. Canonical implementation-status corrections must be made in `docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md`, with any supporting per-phase artifacts updated as derived evidence.
+- This document establishes taxonomy only. Canonical implementation-status corrections must be made in `ROADMAP_MASTER.md`, with any supporting per-phase artifacts updated as derived evidence.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,10 +61,11 @@ Use this order:
 
 ## Authoritative Phase Taxonomy
 The authoritative in-repo source for audited phase-number meanings is [Execution Roadmap](architecture/roadmap/execution_roadmap.md).
-The authoritative in-repo source for phase maturity/status is the broader [Complete Master Roadmap](architecture/roadmap/cilly_trading_execution_roadmap_updated.md).
-The execution roadmap governs audited phase meaning and taxonomy only, while the master roadmap governs canonical phase maturity/status.
+The single authoritative in-repo source for phase maturity/status is [ROADMAP_MASTER.md](../ROADMAP_MASTER.md).
+The execution roadmap governs audited phase meaning and taxonomy only, while `ROADMAP_MASTER.md` governs canonical phase maturity/status.
 Per-phase status files, audit artifacts, and the index are derived navigation or evidence surfaces and must defer to those two authorities.
-Status changes therefore follow one update path: update supporting evidence as needed, then update the master roadmap to change the canonical phase maturity/status.
+Status changes therefore follow one update path: update supporting evidence as needed, then update `ROADMAP_MASTER.md` to change the canonical phase maturity/status.
+PR review must reject roadmap status changes that are not reconciled in `ROADMAP_MASTER.md`.
 
 | Phase | Meaning in the authoritative taxonomy | Primary trace |
 |-------|---------------------------------------|---------------|


### PR DESCRIPTION
Closes #939

## What changed
- Set ROADMAP_MASTER.md as the single canonical authority for phase maturity/status.
- Updated README.md and docs/index.md to avoid competing status authority language.
- Updated docs/architecture/roadmap/execution_roadmap.md to keep taxonomy authority only and defer status authority to ROADMAP_MASTER.md.
- Marked docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md as a derived snapshot and non-authoritative for phase maturity/status.
- Added explicit PR-review governance requiring reconciliation in ROADMAP_MASTER.md for status changes.

## Validation
- Verified authority wording across:
  - README.md
  - docs/index.md
  - ROADMAP_MASTER.md
  - docs/architecture/roadmap/execution_roadmap.md
  - docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md
- Confirmed all phase maturity/status authority statements defer to ROADMAP_MASTER.md.
- Confirmed secondary roadmap/navigation documents no longer act as competing status authorities.

## Scope
- Docs-only change.
- No source code, tests, runtime/config files, CI files, or API surface files changed.