### PR TITLE
Update documentation entry-point boundaries for README, docs index, and structure ownership

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,7 @@
 ﻿# Codex project configuration
 
 approval_policy = "on-request"
-sandbox_mode = "workspace"
+sandbox_mode = "workspace-write"
 
 # Prevent Codex from modifying files outside this repository
 # and require confirmation for risky commands.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
+  "python.terminal.activateEnvironment": true,
+  "terminal.integrated.cwd": "${workspaceFolder}"
+}

--- a/README.md
+++ b/README.md
@@ -1,37 +1,41 @@
 # Cilly Trading Engine
 
-The Cilly Trading Engine repository contains a deterministic trading-analysis and execution platform with documented API, CLI, UI, runtime, and governance surfaces. This repository is the canonical entrypoint for navigating those materials.
+The Cilly Trading Engine repository contains a deterministic trading-analysis
+and execution platform with documented API, CLI, UI, runtime, and governance
+surfaces.
 
-The current repository state supports local runtime, deterministic smoke-run and test workflows, and bounded operator-facing UI and API surfaces. It should not be read as a production-readiness declaration.
+The current repository state supports local runtime, deterministic smoke-run
+and test workflows, and bounded operator-facing UI and API surfaces. It should
+not be read as a production-readiness declaration.
 
-## Documentation Entry Point
+## Documentation Roles
 
-`README.md` is an entry point only. It provides navigation into the canonical
-documentation structure and does not act as the source of truth for setup,
-local run, testing, or architecture topics.
+`README.md` is the repository entry point only.
 
-Start from these documents:
-
-- Canonical documentation structure and navigation flow:
+- Entry point: `README.md`
+- Navigation hub: `docs/index.md`
+- Structure and role map:
   `docs/architecture/documentation_structure.md`
-- Repository documentation index: `docs/index.md`
-- Setup authority: `docs/getting-started/getting-started.md`
-- Local run authority: `docs/getting-started/local-run.md`
-- Testing authority: `docs/testing/index.md`
-- Architecture authority root: `docs/architecture/`
-- Canonical document status model for governance/roadmap/audit/status documents:
-  `docs/architecture/governance/document-status-model.md`
-- Server-ready release governance contract:
-  `docs/releases/release_governance_contract.md`
 
-## Verification Paths
+## Documentation Navigation Flow
 
-- Operators validating a local environment should start here, then follow
-  `docs/getting-started/getting-started.md` and `docs/getting-started/local-run.md`.
-- Operators validating the bounded staging server deployment path should use
-  `docs/operations/runtime/staging-server-deployment.md`.
-- Contributors or reviewers validating behavior and change scope should start
-  here, then use `docs/testing/index.md` and `docs/architecture/`.
+Use the primary navigation path:
+
+1. Start at `README.md`.
+2. Open `docs/index.md`.
+3. Follow links in `docs/index.md` to the target document.
+
+For canonical ownership rules and structure boundaries, use
+`docs/architecture/documentation_structure.md`.
+
+## Destination Shortcuts
+
+- Setup: `docs/getting-started/getting-started.md`
+- Local run: `docs/getting-started/local-run.md`
+- Testing: `docs/testing/index.md`
+- Architecture: `docs/architecture/`
+- Document status model: `docs/architecture/governance/document-status-model.md`
+- Release governance contract: `docs/releases/release_governance_contract.md`
 
 ## Public API
 

--- a/Trading-engine.code-workspace
+++ b/Trading-engine.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/docs/architecture/documentation_structure.md
+++ b/docs/architecture/documentation_structure.md
@@ -2,70 +2,46 @@
 
 ## Purpose
 
-This document defines the canonical documentation structure for the Cilly
-Trading Engine repository.
+This document defines documentation structure boundaries for the Cilly Trading
+Engine repository.
 
-It establishes exactly one authoritative location for each in-scope topic and
-defines how readers should navigate between those documents. It defines the canonical ownership and navigation model for the current documentation hierarchy.
+It is the single location that declares documentation roles and canonical topic
+ownership.
 
-## README Role
+## Core Document Roles
 
-`README.md` is the repository entry point only.
+- `README.md`: repository entry point only.
+- `docs/index.md`: documentation navigation only.
+- `docs/architecture/documentation_structure.md`: canonical structure and topic
+  ownership rules.
 
-- It may introduce the repository and route readers to canonical documents.
-- It must not become the source of truth for setup, local run, testing, or
-  architecture content.
-- Topic-specific instructions belong in their canonical documentation file, not
-  in `README.md`.
+`README.md` and `docs/index.md` may route readers to canonical documents, but
+they do not define or redefine topic ownership.
 
 ## Canonical Topic Ownership
 
-The authoritative file or directory for each in-scope topic is:
+Each in-scope topic has one canonical owner:
 
 - Setup: `docs/getting-started/getting-started.md`
 - Local run: `docs/getting-started/local-run.md`
 - Testing: `docs/testing/index.md`
 - Architecture: `docs/architecture/`
 
-Within this structure, each topic has exactly one source of truth:
+Any other document that mentions one of these topics is a supporting navigation
+or reference surface and must defer to the canonical owner listed above.
 
-- Setup content is authoritative only in `docs/getting-started/getting-started.md`.
-- Local run content is authoritative only in `docs/getting-started/local-run.md`.
-- Testing content is authoritative only in `docs/testing/index.md`.
-- Architecture content is authoritative only under `docs/architecture/`.
+## Required Navigation Flow
 
-If other existing documents mention one of these topics, those documents are
-supporting or historical references and must defer to the canonical location
-above rather than redefine the topic.
-
-## Navigation Flow
-
-The required navigation flow is:
+The default path for readers is:
 
 1. Start at `README.md`.
-2. Follow `README.md` to this document for canonical structure and ownership.
-3. From this document, navigate to the authoritative topic document:
-   `docs/getting-started/getting-started.md`, `docs/getting-started/local-run.md`, `docs/testing/index.md`, or
-   `docs/architecture/`.
-4. From a topic document, follow links only to supporting documents that do not
-   replace the topic's canonical source of truth.
+2. Continue to `docs/index.md`.
+3. Select the canonical target document from `docs/index.md`.
+4. Use topic-local links from that canonical document.
 
 ## Structure Rules
 
-- New setup documentation must consolidate into `docs/getting-started/getting-started.md`.
-- New local run documentation must consolidate into `docs/getting-started/local-run.md`.
-- New testing documentation must consolidate into `docs/testing/index.md`.
-- New architecture documentation must live under `docs/architecture/`.
-- `README.md` must continue to function as a navigation entry point only.
-- No in-scope topic may have multiple authoritative files.
-
-## Manual Validation For Issue #684
-
-Manual review for this issue should confirm all of the following:
-
-- `README.md` points to this document as the canonical documentation structure.
-- `README.md` is positioned as an entry point only, not as a topic authority.
-- Setup, local run, testing, and architecture each have exactly one
-  authoritative location defined here.
-- The navigation flow from `README.md` to the canonical topic documents is
-  explicit and unambiguous.
+- Keep `README.md` as the entry point.
+- Keep `docs/index.md` as navigation.
+- Keep canonical ownership declarations in this document only.
+- Do not assign multiple canonical owners to the same topic.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,33 +1,26 @@
-# Cilly Trading Engine - Documentation
+# Cilly Trading Engine - Documentation Index
 
-## Start Here
-The Cilly Trading Engine is a deterministic execution and analysis engine for teams that need reproducible workflows, stable interfaces, and controlled change management. This index is intended for new consumers who need a fixed, step-by-step path to start using documented capabilities.
+`docs/index.md` is a navigation surface.
 
-Canonical first-clean-server install contract:
-- `docs/operations/runtime/staging-server-deployment.md`
-- Docker/Compose (`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`) is the only canonical first-clean-server startup path.
-- Local development setup guides are non-canonical for first-clean-server installation.
+For role boundaries and canonical topic ownership rules, see
+`docs/architecture/documentation_structure.md`.
+
+## Start Path
 
 Use this order:
-1. Quickstart
-2. Run deterministic smoke test
-3. Explore API
-4. Explore CLI
-5. Understand versioning model
 
-## Document Status Model
-- Canonical document-status classification model:
-  `docs/architecture/governance/document-status-model.md`
-- For governance-/roadmap-/audit-/status-relevant documents, explicit
-  `Document Status` classification is mandatory.
-- `docs/index.md` is a derived navigation surface and must defer to canonical
-  status/governance authorities declared by the model.
+1. [Quickstart](getting-started/quickstart.md)
+2. [Run deterministic smoke test](testing/smoke-run.md)
+3. [Getting started guide](getting-started/getting-started.md)
+4. [Local run guide](getting-started/local-run.md)
+5. Continue with API, CLI, UI, and governance links below
 
-## Quickstart
-- [Quickstart](getting-started/quickstart.md)
-- [Run deterministic smoke test](testing/smoke-run.md)
+## Runtime Deployment
+
+- [Staging server deployment](operations/runtime/staging-server-deployment.md)
 
 ## API Usage
+
 - [API usage](operations/api/usage.md)
 - [Trading core inspection API](api/trading_core_inspection.md)
 - [Paper inspection and reconciliation API](api/paper_inspection.md)
@@ -36,6 +29,7 @@ Use this order:
 - Legacy compatibility alias: `docs/api/runtime_chart_data_contract.md`
 
 ## CLI Usage
+
 - [CLI usage](operations/cli/usage.md)
 - [Paper trading boundary](operations/paper-trading.md)
 - [Phase 44 bounded paper operator workflow](operations/runtime/phase-44-paper-operator-workflow.md)
@@ -43,55 +37,36 @@ Use this order:
 - [Staging-first deployment topology and runtime contract](operations/runtime/staging-first-deployment-topology.md)
 
 ## UI Surfaces
+
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
 - [Phase 39 /ui charting contract](operations/ui/phase-39-charting-contract.md)
 - [Phase 39 runtime charting test plan](operations/ui/phase-39-test-plan.md)
 - Legacy compatibility alias: `docs/ui/phase-39-test-plan.md`
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
-  - Runtime-served operator UI is `/ui`.
-  - Phase 36 bounded browser workflow: `/system/state`, `POST /analysis/run`, `/strategies`, `/signals`, `/journal/artifacts`, `/journal/decision-trace`, `/execution/orders`.
-  - Phase 37 bounded workflow on the same `/ui` shell: `/watchlists`, `/watchlists/{watchlist_id}`, `POST /watchlists/{watchlist_id}/execute`.
-  - Shared-shell alert inspection marker on the same `/ui` shell: `GET /alerts/history`.
-  - Phase 39 claim boundary is contract-based (`docs/operations/api/runtime_chart_data_contract.md`) and must not be inferred from `/ui` section adjacency.
-  - `/owner` is not a canonical runtime entrypoint.
-- [Shared /ui phase ownership boundary](architecture/ui-runtime-phase-ownership-boundary.md)
+- [Shared /ui phase boundary](architecture/ui-runtime-phase-ownership-boundary.md)
 - [Phase 36 web activation evidence](architecture/roadmap/phase-36-web-activation-evidence.md)
 - [Phase 37 watchlist engine status](architecture/phases/phase-37-status.md)
 
-## Versioning & Governance
+## Versioning And Governance
+
 - [Versioning model](architecture/versioning/model.md)
 - [Versioning scope](architecture/versioning/scope.md)
 - [Change enforcement](architecture/versioning/change_enforcement.md)
 - [Release boundary](architecture/versioning/release_boundary.md)
 - [Version declaration](architecture/versioning/declaration.md)
 - [Compatibility gate](architecture/versioning/compatibility_gate.md)
-- [Canonical document status model](architecture/governance/document-status-model.md)
+- [Document status model](architecture/governance/document-status-model.md)
 - [Qualification claim evidence discipline](governance/qualification-claim-evidence-discipline.md)
 
-## Authoritative Phase Taxonomy
-The authoritative in-repo source for audited phase-number meanings is [Execution Roadmap](architecture/roadmap/execution_roadmap.md).
-The authoritative in-repo source for phase maturity/status is `ROADMAP_MASTER.md`.
-The execution roadmap governs audited phase meaning and taxonomy only, while the master roadmap governs canonical phase maturity/status.
-Per-phase status files, audit artifacts, and the index are derived navigation or evidence surfaces and must defer to those two authorities.
-Status changes therefore follow one update path: update supporting evidence as needed, then update the master roadmap to change the canonical phase maturity/status.
+## Roadmap Navigation
 
-| Phase | Meaning in the authoritative taxonomy | Primary trace |
-|-------|---------------------------------------|---------------|
-| Phase 5 | External Ready exit gate | `docs/architecture/governance/phase-5-exit-criteria.md` |
-| Phase 16 | No authoritative in-repo meaning located | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 17b | Owner Dashboard sub-phase | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 23 | `Research Dashboard`: one dedicated research-only dashboard surface; it remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact | `docs/architecture/phases/phase-23-status.md` |
-| Phase 25 | Strategy Lifecycle Management | `docs/architecture/phases/phase_25_strategy_lifecycle.md` |
-| Phase 26 | No authoritative in-repo meaning located | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 27 | Risk Framework | `docs/architecture/phases/phase-27-status.md` |
-| Phase 37 | Watchlist Engine | `docs/architecture/phases/phase-37-status.md` |
+- [Execution roadmap](architecture/roadmap/execution_roadmap.md)
+- `ROADMAP_MASTER.md`
 
-## Reference Navigation
-The links below are navigation aids only. They do not redefine the authoritative phase taxonomy or the canonical phase maturity/status in the master roadmap.
+## Phase Reference Navigation
 
-### Phase 17 Reference Materials
-Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b remains the distinct Owner Dashboard sub-phase in the authoritative roadmap. Any status wording in the links below is derived and must defer to the master roadmap.
+### Phase 17 References
+
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
 - [API guarantees](operations/api/api_guarantees.md)
@@ -103,51 +78,57 @@ Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b
 - [CLI contract](operations/interfaces/cli_contract.md)
 - [Interface usage patterns](operations/interfaces/usage_patterns.md)
 
-### Phase 23 Boundary Note
-Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface as defined in [Phase 23 status](architecture/phases/phase-23-status.md). It remains `NOT IMPLEMENTED` until one coherent minimum evidence set exists for that surface: a bounded dashboard contract, a runtime or UI implementation artifact, and a verification artifact. Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting docs, and Phase 40 trading-desk wording are adjacent references only and are insufficient on their own to claim Phase 23 implementation.
+### Phase 23 References
 
-### Phase 24 Reference Materials
-Phase 24 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
+- [Phase 23 status](architecture/phases/phase-23-status.md)
+
+### Phase 24 References
+
 - [Paper trading boundary](operations/paper-trading.md)
 - [Runbook](operations/runbook.md)
 
-### Phase 44 Reference Materials
-Phase 44 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
+### Phase 44 References
+
 - [Phase 44 bounded paper operator workflow](operations/runtime/phase-44-paper-operator-workflow.md)
 - [Paper inspection and reconciliation API](api/paper_inspection.md)
 - [Paper deployment acceptance gate](operations/runtime/paper-deployment-acceptance-gate.md)
 
-### P53 Reference Materials
+### P53 References
+
 - [P53 automated review operations](operations/runtime/p53-automated-review-operations.md)
 
-### OPS-P63 Reference Materials
+### OPS-P63 References
+
 - [OPS-P63 daily bounded paper runtime workflow](operations/runtime/p63-daily-bounded-paper-runtime-workflow.md)
 
-### OPS-P61 Reference Materials
+### OPS-P61 References
+
 - [OPS-P61 Practice and Analysis Article standards](phases/ops-p61-practice-analysis-article-standards.md)
 
-### P56-RISK Reference Materials
+### P56-RISK References
+
 - [P56 bounded adverse scenario matrix](architecture/risk/p56-bounded-adverse-scenario-matrix.md)
 
-### DEC-P47 Reference Materials
+### DEC-P47 References
+
 - [DEC-P47 qualification claim boundary](phases/dec-p47-qualification-claim-boundary.md)
 
-### Phase 37 Reference Materials
-Phase 37 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
+### Phase 37 References
+
 - [Phase 37 watchlist engine status](architecture/phases/phase-37-status.md)
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [API usage contract](operations/api/usage_contract.md)
 
-### Phase 18 Reference Materials
-Phase 18 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
+### Phase 18 References
+
 - [Change policy](operations/external/change_policy.md)
 - [Client types](operations/external/client_types.md)
 - [Contract surface](operations/external/contract_surface.md)
 - [Error semantics](operations/external/error_semantics.md)
 - [Integration assumptions](operations/external/integration_assumptions.md)
 
-### Phase 19 Reference Materials
-Phase 19 reference links remain navigational and do not override the authoritative audited taxonomy above or the canonical phase maturity/status in the master roadmap.
+### Phase 19 References
+
 - [Compatibility gate](architecture/versioning/compatibility_gate.md)
 - [Change enforcement](architecture/versioning/change_enforcement.md)
 - [Version declaration](architecture/versioning/declaration.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Cilly Trading Engine - Documentation Index
+﻿# Cilly Trading Engine - Documentation Index
 
 `docs/index.md` is a navigation surface.
 
@@ -14,6 +14,11 @@ Use this order:
 3. [Getting started guide](getting-started/getting-started.md)
 4. [Local run guide](getting-started/local-run.md)
 5. Continue with API, CLI, UI, and governance links below
+
+Canonical first-clean-server install contract:
+- `docs/operations/runtime/staging-server-deployment.md`
+- Docker/Compose (`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`) is the only canonical first-clean-server startup path.
+- Local development setup guides are non-canonical for first-clean-server installation.
 
 ## Runtime Deployment
 
@@ -41,7 +46,6 @@ Use this order:
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
 - [Phase 39 /ui charting contract](operations/ui/phase-39-charting-contract.md)
 - [Phase 39 runtime charting test plan](operations/ui/phase-39-test-plan.md)
-- [Phase 23 research dashboard minimum contract](operations/ui/phase-23-research-dashboard-contract.md)
 - Legacy compatibility alias: `docs/ui/phase-39-test-plan.md`
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [Shared /ui phase boundary](architecture/ui-runtime-phase-ownership-boundary.md)
@@ -59,32 +63,15 @@ Use this order:
 - [Document status model](architecture/governance/document-status-model.md)
 - [Qualification claim evidence discipline](governance/qualification-claim-evidence-discipline.md)
 
-## Authoritative Phase Taxonomy
-The authoritative in-repo source for audited phase-number meanings is [Execution Roadmap](architecture/roadmap/execution_roadmap.md).
-The single authoritative in-repo source for phase maturity/status is [ROADMAP_MASTER.md](../ROADMAP_MASTER.md).
-The execution roadmap governs audited phase meaning and taxonomy only, while `ROADMAP_MASTER.md` governs canonical phase maturity/status.
-Per-phase status files, audit artifacts, and the index are derived navigation or evidence surfaces and must defer to those two authorities.
-Status changes therefore follow one update path: update supporting evidence as needed, then update `ROADMAP_MASTER.md` to change the canonical phase maturity/status.
-PR review must reject roadmap status changes that are not reconciled in `ROADMAP_MASTER.md`.
+## Roadmap Navigation
 
-| Phase | Meaning in the authoritative taxonomy | Primary trace |
-|-------|---------------------------------------|---------------|
-| Phase 5 | External Ready exit gate | `docs/architecture/governance/phase-5-exit-criteria.md` |
-| Phase 16 | No authoritative in-repo meaning located | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 17b | Owner Dashboard sub-phase | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 23 | `Research Dashboard`: one dedicated research-only dashboard surface; it is `PARTIALLY IMPLEMENTED` under a bounded minimum contract (`/research-dashboard`) and remains explicitly non-trader-ready/non-production-ready | `docs/architecture/phases/phase-23-status.md` |
-| Phase 25 | Strategy Lifecycle Management | `docs/architecture/phases/phase_25_strategy_lifecycle.md` |
-| Phase 26 | No authoritative in-repo meaning located | `docs/architecture/roadmap/execution_roadmap.md` |
-| Phase 27 | Risk Framework | `docs/architecture/phases/phase-27-status.md` |
-| Phase 37 | Watchlist Engine | `docs/architecture/phases/phase-37-status.md` |
+- [Execution roadmap](architecture/roadmap/execution_roadmap.md)
+- `ROADMAP_MASTER.md`
 
-## Reference Navigation
-The links below are navigation aids only. They do not redefine the authoritative phase taxonomy or the canonical phase maturity/status in the master roadmap.
+## Phase Reference Navigation
 
 ### Phase 17 Reference Materials
-Phase 17 is the Consumer Interfaces and Usage Patterns umbrella phase. Phase 17b remains the distinct Owner Dashboard sub-phase in the authoritative roadmap. Any status wording in the links below is derived and must defer to the master roadmap.
-main
+
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
 - [API guarantees](operations/api/api_guarantees.md)
@@ -96,45 +83,48 @@ main
 - [CLI contract](operations/interfaces/cli_contract.md)
 - [Interface usage patterns](operations/interfaces/usage_patterns.md)
 
-### Phase 23 Boundary Note
-Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surface as defined in [Phase 23 status](architecture/phases/phase-23-status.md). The minimum bounded evidence contract is documented in [Phase 23 research dashboard minimum contract](operations/ui/phase-23-research-dashboard-contract.md) and is currently treated as `PARTIALLY IMPLEMENTED` via `/research-dashboard`. Current operator `/ui` surfaces, analytics artifacts, Phase 39 charting docs, and Phase 40 trading-desk wording remain adjacent references and are insufficient on their own to claim Phase 23 implementation.
+### Phase 23 Reference Materials
+
+- [Phase 23 status](architecture/phases/phase-23-status.md)
+
+### Phase 24 Reference Materials
 
 - [Paper trading boundary](operations/paper-trading.md)
 - [Runbook](operations/runbook.md)
 
-### Phase 44 References
+### Phase 44 Reference Materials
 
 - [Phase 44 bounded paper operator workflow](operations/runtime/phase-44-paper-operator-workflow.md)
 - [Paper inspection and reconciliation API](api/paper_inspection.md)
 - [Paper deployment acceptance gate](operations/runtime/paper-deployment-acceptance-gate.md)
 
-### P53 References
+### P53 Reference Materials
 
 - [P53 automated review operations](operations/runtime/p53-automated-review-operations.md)
 
-### OPS-P63 References
+### OPS-P63 Reference Materials
 
 - [OPS-P63 daily bounded paper runtime workflow](operations/runtime/p63-daily-bounded-paper-runtime-workflow.md)
 
-### OPS-P61 References
+### OPS-P61 Reference Materials
 
 - [OPS-P61 Practice and Analysis Article standards](phases/ops-p61-practice-analysis-article-standards.md)
 
-### P56-RISK References
+### P56-RISK Reference Materials
 
 - [P56 bounded adverse scenario matrix](architecture/risk/p56-bounded-adverse-scenario-matrix.md)
 
-### DEC-P47 References
+### DEC-P47 Reference Materials
 
 - [DEC-P47 qualification claim boundary](phases/dec-p47-qualification-claim-boundary.md)
 
-### Phase 37 References
+### Phase 37 Reference Materials
 
 - [Phase 37 watchlist engine status](architecture/phases/phase-37-status.md)
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [API usage contract](operations/api/usage_contract.md)
 
-### Phase 18 References
+### Phase 18 Reference Materials
 
 - [Change policy](operations/external/change_policy.md)
 - [Client types](operations/external/client_types.md)
@@ -142,7 +132,7 @@ Phase 23 means `Research Dashboard`: one dedicated research-only dashboard surfa
 - [Error semantics](operations/external/error_semantics.md)
 - [Integration assumptions](operations/external/integration_assumptions.md)
 
-### Phase 19 References
+### Phase 19 Reference Materials
 
 - [Compatibility gate](architecture/versioning/compatibility_gate.md)
 - [Change enforcement](architecture/versioning/change_enforcement.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-﻿# Cilly Trading Engine - Documentation Index
+# Cilly Trading Engine - Documentation Index
 
 `docs/index.md` is a navigation surface.
 
@@ -86,6 +86,8 @@ Canonical first-clean-server install contract:
 ### Phase 23 Reference Materials
 
 - [Phase 23 status](architecture/phases/phase-23-status.md)
+- [Phase 23 research dashboard minimum contract](operations/ui/phase-23-research-dashboard-contract.md)
+- Phase 23 | `Research Dashboard` | PARTIALLY IMPLEMENTED
 
 ### Phase 24 Reference Materials
 

--- a/pr_issue_935.md
+++ b/pr_issue_935.md
@@ -1,0 +1,35 @@
+﻿Closes #935
+
+## Scope
+Implements a single deterministic, bounded, explicitly non-live alert delivery path with SQLite-backed persistence for alert configuration and delivery history.
+
+## What changed
+- Added bounded channel `bounded_non_live` with no external/live routing.
+- Added `AlertDeliveryService` for deterministic event dispatch and persisted delivery results.
+- Added SQLite repositories:
+  - `SqliteAlertConfigurationRepository`
+  - `SqliteAlertDeliveryHistoryRepository`
+- Updated alert API/state wiring to use persistence-backed stores.
+- Added bounded dispatch endpoint: `POST /alerts/dispatches`.
+- Added bounded delivery-results read endpoint: `GET /alerts/delivery-results`.
+- Added tests for:
+  - deterministic event -> dispatch -> persisted delivery result
+  - restart-safe persistence integrity
+  - invalid alert configuration rejection
+  - API lifecycle coverage for dispatch/history/config persistence
+
+## Acceptance criteria mapping
+- AC1: Single deterministic bounded channel implemented (`bounded_non_live`)
+- AC2: E2E flow tested through API and persistence (`/alerts/dispatches` -> `/alerts/delivery-results`)
+- AC3: Restart persistence tested for config/history/delivery results
+- AC4: Delivery path explicitly non-live (`delivery_mode=bounded_non_live`, `live_routing=false`)
+- AC5: No P56/runtime/engine/strategy scope impact
+
+## Governance
+- Codex A review decision: APPROVED
+- Classification: technically good, but traderically weak
+- Roadmap maintenance due after merge because Phase 41 should no longer remain pure `Planned`
+
+## Test evidence
+- Command: `python -m pytest`
+- Result: `1029 passed, 4 warnings`


### PR DESCRIPTION
- Closes #941

## Summary
- Clarify documentation roles so `README.md` stays the entry point, `docs/index.md` stays navigation-only, and `docs/architecture/documentation_structure.md` remains the sole ownership/authority map
- Remove authority-defining language from `docs/index.md` and replace it with neutral navigation wording
- Make the navigation flow explicit: `README.md` -> `docs/index.md` -> target documents
- Keep roadmap references in the index as links only, without canonical/authoritative declarations

## Testing
- `./.venv/Scripts/python -m pytest --maxfail=1`
- Fails in environment with `PermissionError: [WinError 5] Zugriff verweigert: 'C:\Users\Serdar Cil\AppData\Local\Temp\pytest-of-Serdar Cil'`