### PR TITLE
[REPO-RATIONALIZATION][05] Consolidate roadmap-adjacent derived documentation (#943)

### DIFF
--- a/docs/architecture/audit/roadmap_compliance_report.md
+++ b/docs/architecture/audit/roadmap_compliance_report.md
@@ -5,6 +5,7 @@
 This audit is based only on repository-verifiable evidence (code, tests, endpoints, and documentation files).
 
 The authoritative in-repo source for audited phase taxonomy is `docs/architecture/roadmap/execution_roadmap.md`. This report now defers to that roadmap for phase-number meanings and uses this document only for audit findings and traceability.
+Canonical phase maturity/status labels are governed only by `ROADMAP_MASTER.md`.
 
 Owner Dashboard is verifiably backend-served at `/ui` via FastAPI `app.mount("/ui", StaticFiles(..., html=True), ...)` and HTML marker `<title>Owner Dashboard</title>`.
 
@@ -18,7 +19,7 @@ Snapshot runtime execution capability is implemented in-repo, while scheduling r
 
 Documentation and implementation are aligned for the audited paper-trading and owner-dashboard surfaces, with remaining caution focused on still-unimplemented roadmap phases rather than stale contradictions.
 
-**Current overall alignment assessment:** **Aligned for audited active surfaces**
+**Current overall alignment assessment (audit snapshot, non-canonical):** **Aligned for audited active surfaces**
 
 ---
 
@@ -30,16 +31,16 @@ Documentation and implementation are aligned for the audited paper-trading and o
 | Phase 16 | No authoritative in-repo phase taxonomy artifact located | `docs/architecture/roadmap/execution_roadmap.md` | Reviewers should treat the phase as unmapped unless a future governance artifact establishes it. |
 | Phase 17 | Consumer Interfaces and Usage Patterns umbrella phase | `docs/architecture/roadmap/execution_roadmap.md` | Distinct from Phase 17b; secondary index links are navigation only. |
 | Phase 17b | Owner Dashboard | `docs/architecture/roadmap/execution_roadmap.md` | This report's Owner Dashboard findings map only to Phase 17b. |
-| Phase 23 | Research Dashboard | `docs/architecture/roadmap/execution_roadmap.md` | Taxonomy authority remains with the roadmap; `docs/architecture/phases/phase-23-status.md` is the dedicated status artifact. |
-| Phase 25 | Strategy Lifecycle Management | `docs/architecture/roadmap/execution_roadmap.md` | Taxonomy authority remains with the roadmap; `docs/architecture/phases/phase_25_strategy_lifecycle.md` is the dedicated status artifact aligned to verified lifecycle modules and tests. |
+| Phase 23 | Research Dashboard | `docs/architecture/roadmap/execution_roadmap.md` | Taxonomy authority remains with the roadmap; `docs/architecture/phases/phase-23-status.md` is a derived evidence artifact. |
+| Phase 25 | Strategy Lifecycle Management | `docs/architecture/roadmap/execution_roadmap.md` | Taxonomy authority remains with the roadmap; `docs/architecture/phases/phase_25_strategy_lifecycle.md` is a derived evidence artifact aligned to verified lifecycle modules and tests. |
 | Phase 26 | No authoritative in-repo phase taxonomy artifact located | `docs/architecture/roadmap/execution_roadmap.md` | Reviewers should not infer a Phase 26 meaning from adjacent roadmap blocks. |
-| Phase 27 | Risk Framework | `docs/architecture/roadmap/execution_roadmap.md` | Taxonomy authority remains with the roadmap; `docs/architecture/phases/phase-27-status.md` is the dedicated status artifact, and Phase 27 remains distinct from Phase 27b Pipeline Enforcement Layer artifacts. |
+| Phase 27 | Risk Framework | `docs/architecture/roadmap/execution_roadmap.md` | Taxonomy authority remains with the roadmap; `docs/architecture/phases/phase-27-status.md` is a derived evidence artifact, and Phase 27 remains distinct from Phase 27b Pipeline Enforcement Layer artifacts. |
 
 ---
 
-## 3. Roadmap Phase Matrix
+## 3. Roadmap Phase Matrix (Audit Snapshot)
 
-| Phase | Status | Evidence | Notes |
+| Phase | Audit observation (non-canonical snapshot) | Evidence | Notes |
 |-------|--------|----------|-------|
 | Phase 17b - Owner Dashboard | Implemented | Backend UI mount in `src/api/main.py` (`app.mount("/ui", StaticFiles(..., html=True), name="ui")`); HTML marker in `src/ui/index.html` (`<title>Owner Dashboard</title>`); tests in `tests/health_endpoint.py`; manual trigger endpoint `POST /analysis/run` in `src/api/main.py`; test in `tests/test_api_manual_analysis_trigger.py`; documentation in `docs/operations/ui/owner_dashboard.md` and `docs/index.md`. | `/ui` is confirmed backend-served. `/owner` is documented only as a frontend development route and not as a runtime backend route. |
 | Hourly Snapshot Runtime | Partially Implemented | `docs/operations/runtime/snapshot_runtime.md` declares in-repo execution capability and external scheduling boundary; `docs/operations/interfaces/batch_execution.md` states no scheduler implementation; no scheduler/cron endpoint verified in `src/api/main.py`. | Runtime execution capability exists in-repo; hourly scheduling is external and not provided by this repository. |
@@ -109,8 +110,8 @@ Documentation and implementation are aligned for the audited paper-trading and o
    - Formally declare the operational boundary: in-repo runtime execution capability with external scheduling ownership.  
    - **Phase classification:** Snapshot Runtime  
 
-2. **Proposed Issue:** `Phase 23 status artifact`  
-   - Keep explicit not-implemented declaration aligned to current repo evidence until implementation artifacts exist.  
+2. **Proposed Issue:** `Phase 23 evidence artifact alignment`  
+   - Keep Phase 23 evidence wording aligned to current repo evidence until additional implementation artifacts exist.  
    - **Phase classification:** Phase 23  
 
 ---

--- a/docs/architecture/phases/phase-23-status.md
+++ b/docs/architecture/phases/phase-23-status.md
@@ -1,19 +1,23 @@
 # Phase 23 - Website-Facing /ui Workflow Consolidation
 
-## Status
-PARTIALLY IMPLEMENTED
+## Document Role
+Derived evidence snapshot for Phase 23 scope verification.
+
+Canonical authority:
+- Phase maturity/status labels: `ROADMAP_MASTER.md`
+- Audited phase taxonomy/meaning: `docs/architecture/roadmap/execution_roadmap.md`
 
 ## Taxonomy Alignment
 Phase 23 means bounded website-facing workflow consolidation under the canonical `/ui` shell in this repository revision.
 
-## Canonical Bounded Message
-Phase 23 is `PARTIALLY IMPLEMENTED` because one coherent bounded evidence set now defines one canonical website-facing workflow shell at `/ui`.
+## Bounded Evidence Message
+This document records one coherent bounded evidence set for a canonical website-facing workflow shell at `/ui`.
 
 The consolidated IA contract is intentionally non-live and does not imply trader validation or operational readiness.
 Canonical product-surface authority and non-inference status separation are defined in:
 - `docs/operations/ui/product-surface-authority-contract.md`
 
-## Authoritative Bounded Scope
+## Bounded Scope Evidence
 Phase 23 in this revision is the repository-verifiable phase for:
 - one canonical `/ui` workflow shell
 - one bounded primary navigation contract for website-facing workflow entry
@@ -43,10 +47,10 @@ The repository must contain tests that validate canonical ownership and bounded 
 - `tests/test_ui_runtime_browser_flow.py`
 - `tests/test_phase23_research_dashboard_contract.py`
 
-## Classification Rule
-- `NOT IMPLEMENTED`: any required evidence class is missing, inconsistent, or points to multiple canonical website-facing entry surfaces
-- `PARTIALLY IMPLEMENTED`: all required classes exist, but broader product-surface expansion remains intentionally out of scope
-- `IMPLEMENTED`: all required classes exist and support complete bounded scope being claimed, without readiness inference
+## Evidence Interpretation (Non-Canonical)
+- Missing evidence classes indicate an incomplete Phase 23 evidence chain.
+- Complete evidence classes indicate bounded implementation evidence exists.
+- Canonical maturity/status labels are set only in `ROADMAP_MASTER.md`.
 
 ## Explicit Phase Boundaries
 Phase 23 consolidation in this revision does not claim:
@@ -77,6 +81,6 @@ This Phase 23 consolidation contract does not replace or widen operational run l
 
 `OPS-P56: Start bounded staged paper-trading runbook and evidence log #914` remains the single operational run log issue.
 
-## Explicit Declaration
+## Snapshot Declaration
 As of this revision, one repository-verifiable canonical `/ui` website-facing workflow shell is confirmed under bounded non-live scope.
-Phase 23 is therefore PARTIALLY IMPLEMENTED under this consolidation contract.
+This declaration is evidence-only and does not set canonical phase maturity/status.

--- a/docs/architecture/phases/phase-27-status.md
+++ b/docs/architecture/phases/phase-27-status.md
@@ -1,7 +1,11 @@
 # Phase 27 - Risk Framework
 
-## Status
-IMPLEMENTATION ARTIFACTS VERIFIED
+## Document Role
+Derived evidence snapshot for Phase 27 risk-framework artifacts.
+
+Canonical authority:
+- Phase maturity/status labels: `ROADMAP_MASTER.md`
+- Audited phase taxonomy/meaning: `docs/architecture/roadmap/execution_roadmap.md`
 
 ## Taxonomy Alignment
 Phase 27 means `Risk Framework` in the authoritative taxonomy source:
@@ -25,4 +29,5 @@ This status artifact records verified framework artifacts only. It does not rede
 
 ## Explicit Declaration
 As of this revision, repository-verifiable Risk Framework artifacts exist for Phase 27.
-Phase 27 must not be described in audited status documents as absent or unimplemented where these artifacts are already present.
+Phase 27 evidence should not be described in audited documents as absent where these artifacts are present.
+This file does not set canonical phase maturity/status.

--- a/docs/architecture/phases/phase-37-status.md
+++ b/docs/architecture/phases/phase-37-status.md
@@ -1,11 +1,15 @@
 # Phase 37 - Watchlist Engine Status
 
-Status: Implemented in Repository  
 Scope: Repository-verified watchlist persistence, CRUD API, execution/ranking workflow, and bounded `/ui` watchlist surface  
-Owner: Governance
+Owner: Governance  
+Role: Derived evidence snapshot (non-canonical status source)
+
+Canonical authority:
+- Phase maturity/status labels: `ROADMAP_MASTER.md`
+- Audited phase taxonomy/meaning: `docs/architecture/roadmap/execution_roadmap.md`
 
 ## Purpose
-This file is the canonical Phase 37 status and contract artifact for repository-verified watchlist workflow.
+This file records repository-verified Phase 37 watchlist workflow evidence.
 
 ## Verified Phase 37 Scope
 
@@ -47,5 +51,5 @@ These endpoints provide deterministic watchlist CRUD and snapshot-only execution
 - Shared-shell sections such as alert history on `/ui` are non-authoritative for Phase 37 completion.
 
 ## Documentation Alignment Rule
-Phase 37 references in `docs/**` must align to this file, `docs/architecture/roadmap/execution_roadmap.md`, and `docs/architecture/ui-runtime-phase-ownership-boundary.md`.
-
+Phase 37 references in `docs/**` must align to `ROADMAP_MASTER.md`, `docs/architecture/roadmap/execution_roadmap.md`, and `docs/architecture/ui-runtime-phase-ownership-boundary.md`.
+This file is an evidence surface and not a canonical status authority.

--- a/docs/architecture/phases/phase-38-status.md
+++ b/docs/architecture/phases/phase-38-status.md
@@ -1,11 +1,15 @@
 # Phase 38 - Market Data Integration Status
 
-Status: Partially Implemented  
 Scope: Direct provider adapter presence, deterministic snapshot boundary, and runtime-safe claim evidence requirements  
-Owner: Governance
+Owner: Governance  
+Role: Derived evidence snapshot (non-canonical status source)
+
+Canonical authority:
+- Phase maturity/status labels: `ROADMAP_MASTER.md`
+- Audited phase taxonomy/meaning: `docs/architecture/roadmap/execution_roadmap.md`
 
 ## Purpose
-This file is the canonical Phase 38 status and contract artifact for repository-safe market-data claims.
+This file records repository-safe Phase 38 market-data evidence and boundaries.
 
 ## Verified In-Repository Artifacts
 - Direct provider loaders exist in `src/cilly_trading/engine/data.py`:
@@ -57,4 +61,5 @@ Tests prove snapshot-only runtime paths do not use live provider loaders and tha
 - No claim that broker integration, live-trading feeds, or websocket market-data delivery is implemented.
 
 ## Documentation Alignment Rule
-Phase 38 references in `docs/**` must align to this file, `docs/architecture/roadmap/execution_roadmap.md`, and `docs/operations/api/usage_contract.md`.
+Phase 38 references in `docs/**` must align to `ROADMAP_MASTER.md`, `docs/architecture/roadmap/execution_roadmap.md`, and `docs/operations/api/usage_contract.md`.
+This file is an evidence surface and not a canonical status authority.

--- a/docs/architecture/phases/phase_25_strategy_lifecycle.md
+++ b/docs/architecture/phases/phase_25_strategy_lifecycle.md
@@ -1,6 +1,11 @@
 # Phase 25 - Strategy Lifecycle Management
 
-**Status:** IMPLEMENTED IN REPOSITORY
+## Document Role
+Derived evidence snapshot for Phase 25 lifecycle artifacts.
+
+Canonical authority:
+- Phase maturity/status labels: `ROADMAP_MASTER.md`
+- Audited phase taxonomy/meaning: `docs/architecture/roadmap/execution_roadmap.md`
 
 ## Taxonomy Alignment
 Phase 25 means `Strategy Lifecycle Management` in the authoritative taxonomy source:
@@ -50,4 +55,5 @@ Execution is governed by a strict production-only policy:
 - Non-production strategies are rejected before execution.
 
 ## Explicit Declaration
-This phase-status artifact is evidence-based. It reflects repository artifacts already present and tested in-tree, rather than pending PR or merge state.
+This artifact is evidence-based and reflects repository artifacts present and tested in-tree.
+It does not set canonical phase maturity/status.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Canonical first-clean-server install contract:
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [Shared /ui phase boundary](architecture/ui-runtime-phase-ownership-boundary.md)
 - [Phase 36 web activation evidence](architecture/roadmap/phase-36-web-activation-evidence.md)
-- [Phase 37 watchlist engine status](architecture/phases/phase-37-status.md)
+- [Phase 37 watchlist evidence snapshot](architecture/phases/phase-37-status.md)
 
 Roadmap track alignment:
 - Product Surface Track: `/ui` is the canonical website-facing authority.
@@ -74,6 +74,8 @@ Roadmap track alignment:
 
 - [Execution roadmap](architecture/roadmap/execution_roadmap.md)
 - [ROADMAP_MASTER.md](../ROADMAP_MASTER.md)
+- Canonical phase maturity/status source: `ROADMAP_MASTER.md`
+- Canonical audited phase taxonomy source: `docs/architecture/roadmap/execution_roadmap.md`
 
 ## Phase Reference Navigation
 
@@ -92,9 +94,9 @@ Roadmap track alignment:
 
 ### Phase 23 Reference Materials
 
-- [Phase 23 status](architecture/phases/phase-23-status.md)
+- [Phase 23 evidence snapshot](architecture/phases/phase-23-status.md)
 - [Phase 23 /ui workflow consolidation contract](operations/ui/phase-23-research-dashboard-contract.md)
-- Phase 23 | `Canonical /ui Workflow Shell` | PARTIALLY IMPLEMENTED
+- Phase 23 references in this index are navigation/evidence only; canonical maturity/status remains in `ROADMAP_MASTER.md`.
 
 ### Phase 24 Reference Materials
 
@@ -129,7 +131,7 @@ Roadmap track alignment:
 
 ### Phase 37 Reference Materials
 
-- [Phase 37 watchlist engine status](architecture/phases/phase-37-status.md)
+- [Phase 37 watchlist evidence snapshot](architecture/phases/phase-37-status.md)
 - [Operator dashboard runtime surface](operations/ui/owner_dashboard.md)
 - [API usage contract](operations/api/usage_contract.md)
 

--- a/tests/test_phase23_research_dashboard_contract.py
+++ b/tests/test_phase23_research_dashboard_contract.py
@@ -62,8 +62,9 @@ def test_phase23_contract_retains_ops_p56_non_interference_boundary() -> None:
 def test_phase23_status_reflects_bounded_ui_consolidation() -> None:
     content = _read(PHASE23_STATUS_DOC)
 
-    assert "## Status" in content
-    assert "PARTIALLY IMPLEMENTED" in content
+    assert "## Document Role" in content
+    assert "Derived evidence snapshot for Phase 23 scope verification." in content
+    assert "Phase maturity/status labels: `ROADMAP_MASTER.md`" in content
     assert "canonical `/ui` workflow shell" in content
     assert "src/ui/index.html" in content
     assert "src/api/main.py" in content
@@ -100,7 +101,8 @@ def test_index_includes_phase23_consolidation_contract_reference() -> None:
     assert "product-surface-authority-contract.md" in index_content
     assert "Canonical /ui product-surface authority contract" in index_content
     assert "Phase 23 /ui workflow consolidation contract" in index_content
-    assert "Phase 23 | `Canonical /ui Workflow Shell` | PARTIALLY IMPLEMENTED" in index_content
+    assert "Phase 23 references in this index are navigation/evidence only; canonical maturity/status remains in `ROADMAP_MASTER.md`." in index_content
+    assert "Canonical phase maturity/status source: `ROADMAP_MASTER.md`" in index_content
     assert "Roadmap track alignment:" in index_content
     assert "Product Surface Track: `/ui` is the canonical website-facing authority." in index_content
     assert "Strategy Readiness Track: readiness claims are governed separately" in index_content


### PR DESCRIPTION
﻿Closes #943

## Summary
- Converted roadmap-adjacent derived phase docs to explicit evidence snapshots.
- Removed canonical-status-authority claims from touched derived docs.
- Updated roadmap compliance audit wording to non-canonical audit snapshot framing.
- Updated roadmap reference blocks in docs/index.md to point canonical maturity/status authority to ROADMAP_MASTER.md.
- Updated Phase 23 verification tests to assert the new evidence-only authority model.

## Scope control
- Changed only in-scope docs:
  - docs/architecture/phases affected subset
  - docs/architecture/audit affected subset
  - docs/index.md roadmap-reference blocks
  - tests/test_phase23_research_dashboard_contract.py
- No src/**, frontend/**, runtime, API, broker, or live-trading changes.

## Validation
- .\.venv\Scripts\python.exe -m pytest
- Result: 1057 passed, 4 warnings.
