### PR TITLE
[REPO-RATIONALIZATION][08] Clean up narrow documentation duplication cluster safely (#946)

### DIFF
--- a/docs/architecture/strategy_packs/reference_pack/README.md
+++ b/docs/architecture/strategy_packs/reference_pack/README.md
@@ -1,24 +1,12 @@
-## Overview
-This reference pack defines a single canonical strategy implementation used as a deterministic baseline.
+# Reference Pack (Legacy Architecture Alias)
 
-## Strategy Objective
-Provide a harmless strategy entry that exercises registry and pack wiring without emitting actionable signals.
+## Document Status
+- Class: Deprecated
+- Canonical Source(s): docs/strategy_packs/reference_pack/README.md
+- Superseded by: docs/strategy_packs/reference_pack/README.md
+- Rationale: Duplicate architecture-path copy removed to keep a single canonical
+  strategy-pack documentation location.
 
-## Strategy Logic Summary
-The strategy is registered with the stable name `REFERENCE` and always returns an empty signal list from `generate_signals`.
-
-## Parameter Definitions
-This strategy accepts a config object to match the engine strategy contract but does not read or mutate any parameters.
-
-## Deterministic Behavior
-This strategy produces identical outputs for identical inputs across environments.
-
-## Risk Disclosure
-This strategy does not provide trading recommendations and emits no signals.
-
-## Version & Compatibility
-Pack version: `1.0.0`.
-Engine compatibility: `>=1.0.0`.
-
-## Change Log Reference
-See repository history for changes affecting `docs/strategy_packs/reference_pack/` and strategy registration.
+This legacy architecture-path document is retained only as a compatibility
+alias. Use `docs/strategy_packs/reference_pack/README.md` as the active
+authority.

--- a/docs/architecture/strategy_packs/reference_pack/metadata.yaml
+++ b/docs/architecture/strategy_packs/reference_pack/metadata.yaml
@@ -1,8 +1,4 @@
-pack_id: reference-pack
-version: 1.0.0
-description: Canonical deterministic reference strategy pack with a no-op strategy.
-author: Trading Engine Team
-created_at: 2026-01-01T00:00:00Z
-deterministic_hash: reference-pack-v1-hash
-engine_compatibility: ">=1.0.0"
-dependencies: []
+status: deprecated
+canonical_metadata: docs/strategy_packs/reference_pack/metadata.yaml
+superseded_by: docs/strategy_packs/reference_pack/metadata.yaml
+rationale: Duplicate architecture-path metadata removed; canonical metadata lives under docs/strategy_packs.


### PR DESCRIPTION
﻿Closes #946

## Scope
Cleaned exactly one narrow documentation duplication cluster:
- docs/architecture/strategy_packs/reference_pack/README.md
- docs/architecture/strategy_packs/reference_pack/metadata.yaml

## What changed
- Replaced duplicated content with explicit deprecated-alias status.
- Added explicit successor/authority chain to:
  - docs/strategy_packs/reference_pack/README.md
  - docs/strategy_packs/reference_pack/metadata.yaml

## Validation
- Linkcheck for cluster + adjacent navigation pages passed.
- Full repository python -m pytest executed; environment has existing unrelated PermissionError failures.
- Focused test passed:
  - python -m pytest tests/strategies/test_reference_pack.py
  - Result: 3 passed
