### PR TITLE
[REPO-RATIONALIZATION][04] Establish archive and deprecation path for uncertain legacy documentation (#942)

### DIFF
--- a/docs/api/public_api_boundary.md
+++ b/docs/api/public_api_boundary.md
@@ -1,5 +1,14 @@
 # Public API Boundary
 
+## Document Status
+- Class: Deprecated
+- Canonical Source(s): docs/operations/api/public_api_boundary.md
+- Superseded by: docs/operations/api/public_api_boundary.md
+- Rationale: Legacy compatibility path retained for older references.
+
+This document is deprecated. Use
+`docs/operations/api/public_api_boundary.md` as the active path.
+
 This document freezes the supported Python import surface for `src/api`.
 
 ## Public surface (supported)

--- a/docs/api/runtime_chart_data_contract.md
+++ b/docs/api/runtime_chart_data_contract.md
@@ -1,5 +1,15 @@
 # Runtime Chart Data Contract
 
+## Document Status
+- Class: Deprecated
+- Canonical Source(s): docs/operations/api/runtime_chart_data_contract.md
+- Superseded by: docs/operations/api/runtime_chart_data_contract.md
+- Rationale: Legacy compatibility path retained while consumers migrate to the
+  operations namespace.
+
+This legacy path is deprecated. The active canonical location is
+`docs/operations/api/runtime_chart_data_contract.md`.
+
 ## Purpose
 This document defines the deterministic chart-data contract for Phase 39 runtime visual analysis on the backend-served `/ui` surface.
 

--- a/docs/archive/archive-deprecation-standard.md
+++ b/docs/archive/archive-deprecation-standard.md
@@ -1,0 +1,71 @@
+# Archive And Deprecation Path Standard
+
+## Document Status
+- Class: Canonical
+- Canonical Source(s): N/A (Class=Canonical)
+- Rationale: This file is the authoritative process standard for safe legacy
+  documentation deprecation and archiving.
+
+## Goal
+
+Define a safe, reversible path to remove uncertain legacy documents from active
+navigation without losing historical knowledge.
+
+## Status Vocabulary
+
+- `Deprecated`: Legacy document remains available for traceability, but active
+  usage must migrate to a named successor.
+- `Archived`: Inactive historical record. Not part of active navigation.
+- `Superseded by`: Mandatory successor reference to the active canonical or
+  derived replacement.
+
+## Mandatory Header For Deprecated/Archived Documents
+
+Every deprecated or archived document must include this block:
+
+```md
+## Document Status
+- Class: <Deprecated|Archived>
+- Canonical Source(s): <authoritative active document(s)>
+- Superseded by: <active replacement path or "N/A">
+- Rationale: <short reason>
+```
+
+If no safe successor exists yet, keep the document out of archive and classify
+it as deprecated until a successor is defined.
+
+## Deprecation Flow
+
+1. Confirm document is uncertain/legacy and not canonical authority.
+2. Add `Document Status` block with `Class: Deprecated`.
+3. Add explicit `Superseded by` path to active replacement.
+4. Remove deprecated path from active navigation (`docs/index.md`) when the
+   successor link is stable.
+5. Keep the deprecated file reachable by direct link during migration.
+
+## Archive Flow
+
+1. Archive only after successor migration is complete.
+2. Ensure archived file keeps `Superseded by` reference.
+3. Keep archive files outside active navigation sections.
+4. Never make canonical main documents primarily depend on archive links.
+
+## Successor Chain Rule
+
+- Every deprecated/archived document must resolve to an active successor path.
+- Successor chains must be finite and end on a non-archived document.
+- Broken or circular successor chains block archival approval.
+
+## Navigation And Canonical Guardrails
+
+- `docs/index.md` is an active navigation surface and must prefer active paths.
+- Canonical main documents must not primarily reference `docs/archive/**`.
+- Archive links are allowed only as historical context, not as primary
+  operational guidance.
+
+## Review Checklist
+
+1. Deprecated/archived document has required status metadata.
+2. `Superseded by` path exists and points to active documentation.
+3. No canonical main document primarily routes users into archive content.
+4. `docs/index.md` keeps active navigation paths and avoids archive-first flows.

--- a/docs/deprecated/legacy-transition-register.md
+++ b/docs/deprecated/legacy-transition-register.md
@@ -1,0 +1,31 @@
+# Legacy Transition Register
+
+## Document Status
+- Class: Derived
+- Canonical Source(s): docs/archive/archive-deprecation-standard.md
+- Rationale: This register prepares and tracks first safe deprecation candidates
+  without deleting historical documentation.
+
+## Purpose
+
+Prepare an initial, low-risk deprecation path for clearly uncertain legacy
+compatibility documents while preserving traceability.
+
+## Initial Candidates
+
+| Legacy path | Class | Superseded by | Navigation role | Status |
+| --- | --- | --- | --- | --- |
+| `docs/api/public_api_boundary.md` | Deprecated | `docs/operations/api/public_api_boundary.md` | No active-first navigation required | Prepared |
+| `docs/api/runtime_chart_data_contract.md` | Deprecated | `docs/operations/api/runtime_chart_data_contract.md` | Compatibility alias retained | Prepared |
+| `docs/ui/phase-39-test-plan.md` | Deprecated | `docs/operations/ui/phase-39-test-plan.md` | Compatibility alias retained | Prepared |
+
+## Chain Check (Current)
+
+All listed legacy paths have direct successor targets under `docs/operations/**`
+and currently form one-hop successor chains.
+
+## Navigation Check (Current)
+
+- Active API and UI sections in `docs/index.md` already prefer
+  `docs/operations/**`.
+- Legacy paths are retained only for compatibility references.

--- a/docs/ui/phase-39-test-plan.md
+++ b/docs/ui/phase-39-test-plan.md
@@ -1,5 +1,15 @@
 # Phase 39 Runtime Charting Test Plan
 
+## Document Status
+- Class: Deprecated
+- Canonical Source(s): docs/operations/ui/phase-39-test-plan.md
+- Superseded by: docs/operations/ui/phase-39-test-plan.md
+- Rationale: Legacy compatibility path retained while active navigation uses the
+  operations namespace.
+
+This legacy path is deprecated. The active canonical location is
+`docs/operations/ui/phase-39-test-plan.md`.
+
 ## Purpose
 This document defines the minimum verification coverage for the bounded Phase 39 chart-data contract while `/ui` is a shared runtime shell.
 
@@ -79,4 +89,3 @@ Required assertions:
 
 ## Success Condition
 Phase 39 verification coverage is considered defined when this plan remains aligned with the repository and the minimum test set above passes.
-

--- a/tests/test_archive_deprecation_standard_docs.py
+++ b/tests/test_archive_deprecation_standard_docs.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARCHIVE_STANDARD = REPO_ROOT / "docs" / "archive" / "archive-deprecation-standard.md"
+LEGACY_REGISTER = REPO_ROOT / "docs" / "deprecated" / "legacy-transition-register.md"
+DOCS_INDEX = REPO_ROOT / "docs" / "index.md"
+DEPRECATED_LEGACY_PATHS = [
+    REPO_ROOT / "docs" / "api" / "public_api_boundary.md",
+    REPO_ROOT / "docs" / "api" / "runtime_chart_data_contract.md",
+    REPO_ROOT / "docs" / "ui" / "phase-39-test-plan.md",
+]
+
+
+def test_archive_deprecation_standard_closes_mandatory_header_code_fence() -> None:
+    content = ARCHIVE_STANDARD.read_text(encoding="utf-8")
+
+    assert "## Mandatory Header For Deprecated/Archived Documents" in content
+    assert content.count("```md") == 1
+    assert content.count("```") == 2
+    assert (
+        "```\n\n"
+        "If no safe successor exists yet"
+    ) in content
+
+
+def test_archive_deprecation_standard_defines_required_terms_and_guardrails() -> None:
+    content = ARCHIVE_STANDARD.read_text(encoding="utf-8")
+
+    assert "`Deprecated`" in content
+    assert "`Archived`" in content
+    assert "`Superseded by`" in content
+    assert "## Successor Chain Rule" in content
+    assert "Successor chains must be finite and end on a non-archived document." in content
+    assert "## Navigation And Canonical Guardrails" in content
+    assert "must prefer active paths" in content
+    assert "must not primarily reference `docs/archive/**`" in content
+    assert "## Deprecation Flow" in content
+    assert "## Archive Flow" in content
+    assert "## Successor Chain Rule" in content
+    assert "## Navigation And Canonical Guardrails" in content
+    assert "## Review Checklist" in content
+
+
+def test_legacy_transition_register_lists_expected_deprecated_paths_and_successors() -> None:
+    content = LEGACY_REGISTER.read_text(encoding="utf-8")
+
+    assert "`docs/api/public_api_boundary.md`" in content
+    assert "`docs/operations/api/public_api_boundary.md`" in content
+    assert "`docs/api/runtime_chart_data_contract.md`" in content
+    assert "`docs/operations/api/runtime_chart_data_contract.md`" in content
+    assert "`docs/ui/phase-39-test-plan.md`" in content
+    assert "`docs/operations/ui/phase-39-test-plan.md`" in content
+
+
+def test_docs_index_does_not_link_archive_or_deprecated_directories() -> None:
+    content = DOCS_INDEX.read_text(encoding="utf-8")
+
+    assert "docs/archive/" not in content
+    assert "docs/deprecated/" not in content
+    assert "archive/" not in content
+    assert "deprecated/" not in content
+
+
+def test_deprecated_legacy_files_include_required_status_metadata() -> None:
+    for path in DEPRECATED_LEGACY_PATHS:
+        content = path.read_text(encoding="utf-8")
+        assert "- Class: Deprecated" in content, f"missing deprecated class in {path}"
+        assert "- Superseded by:" in content, f"missing successor in {path}"


### PR DESCRIPTION
﻿Closes #942

## What changed
- Added canonical archive/deprecation process standard:
  - docs/archive/archive-deprecation-standard.md
- Added first legacy transition register:
  - docs/deprecated/legacy-transition-register.md
- Marked clear legacy compatibility paths as deprecated with explicit successor references:
  - docs/api/public_api_boundary.md
  - docs/api/runtime_chart_data_contract.md
  - docs/ui/phase-39-test-plan.md
- Added verification coverage for archive/deprecation rules, successor references, and active-navigation guardrails.

## Acceptance Criteria mapping
- Clear archive/deprecation standard documented.
- Archive/deprecation path supports safe removal from active navigation.
- Deprecated/archived docs support explicit successor references.
- Canonical/main navigation remains active-path-first and archive is non-primary.

## Validation
- python -m pytest tests/test_archive_deprecation_standard_docs.py tests/test_phase39_chart_contract_docs.py tests/test_phase23_research_dashboard_contract.py
  - Result: 20 passed
