### PR TITLE
[REPO-RATIONALIZATION][09] Repair documentation link hygiene for runtime, testing, and contracts (#947)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,36 +15,36 @@ documentation structure and does not act as the source of truth for setup,
 local run, testing, or architecture topics.
 It also does not act as a source of authority for roadmap phase maturity/status.
 
-- Entry point: `README.md`
-- Navigation hub: `docs/index.md`
+- Entry point: [README.md](README.md)
+- Navigation hub: [docs/index.md](docs/index.md)
 - Structure and role map:
-  `docs/architecture/documentation_structure.md`
-- Repository documentation index: `docs/index.md`
+  [docs/architecture/documentation_structure.md](docs/architecture/documentation_structure.md)
+- Repository documentation index: [docs/index.md](docs/index.md)
 - Canonical /ui product-surface authority contract:
-  `docs/operations/ui/product-surface-authority-contract.md`
+  [docs/operations/ui/product-surface-authority-contract.md](docs/operations/ui/product-surface-authority-contract.md)
 - Product Surface Track authority: `/ui` is the canonical website-facing authority;
   `frontend/` remains interim non-authoritative unless governance promotion is explicit.
 - Strategy Readiness Track boundary: readiness semantics are governed separately from
   Product Surface Track implementation evidence.
-- Setup authority: `docs/getting-started/getting-started.md`
-- Local run authority: `docs/getting-started/local-run.md`
-- Testing authority: `docs/testing/index.md`
-- Architecture authority root: `docs/architecture/`
-- Roadmap phase maturity/status authority: `ROADMAP_MASTER.md`
+- Setup authority: [docs/getting-started/getting-started.md](docs/getting-started/getting-started.md)
+- Local run authority: [docs/getting-started/local-run.md](docs/getting-started/local-run.md)
+- Testing authority: [docs/testing/index.md](docs/testing/index.md)
+- Architecture authority root: [`docs/architecture/`](docs/architecture/)
+- Roadmap phase maturity/status authority: [ROADMAP_MASTER.md](ROADMAP_MASTER.md)
 - Server-ready release governance contract:
-  `docs/releases/release_governance_contract.md`
+  [docs/releases/release_governance_contract.md](docs/releases/release_governance_contract.md)
 
 ## Verification Paths
 
 - Operators validating a local environment should start here, then follow
-  `docs/getting-started/getting-started.md` and `docs/getting-started/local-run.md`.
+  [docs/getting-started/getting-started.md](docs/getting-started/getting-started.md) and [docs/getting-started/local-run.md](docs/getting-started/local-run.md).
 - Operators validating the bounded staging server deployment path should use
-  `docs/operations/runtime/staging-server-deployment.md`.
+  [docs/operations/runtime/staging-server-deployment.md](docs/operations/runtime/staging-server-deployment.md).
 - Contributors or reviewers validating behavior and change scope should start
-  here, then use `docs/testing/index.md` and `docs/architecture/`.
+  here, then use [docs/testing/index.md](docs/testing/index.md) and [`docs/architecture/`](docs/architecture/).
 
 ## Public API
 
 The supported package-level public API for `src/api` is documented in
-`docs/operations/api/public_api_boundary.md`.
-Legacy compatibility path: `docs/api/public_api_boundary.md`.
+[docs/operations/api/public_api_boundary.md](docs/operations/api/public_api_boundary.md).
+Deprecated compatibility alias: [docs/api/public_api_boundary.md](docs/api/public_api_boundary.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Use this order:
 5. Continue with API, CLI, UI, and governance links below
 
 Canonical first-clean-server install contract:
-- `docs/operations/runtime/staging-server-deployment.md`
+- [docs/operations/runtime/staging-server-deployment.md](operations/runtime/staging-server-deployment.md)
 - Docker/Compose (`docker compose -f docker/staging/docker-compose.staging.yml up -d --build`) is the only canonical first-clean-server startup path.
 - Local development setup guides are non-canonical for first-clean-server installation.
 
@@ -31,7 +31,7 @@ Canonical first-clean-server install contract:
 - [Paper inspection and reconciliation API](api/paper_inspection.md)
 - [Decision card inspection API](api/decision_card_inspection.md)
 - [Phase 39 runtime chart data contract](operations/api/runtime_chart_data_contract.md)
-- Legacy compatibility alias: `docs/api/runtime_chart_data_contract.md`
+- Deprecated compatibility alias: [docs/api/runtime_chart_data_contract.md](api/runtime_chart_data_contract.md)
 
 ## CLI Usage
 
@@ -47,7 +47,7 @@ Canonical first-clean-server install contract:
 - [Phase 36 /ui web activation contract](operations/ui/phase-36-web-activation-contract.md)
 - [Phase 39 /ui charting contract](operations/ui/phase-39-charting-contract.md)
 - [Phase 39 runtime charting test plan](operations/ui/phase-39-test-plan.md)
-- Legacy compatibility alias: `docs/ui/phase-39-test-plan.md`
+- Deprecated compatibility alias: [docs/ui/phase-39-test-plan.md](ui/phase-39-test-plan.md)
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [Shared /ui phase boundary](architecture/ui-runtime-phase-ownership-boundary.md)
 - [Phase 36 web activation evidence](architecture/roadmap/phase-36-web-activation-evidence.md)
@@ -73,7 +73,7 @@ Roadmap track alignment:
 ## Roadmap Navigation
 
 - [Execution roadmap](architecture/roadmap/execution_roadmap.md)
-- `ROADMAP_MASTER.md`
+- [ROADMAP_MASTER.md](../ROADMAP_MASTER.md)
 
 ## Phase Reference Navigation
 


### PR DESCRIPTION
﻿Closes #947

## Summary
- Updated README.md and docs/index.md navigation to prioritize canonical active documentation paths.
- Marked legacy alias paths explicitly as deprecated compatibility aliases in main navigation pages.
- Normalized link formatting for consistent user navigation across runtime/testing/API/UI contract entry points.

## Scope
- Docs navigation only.
- No runtime, API, UI, frontend, or architecture behavior changes.
- Local evidence artifact artifacts/issue947_pytest_output.txt is intentionally not committed.

## Validation
- Link hygiene check for README/docs index and relevant runtime/testing/API/UI contract pages: PASS
- Deprecated alias marker verification for legacy alias docs: PASS
- Ran repository tests with python -m pytest; suite has pre-existing environment permission failures unrelated to these docs-only changes.
