### PR TITLE
[BACKTEST][04] Harden deterministic backtest realism with explicit slippage, fee, and execution assumptions (#977)

### DIFF
--- a/docs/testing/backtesting/order_execution_model.md
+++ b/docs/testing/backtesting/order_execution_model.md
@@ -2,17 +2,17 @@
 
 ## Scope
 
-This document defines the deterministic market order execution model for backtesting.
+This document defines the deterministic market-order execution model for backtesting.
 The model is intentionally fixed and reproducible for identical inputs.
+It is a technical replay model only and does not represent live broker execution.
 
-## 1) Market order execution semantics
+## 1) Market-order execution semantics
 
-Fill timing mode is **`next_snapshot`**.
+Fill timing mode is configurable as `next_snapshot` or `same_snapshot`.
 
-- An order created at snapshot `t` is **not** fillable at snapshot `t`.
-- The earliest fill opportunity is snapshot `t+1`.
-- This enforces no-lookahead behavior.
-- No partial fills are allowed. If an order is eligible for a snapshot and snapshot price data exists, the full order quantity is filled deterministically.
+- For `next_snapshot`, an order created at snapshot `t` is not fillable at snapshot `t`; earliest fill is snapshot `t+1`.
+- For `same_snapshot`, an order created at snapshot `t` is fillable at snapshot `t`.
+- No partial fills are allowed. If an order is eligible and snapshot price data exists, the full order quantity is filled deterministically.
 
 ## 2) Deterministic fill price rule
 
@@ -22,16 +22,18 @@ For each fill snapshot:
 2. Else, base fill price is `snapshot.price`.
 3. If neither field exists, execution raises a deterministic error.
 
+Price source is fixed to `open_then_price`.
+
 ## 3) Deterministic slippage model
 
-`slippage_bps` is a fixed integer config value.
+`slippage_bps` is a bounded integer config value.
 
 - BUY: `fill_price = base_price * (1 + slippage_bps / 10_000)`
 - SELL: `fill_price = base_price * (1 - slippage_bps / 10_000)`
 
 ## 4) Deterministic commission model
 
-Commission model is fixed **per order** (`commission_per_order`).
+Commission model is fixed per filled order (`commission_per_order`).
 
 - Every filled order uses the same fixed commission amount from config.
 - Formula: `commission = commission_per_order`
@@ -80,20 +82,12 @@ Snapshot lookup is field-address based (`open`, then `price`) and does not rely 
 
 ## 8) Unmodeled realism boundary
 
-codex/ops-p51-write-only-evidence
 The deterministic execution model is intentionally narrower than real execution.
 
 - Market hours and exchange session rules are not modeled.
 - Broker routing, rejects, cancels, and venue-specific behavior are not modeled.
-- Liquidity, queue position, and market impact are not modeled.
+- Liquidity, queue position, fill probability, latency, and market impact are not modeled.
+- This model is non-live and non-broker by design.
 
 This execution model does not support live-trading readiness claims.
-=======
-The deterministic execution model intentionally excludes the following:
-
-- Market hours and exchange session rules are not modeled.
-- Order book depth and market impact are not modeled.
-- Broker-specific execution behavior and fill quality are not modeled.
-- Exchange-level order rejection or throttling is not modeled.
-
-This model does not support live-trading readiness claims. Backtest output is bounded evidence only and MUST NOT be used to infer production trading performance or broker fill quality.
+This implementation improves technical realism only and does not constitute trader validation.

--- a/docs/testing/backtesting/p56_bounded_backtest_realism_assumptions.md
+++ b/docs/testing/backtesting/p56_bounded_backtest_realism_assumptions.md
@@ -6,6 +6,7 @@ Document and validate currently implemented realism-sensitive assumptions in the
 ## Scope Boundary
 This contract covers only the current deterministic backtest implementation.
 It does not define live-trading behavior, broker behavior, or a market-microstructure simulator.
+Trader validation status for this implementation remains `trader_validation_not_started`.
 
 ## Current Implemented Assumptions (Validated)
 
@@ -35,12 +36,14 @@ It does not define live-trading behavior, broker behavior, or a market-microstru
 ## Evidence Interpretation Boundary
 - Backtest output is bounded evidence for deterministic replay under declared assumptions.
 - It supports controlled review of what the model did on supplied snapshots under fixed cost/fill rules.
+- This implementation improves technical realism only; it does not validate trader readiness, live tradability, or execution quality in production markets.
 
 Unsupported claims:
 - live-trading readiness or approval
 - broker execution realism
 - market-hours compliance realism
 - liquidity or market microstructure realism
+- trader validation or trader approval
 - future profitability or out-of-sample robustness
 
 ## Validation Evidence (Current Repository)
@@ -58,3 +61,4 @@ Classification: technically good, traderically weak.
 Rationale:
 - technically good: deterministic and test-validated for implemented assumptions
 - traderically weak: key market-realism dimensions are intentionally unmodeled
+- trader validation status remains `trader_validation_not_started`

--- a/src/cilly_trading/engine/backtest_execution_contract.py
+++ b/src/cilly_trading/engine/backtest_execution_contract.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, List, Literal, Mapping, Sequence
 
 from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
@@ -89,18 +89,42 @@ class BacktestExecutionAssumptions:
     partial_fills_allowed: bool = False
 
     def __post_init__(self) -> None:
+        if self.fill_model != "deterministic_market":
+            raise ValueError("Execution assumption fill_model must be deterministic_market")
+        if self.fill_timing not in {"next_snapshot", "same_snapshot"}:
+            raise ValueError("Execution assumption fill_timing is unsupported")
+        if self.price_source != "open_then_price":
+            raise ValueError("Execution assumption price_source must be open_then_price")
+        if not isinstance(self.partial_fills_allowed, bool):
+            raise ValueError("Execution assumption partial_fills_allowed must be a boolean")
+        if self.partial_fills_allowed:
+            raise ValueError("Execution assumption partial_fills_allowed must be false")
+
+        if isinstance(self.slippage_bps, bool) or not isinstance(self.slippage_bps, int):
+            raise ValueError("Execution assumption slippage_bps must be an integer")
         if self.slippage_bps < 0:
             raise ValueError("Execution assumption slippage_bps must be >= 0")
         if self.slippage_bps > MAX_SLIPPAGE_BPS:
             raise ValueError(f"Execution assumption slippage_bps must be <= {MAX_SLIPPAGE_BPS}")
-        if self.commission_per_order < Decimal("0"):
+
+        normalized_commission = self._normalize_commission(self.commission_per_order)
+        if normalized_commission < Decimal("0"):
             raise ValueError("Execution assumption commission_per_order must be >= 0")
-        if self.commission_per_order > MAX_COMMISSION_PER_ORDER:
+        if normalized_commission > MAX_COMMISSION_PER_ORDER:
             raise ValueError(
                 f"Execution assumption commission_per_order must be <= {MAX_COMMISSION_PER_ORDER}"
             )
-        if self.partial_fills_allowed:
-            raise ValueError("Execution assumption partial_fills_allowed must be false")
+        object.__setattr__(self, "commission_per_order", normalized_commission)
+
+    @staticmethod
+    def _normalize_commission(value: Decimal | int | float | str) -> Decimal:
+        try:
+            normalized = Decimal(str(value))
+        except (InvalidOperation, ValueError, TypeError) as exc:
+            raise ValueError("Execution assumption commission_per_order must be decimal-compatible") from exc
+        if not normalized.is_finite():
+            raise ValueError("Execution assumption commission_per_order must be finite")
+        return normalized
 
     def to_execution_config(self) -> DeterministicExecutionConfig:
         return DeterministicExecutionConfig(

--- a/tests/cilly_trading/engine/test_backtest_execution_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_execution_contract.py
@@ -63,6 +63,28 @@ def test_contract_validation_rejects_invalid_execution_assumptions() -> None:
         BacktestExecutionAssumptions(partial_fills_allowed=True)
 
 
+def test_contract_validation_rejects_unsupported_execution_assumption_values() -> None:
+    with pytest.raises(ValueError, match="fill_model"):
+        BacktestExecutionAssumptions(fill_model="synthetic_market")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="fill_timing"):
+        BacktestExecutionAssumptions(fill_timing="next_tick")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="price_source"):
+        BacktestExecutionAssumptions(price_source="close_only")  # type: ignore[arg-type]
+
+
+def test_contract_validation_rejects_invalid_execution_input_types() -> None:
+    with pytest.raises(ValueError, match="slippage_bps must be an integer"):
+        BacktestExecutionAssumptions(slippage_bps=True)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="slippage_bps must be an integer"):
+        BacktestExecutionAssumptions(slippage_bps="10")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="commission_per_order must be decimal-compatible"):
+        BacktestExecutionAssumptions(commission_per_order="not-a-number")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="commission_per_order must be finite"):
+        BacktestExecutionAssumptions(commission_per_order=Decimal("NaN"))
+    with pytest.raises(ValueError, match="partial_fills_allowed must be a boolean"):
+        BacktestExecutionAssumptions(partial_fills_allowed="false")  # type: ignore[arg-type]
+
+
 def test_contract_validation_rejects_invalid_contract_version() -> None:
     with pytest.raises(ValueError, match="Unsupported backtest contract_version"):
         BacktestRunContract(contract_version="2.0.0")
@@ -194,6 +216,51 @@ def test_cost_slippage_baseline_is_reproducible() -> None:
     )
 
     assert first == second
+
+
+def test_cost_slippage_baseline_changes_deterministically_when_cost_assumptions_change() -> None:
+    snapshots = sort_snapshots(_sample_flow_snapshots())
+    low_cost_assumptions = BacktestExecutionAssumptions(
+        slippage_bps=0,
+        commission_per_order=Decimal("0"),
+        fill_timing="next_snapshot",
+    )
+    high_cost_assumptions = BacktestExecutionAssumptions(
+        slippage_bps=25,
+        commission_per_order=Decimal("2.00"),
+        fill_timing="next_snapshot",
+    )
+
+    flow_low = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="run-cost-low",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(execution_assumptions=low_cost_assumptions),
+    )
+    flow_high = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="run-cost-high",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(execution_assumptions=high_cost_assumptions),
+    )
+
+    baseline_low = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=flow_low.fills,
+        execution_assumptions=low_cost_assumptions,
+    )
+    baseline_high = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=flow_high.fills,
+        execution_assumptions=high_cost_assumptions,
+    )
+
+    assert baseline_low["summary"]["total_transaction_cost"] == 0.0
+    assert baseline_high["summary"]["total_transaction_cost"] > baseline_low["summary"]["total_transaction_cost"]
+    assert (
+        baseline_high["summary"]["ending_equity_cost_aware"]
+        < baseline_low["summary"]["ending_equity_cost_aware"]
+    )
 
 
 def test_backtest_realism_boundary_reports_modeled_and_unmodeled_assumptions() -> None:

--- a/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
+++ b/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
@@ -102,3 +102,70 @@ def test_p56_bt_cost_assumptions_are_fixed_per_order_and_side_aware() -> None:
     assert baseline["summary"]["total_slippage_cost"] == 0.2
     assert baseline["summary"]["total_transaction_cost"] == 2.7
 
+
+def test_p56_bt_replay_is_deterministic_and_cost_sensitive_to_assumptions() -> None:
+    snapshots = sort_snapshots(
+        [
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {
+                "id": "s2",
+                "timestamp": "2024-01-02T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "101",
+                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {"id": "s3", "timestamp": "2024-01-03T00:00:00Z", "symbol": "AAPL", "open": "102"},
+        ]
+    )
+    assumptions = BacktestExecutionAssumptions(slippage_bps=10, commission_per_order=Decimal("1.25"))
+    run_contract = BacktestRunContract(execution_assumptions=assumptions)
+
+    first = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="p56-bt-repro",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+    second = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="p56-bt-repro",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+    baseline_first = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=first.fills,
+        execution_assumptions=assumptions,
+    )
+    baseline_second = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=second.fills,
+        execution_assumptions=assumptions,
+    )
+    higher_cost_assumptions = BacktestExecutionAssumptions(
+        slippage_bps=20,
+        commission_per_order=Decimal("2.50"),
+    )
+    higher_cost_flow = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="p56-bt-repro",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(execution_assumptions=higher_cost_assumptions),
+    )
+    higher_cost_baseline = build_cost_slippage_metrics_baseline(
+        ordered_snapshots=snapshots,
+        fills=higher_cost_flow.fills,
+        execution_assumptions=higher_cost_assumptions,
+    )
+
+    assert baseline_first == baseline_second
+    assert (
+        higher_cost_baseline["summary"]["ending_equity_cost_aware"]
+        < baseline_first["summary"]["ending_equity_cost_aware"]
+    )

--- a/tests/cilly_trading/engine/test_backtest_runner.py
+++ b/tests/cilly_trading/engine/test_backtest_runner.py
@@ -82,6 +82,56 @@ def test_backtest_runner_deterministic_repeat(tmp_path: Path) -> None:
     assert result1.artifact_sha256 == result2.artifact_sha256
 
 
+def test_backtest_runner_deterministic_repeat_with_identical_realism_assumptions(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=11,
+            commission_per_order=Decimal("1.75"),
+            fill_timing="next_snapshot",
+        )
+    )
+    snapshots = [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "100",
+            "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+        },
+        {
+            "id": "s2",
+            "timestamp": "2024-01-02T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "101",
+            "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+        },
+        {
+            "id": "s3",
+            "timestamp": "2024-01-03T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "102",
+        },
+    ]
+    result1 = runner.run(
+        snapshots=snapshots,
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=tmp_path / "run-1", run_contract=run_contract),
+    )
+    result2 = runner.run(
+        snapshots=snapshots,
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=tmp_path / "run-2", run_contract=run_contract),
+    )
+
+    assert result1.artifact_path.read_bytes() == result2.artifact_path.read_bytes()
+    assert result1.artifact_sha256 == result2.artifact_sha256
+
+
 def test_backtest_runner_snapshot_consistency_order(tmp_path: Path) -> None:
     result, _ = _run_with_spy(tmp_path / "ordered")
 
@@ -365,4 +415,120 @@ def test_backtest_runner_metrics_baseline_cost_aware_differs_from_cost_free(tmp_
             "run_config_execution_assumptions_match_metrics_baseline_assumptions"
         ]
         is True
+    )
+
+
+def test_backtest_runner_cost_outputs_change_when_realism_assumptions_change(tmp_path: Path) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    snapshots = [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "100",
+            "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+        },
+        {
+            "id": "s2",
+            "timestamp": "2024-01-02T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "101",
+            "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+        },
+        {
+            "id": "s3",
+            "timestamp": "2024-01-03T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "102",
+        },
+    ]
+    low_cost = runner.run(
+        snapshots=snapshots,
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(
+            output_dir=tmp_path / "low-cost",
+            run_contract=BacktestRunContract(
+                execution_assumptions=BacktestExecutionAssumptions(
+                    slippage_bps=0,
+                    commission_per_order=Decimal("0"),
+                )
+            ),
+        ),
+    )
+    high_cost = runner.run(
+        snapshots=snapshots,
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(
+            output_dir=tmp_path / "high-cost",
+            run_contract=BacktestRunContract(
+                execution_assumptions=BacktestExecutionAssumptions(
+                    slippage_bps=20,
+                    commission_per_order=Decimal("2.50"),
+                )
+            ),
+        ),
+    )
+
+    low_payload = json.loads(low_cost.artifact_path.read_text(encoding="utf-8"))
+    high_payload = json.loads(high_cost.artifact_path.read_text(encoding="utf-8"))
+
+    assert low_payload["metrics_baseline"]["summary"]["total_transaction_cost"] == 0.0
+    assert (
+        high_payload["metrics_baseline"]["summary"]["total_transaction_cost"]
+        > low_payload["metrics_baseline"]["summary"]["total_transaction_cost"]
+    )
+    assert (
+        high_payload["metrics_baseline"]["summary"]["ending_equity_cost_aware"]
+        < low_payload["metrics_baseline"]["summary"]["ending_equity_cost_aware"]
+    )
+
+
+def test_backtest_runner_persists_identical_realism_assumptions_across_artifact_sections(
+    tmp_path: Path,
+) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    assumptions = BacktestExecutionAssumptions(
+        slippage_bps=9,
+        commission_per_order=Decimal("1.40"),
+        fill_timing="same_snapshot",
+    )
+    result = runner.run(
+        snapshots=[
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "102"},
+        ],
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(
+            output_dir=tmp_path / "assumption-contract",
+            run_contract=BacktestRunContract(execution_assumptions=assumptions),
+        ),
+    )
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+    expected = assumptions.to_payload()
+
+    assert payload["run_config"]["execution_assumptions"] == expected
+    assert payload["metrics_baseline"]["assumptions"] == expected
+    assert payload["realism_boundary"]["modeled_assumptions"]["fills"]["fill_timing"] == expected["fill_timing"]
+    assert payload["realism_boundary"]["modeled_assumptions"]["fills"]["price_source"] == expected["price_source"]
+    assert (
+        payload["realism_boundary"]["modeled_assumptions"]["fees"]["commission_per_order"]
+        == expected["commission_per_order"]
+    )
+    assert (
+        payload["realism_boundary"]["modeled_assumptions"]["slippage"]["slippage_bps"]
+        == expected["slippage_bps"]
     )

--- a/tests/test_backtest_evidence_docs.py
+++ b/tests/test_backtest_evidence_docs.py
@@ -92,4 +92,7 @@ def test_backtest_schema_and_execution_docs_define_realism_disclosures() -> None
     assert "`canonical_handoffs`" in schema_content
     assert "## 8) Unmodeled realism boundary" in execution_content
     assert "Market hours and exchange session rules are not modeled." in execution_content
+    assert "Broker routing, rejects, cancels, and venue-specific behavior are not modeled." in execution_content
+    assert "This model is non-live and non-broker by design." in execution_content
     assert "does not support live-trading readiness claims" in execution_content
+    assert "does not constitute trader validation" in execution_content

--- a/tests/test_p56_bt_backtest_realism_docs.py
+++ b/tests/test_p56_bt_backtest_realism_docs.py
@@ -17,6 +17,7 @@ def test_p56_bt_doc_explicitly_documents_current_assumptions() -> None:
     assert "Fill model is fixed to `deterministic_market`." in content
     assert "Price source is fixed to `open_then_price`" in content
     assert "Commission model is fixed per filled order (`commission_per_order`)." in content
+    assert "Trader validation status for this implementation remains `trader_validation_not_started`." in content
 
 
 def test_p56_bt_doc_explicitly_states_realism_gaps_and_unsupported_claims() -> None:
@@ -28,6 +29,7 @@ def test_p56_bt_doc_explicitly_states_realism_gaps_and_unsupported_claims() -> N
     assert "Order-book depth, queue position" in content
     assert "Unsupported claims:" in content
     assert "live-trading readiness or approval" in content
+    assert "trader validation or trader approval" in content
     assert "future profitability or out-of-sample robustness" in content
 
 
@@ -38,3 +40,4 @@ def test_p56_bt_doc_status_wording_is_evidence_bounded() -> None:
     assert "Classification: technically good, traderically weak." in content
     assert "deterministic and test-validated for implemented assumptions" in content
     assert "key market-realism dimensions are intentionally unmodeled" in content
+    assert "trader validation status remains `trader_validation_not_started`" in content


### PR DESCRIPTION
Closes #977

## What changed
- Hardened fail-closed validation in the canonical backtest execution contract:
  - enforce supported ill_model, ill_timing, and price_source
  - enforce boolean/false-only partial_fills_allowed
  - enforce integer bounded slippage_bps
  - enforce decimal-compatible, finite, bounded commission_per_order
- Added deterministic realism regression coverage:
  - identical assumptions + identical snapshots => deterministic replay stability
  - changed slippage/fee assumptions => deterministic cost-aware output changes
- Added artifact contract assertions:
  - un_config.execution_assumptions
  - metrics_baseline.assumptions
  - ealism_boundary.modeled_assumptions
  are persisted and aligned.
- Tightened docs to explicitly state:
  - non-live, non-broker scope
  - technical realism improvement only
  - does not constitute trader validation
  - trader validation status remains 	rader_validation_not_started

## Validation
- Ran full repository suite:
  - python -m pytest -q
  - Result: 1084 passed, 4 warnings

## Scope Guarantees
- No UI changes
- No /ui changes
- No rontend/ changes
- No live trading changes
- No broker integration
- No strategy-scope expansion
- No new backtesting subsystem

## Governance Result
- Active Issue: #977
- Review Decision: APPROVED
- Classification: technically good, but traderically weak
- Trader validation status: 	rader_validation_not_started
- Operational readiness: not implied