### PR TITLE
[REPO-RATIONALIZATION][02] Introduce canonical document status model (#940)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Start from these documents:
 - Local run authority: `docs/getting-started/local-run.md`
 - Testing authority: `docs/testing/index.md`
 - Architecture authority root: `docs/architecture/`
+- Canonical document status model for governance/roadmap/audit/status documents:
+  `docs/architecture/governance/document-status-model.md`
 - Server-ready release governance contract:
   `docs/releases/release_governance_contract.md`
 

--- a/docs/architecture/governance/document-status-model.md
+++ b/docs/architecture/governance/document-status-model.md
@@ -1,0 +1,125 @@
+# Canonical Document Status Model
+
+## Document Status
+
+- Class: Canonical
+- Canonical Source(s): N/A (Class=Canonical)
+- Rationale: This file is the authoritative source for the document status
+  classification model used by governance-/roadmap-/audit-/status-relevant
+  documents in this repository.
+
+## Purpose
+
+This document defines one canonical status model for governance-, roadmap-,
+audit-, and status-relevant documentation.
+
+The model provides:
+
+- a fixed status vocabulary,
+- deterministic classification rules,
+- a mandatory intake rule for new status-relevant documents.
+
+## Status Classes
+
+### Canonical
+
+The document is a source-of-truth authority for its scoped claim domain.
+Canonical documents may define policy, lifecycle status, or governance gates.
+
+### Derived
+
+The document summarizes, indexes, or explains canonical content but does not set
+authority. Derived documents must explicitly defer to canonical sources.
+
+### Evidence
+
+The document records verification, audit, runtime evidence, or compliance trace
+material supporting a claim. Evidence does not define canonical policy/status by
+itself.
+
+### Deprecated
+
+The document is retained for historical traceability but replaced by a newer
+source. Deprecated documents must not be used to set current policy or status.
+
+### Archived
+
+The document is retained as inactive historical record. Archived documents are
+outside active governance/update flow.
+
+### Compatibility Alias
+
+A compatibility path kept to preserve legacy links/consumer navigation. Alias
+documents or paths must point to the current canonical location and must not
+compete with canonical authority.
+
+## Classification Rules
+
+1. Every governance-/roadmap-/audit-/status-relevant document must have exactly
+   one status class from this model.
+2. Only `Canonical` documents may define authoritative status or governance
+   outcomes.
+3. `Derived`, `Evidence`, and `Compatibility Alias` documents must defer to one
+   or more named canonical documents.
+4. `Deprecated` and `Archived` documents are non-authoritative by definition.
+5. A canonical document must never be labeled `Deprecated` or `Archived` while
+   it remains an active source of truth.
+
+## Canonical Authority Mapping (Current)
+
+The following high-visibility sources are classified as `Canonical` for their
+domains:
+
+- `ROADMAP_MASTER.md` (master phase maturity/status authority)
+- `docs/architecture/roadmap/execution_roadmap.md` (audited phase taxonomy)
+- `docs/architecture/documentation_structure.md`
+  (documentation ownership/navigation authority)
+- `docs/architecture/governance/phase-5-exit-criteria.md`
+  (phase-5 governance gate)
+- `docs/releases/release_governance_contract.md`
+  (release governance boundary)
+
+## Sample Classification (Acceptance Test Trace)
+
+Sample checks against this model:
+
+| Document | Class | Why |
+| --- | --- | --- |
+| `ROADMAP_MASTER.md` | Canonical | Single authoritative in-repo source for phase maturity/status. |
+| `docs/architecture/roadmap/cilly_trading_execution_roadmap_updated.md` | Derived | Snapshot/explanatory roadmap surface that must defer to `ROADMAP_MASTER.md` for phase maturity/status. |
+| `docs/architecture/roadmap/execution_roadmap.md` | Canonical | Explicitly defines authoritative audited taxonomy/phase meaning. |
+| `docs/architecture/audit/roadmap_compliance_report.md` | Evidence | Audits alignment; does not set canonical status authority. |
+| `docs/architecture/phases/phase-37-status.md` | Derived | Per-phase status surface defers to master roadmap authority model. |
+| `docs/index.md` | Derived | Navigation/index surface; must defer to canonical governance sources. |
+| `docs/api/runtime_chart_data_contract.md` | Compatibility Alias | Legacy path kept for compatibility with canonical operations path. |
+
+## Intake Rule For New Status-Relevant Documents
+
+A new governance-/roadmap-/audit-/status-relevant document is allowed only if
+its status class is explicitly declared in the document front matter section
+`Document Status`.
+
+Required header block:
+
+```md
+## Document Status
+- Class: <Canonical|Derived|Evidence|Deprecated|Archived|Compatibility Alias>
+- Canonical Source(s): <required unless Class=Canonical>
+- Rationale: <short reason>
+```
+
+Review gate for PRs that add these documents:
+
+1. `Document Status` block is present and uses one allowed class name exactly.
+2. Non-canonical classes reference canonical source(s).
+3. Wording does not promote derived/evidence/alias docs to canonical authority.
+4. No active canonical file is reclassified as `Deprecated` or `Archived`.
+
+## Compatibility Notes
+
+This model is compatible with the current documentation structure:
+
+- It preserves existing canonical ownership patterns.
+- It allows derived/evidence surfaces to remain in place without mass
+  reclassification.
+- It supports legacy alias paths while keeping one canonical authority per claim.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,14 @@ Use this order:
 4. Explore CLI
 5. Understand versioning model
 
+## Document Status Model
+- Canonical document-status classification model:
+  `docs/architecture/governance/document-status-model.md`
+- For governance-/roadmap-/audit-/status-relevant documents, explicit
+  `Document Status` classification is mandatory.
+- `docs/index.md` is a derived navigation surface and must defer to canonical
+  status/governance authorities declared by the model.
+
 ## Quickstart
 - [Quickstart](getting-started/quickstart.md)
 - [Run deterministic smoke test](testing/smoke-run.md)
@@ -57,11 +65,12 @@ Use this order:
 - [Release boundary](architecture/versioning/release_boundary.md)
 - [Version declaration](architecture/versioning/declaration.md)
 - [Compatibility gate](architecture/versioning/compatibility_gate.md)
+- [Canonical document status model](architecture/governance/document-status-model.md)
 - [Qualification claim evidence discipline](governance/qualification-claim-evidence-discipline.md)
 
 ## Authoritative Phase Taxonomy
 The authoritative in-repo source for audited phase-number meanings is [Execution Roadmap](architecture/roadmap/execution_roadmap.md).
-The authoritative in-repo source for phase maturity/status is the broader [Complete Master Roadmap](architecture/roadmap/cilly_trading_execution_roadmap_updated.md).
+The authoritative in-repo source for phase maturity/status is `ROADMAP_MASTER.md`.
 The execution roadmap governs audited phase meaning and taxonomy only, while the master roadmap governs canonical phase maturity/status.
 Per-phase status files, audit artifacts, and the index are derived navigation or evidence surfaces and must defer to those two authorities.
 Status changes therefore follow one update path: update supporting evidence as needed, then update the master roadmap to change the canonical phase maturity/status.


### PR DESCRIPTION
Closes #940

## Summary
- Add canonical document status model with explicit classes:
  - Canonical
  - Derived
  - Evidence
  - Deprecated
  - Archived
  - Compatibility Alias
- Define deterministic classification rules and authority boundaries.
- Define mandatory intake/review rule for new governance-/roadmap-/audit-/status-relevant documents.
- Add sample classification of high-visibility documents to anchor model usage.
- Wire model references into docs/index.md and README.md for consistent navigation.
- Keep roadmap phase maturity/status authority on ROADMAP_MASTER.md.

## Scope Control
- No architecture changes.
- No runtime/API/source/test code changes.
- No repo-wide mass reclassification.

## Files Changed
- README.md
- docs/index.md
- docs/architecture/governance/document-status-model.md

## Validation
- Verified docs/architecture/governance/document-status-model.md contains an explicit Document Status block for itself.
- Verified canonical authority mapping keeps ROADMAP_MASTER.md as the authoritative phase maturity/status source.
- Verified docs/index.md continues to defer roadmap phase maturity/status to ROADMAP_MASTER.md.
- Verified fenced example block in document-status-model.md is closed and review/compatibility sections are outside the code fence.

## Test Evidence
- Command run: python -m pytest -x
- Result: stopped on pre-existing environment-related pytest temp-directory permission failure:
  - PermissionError: [WinError 5] Zugriff verweigert: 'C:\Users\Serdar Cil\AppData\Local\Temp\pytest-of-Serdar Cil'
- This failure is outside the docs-only change scope.