### PR TITLE
[PRODUCT-SURFACE][05] Align docs/tests with canonical /ui authority and roadmap tracks (#960)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ It also does not act as a source of authority for roadmap phase maturity/status.
 - Repository documentation index: `docs/index.md`
 - Canonical /ui product-surface authority contract:
   `docs/operations/ui/product-surface-authority-contract.md`
+- Product Surface Track authority: `/ui` is the canonical website-facing authority;
+  `frontend/` remains interim non-authoritative unless governance promotion is explicit.
+- Strategy Readiness Track boundary: readiness semantics are governed separately from
+  Product Surface Track implementation evidence.
 - Setup authority: `docs/getting-started/getting-started.md`
 - Local run authority: `docs/getting-started/local-run.md`
 - Testing authority: `docs/testing/index.md`

--- a/docs/architecture/ui-runtime-phase-ownership-boundary.md
+++ b/docs/architecture/ui-runtime-phase-ownership-boundary.md
@@ -14,6 +14,10 @@ It prevents overlap-based phase claims across Phase 36, 37, 39, 40, and 41.
 
 `/ui` is also the single canonical website-facing workflow entrypoint in the bounded IA consolidation contract, with one bounded non-live signal review and trade-evaluation workflow.
 
+Track alignment:
+- Product Surface Track authority remains canonical `/ui`.
+- Strategy Readiness Track remains separate and is not inferred from `/ui` phase-boundary evidence.
+
 ## /ui Section Inventory and Ownership
 
 | Visible `/ui` section or marker | Linked backend surface(s) | Ownership classification |

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,11 @@ Canonical first-clean-server install contract:
 - [Phase 36 web activation evidence](architecture/roadmap/phase-36-web-activation-evidence.md)
 - [Phase 37 watchlist engine status](architecture/phases/phase-37-status.md)
 
+Roadmap track alignment:
+- Product Surface Track: `/ui` is the canonical website-facing authority.
+- Product Surface Track: `frontend/` is interim non-authoritative unless governance explicitly promotes it.
+- Strategy Readiness Track: readiness claims are governed separately from product-surface implementation evidence.
+
 ## Versioning And Governance
 
 - [Versioning model](architecture/versioning/model.md)

--- a/docs/operations/ui/phase-23-research-dashboard-contract.md
+++ b/docs/operations/ui/phase-23-research-dashboard-contract.md
@@ -16,6 +16,10 @@ Canonical product-surface authority and non-inference semantics are defined in:
 
 `/ui` is the only canonical website-facing workflow entrypoint in this contract.
 
+Roadmap track alignment:
+- Product Surface Track: this contract governs canonical `/ui` website-facing workflow authority.
+- Strategy Readiness Track: readiness evidence remains separate and must not be inferred from this Product Surface Track contract.
+
 ## Primary Navigation Contract
 The canonical `/ui` shell owns one bounded signal review and trade-evaluation workflow navigation contract:
 

--- a/docs/operations/ui/product-surface-authority-contract.md
+++ b/docs/operations/ui/product-surface-authority-contract.md
@@ -12,6 +12,11 @@ This contract is bounded to repository documentation and verification evidence.
 
 `/ui` is the only canonical website-facing product-surface authority in this repository revision.
 
+## Roadmap Track Alignment
+- Product Surface Track authority is owned by canonical `/ui` documentation and verification evidence.
+- `frontend/` remains interim non-authoritative unless governance explicitly promotes it.
+- Strategy Readiness Track is a separate governance track and must not be inferred from Product Surface Track evidence.
+
 ## Non-Authoritative `frontend/` Status
 - `frontend/` is non-authoritative for website-facing product-surface authority in this repository revision.
 - `frontend/` may contain exploratory or parallel implementation artifacts, but those artifacts are not authority evidence.
@@ -66,4 +71,3 @@ Prohibited implication patterns:
 - `docs/operations/ui/phase-23-research-dashboard-contract.md`
 - `docs/architecture/ui-runtime-phase-ownership-boundary.md`
 - `docs/architecture/phases/phase-23-status.md`
-

--- a/tests/test_phase23_research_dashboard_contract.py
+++ b/tests/test_phase23_research_dashboard_contract.py
@@ -28,6 +28,9 @@ def test_phase23_contract_defines_single_canonical_ui_workflow_shell() -> None:
     assert "only canonical website-facing workflow entrypoint" in content
     assert "product-surface-authority-contract.md" in content
     assert "frontend/` remains non-authoritative unless governance promotion is explicitly documented" in content
+    assert "Roadmap track alignment:" in content
+    assert "Product Surface Track" in content
+    assert "Strategy Readiness Track" in content
 
 
 def test_phase23_contract_defines_navigation_and_non_live_boundaries() -> None:
@@ -98,6 +101,9 @@ def test_index_includes_phase23_consolidation_contract_reference() -> None:
     assert "Canonical /ui product-surface authority contract" in index_content
     assert "Phase 23 /ui workflow consolidation contract" in index_content
     assert "Phase 23 | `Canonical /ui Workflow Shell` | PARTIALLY IMPLEMENTED" in index_content
+    assert "Roadmap track alignment:" in index_content
+    assert "Product Surface Track: `/ui` is the canonical website-facing authority." in index_content
+    assert "Strategy Readiness Track: readiness claims are governed separately" in index_content
 
 
 def test_product_surface_contract_defines_canonical_authority_and_non_inference() -> None:
@@ -110,6 +116,9 @@ def test_product_surface_contract_defines_canonical_authority_and_non_inference(
     assert "Technical Implementation Status" in content
     assert "Trader Validation Status" in content
     assert "Operational Readiness Status" in content
+    assert "Roadmap Track Alignment" in content
+    assert "Product Surface Track authority is owned by canonical `/ui`" in content
+    assert "Strategy Readiness Track is a separate governance track" in content
     assert "Evidence in one class must not be inferred as evidence in another class." in content
     assert "live trading readiness" in content
     assert "broker execution readiness" in content
@@ -121,4 +130,28 @@ def test_readme_references_canonical_ui_product_surface_contract() -> None:
 
     assert "product-surface-authority-contract.md" in content
     assert "Canonical /ui product-surface authority contract" in content
+    assert "Product Surface Track authority: `/ui` is the canonical website-facing authority;" in content
+    assert "frontend/` remains interim non-authoritative unless governance promotion is explicit." in content
+    assert "Strategy Readiness Track boundary: readiness semantics are governed separately" in content
     assert "not be read as a production-readiness declaration." in content
+
+
+def test_aligned_docs_do_not_state_readiness_inference_claims() -> None:
+    aligned_docs = [
+        README_FILE,
+        DOCS_INDEX,
+        PHASE23_CONTRACT_DOC,
+        PRODUCT_SURFACE_CONTRACT_DOC,
+    ]
+    prohibited_phrases = [
+        "implies live trading readiness",
+        "implies broker execution readiness",
+        "implies production readiness",
+        "confers operational readiness",
+        "is production ready",
+    ]
+
+    for path in aligned_docs:
+        content = _read(path).lower()
+        for phrase in prohibited_phrases:
+            assert phrase not in content, f"{phrase!r} must not appear in {path}"

--- a/tests/test_ui_runtime_phase_ownership_docs.py
+++ b/tests/test_ui_runtime_phase_ownership_docs.py
@@ -21,6 +21,9 @@ def test_ui_runtime_phase_ownership_boundary_doc_maps_shared_ui_sections() -> No
     assert "Watchlist Management / Saved Watchlists" in content
     assert "Recent Alerts card" in content
     assert "Shared-shell read-only inspection boundary" in content
+    assert "Track alignment:" in content
+    assert "Product Surface Track authority remains canonical `/ui`." in content
+    assert "Strategy Readiness Track remains separate" in content
     assert "Technical signal visibility and ranked signal output remain separate" in content
     assert "does not prove" in content
 


### PR DESCRIPTION
﻿Closes #960

## Summary
- Align active docs to consistently declare /ui as canonical website-facing authority.
- Mark frontend/ as interim non-authoritative unless explicit governance promotion.
- Add explicit Product Surface Track and Strategy Readiness Track language to active /ui authority surfaces.
- Add verification assertions to enforce track terminology and guard against readiness-inference phrasing.

## Scope
- Docs-only and docs-verification tests only.
- No feature expansion, architecture changes, or runtime surface changes.

## Validation
- Ran full repository test command: python -m pytest
  - Result: non-zero due pre-existing environment-wide permission/setup failures unrelated to this doc/test slice.
- Ran targeted issue-scoped tests:
  - python -m pytest tests/test_phase23_research_dashboard_contract.py tests/test_ui_runtime_phase_ownership_docs.py
  - Result: 15 passed
