### PR TITLE
[REPO-ALIGNMENT][02] Reconcile roadmap and governance overlays against professional-trading capability target (#988)

### DIFF
--- a/docs/architecture/audit/roadmap_compliance_report.md
+++ b/docs/architecture/audit/roadmap_compliance_report.md
@@ -6,6 +6,9 @@ This audit is based only on repository-verifiable evidence (code, tests, endpoin
 
 The authoritative in-repo source for audited phase taxonomy is `docs/architecture/roadmap/execution_roadmap.md`. This report now defers to that roadmap for phase-number meanings and uses this document only for audit findings and traceability.
 Canonical phase maturity/status labels are governed only by `ROADMAP_MASTER.md`.
+Canonical capability-priority steering is governed by `docs/governance/professional-trading-capability-target.md`.
+
+This report is a secondary/derived audit surface. It is not a primary issue-derivation authority by itself.
 
 Owner Dashboard is verifiably backend-served at `/ui` via FastAPI `app.mount("/ui", StaticFiles(..., html=True), ...)` and HTML marker `<title>Owner Dashboard</title>`.
 
@@ -45,7 +48,7 @@ Documentation and implementation are aligned for the audited paper-trading and o
 | Phase 17b - Owner Dashboard | Implemented | Backend UI mount in `src/api/main.py` (`app.mount("/ui", StaticFiles(..., html=True), name="ui")`); HTML marker in `src/ui/index.html` (`<title>Owner Dashboard</title>`); tests in `tests/health_endpoint.py`; manual trigger endpoint `POST /analysis/run` in `src/api/main.py`; test in `tests/test_api_manual_analysis_trigger.py`; documentation in `docs/operations/ui/owner_dashboard.md` and `docs/index.md`. | `/ui` is confirmed backend-served. `/owner` is documented only as a frontend development route and not as a runtime backend route. |
 | Hourly Snapshot Runtime | Partially Implemented | `docs/operations/runtime/snapshot_runtime.md` declares in-repo execution capability and external scheduling boundary; `docs/operations/interfaces/batch_execution.md` states no scheduler implementation; no scheduler/cron endpoint verified in `src/api/main.py`. | Runtime execution capability exists in-repo; hourly scheduling is external and not provided by this repository. |
 | Phase 24 - Paper Trading Runtime | Implemented | Simulator in `src/cilly_trading/engine/paper_trading.py`; tests in `tests/test_paper_trading_simulator.py`; documentation in `docs/operations/paper-trading.md`, `docs/operations/runbook.md`, `docs/architecture/phase-9-exit.md`, and `docs/getting-started/repo-snapshot.md`. | Engine-level simulation exists and is now documented consistently as non-live and non-broker-integrated. |
-| Phase 23 - Research Dashboard | Not Implemented | No repository-verifiable code, tests, or runtime docs were confirmed beyond roadmap/status tracking references. | No direct implementation artifact was found for the audited phase. |
+| Phase 23 - Research Dashboard | Capability-evidence review snapshot only (non-canonical) | Current evidence remains bounded and must defer to `ROADMAP_MASTER.md` for canonical maturity/status and to `docs/governance/professional-trading-capability-target.md` for capability-priority steering. | This row must not be used as a standalone status authority or as phase-first issue derivation logic. |
 | Phase 25 - Strategy Lifecycle Management | Implemented In Repository | Lifecycle state model in `src/cilly_trading/engine/strategy_lifecycle/model.py`; transition rules in `src/cilly_trading/engine/strategy_lifecycle/transitions.py`; promotion service in `src/cilly_trading/engine/strategy_lifecycle/service.py`; production-only enforcement in `src/cilly_trading/engine/pipeline/orchestrator.py`; tests in `tests/strategy_lifecycle/` and `tests/cilly_trading/engine/test_orchestrator_lifecycle_enforcement.py`. | Earlier "pending PR merge + CI" wording was stale relative to current repo contents. |
 | Phase 27 - Risk Framework | Implementation Artifacts Verified | Risk contracts in `src/risk/contracts.py`; concrete gate implementation in `src/cilly_trading/engine/risk/gate.py`; pipeline integration in `src/cilly_trading/engine/pipeline/orchestrator.py`; architecture/runtime docs in `docs/architecture/risk_framework.md` and `docs/architecture/risk/risk_framework.md`; tests in `tests/cilly_trading/engine/test_risk_gate.py` and related pipeline enforcement tests. | Audited status documents should not claim the framework is absent where these standalone artifacts exist. |
 
@@ -106,13 +109,16 @@ Documentation and implementation are aligned for the audited paper-trading and o
 
 ## 6. Identified Gaps
 
-1. **Proposed Issue:** `Hourly Snapshot Runtime status declaration`  
-   - Formally declare the operational boundary: in-repo runtime execution capability with external scheduling ownership.  
-   - **Phase classification:** Snapshot Runtime  
+Issue derivation from this audit must follow capability-first steering:
 
-2. **Proposed Issue:** `Phase 23 evidence artifact alignment`  
-   - Keep Phase 23 evidence wording aligned to current repo evidence until additional implementation artifacts exist.  
-   - **Phase classification:** Phase 23  
+1. Start with `docs/governance/professional-trading-capability-target.md` to
+   confirm direct professional-capability impact.
+2. Use `ROADMAP_MASTER.md` only for canonical phase maturity/status
+   interpretation.
+3. Use `docs/architecture/roadmap/execution_roadmap.md` only for audited phase
+   taxonomy interpretation.
+4. Do not derive follow-up issues from this report by phase-label movement
+   alone or from boundary wording alone.
 
 ---
 

--- a/docs/architecture/roadmap/execution_roadmap.md
+++ b/docs/architecture/roadmap/execution_roadmap.md
@@ -10,6 +10,7 @@ This file is the single authoritative in-repo source for audited phase-number me
 ## Authority Relationship
 - This file governs the meaning of the audited phase numbers listed below.
 - `ROADMAP_MASTER.md` is the single authoritative in-repo source for phase maturity/status labels and status-change decisions.
+- `docs/governance/professional-trading-capability-target.md` is the canonical capability-direction anchor for issue prioritization and steering.
 - This file does not authoritatively set phase maturity/status labels. Any status wording here, in a per-phase artifact, or in an index must defer to the master roadmap for canonical maturity/status.
 - The master roadmap may summarize broader sequencing and implementation-status context, but it must defer to this file for audited phase meaning.
 - If wording in a secondary roadmap, index, or audit artifact conflicts with the audited phase meanings defined here, this file controls the taxonomy interpretation.
@@ -22,6 +23,8 @@ This file is the single authoritative in-repo source for audited phase-number me
 
 ## How to Use
 - Use this file to resolve the meaning of an audited phase number before relying on any secondary roadmap, index, or audit artifact.
+- Use `docs/governance/professional-trading-capability-target.md` as the primary steering input for capability-priority issue derivation.
+- Do not use this taxonomy file by itself as a primary issue-priority mechanism.
 - Treat secondary documents as navigation or status evidence only unless they explicitly defer to this file for taxonomy and to the master roadmap for phase maturity/status.
 - If a phase is marked here as "no authoritative in-repo meaning located", do not infer a meaning from neighboring phases or legacy headings.
 
@@ -75,50 +78,50 @@ Define and track the Owner Dashboard sub-phase based on repository-verified arti
 ## Phase 23
 
 ### Goal
-Define Phase 23 status using only repository-verified evidence.
+Define the authoritative audited taxonomy meaning of Phase 23 as
+`Research Dashboard`.
 
 > Governance Note  
-> The implementation status of Phase 23 is explicitly documented in:  
-> `docs/architecture/phases/phase-23-status.md`
+> Canonical phase maturity/status for Phase 23 is governed only by
+> `ROADMAP_MASTER.md`.  
+> `docs/architecture/phases/phase-23-status.md` is a derived evidence artifact.
 
 ### Explicit Deliverables
-- Explicit status declaration: Research Dashboard implementation artifact not confirmed in repository.
-- Phase 23 tracking issue/PR references this canonical roadmap entry when changing status.
+- Phase 23 references use the canonical meaning `Research Dashboard`.
+- Issues and PRs that mention Phase 23 map scope wording to this taxonomy.
 
 ### Explicitly Out of Scope
-- Claiming a Research Dashboard implementation without verified code, docs, or tests.
-- Inferring hidden or external artifacts as in-repo completion evidence.
+- Setting canonical phase maturity/status inside this taxonomy file.
+- Using phase-number progression as a substitute for capability-impact steering.
 
 ### Acceptance Evidence Requirements
-- Any status change from "Not Implemented" is backed by repository-verifiable code/docs/tests.
-- PR/issue history explicitly maps new artifacts to Phase 23.
+- Secondary artifacts that mention Phase 23 defer status to
+  `ROADMAP_MASTER.md`.
+- Issue and PR history keeps `Research Dashboard` wording aligned to this
+  taxonomy entry.
 
 ---
 
 ## Phase 27
 
 ### Goal
-Explicitly distinguish risk-related artifacts from a standalone Risk Framework implementation.
+Define the authoritative audited taxonomy meaning of Phase 27 as
+`Risk Framework`.
 
 > Governance Note  
-> The implementation status of Phase 27 is explicitly documented in:  
-> `docs/architecture/phases/phase-27-status.md`
-
-### Verified Existing Artifacts
-- Risk-related configuration fields exist.
-- Risk-related metrics and tests exist.
-
-### Framework Status
-No standalone Phase 27 Risk Framework module was verified.
+> Canonical phase maturity/status for Phase 27 is governed only by
+> `ROADMAP_MASTER.md`.  
+> `docs/architecture/phases/phase-27-status.md` is a derived evidence artifact.
 
 ### Explicitly Out of Scope
-- Treating config fields or metrics as proof of a completed framework.
-- Declaring framework completion without standalone artifact evidence.
+- Setting canonical phase maturity/status inside this taxonomy file.
+- Collapsing Phase 27 taxonomy into Phase 27b or other risk-adjacent artifacts.
 
 ### Acceptance Evidence Requirements
-- Standalone repository-verifiable framework module(s).
-- Explicit policy logic definition.
-- Documentation and tests mapped directly to Phase 27 framework scope.
+- Secondary artifacts that mention Phase 27 defer status to
+  `ROADMAP_MASTER.md`.
+- Issue and PR wording preserves the taxonomy distinction between Phase 27
+  (`Risk Framework`) and Phase 27b (Pipeline Enforcement Layer).
 
 ---
 

--- a/docs/governance/professional-trading-capability-target.md
+++ b/docs/governance/professional-trading-capability-target.md
@@ -19,6 +19,34 @@ vision statement.
 - It does not authorize live trading, broker integration, or production
   readiness claims.
 
+## Steering Precedence and Issue-Derivation Rules
+
+### Leading (Primary Steering Inputs)
+
+1. This document:
+   capability-direction and prioritization anchor for follow-up issue
+   derivation.
+2. `ROADMAP_MASTER.md`:
+   canonical phase maturity/status authority only.
+3. `docs/architecture/roadmap/execution_roadmap.md`:
+   canonical audited phase taxonomy authority only.
+
+### Secondary (Derived, Explanatory, or Evidence-Bearing Inputs)
+
+- `docs/architecture/audit/roadmap_compliance_report.md`
+- per-phase status artifacts under `docs/architecture/phases/**`
+- documentation index/navigation surfaces (for example `docs/index.md`)
+- derived roadmap snapshots and compatibility copies
+
+Secondary artifacts may support evidence and traceability, but they must not
+override the leading steering inputs above.
+
+### No Longer Valid as Primary Steering Logic
+
+- phase-number-first progression logic by itself
+- boundary-only governance wording by itself (without direct capability impact)
+- stale status wording from derived/secondary roadmap artifacts
+
 ## Canonical Direction Statement
 
 For this repository revision, "mehr Trading Profi" means:

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,8 +75,11 @@ Roadmap track alignment:
 
 - [Execution roadmap](architecture/roadmap/execution_roadmap.md)
 - [ROADMAP_MASTER.md](../ROADMAP_MASTER.md)
+- [Professional trading capability target (canonical)](governance/professional-trading-capability-target.md)
+- Leading steering for issue derivation: capability target first, then canonical status/taxonomy authorities.
 - Canonical phase maturity/status source: `ROADMAP_MASTER.md`
 - Canonical audited phase taxonomy source: `docs/architecture/roadmap/execution_roadmap.md`
+- Secondary/derived only: audit reports, per-phase artifacts, and roadmap snapshot copies.
 
 ## Phase Reference Navigation
 


### PR DESCRIPTION
Closes #988

## What changed

- Strengthened the canonical capability target with explicit steering precedence and issue-derivation rules:
  - docs/governance/professional-trading-capability-target.md
- Aligned the authoritative audited taxonomy document to the new steering model:
  - docs/architecture/roadmap/execution_roadmap.md
- Reframed the roadmap compliance audit as a secondary/derived audit surface only:
  - docs/architecture/audit/roadmap_compliance_report.md
- Updated documentation navigation to reflect the new steering order:
  - docs/index.md

## Why

This change reconciles roadmap and governance overlays against the canonical professional-trading capability target so that follow-up work is derived from:
1. capability impact first
2. canonical phase maturity/status authority second
3. canonical audited taxonomy authority third

It explicitly prevents issue derivation from:
- phase-number-first progression logic by itself
- boundary-only governance wording by itself
- stale derived roadmap/audit wording

## Scope control

- Governance/roadmap/audit/navigation docs only
- No engine, API, UI, runtime, or frontend behavior changes
- No new roadmap phases
- No live-trading or broker-scope expansion
- No broad repo rationalization outside direct steering-conflict cleanup

## Validation

- .\.venv\Scripts\python.exe -m pytest
- Result: 1084 passed, 4 warnings

## Governance result

- Active Issue: #988
- Review Decision: APPROVED
- Classification: technically good
- Trader validation status: not implied
- Operational readiness: not implied