### PR TITLE
[STRATEGY-READINESS][01] Define bounded strategy-readiness governance gates (#958)

### DIFF
--- a/docs/governance/strategy-readiness-gates.md
+++ b/docs/governance/strategy-readiness-gates.md
@@ -1,0 +1,123 @@
+﻿# Strategy Readiness Governance Gates
+
+## 1. Purpose
+
+This governance contract defines bounded strategy-readiness gates for:
+
+- technical implementation status
+- trader validation status
+- operational readiness status
+
+The three gates are independent. Evidence in one gate must not be inferred as evidence in another gate.
+
+## 2. Gate Classes and Status Semantics
+
+### 2.1 Technical Implementation Gate
+
+Status semantics:
+
+- `technical_not_started`: implementation evidence does not yet exist.
+- `technical_in_progress`: implementation work exists, but required gate evidence is incomplete.
+- `technical_gate_passed`: required technical implementation evidence is complete and verified.
+
+Bounded meaning:
+
+- Technical gate status applies only to repository-verified implementation and test artifacts.
+- Technical gate status does not imply trader validation, operational readiness, live trading approval, broker readiness, or production authorization.
+
+### 2.2 Trader Validation Gate
+
+Status semantics:
+
+- `trader_validation_not_started`: trader validation evidence does not yet exist.
+- `trader_validation_in_progress`: trader validation is active, but required evidence is incomplete.
+- `trader_validation_gate_passed`: required trader validation evidence is complete and explicitly recorded.
+
+Bounded meaning:
+
+- Trader validation gate status applies only to trader-owned validation evidence and explicit sign-off records.
+- Trader validation gate status does not imply technical completion outside documented technical evidence.
+- Trader validation gate status does not imply operational readiness, live trading approval, broker readiness, or production authorization.
+
+### 2.3 Operational Readiness Gate
+
+Status semantics:
+
+- `operational_not_started`: operational readiness evidence does not yet exist.
+- `operational_in_progress`: operational readiness work is active, but required evidence is incomplete.
+- `operational_gate_passed`: required operational readiness evidence is complete and governance-accepted.
+
+Bounded meaning:
+
+- Operational readiness gate status applies only to operations-governed runbook, deployment, and acceptance evidence.
+- Operational readiness gate status does not imply live trading authorization or broker execution scope completion.
+- Operational readiness gate status does not retroactively validate trader decisions or replace technical evidence.
+
+## 3. Gate Transitions and Required Evidence Types
+
+Transitions are bounded and explicit. No implicit transition is allowed.
+
+### 3.1 Technical Implementation Gate Transitions
+
+- `technical_not_started -> technical_in_progress`
+  - Required evidence types:
+    - issue-scoped implementation plan or task record
+    - active change set scoped to allowed implementation paths
+
+- `technical_in_progress -> technical_gate_passed`
+  - Required evidence types:
+    - merged technical artifacts in governed repository paths
+    - passing deterministic tests that cover the implemented scope
+    - documentation updates that describe bounded technical behavior
+
+### 3.2 Trader Validation Gate Transitions
+
+- `trader_validation_not_started -> trader_validation_in_progress`
+  - Required evidence types:
+    - explicit trader validation start record
+    - declared validation protocol for the strategy under review
+
+- `trader_validation_in_progress -> trader_validation_gate_passed`
+  - Required evidence types:
+    - completed trader validation record with outcomes
+    - explicit trader sign-off in governed validation artifacts
+    - references to bounded evidence inputs used during validation
+
+### 3.3 Operational Readiness Gate Transitions
+
+- `operational_not_started -> operational_in_progress`
+  - Required evidence types:
+    - operations readiness plan or checklist record
+    - defined runbook scope for the reviewed release/stage
+
+- `operational_in_progress -> operational_gate_passed`
+  - Required evidence types:
+    - completed operational checklist and runbook verification
+    - deployment acceptance evidence in governed operations artifacts
+    - rollback and incident handling readiness evidence
+
+## 4. Non-Inference and Claim Prohibitions
+
+The following are prohibited:
+
+- claiming trader-ready status from technical artifacts alone
+- claiming operational-readiness status from technical artifacts alone
+- collapsing technical implementation status into trader validation status
+- collapsing trader validation status into operational readiness status
+- claiming live-trading readiness, live-trading authorization, or broker execution readiness from any single gate
+
+## 5. Non-Live Boundary
+
+This contract does not introduce live trading scope.
+
+Passing any strategy-readiness gate:
+
+- does not enable live trading
+- does not authorize broker execution
+- does not declare production trading readiness
+
+## 6. Alignment References
+
+- `docs/governance/qualification-claim-evidence-discipline.md`
+- `docs/operations/ui/product-surface-authority-contract.md`
+- `docs/operations/runtime/paper-deployment-acceptance-gate.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Canonical first-clean-server install contract:
 - [Compatibility gate](architecture/versioning/compatibility_gate.md)
 - [Document status model](architecture/governance/document-status-model.md)
 - [Qualification claim evidence discipline](governance/qualification-claim-evidence-discipline.md)
+- [Strategy readiness governance gates](governance/strategy-readiness-gates.md)
 
 ## Roadmap Navigation
 

--- a/tests/test_strategy_readiness_gates_docs.py
+++ b/tests/test_strategy_readiness_gates_docs.py
@@ -1,0 +1,51 @@
+﻿from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GATES_DOC = REPO_ROOT / "docs" / "governance" / "strategy-readiness-gates.md"
+
+
+def test_strategy_readiness_gates_define_three_independent_gate_classes() -> None:
+    content = GATES_DOC.read_text(encoding="utf-8")
+
+    assert content.lstrip("\ufeff").startswith("# Strategy Readiness Governance Gates")
+    assert "Technical Implementation Gate" in content
+    assert "Trader Validation Gate" in content
+    assert "Operational Readiness Gate" in content
+    assert "independent" in content
+    assert "must not be inferred as evidence in another gate" in content
+
+
+def test_strategy_readiness_gates_define_bounded_status_semantics_and_transitions() -> None:
+    content = GATES_DOC.read_text(encoding="utf-8")
+
+    assert "technical_not_started" in content
+    assert "technical_in_progress" in content
+    assert "technical_gate_passed" in content
+    assert "trader_validation_not_started" in content
+    assert "trader_validation_in_progress" in content
+    assert "trader_validation_gate_passed" in content
+    assert "operational_not_started" in content
+    assert "operational_in_progress" in content
+    assert "operational_gate_passed" in content
+    assert "Gate Transitions and Required Evidence Types" in content
+    assert "No implicit transition is allowed" in content
+    assert "Required evidence types" in content
+
+
+def test_strategy_readiness_gates_prohibit_trader_ready_inference_from_technical_artifacts() -> None:
+    content = GATES_DOC.read_text(encoding="utf-8")
+
+    assert "claiming trader-ready status from technical artifacts alone" in content
+    assert "claiming operational-readiness status from technical artifacts alone" in content
+    assert "does not enable live trading" in content
+    assert "does not authorize broker execution" in content
+    assert "does not declare production trading readiness" in content
+
+
+def test_docs_index_references_strategy_readiness_gates_contract() -> None:
+    index_content = (REPO_ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+
+    assert "governance/strategy-readiness-gates.md" in index_content


### PR DESCRIPTION
﻿Closes #958

## What changed
- Added docs/governance/strategy-readiness-gates.md to define explicit, bounded gate classes for technical implementation, trader validation, and operational readiness.
- Defined explicit status semantics and bounded transition evidence requirements for each gate.
- Added explicit non-inference and non-live prohibitions, including prohibition of trader-ready claims from technical artifacts alone.
- Added docs navigation link in docs/index.md.
- Added tests/test_strategy_readiness_gates_docs.py to verify gate definitions, transition/evidence terminology, non-live boundaries, and index linkage.

## Scope control
- Changes are limited to docs/** and tests/**.
- No live-trading or broker-execution surfaces were changed.
- No architecture changes or unrelated refactors were introduced.

## Validation
- python -m pytest tests\test_strategy_readiness_gates_docs.py tests\test_ui_runtime_phase_ownership_docs.py
  - Result: 9 passed
