### PR TITLE
[BACKTEST][05] Fix professional review contract export and backtest boundary schema (#992)

### DIFF
--- a/src/api/models/inspection_models.py
+++ b/src/api/models/inspection_models.py
@@ -447,6 +447,12 @@ class BacktestReadBoundaryResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     mode: Literal["non_live_backtest_read_only"]
+    review_contract_id: str
+    review_contract_version: str
+    review_required_evidence: List[str]
+    review_comparison_axes: List[str]
+    decision_relevance_statement: str
+    readiness_non_inference_statement: str
     technical_availability_statement: str
     trader_validation_statement: str
     operational_readiness_statement: str

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Literal, Optional
 from fastapi import HTTPException
 from pydantic import ValidationError
 
+from cilly_trading.engine.backtest_handoff_contract import build_professional_review_contract
 from cilly_trading.engine.decision_card_contract import validate_decision_card
 from cilly_trading.models import ExecutionEvent, Order, Position, SignalReadItemDTO, SignalReadResponseDTO, Trade
 
@@ -1141,8 +1142,15 @@ def read_journal_artifact_file_content(
 
 
 def _build_backtest_read_boundary() -> BacktestReadBoundaryResponse:
+    review_contract = build_professional_review_contract()
     return BacktestReadBoundaryResponse(
         mode="non_live_backtest_read_only",
+        review_contract_id=review_contract["contract_id"],
+        review_contract_version=review_contract["contract_version"],
+        review_required_evidence=list(review_contract["required_visible_evidence"]),
+        review_comparison_axes=list(review_contract["comparison_axes"]),
+        decision_relevance_statement=review_contract["decision_relevance_statement"],
+        readiness_non_inference_statement=review_contract["readiness_non_inference_statement"],
         technical_availability_statement=(
             "This flow only confirms technical availability of governed backtest artifacts."
         ),

--- a/src/cilly_trading/engine/backtest_handoff_contract.py
+++ b/src/cilly_trading/engine/backtest_handoff_contract.py
@@ -7,6 +7,17 @@ from typing import Any, Iterable, Mapping
 
 
 HANDOFF_CONTRACT_VERSION = "1.0.0"
+PROFESSIONAL_REVIEW_CONTRACT_ID = "bounded_backtest_evidence_professional_review.v1"
+PROFESSIONAL_REVIEW_CONTRACT_VERSION = "1.0.0"
+PROFESSIONAL_REVIEW_CONTEXT = "professional_non_live_evidence_review"
+PROFESSIONAL_REVIEW_DECISION_RELEVANCE_STATEMENT = (
+    "Backtest evidence is exposed for bounded professional non-live review where explicit "
+    "comparability is required for decision support."
+)
+PROFESSIONAL_REVIEW_READINESS_NON_INFERENCE_STATEMENT = (
+    "Technical implementation evidence must remain separated from trader validation and "
+    "operational readiness."
+)
 
 PHASE_43_REQUIRED_FIELDS: tuple[str, ...] = (
     "artifact_version",
@@ -45,6 +56,42 @@ PHASE_44_REQUIRED_FIELDS: tuple[str, ...] = (
 PORTFOLIO_TO_PAPER_REQUIRED_INPUTS: tuple[str, ...] = (
     *PHASE_43_REQUIRED_FIELDS,
     *PHASE_44_REQUIRED_FIELDS,
+)
+
+PROFESSIONAL_REVIEW_REQUIRED_VISIBLE_FIELDS: tuple[str, ...] = (
+    "run.run_id",
+    "snapshot_linkage.mode",
+    "snapshot_linkage.start",
+    "snapshot_linkage.end",
+    "snapshot_linkage.count",
+    "strategy.name",
+    "strategy.params",
+    "run_config.execution_assumptions",
+    "realism_boundary.modeled_assumptions",
+    "realism_boundary.unmodeled_assumptions",
+    "realism_boundary.evidence_boundary.unsupported_claims",
+    "summary.start_equity",
+    "summary.end_equity",
+    "metrics_baseline.summary",
+    "metrics_baseline.metrics.cost_aware",
+    "phase_handoff.acceptance_gates.technically_valid_backtest_artifact",
+    "phase_handoff.acceptance_gates.phase_43_portfolio_simulation_ready",
+    "phase_handoff.acceptance_gates.phase_44_paper_trading_readiness_evidence_ready",
+)
+
+PROFESSIONAL_REVIEW_COMPARISON_AXES: tuple[str, ...] = (
+    "snapshot window and count",
+    "strategy identity and params",
+    "execution assumptions and baseline assumption alignment",
+    "modeled vs unmodeled realism boundary",
+    "cost-aware outcome summary and deltas",
+    "phase handoff gate outcomes",
+)
+
+PROFESSIONAL_REVIEW_UNSUPPORTED_INFERENCE_CLAIMS: tuple[str, ...] = (
+    "trader validation inferred from technical artifact availability",
+    "operational readiness inferred from backtest evidence alone",
+    "live-trading readiness or broker execution approval",
 )
 
 TRADER_AUTHORITATIVE_FIELDS: tuple[str, ...] = (
@@ -127,6 +174,7 @@ def build_phase_handoff_contract(payload: Mapping[str, Any]) -> dict[str, Any]:
         "contract_version": HANDOFF_CONTRACT_VERSION,
         "source_phase": "42b",
         "target_phases": ["43", "44"],
+        "review_contract": build_professional_review_contract(),
         "required_evidence": {
             "phase_43_portfolio_simulation": list(PHASE_43_REQUIRED_FIELDS),
             "phase_44_paper_trading_readiness": list(PHASE_44_REQUIRED_FIELDS),
@@ -169,6 +217,19 @@ def build_phase_handoff_contract(payload: Mapping[str, Any]) -> dict[str, Any]:
             "phase_43_portfolio_simulation_ready": phase_43_gate.to_payload(),
             "phase_44_paper_trading_readiness_evidence_ready": phase_44_gate.to_payload(),
         },
+    }
+
+
+def build_professional_review_contract() -> dict[str, Any]:
+    return {
+        "contract_id": PROFESSIONAL_REVIEW_CONTRACT_ID,
+        "contract_version": PROFESSIONAL_REVIEW_CONTRACT_VERSION,
+        "review_context": PROFESSIONAL_REVIEW_CONTEXT,
+        "required_visible_evidence": list(PROFESSIONAL_REVIEW_REQUIRED_VISIBLE_FIELDS),
+        "comparison_axes": list(PROFESSIONAL_REVIEW_COMPARISON_AXES),
+        "decision_relevance_statement": PROFESSIONAL_REVIEW_DECISION_RELEVANCE_STATEMENT,
+        "readiness_non_inference_statement": PROFESSIONAL_REVIEW_READINESS_NON_INFERENCE_STATEMENT,
+        "unsupported_inference_claims": list(PROFESSIONAL_REVIEW_UNSUPPORTED_INFERENCE_CLAIMS),
     }
 
 

--- a/tests/cilly_trading/engine/test_backtest_handoff_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_handoff_contract.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
-from cilly_trading.engine.backtest_handoff_contract import build_phase_handoff_contract
+from cilly_trading.engine.backtest_handoff_contract import (
+    build_professional_review_contract,
+    build_phase_handoff_contract,
+)
 
 
 def _base_payload() -> dict[str, Any]:
@@ -95,15 +98,80 @@ def _base_payload() -> dict[str, Any]:
     }
 
 
+def test_build_professional_review_contract_returns_canonical_payload() -> None:
+    review_contract = build_professional_review_contract()
+
+    assert review_contract == {
+        "contract_id": "bounded_backtest_evidence_professional_review.v1",
+        "contract_version": "1.0.0",
+        "review_context": "professional_non_live_evidence_review",
+        "required_visible_evidence": [
+            "run.run_id",
+            "snapshot_linkage.mode",
+            "snapshot_linkage.start",
+            "snapshot_linkage.end",
+            "snapshot_linkage.count",
+            "strategy.name",
+            "strategy.params",
+            "run_config.execution_assumptions",
+            "realism_boundary.modeled_assumptions",
+            "realism_boundary.unmodeled_assumptions",
+            "realism_boundary.evidence_boundary.unsupported_claims",
+            "summary.start_equity",
+            "summary.end_equity",
+            "metrics_baseline.summary",
+            "metrics_baseline.metrics.cost_aware",
+            "phase_handoff.acceptance_gates.technically_valid_backtest_artifact",
+            "phase_handoff.acceptance_gates.phase_43_portfolio_simulation_ready",
+            "phase_handoff.acceptance_gates.phase_44_paper_trading_readiness_evidence_ready",
+        ],
+        "comparison_axes": [
+            "snapshot window and count",
+            "strategy identity and params",
+            "execution assumptions and baseline assumption alignment",
+            "modeled vs unmodeled realism boundary",
+            "cost-aware outcome summary and deltas",
+            "phase handoff gate outcomes",
+        ],
+        "decision_relevance_statement": (
+            "Backtest evidence is exposed for bounded professional non-live review where explicit "
+            "comparability is required for decision support."
+        ),
+        "readiness_non_inference_statement": (
+            "Technical implementation evidence must remain separated from trader validation and "
+            "operational readiness."
+        ),
+        "unsupported_inference_claims": [
+            "trader validation inferred from technical artifact availability",
+            "operational readiness inferred from backtest evidence alone",
+            "live-trading readiness or broker execution approval",
+        ],
+    }
+
+
 def test_phase_handoff_contract_reports_passed_gates_for_complete_payload() -> None:
     handoff = build_phase_handoff_contract(_base_payload())
     gates = handoff["acceptance_gates"]
     artifact_lineage = handoff["artifact_lineage"]
+    review_contract = handoff["review_contract"]
+    canonical_review_contract = build_professional_review_contract()
     backtest_to_portfolio = handoff["canonical_handoffs"]["backtest_to_portfolio"]
     portfolio_to_paper = handoff["canonical_handoffs"]["portfolio_to_paper"]
 
     assert handoff["source_phase"] == "42b"
     assert handoff["target_phases"] == ["43", "44"]
+    assert review_contract["contract_id"] == "bounded_backtest_evidence_professional_review.v1"
+    assert review_contract["contract_version"] == "1.0.0"
+    assert review_contract["review_context"] == "professional_non_live_evidence_review"
+    assert review_contract == canonical_review_contract
+    assert "run.run_id" in review_contract["required_visible_evidence"]
+    assert "metrics_baseline.metrics.cost_aware" in review_contract["required_visible_evidence"]
+    assert "phase handoff gate outcomes" in review_contract["comparison_axes"]
+    assert "must remain separated" in review_contract["readiness_non_inference_statement"]
+    assert (
+        "live-trading readiness or broker execution approval"
+        in review_contract["unsupported_inference_claims"]
+    )
     assert "realism_boundary" in handoff["authoritative_outputs"]["trader_interpretation"]
     assert artifact_lineage["complete"] is True
     assert "run.run_id" in artifact_lineage["required_fields"]


### PR DESCRIPTION
## Summary
- restore canonical export for `build_professional_review_contract`
- extend `BacktestReadBoundaryResponse` with emitted review-contract fields
- preserve regression coverage for the bounded backtest artifact read surface

## Root cause
GitHub smoke tests failed during collection because `src/api/services/inspection_service.py` imported `build_professional_review_contract`, but that constructor was not exported from `src/cilly_trading/engine/backtest_handoff_contract.py`.

After restoring the export, route-level backtest tests exposed a second issue: `BacktestReadBoundaryResponse` rejected emitted review-contract fields as forbidden extras.

## Scope
Issue: #992 - [BACKTEST][05] Define professional review contract for bounded backtest evidence consumption

In scope:
- `src/cilly_trading/engine/backtest_handoff_contract.py`
- `src/api/models/inspection_models.py`
- `tests/cilly_trading/engine/test_backtest_handoff_contract.py`
- route-level regression coverage represented by existing `tests/test_api_backtest_entry_read.py`

Out of scope:
- trader validation claims
- operational-readiness claims
- roadmap or governance changes
- unrelated cleanup

## Validation
Local command:
.\.venv\Scripts\python -m pytest

Result:
- 1087 passed
- 4 warnings
- 0 failed

## Readiness boundary
This PR establishes bounded non-live technical evidence consumption only.
It does not establish trader validation.
It does not establish operational readiness.
