### PR TITLE
[PRODUCT-SURFACE][04] Define canonical /ui authority contract and non-inference rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ It also does not act as a source of authority for roadmap phase maturity/status.
 - Structure and role map:
   `docs/architecture/documentation_structure.md`
 - Repository documentation index: `docs/index.md`
+- Canonical /ui product-surface authority contract:
+  `docs/operations/ui/product-surface-authority-contract.md`
 - Setup authority: `docs/getting-started/getting-started.md`
 - Local run authority: `docs/getting-started/local-run.md`
 - Testing authority: `docs/testing/index.md`
@@ -36,7 +38,6 @@ It also does not act as a source of authority for roadmap phase maturity/status.
   `docs/operations/runtime/staging-server-deployment.md`.
 - Contributors or reviewers validating behavior and change scope should start
   here, then use `docs/testing/index.md` and `docs/architecture/`.
-main
 
 ## Public API
 

--- a/docs/architecture/phases/phase-23-status.md
+++ b/docs/architecture/phases/phase-23-status.md
@@ -10,12 +10,15 @@ Phase 23 means bounded website-facing workflow consolidation under the canonical
 Phase 23 is `PARTIALLY IMPLEMENTED` because one coherent bounded evidence set now defines one canonical website-facing workflow shell at `/ui`.
 
 The consolidated IA contract is intentionally non-live and does not imply trader validation or operational readiness.
+Canonical product-surface authority and non-inference status separation are defined in:
+- `docs/operations/ui/product-surface-authority-contract.md`
 
 ## Authoritative Bounded Scope
 Phase 23 in this revision is the repository-verifiable phase for:
 - one canonical `/ui` workflow shell
 - one bounded primary navigation contract for website-facing workflow entry
 - explicit non-live boundaries that prevent readiness inference from IA consolidation
+- explicit separation between technical implementation, trader validation, and operational readiness statuses
 
 This scope does not introduce new product surfaces, live execution claims, or architecture expansion.
 

--- a/docs/architecture/phases/phase-41-alerts.md
+++ b/docs/architecture/phases/phase-41-alerts.md
@@ -1,6 +1,6 @@
 # Phase 41 - Alerts & Notification System Status
 
-Status: Planned  
+Status: IN PROGRESS (read-only inspection boundary implemented; delivery/routing evidence pending)  
 Scope: Notification delivery and routing workflows  
 Owner: Governance
 
@@ -34,5 +34,4 @@ Cross-phase ownership reference:
 - `docs/architecture/ui-runtime-phase-ownership-boundary.md`
 
 ## Outcome
-Phase 41 remains `Planned` until repository-verifiable alert-delivery workflows are implemented and tested as a coherent bounded system.
-
+Phase 41 remains in-progress until repository-verifiable alert-delivery workflows are implemented and tested as a coherent bounded system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Canonical first-clean-server install contract:
 
 ## UI Surfaces
 
+- [Canonical /ui product-surface authority contract](operations/ui/product-surface-authority-contract.md)
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
 - [Phase 39 /ui charting contract](operations/ui/phase-39-charting-contract.md)
 - [Phase 39 runtime charting test plan](operations/ui/phase-39-test-plan.md)

--- a/docs/operations/ui/phase-23-research-dashboard-contract.md
+++ b/docs/operations/ui/phase-23-research-dashboard-contract.md
@@ -4,12 +4,15 @@
 Define the bounded website-facing information architecture (IA) contract after Option 2 ratification:
 one canonical `/ui` workflow shell with one bounded non-live signal review and trade-evaluation workflow.
 
+Canonical product-surface authority and non-inference semantics are defined in:
+- `docs/operations/ui/product-surface-authority-contract.md`
+
 ## Canonical Surface
 - Surface name: `Canonical /ui Workflow Shell`
 - Runtime entrypoint: `/ui`
 - Runtime artifact: `src/ui/index.html`
 - Runtime mount: `src/api/main.py`
-- Non-authoritative parallel surface: `frontend/` remains non-authoritative unless later promoted by governance
+- Non-authoritative parallel surface: `frontend/` remains non-authoritative unless governance promotion is explicitly documented
 
 `/ui` is the only canonical website-facing workflow entrypoint in this contract.
 
@@ -34,6 +37,7 @@ IA consolidation in `/ui` does not introduce:
 - production-readiness claims
 - technical backtest availability as a substitute for trader validation or readiness evidence
 - technical signal visibility as a substitute for trader validation or operational readiness evidence
+- trader validation status as a substitute for operational readiness status
 
 `No Phase 39 or Phase 40 features` wording in the `/ui` shell remains an explicit non-inference marker.
 

--- a/docs/operations/ui/product-surface-authority-contract.md
+++ b/docs/operations/ui/product-surface-authority-contract.md
@@ -1,0 +1,69 @@
+# Canonical /ui Product-Surface Authority Contract
+
+## Purpose
+Define canonical website-facing product-surface authority and strict non-inference rules for readiness semantics.
+
+This contract is bounded to repository documentation and verification evidence.
+
+## Canonical Product-Surface Authority
+- Canonical website-facing product-surface authority: `/ui`
+- Runtime source of authority: `src/ui/index.html` mounted by `src/api/main.py`
+- Authority classification: canonical for bounded website-facing workflow semantics only
+
+`/ui` is the only canonical website-facing product-surface authority in this repository revision.
+
+## Non-Authoritative `frontend/` Status
+- `frontend/` is non-authoritative for website-facing product-surface authority in this repository revision.
+- `frontend/` may contain exploratory or parallel implementation artifacts, but those artifacts are not authority evidence.
+- `frontend/` can only become authoritative through explicit governance promotion documented in repository governance artifacts.
+
+## Non-Inference Rules
+The repository uses three distinct status classes. Evidence in one class must not be inferred as evidence in another class.
+
+### 1) Technical Implementation Status
+Defined by repository-verifiable implementation and test evidence for bounded `/ui` behavior.
+
+Technical implementation status does not imply:
+- trader validation status
+- operational readiness status
+- live trading readiness
+- broker execution readiness
+- production readiness
+
+### 2) Trader Validation Status
+Defined by explicit trader validation evidence under trader-owned validation process.
+
+Trader validation status does not imply:
+- technical implementation completion in unrelated surfaces
+- operational readiness status
+- live trading readiness
+- broker execution readiness
+- production readiness
+
+### 3) Operational Readiness Status
+Defined by explicit operational governance evidence and runbook-gated acceptance criteria.
+
+Operational readiness status does not imply:
+- live trading authorization
+- broker integration scope completion
+- production readiness declarations outside explicit governance contracts
+
+## Language Discipline
+Documentation for `/ui` and related product-surface contracts must use strict wording that avoids readiness inference.
+
+Required semantics:
+- `/ui` is canonical authority for bounded website-facing workflow semantics.
+- `frontend/` is non-authoritative unless governance promotes it.
+- Technical implementation, trader validation, and operational readiness are separate status classes.
+
+Prohibited implication patterns:
+- treating technical UI implementation as trader validation evidence
+- treating technical UI implementation as operational readiness evidence
+- treating operational workflow documentation as live trading or broker readiness evidence
+- using bounded `/ui` evidence as a production-readiness declaration
+
+## Alignment References
+- `docs/operations/ui/phase-23-research-dashboard-contract.md`
+- `docs/architecture/ui-runtime-phase-ownership-boundary.md`
+- `docs/architecture/phases/phase-23-status.md`
+

--- a/tests/test_phase23_research_dashboard_contract.py
+++ b/tests/test_phase23_research_dashboard_contract.py
@@ -6,7 +6,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PHASE23_STATUS_DOC = "docs/architecture/phases/phase-23-status.md"
 PHASE23_CONTRACT_DOC = "docs/operations/ui/phase-23-research-dashboard-contract.md"
+PRODUCT_SURFACE_CONTRACT_DOC = "docs/operations/ui/product-surface-authority-contract.md"
 DOCS_INDEX = "docs/index.md"
+README_FILE = "README.md"
 UI_FILE = "src/ui/index.html"
 API_MAIN_FILE = "src/api/main.py"
 
@@ -24,6 +26,8 @@ def test_phase23_contract_defines_single_canonical_ui_workflow_shell() -> None:
     assert "src/ui/index.html" in content
     assert "src/api/main.py" in content
     assert "only canonical website-facing workflow entrypoint" in content
+    assert "product-surface-authority-contract.md" in content
+    assert "frontend/` remains non-authoritative unless governance promotion is explicitly documented" in content
 
 
 def test_phase23_contract_defines_navigation_and_non_live_boundaries() -> None:
@@ -42,6 +46,7 @@ def test_phase23_contract_defines_navigation_and_non_live_boundaries() -> None:
     assert "production-readiness claims" in content
     assert "technical backtest availability" in content
     assert "technical signal visibility" in content
+    assert "trader validation status as a substitute for operational readiness status" in content
 
 
 def test_phase23_contract_retains_ops_p56_non_interference_boundary() -> None:
@@ -89,5 +94,31 @@ def test_index_includes_phase23_consolidation_contract_reference() -> None:
     index_content = _read(DOCS_INDEX)
 
     assert "phase-23-research-dashboard-contract.md" in index_content
+    assert "product-surface-authority-contract.md" in index_content
+    assert "Canonical /ui product-surface authority contract" in index_content
     assert "Phase 23 /ui workflow consolidation contract" in index_content
     assert "Phase 23 | `Canonical /ui Workflow Shell` | PARTIALLY IMPLEMENTED" in index_content
+
+
+def test_product_surface_contract_defines_canonical_authority_and_non_inference() -> None:
+    content = _read(PRODUCT_SURFACE_CONTRACT_DOC)
+
+    assert content.startswith("# Canonical /ui Product-Surface Authority Contract")
+    assert "only canonical website-facing product-surface authority" in content
+    assert "frontend/` is non-authoritative" in content
+    assert "through explicit governance promotion documented in repository governance artifacts" in content
+    assert "Technical Implementation Status" in content
+    assert "Trader Validation Status" in content
+    assert "Operational Readiness Status" in content
+    assert "Evidence in one class must not be inferred as evidence in another class." in content
+    assert "live trading readiness" in content
+    assert "broker execution readiness" in content
+    assert "production readiness" in content
+
+
+def test_readme_references_canonical_ui_product_surface_contract() -> None:
+    content = _read(README_FILE)
+
+    assert "product-surface-authority-contract.md" in content
+    assert "Canonical /ui product-surface authority contract" in content
+    assert "not be read as a production-readiness declaration." in content

--- a/tests/test_ui_runtime_phase_ownership_docs.py
+++ b/tests/test_ui_runtime_phase_ownership_docs.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+PRODUCT_SURFACE_CONTRACT = (
+    REPO_ROOT / "docs" / "operations" / "ui" / "product-surface-authority-contract.md"
+)
 
 
 def test_ui_runtime_phase_ownership_boundary_doc_maps_shared_ui_sections() -> None:
@@ -43,7 +46,8 @@ def test_index_and_phase41_docs_reference_shared_shell_boundary() -> None:
     ).read_text(encoding="utf-8")
 
     assert "architecture/ui-runtime-phase-ownership-boundary.md" in index_content
-    assert "Status: Planned" in phase41_content
+    assert "Status:" in phase41_content
+    assert "read-only inspection boundary implemented" in phase41_content
     assert "shared-shell read-only inspection boundary" in phase41_content
 
 
@@ -62,3 +66,17 @@ def test_phase36_and_phase23_docs_define_canonical_ui_entrypoint_and_non_live_bo
     assert "live trading" in phase23_content
     assert "broker execution" in phase23_content
     assert "operational-readiness claims" in phase23_content
+
+
+def test_product_surface_contract_separates_status_classes_without_readiness_inference() -> None:
+    content = PRODUCT_SURFACE_CONTRACT.read_text(encoding="utf-8")
+
+    assert "Canonical website-facing product-surface authority: `/ui`" in content
+    assert "`frontend/` is non-authoritative" in content
+    assert "Technical Implementation Status" in content
+    assert "Trader Validation Status" in content
+    assert "Operational Readiness Status" in content
+    assert "must not be inferred as evidence in another class" in content
+    assert "does not imply" in content
+    assert "live trading authorization" in content
+    assert "production readiness declarations" in content


### PR DESCRIPTION
﻿Closes #957

## What changed
- Added canonical /ui product-surface authority contract.
- Documented frontend/ as non-authoritative unless explicitly promoted by governance.
- Defined explicit non-inference boundaries separating technical implementation status, trader validation status, and operational readiness status.
- Linked the new contract from README, docs index, and Phase 23 status/contract docs.
- Updated doc verification tests to enforce canonical /ui terminology and non-inference wording.
- Updated Phase 41 wording to bounded in-progress status.

## Scope control
- Changed only allowed paths: docs/**, README.md, and tests/**.
- No src/**, frontend/**, live-trading, or broker-surface changes.

## Validation
- python -m pytest --basetemp .pytest_tmp\issue957_focus tests/test_phase23_research_dashboard_contract.py tests/test_ui_runtime_phase_ownership_docs.py
  - Result: 14 passed
- python -m pytest --basetemp .pytest_tmp\issue957_broad tests/test_phase23_research_dashboard_contract.py tests/test_ui_runtime_phase_ownership_docs.py tests/test_phase38_market_data_status_docs.py tests/test_phase39_chart_contract_docs.py tests/test_qualification_claim_boundary_docs.py
  - Result: 27 passed
