### PR TITLE
[SIGNAL-VALIDATION][02] Add bounded expected-value validation and deterministic decision actions for paper evaluation (#979)

### DIFF
--- a/docs/governance/signal-quality-bounded-contract.md
+++ b/docs/governance/signal-quality-bounded-contract.md
@@ -34,6 +34,38 @@ Within this repository, "signal quality" is bounded to three implementation-leve
 This contract evaluates ordering and filtering consistency only. It does not evaluate
 market edge, profitability, or production trading outcomes.
 
+## Bounded Win-Rate and Expected-Value Evidence
+
+For paper-evaluation qualification output, bounded signal-quality evidence also includes:
+
+- bounded win-rate formula: `win_rate=((signal_quality*0.60)+(backtest_quality*0.40))/100`
+- bounded expected-value formula:
+  `expected_value=(win_rate*bounded_reward_multiplier)-(1-win_rate)`
+  where `bounded_reward_multiplier=clamp((risk_alignment+execution_readiness)/100,0.50,1.50)`
+
+Both values are deterministic, clamped (`win_rate` in `[0,1]`, `expected_value` in `[-1,1]`), and
+derived only from existing bounded component evidence. They are technical evidence fields only.
+
+## Deterministic Action Boundary
+
+The qualification output includes one deterministic paper-evaluation action:
+
+- `entry`
+- `exit`
+- `ignore`
+
+Deterministic paper-evaluation action is resolved with hard gates plus bounded aggregate,
+win-rate, and expected-value evidence:
+
+1. blocking hard-gate failure -> `ignore`
+2. negative expected value -> `exit` (never `entry`)
+3. qualified (`paper_candidate`/`paper_approved`) with weak bounded win-rate (`<= 0.50`) -> `exit`
+4. qualified with bounded win-rate (`>= 0.55`) and non-negative expected value -> `entry`
+5. otherwise -> `ignore`
+
+These action semantics are bounded to paper evaluation and must not be interpreted as
+live-trading authorization.
+
 ## Deterministic Ranking Boundary
 
 For setup-stage candidates that meet the configured score floor, ranking is deterministic:

--- a/docs/governance/strategy-readiness-gates.md
+++ b/docs/governance/strategy-readiness-gates.md
@@ -132,6 +132,16 @@ Bounded API/UI evidence semantics:
 - operational-readiness evidence state is surfaced separately and must remain independent from technical and trader-validation evidence
 - API/UI outputs must not collapse these states into a single inferred readiness claim
 
+Decision-evidence status boundary for qualification outputs:
+
+- qualification and action outputs may include `technical_implementation_status` as technical-only evidence metadata
+- qualification and action outputs may include `trader_validation_status` as independent trader-validation metadata
+- technical and trader-validation statuses must remain explicit, separate fields
+- default bounded interpretation for current paper-evaluation action evidence:
+  - technical implementation status may be `technical_in_progress`
+  - trader validation status may remain `trader_validation_not_started`
+- action outputs (`entry`, `exit`, `ignore`) are deterministic technical evidence and are not trader sign-off
+
 Non-live and governance boundary for this scope:
 
 - no live-trading readiness or authorization claim

--- a/docs/phases/dec-p49-canonical-decision-card-contract.md
+++ b/docs/phases/dec-p49-canonical-decision-card-contract.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Define the canonical decision-card contract with explicit hard-gate behavior, bounded component-score semantics, and bounded qualification state semantics.
+Define the canonical decision-card contract with explicit hard-gate behavior, bounded component-score semantics, bounded expected-value and win-rate semantics, bounded deterministic decision actions, and bounded qualification state semantics.
 
 ## Canonical Runtime Contract
 
@@ -17,6 +17,7 @@ The contract is canonical and deterministic:
 1. hard gates are explicit and independently represented
 2. component scores are explicit, category-complete, and bounded
 3. qualification state is bounded and deterministically resolved from gate + score semantics
+4. decision action is explicit and deterministically resolved for paper evaluation
 
 ## Hard-Gate Behavior
 
@@ -38,6 +39,28 @@ The contract is canonical and deterministic:
 - aggregate score range is bounded to `[0, 100]`
 - confidence tier is bounded (`low` | `medium` | `high`)
 - confidence reason is evidence-bounded and rejects unsupported inflation language
+- win-rate evidence is bounded to `[0, 1]` and derived from deterministic component inputs
+- expected-value evidence is bounded to `[-1, 1]` and derived from deterministic component inputs
+- documented formulas:
+  - `win_rate=((signal_quality*0.60)+(backtest_quality*0.40))/100`
+  - `expected_value=(win_rate*bounded_reward_multiplier)-(1-win_rate)`
+  - `bounded_reward_multiplier=clamp((risk_alignment+execution_readiness)/100,0.50,1.50)`
+
+## Decision Action Semantics
+
+Action vocabulary is bounded:
+
+- `entry`
+- `exit`
+- `ignore`
+
+Deterministic action resolution is contract-enforced:
+
+1. blocking hard-gate failure -> `ignore`
+2. negative expected value -> `exit` (must not resolve to `entry`)
+3. qualified (`paper_candidate`/`paper_approved`) with bounded win-rate `<= 0.50` -> `exit`
+4. qualified with bounded win-rate `>= 0.55` and non-negative expected value -> `entry`
+5. otherwise -> `ignore`
 
 ## Qualification-State Semantics
 
@@ -70,6 +93,7 @@ Inspection wording aligns with the canonical contract by requiring:
 - bounded component and aggregate scoring language
 - bounded paper-trading qualification wording
 - explicit non-implication of live-trading approval
+- explicit technical implementation evidence status separate from trader validation status
 
 ## Non-Goals
 

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -11,6 +11,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 DECISION_CARD_CONTRACT_VERSION = "2.0.0"
 QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD = 60.0
 QUALIFICATION_HIGH_AGGREGATE_THRESHOLD = 80.0
+ACTION_EXIT_WIN_RATE_MAX = 0.50
+ACTION_ENTRY_WIN_RATE_MIN = 0.55
 
 CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY = (
     "Decision-card scores are bounded to within-strategy evaluation for a single opportunity. "
@@ -41,6 +43,7 @@ DecisionConfidenceTier = Literal["low", "medium", "high"]
 HardGateStatus = Literal["pass", "fail"]
 QualificationState = Literal["reject", "watch", "paper_candidate", "paper_approved"]
 QualificationColor = Literal["green", "yellow", "red"]
+DecisionAction = Literal["entry", "exit", "ignore"]
 
 REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
     "signal_quality",
@@ -74,6 +77,7 @@ CLAIM_BOUNDARY_FORBIDDEN_PHRASES: tuple[str, ...] = (
     "broker-ready",
     "trader validated",
     "trader-validated",
+    "trader validation",
     "guaranteed",
     "guarantee",
     "certain outcome",
@@ -81,6 +85,8 @@ CLAIM_BOUNDARY_FORBIDDEN_PHRASES: tuple[str, ...] = (
     "confirmed opportunity",
     "validated outcome",
     "strong certainty",
+    "live approval",
+    "production readiness",
 )
 
 
@@ -90,6 +96,71 @@ def _contains_forbidden_claim_phrase(value: str) -> str | None:
         if phrase in normalized:
             return phrase
     return None
+
+
+def _derive_bounded_win_rate_from_components(component_scores: list[dict[str, Any]]) -> float:
+    by_category: dict[str, float] = {}
+    for component in component_scores:
+        category = component.get("category")
+        score = component.get("score")
+        if isinstance(category, str):
+            try:
+                by_category[category] = float(score)
+            except (TypeError, ValueError):
+                continue
+    signal_quality = by_category.get("signal_quality", 0.0)
+    backtest_quality = by_category.get("backtest_quality", 0.0)
+    bounded = ((signal_quality * 0.60) + (backtest_quality * 0.40)) / 100.0
+    return max(0.0, min(1.0, round(bounded, 4)))
+
+
+def _derive_bounded_expected_value_from_components(
+    *,
+    component_scores: list[dict[str, Any]],
+    win_rate: float,
+) -> float:
+    by_category: dict[str, float] = {}
+    for component in component_scores:
+        category = component.get("category")
+        score = component.get("score")
+        if isinstance(category, str):
+            try:
+                by_category[category] = float(score)
+            except (TypeError, ValueError):
+                continue
+    risk_alignment = by_category.get("risk_alignment", 0.0)
+    execution_readiness = by_category.get("execution_readiness", 0.0)
+    reward_multiplier = (risk_alignment + execution_readiness) / 100.0
+    bounded_reward_multiplier = max(0.50, min(1.50, reward_multiplier))
+    expected_value = (win_rate * bounded_reward_multiplier) - (1.0 - win_rate)
+    return max(-1.0, min(1.0, round(expected_value, 4)))
+
+
+def _derive_decision_action_from_fields(
+    *,
+    has_blocking_failure: bool,
+    qualification_state: str | None,
+    confidence_tier: str | None,
+    aggregate_score: float | None,
+    win_rate: float,
+    expected_value: float,
+) -> DecisionAction:
+    if has_blocking_failure:
+        return "ignore"
+    if expected_value < 0.0:
+        return "exit"
+    if qualification_state in {"paper_candidate", "paper_approved"} and win_rate <= ACTION_EXIT_WIN_RATE_MAX:
+        return "exit"
+    if (
+        confidence_tier == "low"
+        or aggregate_score is None
+        or aggregate_score < QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD
+        or qualification_state in {"reject", "watch"}
+    ):
+        return "ignore"
+    if qualification_state in {"paper_candidate", "paper_approved"} and win_rate >= ACTION_ENTRY_WIN_RATE_MIN:
+        return "entry"
+    return "ignore"
 
 
 class HardGateResult(BaseModel):
@@ -162,6 +233,8 @@ class ScoreEvaluation(BaseModel):
     confidence_tier: DecisionConfidenceTier
     confidence_reason: str = Field(min_length=8)
     aggregate_score: float = Field(ge=0.0, le=100.0)
+    win_rate: float = Field(ge=0.0, le=1.0)
+    expected_value: float = Field(ge=-1.0, le=1.0)
 
     @field_validator("component_scores")
     @classmethod
@@ -271,9 +344,67 @@ class DecisionCard(BaseModel):
     strategy_id: str = Field(min_length=1)
     hard_gates: HardGateEvaluation
     score: ScoreEvaluation
+    action: DecisionAction
     qualification: Qualification
     rationale: DecisionRationale
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _hydrate_compatibility_fields(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        payload = dict(data)
+        score_payload = dict(payload.get("score") or {})
+        component_scores = score_payload.get("component_scores")
+        if not isinstance(component_scores, list):
+            component_scores = []
+
+        win_rate_value = score_payload.get("win_rate")
+        if win_rate_value is None:
+            win_rate = _derive_bounded_win_rate_from_components(component_scores)
+            score_payload["win_rate"] = win_rate
+        else:
+            win_rate = float(win_rate_value)
+
+        expected_value_value = score_payload.get("expected_value")
+        if expected_value_value is None:
+            expected_value = _derive_bounded_expected_value_from_components(
+                component_scores=component_scores,
+                win_rate=win_rate,
+            )
+            score_payload["expected_value"] = expected_value
+        else:
+            expected_value = float(expected_value_value)
+
+        payload["score"] = score_payload
+        if payload.get("action") is None:
+            hard_gates_payload = dict(payload.get("hard_gates") or {})
+            gate_items = hard_gates_payload.get("gates")
+            has_blocking_failure = False
+            if isinstance(gate_items, list):
+                has_blocking_failure = any(
+                    isinstance(gate, dict)
+                    and gate.get("status") == "fail"
+                    and gate.get("blocking", True) is True
+                    for gate in gate_items
+                )
+            qualification_payload = dict(payload.get("qualification") or {})
+            qualification_state = qualification_payload.get("state")
+            confidence_tier = score_payload.get("confidence_tier")
+            aggregate_score_value = score_payload.get("aggregate_score")
+            aggregate_score = (
+                float(aggregate_score_value) if aggregate_score_value is not None else None
+            )
+            payload["action"] = _derive_decision_action_from_fields(
+                has_blocking_failure=has_blocking_failure,
+                qualification_state=qualification_state,
+                confidence_tier=confidence_tier,
+                aggregate_score=aggregate_score,
+                win_rate=win_rate,
+                expected_value=expected_value,
+            )
+        return payload
 
     @field_validator("contract_version")
     @classmethod
@@ -317,6 +448,14 @@ class DecisionCard(BaseModel):
             )
         if self.hard_gates.has_blocking_failure and self.qualification.color != "red":
             raise ValueError("Blocking hard-gate failures require red qualification color")
+        if self.action == "entry" and self.score.expected_value < 0.0:
+            raise ValueError("Negative expected value must not resolve to entry action")
+        expected_action = self._expected_decision_action()
+        if self.action != expected_action:
+            raise ValueError(
+                "Decision action must match deterministic resolution "
+                f"(expected={expected_action}, actual={self.action})"
+            )
         return self
 
     def _expected_qualification_state(self) -> QualificationState:
@@ -333,6 +472,29 @@ class DecisionCard(BaseModel):
         ):
             return "paper_approved"
         return "paper_candidate"
+
+    def _expected_decision_action(self) -> DecisionAction:
+        if self.hard_gates.has_blocking_failure:
+            return "ignore"
+        if self.score.expected_value < 0.0:
+            return "exit"
+        if (
+            self.qualification.state in {"paper_candidate", "paper_approved"}
+            and self.score.win_rate <= ACTION_EXIT_WIN_RATE_MAX
+        ):
+            return "exit"
+        if (
+            self.score.confidence_tier == "low"
+            or self.score.aggregate_score < QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD
+            or self.qualification.state in {"reject", "watch"}
+        ):
+            return "ignore"
+        if (
+            self.qualification.state in {"paper_candidate", "paper_approved"}
+            and self.score.win_rate >= ACTION_ENTRY_WIN_RATE_MIN
+        ):
+            return "entry"
+        return "ignore"
 
     def to_canonical_payload(self) -> dict[str, Any]:
         return self.model_dump(mode="python")
@@ -365,8 +527,11 @@ __all__ = [
     "QUALIFICATION_HIGH_AGGREGATE_THRESHOLD",
     "QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD",
     "REQUIRED_COMPONENT_CATEGORIES",
+    "ACTION_ENTRY_WIN_RATE_MIN",
+    "ACTION_EXIT_WIN_RATE_MAX",
     "QUALIFICATION_COLOR_BY_STATE",
     "ComponentScore",
+    "DecisionAction",
     "DecisionCard",
     "DecisionRationale",
     "HardGateEvaluation",

--- a/src/cilly_trading/engine/qualification_engine.py
+++ b/src/cilly_trading/engine/qualification_engine.py
@@ -6,12 +6,15 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from cilly_trading.engine.decision_card_contract import (
+    ACTION_ENTRY_WIN_RATE_MIN,
+    ACTION_EXIT_WIN_RATE_MAX,
     DECISION_CARD_CONTRACT_VERSION,
     CONFIDENCE_TIER_PRECISION_DISCLAIMER,
     UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND,
     REQUIRED_COMPONENT_CATEGORIES,
     ComponentScore,
     DecisionCard,
+    DecisionAction,
     DecisionComponentCategory,
     DecisionConfidenceTier,
     HardGateEvaluation,
@@ -40,6 +43,12 @@ CONFIDENCE_THRESHOLDS: dict[str, float] = {
 
 SENTIMENT_OVERLAY_MAX_POINTS = 4.0
 SENTIMENT_DEFAULT_STALE_AFTER_HOURS = 24
+WIN_RATE_SIGNAL_QUALITY_WEIGHT = 0.60
+WIN_RATE_BACKTEST_QUALITY_WEIGHT = 0.40
+EXPECTED_VALUE_REWARD_MULTIPLIER_MIN = 0.50
+EXPECTED_VALUE_REWARD_MULTIPLIER_MAX = 1.50
+EXPECTED_VALUE_MIN = -1.0
+EXPECTED_VALUE_MAX = 1.0
 
 
 @dataclass(frozen=True)
@@ -111,10 +120,23 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         component_scores=integrated_component_scores,
     )
     confidence_reason = _confidence_reason(confidence_tier=confidence_tier, aggregate_score=aggregate_score)
+    win_rate = compute_bounded_win_rate(component_scores=integrated_component_scores)
+    expected_value = compute_bounded_expected_value(
+        component_scores=integrated_component_scores,
+        win_rate=win_rate,
+    )
     state, color, qualification_summary = resolve_qualification_state(
         hard_gate_evaluation=hard_gate_evaluation,
         aggregate_score=aggregate_score,
         confidence_tier=confidence_tier,
+    )
+    action = resolve_decision_action(
+        hard_gate_evaluation=hard_gate_evaluation,
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+        qualification_state=state,
+        win_rate=win_rate,
+        expected_value=expected_value,
     )
     payload = {
         "contract_version": DECISION_CARD_CONTRACT_VERSION,
@@ -137,7 +159,10 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             "confidence_tier": confidence_tier,
             "confidence_reason": confidence_reason,
             "aggregate_score": aggregate_score,
+            "win_rate": win_rate,
+            "expected_value": expected_value,
         },
+        "action": action,
         "qualification": {
             "state": state,
             "color": color,
@@ -151,19 +176,26 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
                 base_aggregate_score=base_aggregate_score,
                 aggregate_score=aggregate_score,
                 confidence_tier=confidence_tier,
+                win_rate=win_rate,
+                expected_value=expected_value,
+                action=action,
                 sentiment_resolution=sentiment_resolution,
                 backtest_input_applied=input_data.backtest_evidence is not None,
                 portfolio_fit_input_applied=input_data.portfolio_fit_input is not None,
             ),
             "final_explanation": (
-                "Action state is deterministic and does not imply live-trading approval; "
-                "it indicates reject, watch, paper candidate, or paper approved."
+                "Decision action and qualification are deterministic technical implementation evidence "
+                "and does not imply live-trading approval. Validation gate status remains explicitly "
+                "separate and defaults to trader_validation_not_started unless governed evidence is recorded."
             ),
         },
         "metadata": _build_metadata(
             input_data=input_data,
             base_aggregate_score=base_aggregate_score,
             sentiment_resolution=sentiment_resolution,
+            win_rate=win_rate,
+            expected_value=expected_value,
+            action=action,
         ),
     }
     return validate_decision_card(payload)
@@ -305,6 +337,34 @@ def assign_confidence_tier(
     return "low"
 
 
+def compute_bounded_win_rate(*, component_scores: list[ComponentScore]) -> float:
+    """Compute bounded win-rate evidence in [0, 1] from deterministic component inputs."""
+    score_by_category = {component.category: float(component.score) for component in component_scores}
+    weighted_score = (
+        (score_by_category["signal_quality"] * WIN_RATE_SIGNAL_QUALITY_WEIGHT)
+        + (score_by_category["backtest_quality"] * WIN_RATE_BACKTEST_QUALITY_WEIGHT)
+    )
+    return max(0.0, min(1.0, round(weighted_score / 100.0, 4)))
+
+
+def compute_bounded_expected_value(
+    *,
+    component_scores: list[ComponentScore],
+    win_rate: float,
+) -> float:
+    """Compute bounded expected value in [-1, 1] from win-rate and reward multiplier evidence."""
+    score_by_category = {component.category: float(component.score) for component in component_scores}
+    reward_multiplier = (
+        score_by_category["risk_alignment"] + score_by_category["execution_readiness"]
+    ) / 100.0
+    bounded_reward_multiplier = max(
+        EXPECTED_VALUE_REWARD_MULTIPLIER_MIN,
+        min(EXPECTED_VALUE_REWARD_MULTIPLIER_MAX, reward_multiplier),
+    )
+    expected_value = (win_rate * bounded_reward_multiplier) - (1.0 - win_rate)
+    return max(EXPECTED_VALUE_MIN, min(EXPECTED_VALUE_MAX, round(expected_value, 4)))
+
+
 def resolve_qualification_state(
     *,
     hard_gate_evaluation: HardGateEvaluation,
@@ -335,6 +395,29 @@ def resolve_qualification_state(
         "yellow",
         "Opportunity is a paper-trading candidate but not yet approved.",
     )
+
+
+def resolve_decision_action(
+    *,
+    hard_gate_evaluation: HardGateEvaluation,
+    aggregate_score: float,
+    confidence_tier: DecisionConfidenceTier,
+    qualification_state: DecisionActionState,
+    win_rate: float,
+    expected_value: float,
+) -> DecisionAction:
+    """Resolve deterministic paper-evaluation action from bounded evidence fields."""
+    if hard_gate_evaluation.has_blocking_failure:
+        return "ignore"
+    if expected_value < 0.0:
+        return "exit"
+    if qualification_state in {"paper_candidate", "paper_approved"} and win_rate <= ACTION_EXIT_WIN_RATE_MAX:
+        return "exit"
+    if confidence_tier == "low" or aggregate_score < CONFIDENCE_THRESHOLDS["medium_aggregate"]:
+        return "ignore"
+    if qualification_state in {"paper_candidate", "paper_approved"} and win_rate >= ACTION_ENTRY_WIN_RATE_MIN:
+        return "entry"
+    return "ignore"
 
 
 def _confidence_reason(*, confidence_tier: DecisionConfidenceTier, aggregate_score: float) -> str:
@@ -377,6 +460,9 @@ def _score_explanations(
     base_aggregate_score: float,
     aggregate_score: float,
     confidence_tier: DecisionConfidenceTier,
+    win_rate: float,
+    expected_value: float,
+    action: DecisionAction,
     sentiment_resolution: SentimentOverlayResolution,
     backtest_input_applied: bool,
     portfolio_fit_input_applied: bool,
@@ -390,12 +476,29 @@ def _score_explanations(
         f"Portfolio-fit input path is {'explicitly integrated' if portfolio_fit_input_applied else 'not provided; component value is used as-is'}.",
         f"Bounded weighted aggregate score={base_aggregate_score:.4f} using fixed category weights.",
         (
+            "Bounded win-rate formula: "
+            "win_rate=((signal_quality*0.60)+(backtest_quality*0.40))/100 -> "
+            f"{win_rate:.4f}."
+        ),
+        (
+            "Bounded expected-value formula: "
+            "expected_value=(win_rate*bounded_reward_multiplier)-(1-win_rate), "
+            "bounded_reward_multiplier=clamp((risk_alignment+execution_readiness)/100,0.50,1.50) -> "
+            f"{expected_value:.4f}."
+        ),
+        (
             f"Sentiment overlay status={sentiment_resolution.status}, points={sentiment_resolution.points:.4f}, "
             f"cap={sentiment_resolution.cap_points:.4f}."
         ),
         f"Final aggregate score after sentiment overlay={aggregate_score:.4f}.",
         f"Component scores by category: {component_summary}.",
         f"Confidence tier resolved deterministically as {confidence_tier}.",
+        (
+            "Action rules: blocking hard-gate failure -> ignore; negative expected value -> exit; "
+            f"qualified win_rate <= {ACTION_EXIT_WIN_RATE_MAX:.2f} -> exit; "
+            f"qualified win_rate >= {ACTION_ENTRY_WIN_RATE_MIN:.2f} with non-negative expected value -> entry; "
+            f"else ignore. Resolved action={action}."
+        ),
     ]
 
 
@@ -404,6 +507,9 @@ def _build_metadata(
     input_data: QualificationEngineInput,
     base_aggregate_score: float,
     sentiment_resolution: SentimentOverlayResolution,
+    win_rate: float,
+    expected_value: float,
+    action: DecisionAction,
 ) -> dict[str, object]:
     metadata = dict(input_data.metadata or {})
     metadata["base_aggregate_score"] = base_aggregate_score
@@ -415,6 +521,16 @@ def _build_metadata(
     metadata["sentiment_overlay_reason"] = sentiment_resolution.reason
     if sentiment_resolution.sentiment_score is not None:
         metadata["sentiment_overlay_score"] = sentiment_resolution.sentiment_score
+    metadata["win_rate"] = win_rate
+    metadata["expected_value"] = expected_value
+    metadata["decision_action"] = action
+    metadata["decision_action_policy_version"] = "paper-action.v1"
+    metadata["technical_implementation_status"] = metadata.get(
+        "technical_implementation_status", "technical_in_progress"
+    )
+    metadata["trader_validation_status"] = metadata.get(
+        "trader_validation_status", "trader_validation_not_started"
+    )
     return dict(sorted(metadata.items()))
 
 
@@ -430,7 +546,10 @@ __all__ = [
     "SENTIMENT_DEFAULT_STALE_AFTER_HOURS",
     "SENTIMENT_OVERLAY_MAX_POINTS",
     "assign_confidence_tier",
+    "compute_bounded_expected_value",
+    "compute_bounded_win_rate",
     "compute_aggregate_score",
     "evaluate_qualification",
+    "resolve_decision_action",
     "resolve_qualification_state",
 ]

--- a/tests/cilly_trading/engine/test_decision_card_contract.py
+++ b/tests/cilly_trading/engine/test_decision_card_contract.py
@@ -14,7 +14,12 @@ from cilly_trading.engine.decision_card_contract import (
 )
 
 
-def _valid_payload(*, qualification_state: str = "paper_candidate", qualification_color: str = "yellow") -> dict[str, Any]:
+def _valid_payload(
+    *,
+    qualification_state: str = "paper_candidate",
+    qualification_color: str = "yellow",
+    action: str = "entry",
+) -> dict[str, Any]:
     return {
         "contract_version": DECISION_CARD_CONTRACT_VERSION,
         "decision_card_id": "dc_20260324_AAPL_RSI2",
@@ -76,7 +81,10 @@ def _valid_payload(*, qualification_state: str = "paper_candidate", qualificatio
             "confidence_tier": "high",
             "confidence_reason": "Aggregate score and component thresholds support high confidence with explicit evidence.",
             "aggregate_score": 79.0,
+            "win_rate": 0.58,
+            "expected_value": 0.0564,
         },
+        "action": action,
         "qualification": {
             "state": qualification_state,
             "color": qualification_color,
@@ -110,6 +118,9 @@ def test_decision_card_model_validation_representative_payload() -> None:
     assert card.contract_version == DECISION_CARD_CONTRACT_VERSION
     assert card.hard_gates.has_blocking_failure is False
     assert card.score.aggregate_score == 79.0
+    assert card.score.win_rate == 0.58
+    assert card.score.expected_value == 0.0564
+    assert card.action == "entry"
     assert [component.category for component in card.score.component_scores] == [
         "backtest_quality",
         "execution_readiness",
@@ -158,16 +169,16 @@ def test_negative_validation_rejects_non_rejected_state_on_blocking_failure() ->
 
 
 @pytest.mark.parametrize(
-    ("state", "color"),
+    ("state", "color", "action"),
     [
-        ("paper_approved", "green"),
-        ("paper_candidate", "yellow"),
-        ("watch", "yellow"),
-        ("reject", "red"),
+        ("paper_approved", "green", "entry"),
+        ("paper_candidate", "yellow", "entry"),
+        ("watch", "yellow", "ignore"),
+        ("reject", "red", "ignore"),
     ],
 )
-def test_representative_qualification_payloads_validate(state: str, color: str) -> None:
-    payload = _valid_payload(qualification_state=state, qualification_color=color)
+def test_representative_qualification_payloads_validate(state: str, color: str, action: str) -> None:
+    payload = _valid_payload(qualification_state=state, qualification_color=color, action=action)
     if state == "reject":
         payload["hard_gates"]["gates"][0]["status"] = "fail"
         payload["hard_gates"]["gates"][0]["failure_reason"] = "Risk cap breach"
@@ -179,6 +190,7 @@ def test_representative_qualification_payloads_validate(state: str, color: str) 
         payload["score"]["confidence_reason"] = (
             "Aggregate score or component threshold evidence is below medium confidence."
         )
+        payload["score"]["aggregate_score"] = 58.0
         payload["qualification"]["summary"] = (
             "Opportunity requires further evidence before paper-trading qualification."
         )
@@ -216,6 +228,8 @@ def test_representative_qualification_payloads_validate(state: str, color: str) 
             },
         ]
         payload["score"]["aggregate_score"] = 86.2
+        payload["score"]["win_rate"] = 0.66
+        payload["score"]["expected_value"] = 0.2872
         payload["score"]["confidence_tier"] = "high"
         payload["score"]["confidence_reason"] = (
             "Aggregate score and component thresholds satisfy high confidence with explicit evidence."
@@ -297,3 +311,31 @@ def test_confidence_inflation_phrases_are_rejected() -> None:
         )
         with pytest.raises(ValidationError, match="confidence_reason contains unsupported claim language"):
             validate_decision_card(payload)
+
+
+def test_negative_validation_rejects_negative_expected_value_entry_action() -> None:
+    payload = _valid_payload(action="entry")
+    payload["score"]["expected_value"] = -0.01
+
+    with pytest.raises(ValidationError, match="Negative expected value must not resolve to entry action"):
+        validate_decision_card(payload)
+
+
+def test_negative_validation_rejects_action_that_violates_deterministic_resolution() -> None:
+    payload = _valid_payload(qualification_state="watch", qualification_color="yellow", action="entry")
+    payload["score"]["confidence_tier"] = "low"
+    payload["score"]["aggregate_score"] = 55.0
+
+    with pytest.raises(ValidationError, match="Decision action must match deterministic resolution"):
+        validate_decision_card(payload)
+
+
+@pytest.mark.parametrize("forbidden_phrase", ["trader validation", "live approval", "production readiness"])
+def test_negative_validation_rejects_additional_forbidden_claim_phrases(forbidden_phrase: str) -> None:
+    payload = _valid_payload()
+    payload["score"]["confidence_reason"] = (
+        f"Aggregate component threshold evidence supports confidence without {forbidden_phrase}."
+    )
+
+    with pytest.raises(ValidationError, match="confidence_reason contains unsupported claim language"):
+        validate_decision_card(payload)

--- a/tests/decision/test_decision_integration_layer.py
+++ b/tests/decision/test_decision_integration_layer.py
@@ -7,6 +7,8 @@ from cilly_trading.engine.qualification_engine import (
     QualificationEngineInput,
     SENTIMENT_OVERLAY_MAX_POINTS,
     SentimentOverlayInput,
+    compute_bounded_expected_value,
+    compute_bounded_win_rate,
     evaluate_qualification,
 )
 
@@ -67,6 +69,8 @@ def _base_hard_gates() -> list[HardGateResult]:
 
 def _engine_input(
     *,
+    hard_gates: list[HardGateResult] | None = None,
+    component_scores: list[ComponentScore] | None = None,
     backtest_evidence: BacktestEvidenceInput | None = None,
     portfolio_fit_input: PortfolioFitInput | None = None,
     sentiment_overlay: SentimentOverlayInput | None = None,
@@ -76,8 +80,8 @@ def _engine_input(
         generated_at_utc="2026-03-29T10:00:00Z",
         symbol="AAPL",
         strategy_id="RSI2",
-        hard_gates=_base_hard_gates(),
-        component_scores=_base_component_scores(),
+        hard_gates=list(hard_gates or _base_hard_gates()),
+        component_scores=list(component_scores or _base_component_scores()),
         backtest_evidence=backtest_evidence,
         portfolio_fit_input=portfolio_fit_input,
         sentiment_overlay=sentiment_overlay,
@@ -161,3 +165,178 @@ def test_confidence_boundary_is_explicitly_upstream_evidence_limited() -> None:
     assert "upstream evidence quality" in confidence_reason
     assert any(term in confidence_reason for term in ("aggregate", "component", "threshold", "evidence"))
     assert "does not imply live-trading approval" in card.rationale.final_explanation.casefold()
+
+
+def test_expected_value_calculation_positive_zero_negative_cases() -> None:
+    base_components = _base_component_scores()
+    positive_win_rate = compute_bounded_win_rate(component_scores=base_components)
+    positive_expected_value = compute_bounded_expected_value(
+        component_scores=base_components,
+        win_rate=positive_win_rate,
+    )
+    assert positive_expected_value > 0.0
+
+    zero_components = [
+        ComponentScore(
+            category="signal_quality",
+            score=50.0,
+            rationale="Signal quality is neutral in bounded evidence space",
+            evidence=["hit_rate=0.50"],
+        ),
+        ComponentScore(
+            category="backtest_quality",
+            score=50.0,
+            rationale="Backtest quality is neutral in bounded evidence space",
+            evidence=["profit_factor=1.00"],
+        ),
+        ComponentScore(
+            category="portfolio_fit",
+            score=70.0,
+            rationale="Portfolio fit remains bounded for neutral EV check",
+            evidence=["sector=0.20"],
+        ),
+        ComponentScore(
+            category="risk_alignment",
+            score=50.0,
+            rationale="Risk alignment neutral for bounded EV check",
+            evidence=["risk_trade=0.005"],
+        ),
+        ComponentScore(
+            category="execution_readiness",
+            score=50.0,
+            rationale="Execution readiness neutral for bounded EV check",
+            evidence=["slippage_bps=10"],
+        ),
+    ]
+    zero_win_rate = compute_bounded_win_rate(component_scores=zero_components)
+    zero_expected_value = compute_bounded_expected_value(
+        component_scores=zero_components,
+        win_rate=zero_win_rate,
+    )
+    assert zero_expected_value == 0.0
+
+    negative_components = [
+        ComponentScore(
+            category="signal_quality",
+            score=45.0,
+            rationale="Signal quality weakens under bounded evidence assumptions",
+            evidence=["hit_rate=0.45"],
+        ),
+        ComponentScore(
+            category="backtest_quality",
+            score=40.0,
+            rationale="Backtest quality weakens under bounded evidence assumptions",
+            evidence=["profit_factor=0.90"],
+        ),
+        ComponentScore(
+            category="portfolio_fit",
+            score=65.0,
+            rationale="Portfolio fit remains bounded for negative EV check",
+            evidence=["sector=0.22"],
+        ),
+        ComponentScore(
+            category="risk_alignment",
+            score=40.0,
+            rationale="Risk alignment weakens under bounded evidence assumptions",
+            evidence=["risk_trade=0.009"],
+        ),
+        ComponentScore(
+            category="execution_readiness",
+            score=40.0,
+            rationale="Execution readiness weakens under bounded evidence assumptions",
+            evidence=["slippage_bps=18"],
+        ),
+    ]
+    negative_win_rate = compute_bounded_win_rate(component_scores=negative_components)
+    negative_expected_value = compute_bounded_expected_value(
+        component_scores=negative_components,
+        win_rate=negative_win_rate,
+    )
+    assert negative_expected_value < 0.0
+
+
+def test_decision_action_resolution_scenarios() -> None:
+    hard_gate_failures = _base_hard_gates()
+    hard_gate_failures[0] = HardGateResult(
+        gate_id="drawdown_safety",
+        status="fail",
+        blocking=True,
+        reason="Drawdown threshold breached",
+        failure_reason="Max drawdown exceeded configured cap",
+        evidence=["max_dd=0.15", "threshold=0.12"],
+    )
+    ignored = evaluate_qualification(_engine_input(hard_gates=hard_gate_failures))
+    assert ignored.action == "ignore"
+
+    weak_components = _base_component_scores()
+    weak_components[0] = ComponentScore(
+        category="signal_quality",
+        score=52.0,
+        rationale="Signal quality is insufficient for bounded confidence support",
+        evidence=["hit_rate=0.52", "window=120d"],
+    )
+    weak_components[1] = ComponentScore(
+        category="backtest_quality",
+        score=53.0,
+        rationale="Backtest quality is insufficient for bounded confidence support",
+        evidence=["profit_factor=1.01", "window=120d"],
+    )
+    weak_components[4] = ComponentScore(
+        category="execution_readiness",
+        score=45.0,
+        rationale="Execution readiness weakens expected evidence confidence",
+        evidence=["slippage_bps=19", "commission=1.00"],
+    )
+    weak = evaluate_qualification(_engine_input(component_scores=weak_components))
+    assert weak.qualification.state == "watch"
+    assert weak.action == "ignore"
+
+    positive = evaluate_qualification(_engine_input())
+    assert positive.score.expected_value >= 0.0
+    assert positive.action == "entry"
+
+    exit_components = _base_component_scores()
+    exit_components[0] = ComponentScore(
+        category="signal_quality",
+        score=66.0,
+        rationale="Signal quality remains above watch threshold",
+        evidence=["hit_rate=0.66", "window=120d"],
+    )
+    exit_components[1] = ComponentScore(
+        category="backtest_quality",
+        score=66.0,
+        rationale="Backtest quality remains above watch threshold",
+        evidence=["profit_factor=1.10", "window=120d"],
+    )
+    exit_components[2] = ComponentScore(
+        category="portfolio_fit",
+        score=70.0,
+        rationale="Portfolio fit remains inside bounded threshold",
+        evidence=["sector=0.19", "corr_cluster=0.44"],
+    )
+    exit_components[3] = ComponentScore(
+        category="risk_alignment",
+        score=30.0,
+        rationale="Risk alignment weakens payoff assumptions",
+        evidence=["risk_trade=0.010", "max_dd=0.14"],
+    )
+    exit_components[4] = ComponentScore(
+        category="execution_readiness",
+        score=20.0,
+        rationale="Execution readiness weakens payoff assumptions",
+        evidence=["slippage_bps=25", "commission=1.00"],
+    )
+    exiting = evaluate_qualification(_engine_input(component_scores=exit_components))
+    assert exiting.qualification.state in {"watch", "paper_candidate"}
+    assert exiting.score.expected_value < 0.0
+    assert exiting.action == "exit"
+
+
+def test_regression_identical_inputs_produce_identical_action_expected_value_and_win_rate() -> None:
+    input_data = _engine_input()
+    first = evaluate_qualification(input_data)
+    second = evaluate_qualification(input_data)
+
+    assert first.action == second.action
+    assert first.score.expected_value == second.score.expected_value
+    assert first.score.win_rate == second.score.win_rate

--- a/tests/test_sig_p56_signal_quality_contract.py
+++ b/tests/test_sig_p56_signal_quality_contract.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+from pydantic import ValidationError
+
 from api.services.analysis_service import build_ranked_symbol_results
+from cilly_trading.engine.decision_card_contract import (
+    DECISION_CARD_CONTRACT_VERSION,
+    validate_decision_card,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -91,3 +98,96 @@ def test_p56_contract_doc_is_bounded_and_no_trader_readiness_claim() -> None:
     assert "Classification: technically good, traderically weak" in content
     assert "does not claim trader readiness" in content
     assert "no live-trading readiness, execution approval, or profitability guarantee" in content
+    assert "bounded win-rate formula" in content
+    assert "bounded expected-value formula" in content
+    assert "deterministic paper-evaluation action" in content
+
+
+def _decision_card_payload_with_confidence_reason(confidence_reason: str) -> dict[str, object]:
+    return {
+        "contract_version": DECISION_CARD_CONTRACT_VERSION,
+        "decision_card_id": "dc_20260417_AAPL_RSI2",
+        "generated_at_utc": "2026-04-17T10:00:00Z",
+        "symbol": "AAPL",
+        "strategy_id": "RSI2",
+        "hard_gates": {
+            "policy_version": "hard-gates.v1",
+            "gates": [
+                {
+                    "gate_id": "drawdown_safety",
+                    "status": "pass",
+                    "blocking": True,
+                    "reason": "Drawdown remains below configured threshold",
+                    "evidence": ["max_dd=0.08", "threshold=0.12"],
+                }
+            ],
+        },
+        "score": {
+            "component_scores": [
+                {
+                    "category": "signal_quality",
+                    "score": 84.0,
+                    "rationale": "Signal quality remains stable across deterministic windows",
+                    "evidence": ["hit_rate=0.62", "window_days=90"],
+                },
+                {
+                    "category": "backtest_quality",
+                    "score": 82.0,
+                    "rationale": "Backtest quality remains stable in deterministic replay",
+                    "evidence": ["sharpe=1.36", "profit_factor=1.58"],
+                },
+                {
+                    "category": "portfolio_fit",
+                    "score": 78.0,
+                    "rationale": "Portfolio fit remains bounded under concentration limits",
+                    "evidence": ["sector_weight=0.19", "corr_cluster=0.43"],
+                },
+                {
+                    "category": "risk_alignment",
+                    "score": 86.0,
+                    "rationale": "Risk alignment remains bounded under policy controls",
+                    "evidence": ["risk_trade=0.005", "max_dd=0.10"],
+                },
+                {
+                    "category": "execution_readiness",
+                    "score": 76.0,
+                    "rationale": "Execution readiness remains bounded with explicit assumptions",
+                    "evidence": ["slippage_bps=9", "commission=1.00"],
+                },
+            ],
+            "confidence_tier": "high",
+            "confidence_reason": confidence_reason,
+            "aggregate_score": 80.5,
+            "win_rate": 0.61,
+            "expected_value": 0.1281,
+        },
+        "action": "entry",
+        "qualification": {
+            "state": "paper_approved",
+            "color": "green",
+            "summary": "Opportunity is approved for bounded paper-trading only.",
+        },
+        "rationale": {
+            "summary": "Hard gates pass and bounded component evidence supports deterministic qualification",
+            "gate_explanations": ["Gate drawdown_safety passed with explicit bounded evidence."],
+            "score_explanations": ["Bounded deterministic score evidence is complete for this decision card."],
+            "final_explanation": (
+                "Decision action and qualification are deterministic technical implementation evidence "
+                "and do not imply live-trading approval."
+            ),
+        },
+        "metadata": {
+            "technical_implementation_status": "technical_in_progress",
+            "trader_validation_status": "trader_validation_not_started",
+        },
+    }
+
+
+@pytest.mark.parametrize("phrase", ["trader validation", "live approval", "production readiness"])
+def test_p56_contract_rejects_unsupported_claim_wording_in_decision_output(phrase: str) -> None:
+    payload = _decision_card_payload_with_confidence_reason(
+        f"Aggregate component threshold evidence is bounded and excludes {phrase}."
+    )
+
+    with pytest.raises(ValidationError, match="unsupported claim language"):
+        validate_decision_card(payload)


### PR DESCRIPTION
Closes #979

## Summary
- Added deterministic bounded win_rate and expected_value evidence to qualification output.
- Added single explicit deterministic ction field (entry | exit | ignore) to decision output.
- Enforced deterministic action resolution in both qualification engine output and decision-card contract validation.
- Kept qualification state contract (eject, watch, paper_candidate, paper_approved) unchanged.
- Added compatibility hydration for legacy decision-card payloads so inspection reads remain stable.
- Updated governance and phase docs with formulas, action rules, and explicit separation of technical evidence from trader validation status.

## Deterministic Formulas
- win_rate=((signal_quality*0.60)+(backtest_quality*0.40))/100, bounded to [0,1]
- expected_value=(win_rate*bounded_reward_multiplier)-(1-win_rate), bounded to [-1,1]
- ounded_reward_multiplier=clamp((risk_alignment+execution_readiness)/100,0.50,1.50)

## Action Rules
1. blocking hard-gate failure -> ignore
2. negative expected value -> exit (never entry)
3. qualified (paper_candidate / paper_approved) with win_rate <= 0.50 -> exit
4. qualified with win_rate >= 0.55 and non-negative expected value -> entry
5. otherwise -> ignore

## Scope Guarantees
- No UI changes
- No /ui changes
- No rontend/ changes
- No broker integration
- No live trading
- No new strategy types
- No ungoverned signal-surface expansion

## Governance Result
- Active Issue: #979
- Review Decision: APPROVED
- Classification: technically good, but traderically weak
- Trader validation status: 	rader_validation_not_started
- Operational readiness: not implied