### PR TITLE
[RISK-MODEL][01] Harden deterministic trade-level and portfolio-level risk allocation (#981)

### DIFF
--- a/docs/architecture/risk/portfolio_framework.md
+++ b/docs/architecture/risk/portfolio_framework.md
@@ -276,3 +276,29 @@ When signals compete for constrained portfolio capacity, the pipeline remains st
    - `intent.higher_priority_approved_signal_ids` listing the approved signals that consumed capacity earlier in the same run
 
 This keeps constrained-capacity behavior deterministic and operator-inspectable without introducing optimization or trader-readiness claims beyond the verified decision semantics.
+
+## 12. Deterministic Trade-Level Risk Allocation (Issue #981)
+
+For bounded paper/simulation entry, deterministic trade-level notional sizing is
+computed from:
+
+- `account_equity`
+- `max_risk_per_trade_pct`
+- bounded trade-risk input (`trade_risk_pct`)
+
+The sizing contract is fail-closed for missing or invalid inputs and emits
+stable machine-readable reason codes for equivalent inputs. Portfolio-level
+enforcement in the same decision path blocks candidates that would exceed:
+
+- max risk per trade
+- max total portfolio exposure
+- max strategy exposure
+- max symbol exposure
+- max concurrent positions
+
+Sizing and cap-evaluation inputs are exposed in non-UI decision artifacts for
+deterministic inspection.
+
+Implementation scope note: this issue provides technical implementation
+evidence only. It does not imply trader validation, trader-approved thresholds,
+live readiness, or broker readiness.

--- a/docs/operations/runtime/signal_to_paper_execution_policy.md
+++ b/docs/operations/runtime/signal_to_paper_execution_policy.md
@@ -36,6 +36,8 @@ evaluation sequence is applied to every candidate signal:
 3. **Duplicate-entry check** - no duplicate open position may exist.
 4. **Cooldown check** - minimum cooldown between entries must be satisfied.
 5. **Exposure check** - position and exposure limits must not be exceeded.
+   This step includes deterministic trade-level sizing from account equity,
+   max risk per trade, and bounded `trade_risk_pct`.
 
 Step 5 is evaluated through the canonical deterministic risk framework via one
 bounded adapter path:
@@ -149,6 +151,29 @@ A minimum cooldown period must elapse between paper entries for the same
 
 Paper entry is blocked when exposure or position limits would be exceeded.
 
+### Deterministic trade-level sizing (Issue #981)
+
+Before exposure-cap checks are evaluated, paper-entry sizing is computed in a
+fail-closed deterministic function:
+
+- required input: `trade_risk_pct` on the signal candidate
+- bounded risk input: `trade_risk_pct` is clamped to
+  `[min_trade_risk_pct, max_trade_risk_pct]`
+- risk budget: `account_equity * max_risk_per_trade_pct`
+- proposed notional: `risk_budget_notional / bounded_trade_risk_pct`
+- deterministic rounding: configured notional quantum with `ROUND_HALF_UP`
+
+Fail-closed outcomes:
+
+- missing trade-risk input -> `reject:missing_trade_risk_input`
+- invalid trade-risk input -> `reject:invalid_trade_risk_input`
+- rounded sizing that breaches max risk per trade ->
+  `reject:max_risk_per_trade_exceeded`
+
+Sizing and cap-evaluation inputs are exposed in non-UI worker decision
+artifacts (`SignalEvaluationResult.decision_inputs`) for deterministic
+inspection.
+
 ### Per-position exposure limit
 
 - The default maximum position size is `10%` of current account equity per
@@ -199,6 +224,9 @@ are not live-trading risk controls and do not constitute broker risk management.
 | Skip | `skip:cooldown_active` | Cooldown window has not elapsed for `(symbol, strategy)`. |
 | Reject | `reject:invalid_signal_fields` | Required signal field is absent or outside its allowed boundary. |
 | Reject | `reject:position_size_exceeds_limit` | Proposed position size exceeds per-position cap. |
+| Reject | `reject:missing_trade_risk_input` | Required bounded trade-risk input is missing. |
+| Reject | `reject:invalid_trade_risk_input` | Required bounded trade-risk input is invalid. |
+| Reject | `reject:max_risk_per_trade_exceeded` | Rounded deterministic size breaches max risk per trade. |
 | Reject | `reject:total_exposure_exceeds_limit` | Proposed position would push total exposure over global cap. |
 | Reject | `reject:strategy_exposure_exceeds_limit` | Proposed position would push strategy exposure over strategy cap. |
 | Reject | `reject:symbol_exposure_exceeds_limit` | Proposed position would push symbol exposure over symbol cap. |
@@ -216,6 +244,10 @@ Risk decision reason codes are deterministic and adapter-driven (for example
 `rejected:risk_framework_max_account_exposure_pct_exceeded`), so equivalent
 bounded inputs produce equivalent approve/reject reasons across covered
 non-live execution paths.
+
+Issue #981 completion is technical implementation evidence only. It does not
+claim trader validation, trader approval of thresholds, live readiness, or
+broker readiness.
 
 ## Policy Application Boundary
 

--- a/src/cilly_trading/engine/paper_execution_risk_profile.py
+++ b/src/cilly_trading/engine/paper_execution_risk_profile.py
@@ -48,6 +48,10 @@ class PaperExecutionRiskProfile:
     contract_id: str = PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID
     min_score_threshold: float = 60.0
     max_position_pct: Decimal = Decimal("0.10")
+    max_risk_per_trade_pct: Decimal = Decimal("0.01")
+    min_trade_risk_pct: Decimal = Decimal("0.005")
+    max_trade_risk_pct: Decimal = Decimal("0.20")
+    notional_rounding_quantum: Decimal = Decimal("0.01")
     max_total_exposure_pct: Decimal = Decimal("0.80")
     max_strategy_exposure_pct: Decimal = Decimal("0.80")
     max_symbol_exposure_pct: Decimal = Decimal("0.80")
@@ -68,6 +72,24 @@ class PaperExecutionRiskProfile:
             value=self.min_score_threshold,
         )
         _require_finite_pct(name="max_position_pct", value=self.max_position_pct)
+        _require_finite_pct(
+            name="max_risk_per_trade_pct",
+            value=self.max_risk_per_trade_pct,
+        )
+        _require_finite_pct(
+            name="min_trade_risk_pct",
+            value=self.min_trade_risk_pct,
+        )
+        _require_finite_pct(
+            name="max_trade_risk_pct",
+            value=self.max_trade_risk_pct,
+        )
+        if self.min_trade_risk_pct > self.max_trade_risk_pct:
+            raise ValueError("min_trade_risk_pct must be <= max_trade_risk_pct")
+        _require_finite_positive_decimal(
+            name="notional_rounding_quantum",
+            value=self.notional_rounding_quantum,
+        )
         _require_finite_pct(
             name="max_total_exposure_pct",
             value=self.max_total_exposure_pct,
@@ -103,6 +125,10 @@ class PaperExecutionRiskProfile:
             "contract_id": self.contract_id,
             "min_score_threshold": self.min_score_threshold,
             "max_position_pct": str(self.max_position_pct),
+            "max_risk_per_trade_pct": str(self.max_risk_per_trade_pct),
+            "min_trade_risk_pct": str(self.min_trade_risk_pct),
+            "max_trade_risk_pct": str(self.max_trade_risk_pct),
+            "notional_rounding_quantum": str(self.notional_rounding_quantum),
             "max_total_exposure_pct": str(self.max_total_exposure_pct),
             "max_strategy_exposure_pct": str(self.max_strategy_exposure_pct),
             "max_symbol_exposure_pct": str(self.max_symbol_exposure_pct),

--- a/src/cilly_trading/engine/paper_execution_worker.py
+++ b/src/cilly_trading/engine/paper_execution_worker.py
@@ -47,6 +47,10 @@ from cilly_trading.models import (
     compute_signal_id,
     sha256_hex,
 )
+from cilly_trading.portfolio_framework.capital_allocation_policy import (
+    DeterministicTradeSizingInput,
+    compute_deterministic_trade_notional,
+)
 from cilly_trading.repositories import CanonicalExecutionRepository
 from cilly_trading.risk_framework.allocation_rules import RiskLimits
 
@@ -60,6 +64,22 @@ MIN_SCORE_THRESHOLD: float = DEFAULT_PAPER_EXECUTION_RISK_PROFILE.min_score_thre
 
 #: Maximum fraction of account equity for a single paper position.
 MAX_POSITION_PCT: Decimal = DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_position_pct
+
+#: Maximum trade-level risk budget fraction of account equity.
+MAX_RISK_PER_TRADE_PCT: Decimal = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_risk_per_trade_pct
+)
+
+#: Minimum bounded trade-risk input used for deterministic sizing.
+MIN_TRADE_RISK_PCT: Decimal = DEFAULT_PAPER_EXECUTION_RISK_PROFILE.min_trade_risk_pct
+
+#: Maximum bounded trade-risk input used for deterministic sizing.
+MAX_TRADE_RISK_PCT: Decimal = DEFAULT_PAPER_EXECUTION_RISK_PROFILE.max_trade_risk_pct
+
+#: Notional rounding quantum for deterministic sizing.
+NOTIONAL_ROUNDING_QUANTUM: Decimal = (
+    DEFAULT_PAPER_EXECUTION_RISK_PROFILE.notional_rounding_quantum
+)
 
 #: Maximum fraction of account equity across all open paper positions.
 MAX_TOTAL_EXPOSURE_PCT: Decimal = (
@@ -108,6 +128,9 @@ OutcomeCode = Literal[
     "skip:duplicate_entry",
     "skip:cooldown_active",
     "reject:invalid_signal_fields",
+    "reject:missing_trade_risk_input",
+    "reject:invalid_trade_risk_input",
+    "reject:max_risk_per_trade_exceeded",
     "reject:position_size_exceeds_limit",
     "reject:total_exposure_exceeds_limit",
     "reject:strategy_exposure_exceeds_limit",
@@ -148,6 +171,7 @@ class SignalEvaluationResult:
     order_id: Optional[str] = None
     trade_id: Optional[str] = None
     reason: Optional[str] = None
+    decision_inputs: Optional[dict[str, str]] = None
 
 
 # ---------------------------------------------------------------------------
@@ -255,6 +279,62 @@ def _risk_rejection_outcome(reason: str) -> OutcomeCode:
     return outcome
 
 
+def _resolve_trade_risk_pct(signal: Signal) -> tuple[OutcomeCode | None, Decimal | None, str | None]:
+    raw_trade_risk_pct = signal.get("trade_risk_pct")
+    if raw_trade_risk_pct is None:
+        return (
+            "reject:missing_trade_risk_input",
+            None,
+            "trade_risk_pct is required for deterministic sizing",
+        )
+    try:
+        trade_risk_pct = Decimal(str(raw_trade_risk_pct))
+    except Exception:
+        return (
+            "reject:invalid_trade_risk_input",
+            None,
+            f"trade_risk_pct is not numeric: {raw_trade_risk_pct!r}",
+        )
+    if not trade_risk_pct.is_finite():
+        return (
+            "reject:invalid_trade_risk_input",
+            None,
+            "trade_risk_pct must be finite",
+        )
+    if trade_risk_pct <= Decimal("0"):
+        return (
+            "reject:invalid_trade_risk_input",
+            None,
+            f"trade_risk_pct must be > 0, got {trade_risk_pct}",
+        )
+    return None, trade_risk_pct, None
+
+
+def _build_decision_inputs_payload(
+    *,
+    trade_risk_pct: Decimal,
+    bounded_trade_risk_pct: Decimal,
+    risk_budget_notional: Decimal,
+    proposed_notional: Decimal,
+    account_equity: Decimal,
+    profile: PaperExecutionRiskProfile,
+    entry_price: Decimal,
+) -> dict[str, str]:
+    return {
+        "account_equity": str(account_equity),
+        "max_risk_per_trade_pct": str(profile.max_risk_per_trade_pct),
+        "trade_risk_pct": str(trade_risk_pct),
+        "bounded_trade_risk_pct": str(bounded_trade_risk_pct),
+        "risk_budget_notional": str(risk_budget_notional),
+        "proposed_position_notional": str(proposed_notional),
+        "entry_price": str(entry_price),
+        "max_total_exposure_pct": str(profile.max_total_exposure_pct),
+        "max_strategy_exposure_pct": str(profile.max_strategy_exposure_pct),
+        "max_symbol_exposure_pct": str(profile.max_symbol_exposure_pct),
+        "max_concurrent_positions": str(profile.max_concurrent_positions),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Worker
 # ---------------------------------------------------------------------------
@@ -299,7 +379,10 @@ class BoundedPaperExecutionWorker:
         """
         result = self._evaluate(signal)
         if result.outcome == "eligible":
-            result = self._persist_paper_entry(signal)
+            result = self._persist_paper_entry(
+                signal,
+                decision_inputs=result.decision_inputs,
+            )
         return result
 
     def process_batch(self, signals: Sequence[Signal]) -> list[SignalEvaluationResult]:
@@ -316,16 +399,70 @@ class BoundedPaperExecutionWorker:
 
     def _build_risk_limits(self) -> RiskLimits:
         """Build deterministic risk-framework limits for paper execution."""
+        max_notional_from_risk_budget = (
+            self._risk_profile.account_equity
+            * self._risk_profile.max_risk_per_trade_pct
+            / self._risk_profile.min_trade_risk_pct
+        )
         return RiskLimits(
             max_account_exposure_pct=float(self._risk_profile.max_total_exposure_pct),
-            max_position_size=float(
-                self._risk_profile.account_equity * self._risk_profile.max_position_pct
-            ),
+            max_position_size=float(max_notional_from_risk_budget),
             max_strategy_exposure_pct=float(
                 self._risk_profile.max_strategy_exposure_pct
             ),
             max_symbol_exposure_pct=float(self._risk_profile.max_symbol_exposure_pct),
         )
+
+    def _compute_trade_sizing_for_signal(
+        self,
+        signal: Signal,
+        *,
+        entry_price: Decimal,
+    ) -> tuple[SignalEvaluationResult | None, Decimal | None, dict[str, str] | None]:
+        rejection_outcome, trade_risk_pct, rejection_reason = _resolve_trade_risk_pct(signal)
+        if rejection_outcome is not None or trade_risk_pct is None:
+            return (
+                SignalEvaluationResult(
+                    outcome=rejection_outcome or "reject:invalid_trade_risk_input",
+                    reason=rejection_reason,
+                ),
+                None,
+                None,
+            )
+
+        sizing_decision = compute_deterministic_trade_notional(
+            DeterministicTradeSizingInput(
+                account_equity=self._risk_profile.account_equity,
+                max_risk_per_trade_pct=self._risk_profile.max_risk_per_trade_pct,
+                trade_risk_pct=trade_risk_pct,
+                min_trade_risk_pct=self._risk_profile.min_trade_risk_pct,
+                max_trade_risk_pct=self._risk_profile.max_trade_risk_pct,
+                notional_rounding_quantum=self._risk_profile.notional_rounding_quantum,
+            )
+        )
+        decision_inputs = _build_decision_inputs_payload(
+            trade_risk_pct=sizing_decision.trade_risk_pct,
+            bounded_trade_risk_pct=sizing_decision.bounded_trade_risk_pct,
+            risk_budget_notional=sizing_decision.risk_budget_notional,
+            proposed_notional=sizing_decision.rounded_position_notional,
+            account_equity=self._risk_profile.account_equity,
+            profile=self._risk_profile,
+            entry_price=entry_price,
+        )
+        if not sizing_decision.accepted:
+            rejection_outcome_code: OutcomeCode = "reject:invalid_trade_risk_input"
+            if sizing_decision.reason_code == "sizing_rejected:max_risk_per_trade_exceeded":
+                rejection_outcome_code = "reject:max_risk_per_trade_exceeded"
+            return (
+                SignalEvaluationResult(
+                    outcome=rejection_outcome_code,
+                    reason=sizing_decision.reason_code,
+                    decision_inputs=decision_inputs,
+                ),
+                None,
+                decision_inputs,
+            )
+        return None, sizing_decision.rounded_position_notional, decision_inputs
 
     # ------------------------------------------------------------------
     # Policy evaluation (read-only)
@@ -405,7 +542,15 @@ class BoundedPaperExecutionWorker:
             signal,
             fallback_entry_price=self._risk_profile.default_paper_entry_price,
         )
-        proposed_notional = self._risk_profile.default_paper_quantity * entry_price
+        sizing_rejection, proposed_notional, decision_inputs = self._compute_trade_sizing_for_signal(
+            signal,
+            entry_price=entry_price,
+        )
+        if sizing_rejection is not None or proposed_notional is None:
+            return sizing_rejection or SignalEvaluationResult(
+                outcome="reject:invalid_trade_risk_input",
+                reason="trade sizing failed",
+            )
 
         # Load all open trades for canonical exposure/concurrent-position checks.
         # The limit of 1000 reflects the bounded paper simulation scope
@@ -422,6 +567,7 @@ class BoundedPaperExecutionWorker:
                     f"concurrent_positions={len(all_open_trades)} >= "
                     f"limit={self._risk_profile.max_concurrent_positions}"
                 ),
+                decision_inputs=decision_inputs,
             )
 
         current_exposure = sum(
@@ -455,15 +601,21 @@ class BoundedPaperExecutionWorker:
             return SignalEvaluationResult(
                 outcome=_risk_rejection_outcome(risk_decision.reason),
                 reason=risk_decision.reason,
+                decision_inputs=decision_inputs,
             )
 
-        return SignalEvaluationResult(outcome="eligible")
+        return SignalEvaluationResult(outcome="eligible", decision_inputs=decision_inputs)
 
     # ------------------------------------------------------------------
     # Paper entity creation and persistence
     # ------------------------------------------------------------------
 
-    def _persist_paper_entry(self, signal: Signal) -> SignalEvaluationResult:
+    def _persist_paper_entry(
+        self,
+        signal: Signal,
+        *,
+        decision_inputs: dict[str, str] | None,
+    ) -> SignalEvaluationResult:
         """Create and persist canonical paper entities for an eligible signal.
 
         Deterministic: the same signal always produces the same entity IDs
@@ -483,7 +635,15 @@ class BoundedPaperExecutionWorker:
             signal,
             fallback_entry_price=self._risk_profile.default_paper_entry_price,
         )
-        quantity = self._risk_profile.default_paper_quantity
+        proposed_notional = (
+            Decimal(decision_inputs["proposed_position_notional"])
+            if decision_inputs is not None
+            else self._risk_profile.default_paper_quantity * entry_price
+        )
+        quantity = (proposed_notional / entry_price).quantize(
+            Decimal("0.00000001"),
+            rounding=ROUND_HALF_UP,
+        )
         side = _direction_to_order_side(direction)
 
         # --- Execution events ------------------------------------------
@@ -604,6 +764,7 @@ class BoundedPaperExecutionWorker:
             signal_id=signal_id,
             order_id=order_id,
             trade_id=trade_id,
+            decision_inputs=decision_inputs,
         )
 
 
@@ -613,6 +774,10 @@ __all__ = [
     "SignalEvaluationResult",
     "MIN_SCORE_THRESHOLD",
     "MAX_POSITION_PCT",
+    "MAX_RISK_PER_TRADE_PCT",
+    "MIN_TRADE_RISK_PCT",
+    "MAX_TRADE_RISK_PCT",
+    "NOTIONAL_ROUNDING_QUANTUM",
     "MAX_STRATEGY_EXPOSURE_PCT",
     "MAX_SYMBOL_EXPOSURE_PCT",
     "MAX_TOTAL_EXPOSURE_PCT",

--- a/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
+++ b/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
 from typing import Callable, Literal
 
 from cilly_trading.portfolio_framework.contract import PortfolioPosition, PortfolioState
@@ -208,6 +209,108 @@ class PortfolioDecisionResult:
 
 
 BoundedPositionSizingHook = Callable[[PrioritizedAllocationSignal, float], float]
+
+
+@dataclass(frozen=True)
+class DeterministicTradeSizingInput:
+    """Input contract for deterministic per-trade sizing."""
+
+    account_equity: Decimal
+    max_risk_per_trade_pct: Decimal
+    trade_risk_pct: Decimal
+    min_trade_risk_pct: Decimal
+    max_trade_risk_pct: Decimal
+    notional_rounding_quantum: Decimal = Decimal("0.01")
+
+
+@dataclass(frozen=True)
+class DeterministicTradeSizingDecision:
+    """Deterministic position-notional sizing decision."""
+
+    accepted: bool
+    reason_code: str
+    account_equity: Decimal
+    max_risk_per_trade_pct: Decimal
+    trade_risk_pct: Decimal
+    bounded_trade_risk_pct: Decimal
+    risk_budget_notional: Decimal
+    proposed_position_notional: Decimal
+    rounded_position_notional: Decimal
+
+
+def compute_deterministic_trade_notional(
+    sizing_input: DeterministicTradeSizingInput,
+) -> DeterministicTradeSizingDecision:
+    """Compute deterministic per-trade notional from equity and bounded trade risk.
+
+    The function is fail-closed:
+    - missing/invalid inputs return accepted=False with stable reason_code
+    - successful outputs are rounded deterministically using ROUND_HALF_UP
+    """
+
+    invalid_input = _validate_trade_sizing_input(sizing_input)
+    if invalid_input is not None:
+        return DeterministicTradeSizingDecision(
+            accepted=False,
+            reason_code=invalid_input,
+            account_equity=sizing_input.account_equity,
+            max_risk_per_trade_pct=sizing_input.max_risk_per_trade_pct,
+            trade_risk_pct=sizing_input.trade_risk_pct,
+            bounded_trade_risk_pct=Decimal("0"),
+            risk_budget_notional=Decimal("0"),
+            proposed_position_notional=Decimal("0"),
+            rounded_position_notional=Decimal("0"),
+        )
+
+    bounded_trade_risk_pct = min(
+        max(sizing_input.trade_risk_pct, sizing_input.min_trade_risk_pct),
+        sizing_input.max_trade_risk_pct,
+    )
+    risk_budget_notional = sizing_input.account_equity * sizing_input.max_risk_per_trade_pct
+    proposed_position_notional = risk_budget_notional / bounded_trade_risk_pct
+    rounded_position_notional = proposed_position_notional.quantize(
+        sizing_input.notional_rounding_quantum,
+        rounding=ROUND_HALF_UP,
+    )
+
+    if rounded_position_notional <= Decimal("0"):
+        return DeterministicTradeSizingDecision(
+            accepted=False,
+            reason_code="sizing_rejected:non_positive_notional",
+            account_equity=sizing_input.account_equity,
+            max_risk_per_trade_pct=sizing_input.max_risk_per_trade_pct,
+            trade_risk_pct=sizing_input.trade_risk_pct,
+            bounded_trade_risk_pct=bounded_trade_risk_pct,
+            risk_budget_notional=risk_budget_notional,
+            proposed_position_notional=proposed_position_notional,
+            rounded_position_notional=Decimal("0"),
+        )
+
+    realized_risk = rounded_position_notional * bounded_trade_risk_pct
+    if realized_risk > risk_budget_notional:
+        return DeterministicTradeSizingDecision(
+            accepted=False,
+            reason_code="sizing_rejected:max_risk_per_trade_exceeded",
+            account_equity=sizing_input.account_equity,
+            max_risk_per_trade_pct=sizing_input.max_risk_per_trade_pct,
+            trade_risk_pct=sizing_input.trade_risk_pct,
+            bounded_trade_risk_pct=bounded_trade_risk_pct,
+            risk_budget_notional=risk_budget_notional,
+            proposed_position_notional=proposed_position_notional,
+            rounded_position_notional=rounded_position_notional,
+        )
+
+    return DeterministicTradeSizingDecision(
+        accepted=True,
+        reason_code="sizing_accepted",
+        account_equity=sizing_input.account_equity,
+        max_risk_per_trade_pct=sizing_input.max_risk_per_trade_pct,
+        trade_risk_pct=sizing_input.trade_risk_pct,
+        bounded_trade_risk_pct=bounded_trade_risk_pct,
+        risk_budget_notional=risk_budget_notional,
+        proposed_position_notional=proposed_position_notional,
+        rounded_position_notional=rounded_position_notional,
+    )
 
 
 def assess_capital_allocation(
@@ -754,6 +857,29 @@ def _safe_ratio(numerator: float, denominator: float) -> float:
     if denominator == 0.0:
         return 0.0
     return numerator / denominator
+
+
+def _validate_trade_sizing_input(
+    sizing_input: DeterministicTradeSizingInput,
+) -> str | None:
+    if sizing_input.account_equity <= Decimal("0"):
+        return "sizing_rejected:invalid_account_equity"
+    if (
+        sizing_input.max_risk_per_trade_pct <= Decimal("0")
+        or sizing_input.max_risk_per_trade_pct > Decimal("1")
+    ):
+        return "sizing_rejected:invalid_max_risk_per_trade_pct"
+    if sizing_input.trade_risk_pct <= Decimal("0"):
+        return "sizing_rejected:invalid_trade_risk_pct"
+    if (
+        sizing_input.min_trade_risk_pct <= Decimal("0")
+        or sizing_input.max_trade_risk_pct <= Decimal("0")
+        or sizing_input.min_trade_risk_pct > sizing_input.max_trade_risk_pct
+    ):
+        return "sizing_rejected:invalid_trade_risk_bounds"
+    if sizing_input.notional_rounding_quantum <= Decimal("0"):
+        return "sizing_rejected:invalid_rounding_quantum"
+    return None
 
 
 def _append_allocated_position(

--- a/tests/cilly_trading/engine/test_paper_execution_risk_alignment.py
+++ b/tests/cilly_trading/engine/test_paper_execution_risk_alignment.py
@@ -30,6 +30,7 @@ def _signal(
         "score": 90.0,
         "timestamp": timestamp,
         "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.2,
         "signal_id": signal_id,
     }
 
@@ -41,7 +42,7 @@ def test_paper_execution_account_exposure_rejection_uses_canonical_reason(
         repository=repo,
         risk_profile=PaperExecutionRiskProfile(
             account_equity=Decimal("1000"),
-            max_position_pct=Decimal("0.20"),
+            max_risk_per_trade_pct=Decimal("0.02"),
             max_total_exposure_pct=Decimal("0.80"),
             max_strategy_exposure_pct=Decimal("1.00"),
             max_symbol_exposure_pct=Decimal("1.00"),
@@ -73,7 +74,7 @@ def test_paper_execution_strategy_exposure_rejection_uses_canonical_reason(
         repository=repo,
         risk_profile=PaperExecutionRiskProfile(
             account_equity=Decimal("1000"),
-            max_position_pct=Decimal("0.20"),
+            max_risk_per_trade_pct=Decimal("0.02"),
             max_total_exposure_pct=Decimal("1.00"),
             max_strategy_exposure_pct=Decimal("0.20"),
             max_symbol_exposure_pct=Decimal("1.00"),
@@ -98,7 +99,7 @@ def test_paper_execution_symbol_exposure_rejection_uses_canonical_reason(
         repository=repo,
         risk_profile=PaperExecutionRiskProfile(
             account_equity=Decimal("1000"),
-            max_position_pct=Decimal("0.20"),
+            max_risk_per_trade_pct=Decimal("0.02"),
             max_total_exposure_pct=Decimal("1.00"),
             max_strategy_exposure_pct=Decimal("1.00"),
             max_symbol_exposure_pct=Decimal("0.20"),

--- a/tests/engine/test_paper_execution_risk_profile_contract.py
+++ b/tests/engine/test_paper_execution_risk_profile_contract.py
@@ -23,6 +23,7 @@ def _signal(*, signal_id: str, score: float = 90.0) -> Signal:
         "score": score,
         "timestamp": "2026-01-01T00:00:00Z",
         "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.02,
         "signal_id": signal_id,
     }
 
@@ -43,6 +44,13 @@ def test_invalid_profile_values_fail_closed() -> None:
 
     with pytest.raises(ValueError, match="min_score_threshold must be in range"):
         PaperExecutionRiskProfile(min_score_threshold=101.0)
+    with pytest.raises(ValueError, match="max_risk_per_trade_pct must be in range"):
+        PaperExecutionRiskProfile(max_risk_per_trade_pct=Decimal("0"))
+    with pytest.raises(ValueError, match="min_trade_risk_pct must be <= max_trade_risk_pct"):
+        PaperExecutionRiskProfile(
+            min_trade_risk_pct=Decimal("0.21"),
+            max_trade_risk_pct=Decimal("0.20"),
+        )
 
 
 def test_same_profile_and_same_input_produce_same_outcome(tmp_path: Path) -> None:

--- a/tests/engine/test_paper_execution_worker.py
+++ b/tests/engine/test_paper_execution_worker.py
@@ -21,7 +21,11 @@ from cilly_trading.engine.paper_execution_worker import (
     COOLDOWN_HOURS,
     DEFAULT_PAPER_ENTRY_PRICE,
     DEFAULT_PAPER_QUANTITY,
+    MAX_RISK_PER_TRADE_PCT,
+    MAX_TRADE_RISK_PCT,
     MAX_CONCURRENT_POSITIONS,
+    MIN_TRADE_RISK_PCT,
+    NOTIONAL_ROUNDING_QUANTUM,
     MAX_POSITION_PCT,
     MAX_TOTAL_EXPOSURE_PCT,
     MIN_SCORE_THRESHOLD,
@@ -58,6 +62,7 @@ def _make_signal(
     score: float = 75.0,
     timestamp: str = "2024-01-15T10:00:00Z",
     stage: str = "setup",
+    trade_risk_pct: float = 0.20,
     signal_id: str | None = None,
 ) -> Signal:
     sig: Signal = {
@@ -67,6 +72,7 @@ def _make_signal(
         "score": score,
         "timestamp": timestamp,
         "stage": stage,  # type: ignore[typeddict-item]
+        "trade_risk_pct": trade_risk_pct,
     }
     if signal_id is not None:
         sig["signal_id"] = signal_id
@@ -82,6 +88,10 @@ def test_policy_constants_match_documented_defaults() -> None:
     """AC5: policy constants match the values declared in the policy doc."""
     assert MIN_SCORE_THRESHOLD == 60.0
     assert MAX_POSITION_PCT == Decimal("0.10")
+    assert MAX_RISK_PER_TRADE_PCT == Decimal("0.01")
+    assert MIN_TRADE_RISK_PCT == Decimal("0.005")
+    assert MAX_TRADE_RISK_PCT == Decimal("0.20")
+    assert NOTIONAL_ROUNDING_QUANTUM == Decimal("0.01")
     assert MAX_TOTAL_EXPOSURE_PCT == Decimal("0.80")
     assert MAX_CONCURRENT_POSITIONS == 10
     assert COOLDOWN_HOURS == 24
@@ -200,8 +210,8 @@ def test_eligible_signal_creates_order_in_repository(
     assert order.strategy_id == "rsi2"
     assert order.side == "BUY"  # "long" direction → BUY side
     assert order.status == "filled"
-    assert order.quantity == DEFAULT_PAPER_QUANTITY
-    assert order.filled_quantity == DEFAULT_PAPER_QUANTITY
+    assert order.quantity > Decimal("0")
+    assert order.filled_quantity == order.quantity
 
 
 def test_eligible_signal_creates_execution_events_in_repository(
@@ -236,7 +246,7 @@ def test_eligible_signal_creates_open_trade_in_repository(
     assert trade.direction == "long"
     assert trade.symbol == "AAPL"
     assert trade.strategy_id == "rsi2"
-    assert trade.quantity_opened == DEFAULT_PAPER_QUANTITY
+    assert trade.quantity_opened > Decimal("0")
     assert trade.average_entry_price == DEFAULT_PAPER_ENTRY_PRICE
 
 
@@ -251,6 +261,8 @@ def test_eligible_signal_result_contains_signal_and_entity_ids(
     assert result.signal_id == "sig-004"
     assert result.order_id is not None
     assert result.trade_id is not None
+    assert result.decision_inputs is not None
+    assert result.decision_inputs["max_risk_per_trade_pct"] == "0.01"
 
 
 # ---------------------------------------------------------------------------
@@ -504,9 +516,11 @@ def test_total_exposure_limit_enforced(
         repository=repo,
         risk_profile=PaperExecutionRiskProfile(
             account_equity=Decimal("1000"),
+            max_risk_per_trade_pct=Decimal("0.10"),
+            min_trade_risk_pct=Decimal("0.10"),
+            max_trade_risk_pct=Decimal("1.00"),
             max_total_exposure_pct=Decimal("0.80"),
             max_concurrent_positions=20,
-            max_position_pct=Decimal("0.20"),  # 20% of 1000 = 200 > 100 ✓
         ),
     )
 
@@ -517,6 +531,7 @@ def test_total_exposure_limit_enforced(
             symbol=f"SYM{i:02d}",
             signal_id=f"sig-exp-{i:03d}",
             timestamp="2024-03-01T10:00:00Z",
+            trade_risk_pct=1.0,
         )
         result = worker.process_signal(sig)
         if result.outcome == "eligible":
@@ -528,7 +543,7 @@ def test_total_exposure_limit_enforced(
     assert reject_count == 2
 
 
-def test_position_size_limit_enforced(
+def test_max_risk_per_trade_limit_enforced(
     repo: SqliteCanonicalExecutionRepository,
 ) -> None:
     """AC5: proposed position exceeding per-position cap → reject:position_size_exceeds_limit."""
@@ -537,12 +552,49 @@ def test_position_size_limit_enforced(
     worker = BoundedPaperExecutionWorker(
         repository=repo,
         risk_profile=PaperExecutionRiskProfile(
-            account_equity=Decimal("500"),
-            max_position_pct=Decimal("0.10"),
+            account_equity=Decimal("90"),
+            max_risk_per_trade_pct=Decimal("0.0001"),
+            min_trade_risk_pct=Decimal("0.005"),
+            max_trade_risk_pct=Decimal("0.20"),
         ),
     )
-    result = worker.process_signal(_make_signal(signal_id="sig-pos-001"))
-    assert result.outcome == "reject:position_size_exceeds_limit"
+    result = worker.process_signal(_make_signal(signal_id="sig-pos-001", trade_risk_pct=0.20))
+    assert result.outcome == "reject:max_risk_per_trade_exceeded"
+
+
+def test_missing_trade_risk_input_is_rejected_fail_closed(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    signal = _make_signal(signal_id="sig-missing-trade-risk")
+    del signal["trade_risk_pct"]
+    result = worker.process_signal(signal)
+    assert result.outcome == "reject:missing_trade_risk_input"
+
+
+def test_invalid_trade_risk_input_is_rejected_fail_closed(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    signal = _make_signal(signal_id="sig-invalid-trade-risk")
+    signal["trade_risk_pct"] = -0.1
+    result = worker.process_signal(signal)
+    assert result.outcome == "reject:invalid_trade_risk_input"
+
+
+def test_identical_inputs_produce_identical_reason_codes_and_sizing_payloads(
+    repo: SqliteCanonicalExecutionRepository,
+) -> None:
+    worker_a = BoundedPaperExecutionWorker(repository=repo)
+    worker_b = BoundedPaperExecutionWorker(repository=repo)
+    signal = _make_signal(signal_id="sig-deterministic-reject")
+    del signal["trade_risk_pct"]
+
+    result_a = worker_a.process_signal(signal)
+    result_b = worker_b.process_signal(signal)
+
+    assert result_a.outcome == "reject:missing_trade_risk_input"
+    assert result_b.outcome == "reject:missing_trade_risk_input"
+    assert result_a.reason == result_b.reason
+    assert result_a.decision_inputs == result_b.decision_inputs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/portfolio/test_capital_allocation_policy.py
+++ b/tests/portfolio/test_capital_allocation_policy.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from cilly_trading.portfolio_framework.capital_allocation_policy import (
+    CapitalAllocationRules,
+    DeterministicTradeSizingInput,
     PrioritizedAllocationConfig,
     PrioritizedAllocationSignal,
-    CapitalAllocationRules,
     StrategyAllocationRule,
     allocate_prioritized_signals,
     assess_capital_allocation,
+    compute_deterministic_trade_notional,
 )
 from cilly_trading.portfolio_framework.contract import PortfolioPosition, PortfolioState
 
@@ -315,3 +319,66 @@ def test_regression_input_permutation_and_bounded_sizing_hook_remain_determinist
     assert result_a.accepted_signal_ids == ("sig-y", "sig-x")
     assert result_a.total_allocated_notional == 130.0
     assert result_a.remaining_capital_notional == 70.0
+
+
+def test_trade_sizing_computes_deterministic_notional_from_risk_budget() -> None:
+    decision = compute_deterministic_trade_notional(
+        DeterministicTradeSizingInput(
+            account_equity=Decimal("100000"),
+            max_risk_per_trade_pct=Decimal("0.01"),
+            trade_risk_pct=Decimal("0.02"),
+            min_trade_risk_pct=Decimal("0.005"),
+            max_trade_risk_pct=Decimal("0.20"),
+            notional_rounding_quantum=Decimal("0.01"),
+        )
+    )
+
+    assert decision.accepted is True
+    assert decision.reason_code == "sizing_accepted"
+    assert decision.risk_budget_notional == Decimal("1000.00")
+    assert decision.rounded_position_notional == Decimal("50000.00")
+
+
+def test_trade_sizing_rejects_zero_or_negative_inputs_fail_closed() -> None:
+    invalid_equity = compute_deterministic_trade_notional(
+        DeterministicTradeSizingInput(
+            account_equity=Decimal("0"),
+            max_risk_per_trade_pct=Decimal("0.01"),
+            trade_risk_pct=Decimal("0.02"),
+            min_trade_risk_pct=Decimal("0.005"),
+            max_trade_risk_pct=Decimal("0.20"),
+            notional_rounding_quantum=Decimal("0.01"),
+        )
+    )
+    invalid_trade_risk = compute_deterministic_trade_notional(
+        DeterministicTradeSizingInput(
+            account_equity=Decimal("100000"),
+            max_risk_per_trade_pct=Decimal("0.01"),
+            trade_risk_pct=Decimal("-0.02"),
+            min_trade_risk_pct=Decimal("0.005"),
+            max_trade_risk_pct=Decimal("0.20"),
+            notional_rounding_quantum=Decimal("0.01"),
+        )
+    )
+
+    assert invalid_equity.accepted is False
+    assert invalid_equity.reason_code == "sizing_rejected:invalid_account_equity"
+    assert invalid_trade_risk.accepted is False
+    assert invalid_trade_risk.reason_code == "sizing_rejected:invalid_trade_risk_pct"
+
+
+def test_trade_sizing_applies_deterministic_rounding() -> None:
+    decision = compute_deterministic_trade_notional(
+        DeterministicTradeSizingInput(
+            account_equity=Decimal("10000"),
+            max_risk_per_trade_pct=Decimal("0.01"),
+            trade_risk_pct=Decimal("0.03"),
+            min_trade_risk_pct=Decimal("0.005"),
+            max_trade_risk_pct=Decimal("0.20"),
+            notional_rounding_quantum=Decimal("0.01"),
+        )
+    )
+
+    assert decision.accepted is True
+    assert decision.proposed_position_notional == Decimal("3333.333333333333333333333333")
+    assert decision.rounded_position_notional == Decimal("3333.33")


### PR DESCRIPTION
Closes #981

## What changed
- Added deterministic trade-level sizing based on account equity, max risk per trade, and bounded trade-risk input.
- Added fail-closed validation for missing, invalid, zero, and negative sizing inputs.
- Enforced deterministic paper-entry rejection for:
  - max risk per trade
  - max total portfolio exposure
  - max strategy exposure
  - max symbol exposure
  - max concurrent positions
- Added explicit machine-readable rejection reason codes for deterministic inspection.
- Exposed sizing and cap-evaluation inputs in non-UI decision artifacts.
- Updated bounded runtime and portfolio-framework documentation with explicit technical-only semantics.
- Added deterministic unit, decision-path, regression, and documentation contract coverage.

## Scope guarantees
- No UI changes
- No /ui changes
- No frontend changes
- No broker integration
- No live trading
- No new strategy types
- No portfolio optimization engine expansion

## Governance result
- Active Issue: #981
- Classification: technically good
- Trader validation status: trader_validation_not_started
- Operational status: bounded technical implementation only; not live-ready