### PR TITLE
[RISK-MODEL][02] Consolidate portfolio/exposure policies into professional non-live evaluation contract

### DIFF
--- a/docs/architecture/risk/non_live_evaluation_contract.md
+++ b/docs/architecture/risk/non_live_evaluation_contract.md
@@ -1,0 +1,111 @@
+# Professional Non-Live Risk and Exposure Evaluation Contract
+
+## Purpose
+
+Define one deterministic, reviewable contract for non-live risk/exposure
+evaluation evidence across:
+
+- trade-level risk checks
+- symbol-level exposure checks
+- strategy-level exposure checks
+- portfolio-level cap and guardrail checks
+
+This contract hardens repository direction from:
+
+- `docs/governance/professional-trading-capability-target.md`
+
+## Scope and Boundary
+
+This contract is technical evidence only.
+
+In scope:
+
+- deterministic reject/cap/boundary semantics
+- explicit policy evidence rows emitted by evaluators
+- priority/ordering behavior for conflicting policy outcomes
+
+Out of scope:
+
+- live trading enablement
+- broker execution integration
+- external portfolio optimization subsystems
+
+## Canonical Evidence Model
+
+Module:
+
+- `src/cilly_trading/non_live_evaluation_contract.py`
+
+Evidence row:
+
+- `NonLiveEvaluationEvidence`
+
+Mandatory fields:
+
+- `decision` (`approve` or `reject`)
+- `semantic` (`cap` or `boundary`)
+- `scope` (`trade`, `symbol`, `strategy`, `portfolio`, `runtime`)
+- `rule_code`
+- `reason_code`
+- `observed_value`
+- `limit_value`
+
+For issue #993 producer paths, evidence rows are emitted only when a cap or
+boundary is violated. Approved outcomes remain deterministic and carry an empty
+evidence tuple.
+
+## Runtime and Portfolio Producers
+
+Risk producer:
+
+- `src/cilly_trading/risk_framework/risk_evaluator.py`
+- emits `RiskEvaluationResponse.policy_evidence`
+
+Approval discipline:
+
+- approved risk outcomes (`approved: within_risk_limits`) emit no evidence rows
+- reject outcomes emit one canonical reject/cap/boundary evidence row
+
+Execution adapter propagation:
+
+- `src/cilly_trading/engine/risk/gate.py`
+- maps framework decision and propagates `policy_evidence` into `RiskDecision`
+
+Portfolio producers:
+
+- `src/cilly_trading/portfolio_framework/capital_allocation_policy.py`
+- `src/cilly_trading/portfolio_framework/guardrails.py`
+- emit `CapitalAllocationAssessment.policy_evidence`,
+  `PortfolioGuardrailAssessment.policy_evidence`, and
+  `PortfolioDecisionRecord.policy_evidence`
+
+Portfolio discipline:
+
+- portfolio pipeline outcomes are `approved`, `rejected`, or `constraint_hit`
+- policy evidence is emitted only for violated cap/boundary outcomes
+- fully approved outcomes carry an empty evidence tuple
+
+## Priority and Conflict Semantics
+
+Deterministic ordering for per-request risk evaluation:
+
+1. runtime boundary (`kill_switch_enabled`)
+2. trade cap (`max_position_size`)
+3. portfolio cap (`max_account_exposure_pct`)
+4. strategy cap (`max_strategy_exposure_pct`)
+5. symbol cap (`max_symbol_exposure_pct`)
+
+Deterministic ordering for portfolio decision pipeline:
+
+1. allocation intent feasibility
+2. capital allocation caps
+3. portfolio guardrail boundaries
+
+If any cap/boundary rejects the candidate, the signal is not applied to final
+state.
+
+## Non-Live Readiness Discipline
+
+Passing this contract means deterministic technical policy consistency only.
+It does not imply trader validation, production readiness, live-trading
+readiness, or broker go-live approval.

--- a/docs/architecture/risk/portfolio_framework.md
+++ b/docs/architecture/risk/portfolio_framework.md
@@ -302,3 +302,26 @@ deterministic inspection.
 Implementation scope note: this issue provides technical implementation
 evidence only. It does not imply trader validation, trader-approved thresholds,
 live readiness, or broker readiness.
+
+## 13. Professional Non-Live Evaluation Contract (Issue #993)
+
+Portfolio enforcement emits structured cap/boundary violation evidence rows
+through
+the canonical non-live evaluation contract:
+
+- `src/cilly_trading/non_live_evaluation_contract.py`
+- `CapitalAllocationAssessment.policy_evidence`
+- `PortfolioGuardrailAssessment.policy_evidence`
+- `PortfolioDecisionRecord.policy_evidence`
+
+This aligns strategy/symbol/portfolio cap and boundary outcomes with one
+reviewable evidence model while preserving deterministic non-live behavior.
+
+Portfolio pipeline outcomes are `approved`, `rejected`, or `constraint_hit`.
+Evidence rows are emitted only for violated cap/boundary outcomes (for example,
+`constraint_hit` outcomes from allocation/guardrail enforcement). Fully
+approved portfolio outcomes carry an empty evidence tuple.
+
+Canonical contract reference:
+
+- `docs/architecture/risk/non_live_evaluation_contract.md`

--- a/docs/architecture/risk/risk_framework.md
+++ b/docs/architecture/risk/risk_framework.md
@@ -72,6 +72,26 @@ Adapter scope is bounded to non-live operation and maps canonical outcomes for:
 The adapter does not alter risk rules. It only translates deterministic
 risk-framework outcomes into deterministic execution decision codes.
 
+## 8.1) Professional Non-Live Evaluation Contract
+Risk evaluation outputs also emit structured non-live evidence rows for
+reviewable reject/cap/boundary semantics through:
+
+- `src/cilly_trading/non_live_evaluation_contract.py`
+- `RiskEvaluationResponse.policy_evidence` in
+  `src/cilly_trading/risk_framework/risk_evaluator.py`
+- propagated execution evidence in `RiskDecision.policy_evidence` via
+  `src/cilly_trading/engine/risk/gate.py`
+
+The canonical cross-framework contract is:
+
+- `docs/architecture/risk/non_live_evaluation_contract.md`
+
+Evidence discipline for this bounded contract:
+
+- risk evaluator outcomes are `approved` or `rejected`
+- evidence rows are emitted only when a cap/boundary is violated (`rejected`)
+- approved outcomes emit an empty evidence tuple
+
 ## 9) MVP Guardrails
 For MVP scope control, the Risk Framework shall exclude the following:
 

--- a/docs/operations/runtime/signal_to_paper_execution_policy.md
+++ b/docs/operations/runtime/signal_to_paper_execution_policy.md
@@ -245,6 +245,27 @@ Risk decision reason codes are deterministic and adapter-driven (for example
 bounded inputs produce equivalent approve/reject reasons across covered
 non-live execution paths.
 
+Additionally, the underlying framework and portfolio evaluators emit structured
+reject/cap/boundary evidence rows via:
+
+- `src/cilly_trading/non_live_evaluation_contract.py`
+- `RiskEvaluationResponse.policy_evidence`
+- `CapitalAllocationAssessment.policy_evidence`
+- `PortfolioGuardrailAssessment.policy_evidence`
+
+Canonical contract reference:
+
+- `docs/architecture/risk/non_live_evaluation_contract.md`
+
+For this non-live contract, evidence rows are emitted only for violated
+cap/boundary outcomes:
+
+- risk evaluator outcomes are `approved` or `rejected`, and evidence is emitted
+  on `rejected` outcomes only
+- portfolio pipeline outcomes are `approved`, `rejected`, or `constraint_hit`,
+  and evidence is emitted on cap/boundary `constraint_hit` outcomes
+- approved outcomes emit an empty evidence tuple
+
 Issue #981 completion is technical implementation evidence only. It does not
 claim trader validation, trader approval of thresholds, live readiness, or
 broker readiness.

--- a/src/cilly_trading/non_live_evaluation_contract.py
+++ b/src/cilly_trading/non_live_evaluation_contract.py
@@ -1,0 +1,29 @@
+"""Canonical non-live evaluation evidence contract.
+
+This contract is shared by deterministic risk and portfolio policy evaluators
+to make reject/cap/boundary semantics explicit and reviewable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+NonLiveDecision = Literal["approve", "reject"]
+NonLiveSemantic = Literal["cap", "boundary"]
+NonLiveScope = Literal["trade", "symbol", "strategy", "portfolio", "runtime"]
+
+
+@dataclass(frozen=True)
+class NonLiveEvaluationEvidence:
+    """Structured deterministic evidence for one policy decision edge."""
+
+    decision: NonLiveDecision
+    semantic: NonLiveSemantic
+    scope: NonLiveScope
+    rule_code: str
+    reason_code: str
+    observed_value: float
+    limit_value: float
+

--- a/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
+++ b/src/cilly_trading/portfolio_framework/capital_allocation_policy.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Callable, Literal
 
+from cilly_trading.non_live_evaluation_contract import NonLiveEvaluationEvidence
 from cilly_trading.portfolio_framework.contract import PortfolioPosition, PortfolioState
 from cilly_trading.portfolio_framework.exposure_aggregator import aggregate_portfolio_exposure
 from cilly_trading.portfolio_framework.guardrails import (
@@ -79,6 +80,7 @@ class CapitalAllocationAssessment:
         global_cap_notional: Global cap converted to notional limit.
         global_within_cap: Whether global exposure is within global cap.
         strategy_assessments: Per-strategy deterministic assessments.
+        policy_evidence: Structured non-live reject/cap/boundary evidence rows.
     """
 
     approved: bool
@@ -87,6 +89,7 @@ class CapitalAllocationAssessment:
     global_cap_notional: float
     global_within_cap: bool
     strategy_assessments: tuple[StrategyAllocationAssessment, ...]
+    policy_evidence: tuple[NonLiveEvaluationEvidence, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -194,6 +197,7 @@ class PortfolioDecisionRecord:
     proposed_state: PortfolioState | None
     allocation_assessment: CapitalAllocationAssessment | None
     guardrail_assessment: PortfolioGuardrailAssessment | None
+    policy_evidence: tuple[NonLiveEvaluationEvidence, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -353,24 +357,21 @@ def assess_capital_allocation(
         for rule in ordered_rules
     )
 
-    violated_strategy_ids = tuple(
-        item.strategy_id for item in strategy_assessments if not item.within_cap
-    )
-
-    reasons = _build_reasons(
+    reasons, policy_evidence = _build_reasons_and_policy_evidence(
         global_within_cap=global_within_cap,
         total_absolute_notional=total_absolute_notional,
         global_cap_notional=global_cap_notional,
-        violated_strategy_ids=violated_strategy_ids,
+        strategy_assessments=strategy_assessments,
     )
 
     return CapitalAllocationAssessment(
-        approved=global_within_cap and not violated_strategy_ids,
+        approved=not reasons,
         reasons=reasons,
         total_absolute_notional=total_absolute_notional,
         global_cap_notional=global_cap_notional,
         global_within_cap=global_within_cap,
         strategy_assessments=strategy_assessments,
+        policy_evidence=policy_evidence,
     )
 
 
@@ -546,6 +547,7 @@ def run_portfolio_decision_pipeline(
                     proposed_state=None,
                     allocation_assessment=None,
                     guardrail_assessment=None,
+                    policy_evidence=(),
                 )
             )
             continue
@@ -588,6 +590,7 @@ def run_portfolio_decision_pipeline(
                     proposed_state=None,
                     allocation_assessment=None,
                     guardrail_assessment=None,
+                    policy_evidence=(),
                 )
             )
             continue
@@ -600,6 +603,10 @@ def run_portfolio_decision_pipeline(
         allocation_assessment = assess_capital_allocation(proposed_state, allocation_rules)
         guardrail_assessment = assess_portfolio_guardrails(proposed_state, guardrail_limits)
         constraint_reasons = allocation_assessment.reasons + guardrail_assessment.reasons
+        policy_evidence = (
+            allocation_assessment.policy_evidence
+            + guardrail_assessment.policy_evidence
+        )
 
         if constraint_reasons:
             intent = PortfolioDecisionIntent(
@@ -630,6 +637,7 @@ def run_portfolio_decision_pipeline(
                     proposed_state=proposed_state,
                     allocation_assessment=allocation_assessment,
                     guardrail_assessment=guardrail_assessment,
+                    policy_evidence=policy_evidence,
                 )
             )
             continue
@@ -666,6 +674,7 @@ def run_portfolio_decision_pipeline(
                 proposed_state=proposed_state,
                 allocation_assessment=allocation_assessment,
                 guardrail_assessment=guardrail_assessment,
+                policy_evidence=(),
             )
         )
 
@@ -807,40 +816,66 @@ def _constraint_category(
     raise ValueError(f"unsupported portfolio decision reason: {reason}")
 
 
-def _build_reasons(
+def _build_reasons_and_policy_evidence(
     *,
     global_within_cap: bool,
     total_absolute_notional: float,
     global_cap_notional: float,
-    violated_strategy_ids: tuple[str, ...],
-) -> tuple[str, ...]:
+    strategy_assessments: tuple[StrategyAllocationAssessment, ...],
+) -> tuple[tuple[str, ...], tuple[NonLiveEvaluationEvidence, ...]]:
     """Return deterministically ordered violation reasons.
 
     Args:
         global_within_cap: Whether global exposure is within cap.
         total_absolute_notional: Current total absolute notional.
         global_cap_notional: Allowed global cap notional.
-        violated_strategy_ids: Strategy identifiers that violated strategy limits.
+        strategy_assessments: Deterministic per-strategy cap assessments.
 
     Returns:
-        tuple[str, ...]: Deterministically ordered violation reasons.
+        tuple[tuple[str, ...], tuple[NonLiveEvaluationEvidence, ...]]:
+            Deterministically ordered violation reasons and structured evidence.
     """
 
     reasons: list[str] = []
+    policy_evidence: list[NonLiveEvaluationEvidence] = []
 
     if not global_within_cap:
-        reasons.append(
+        reason = (
             "global_cap_exceeded: "
             f"total_absolute_notional={total_absolute_notional} "
             f"global_cap_notional={global_cap_notional}"
         )
+        reasons.append(reason)
+        policy_evidence.append(
+            NonLiveEvaluationEvidence(
+                decision="reject",
+                semantic="cap",
+                scope="portfolio",
+                rule_code="global_cap_notional",
+                reason_code=reason,
+                observed_value=total_absolute_notional,
+                limit_value=global_cap_notional,
+            )
+        )
 
-    reasons.extend(
-        f"strategy_cap_exceeded: strategy_id={strategy_id}"
-        for strategy_id in sorted(violated_strategy_ids)
-    )
+    for assessment in strategy_assessments:
+        if assessment.within_cap:
+            continue
+        reason = f"strategy_cap_exceeded: strategy_id={assessment.strategy_id}"
+        reasons.append(reason)
+        policy_evidence.append(
+            NonLiveEvaluationEvidence(
+                decision="reject",
+                semantic="cap",
+                scope="strategy",
+                rule_code="strategy_cap_notional",
+                reason_code=reason,
+                observed_value=assessment.current_absolute_notional,
+                limit_value=assessment.effective_allowed_notional,
+            )
+        )
 
-    return tuple(reasons)
+    return tuple(reasons), tuple(policy_evidence)
 
 
 def _safe_ratio(numerator: float, denominator: float) -> float:

--- a/src/cilly_trading/portfolio_framework/guardrails.py
+++ b/src/cilly_trading/portfolio_framework/guardrails.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from cilly_trading.non_live_evaluation_contract import (
+    NonLiveEvaluationEvidence,
+    NonLiveScope,
+)
 from cilly_trading.portfolio_framework.contract import PortfolioState
 from cilly_trading.portfolio_framework.exposure_aggregator import PortfolioExposureSummary, aggregate_portfolio_exposure
 
@@ -42,6 +46,7 @@ class PortfolioGuardrailAssessment:
         max_strategy_concentration_pct_observed: Largest observed strategy concentration.
         max_symbol_concentration_pct_observed: Largest observed symbol concentration.
         max_position_concentration_pct_observed: Largest observed position concentration.
+        policy_evidence: Structured non-live reject/cap/boundary evidence rows.
     """
 
     approved: bool
@@ -52,6 +57,7 @@ class PortfolioGuardrailAssessment:
     max_strategy_concentration_pct_observed: float
     max_symbol_concentration_pct_observed: float
     max_position_concentration_pct_observed: float
+    policy_evidence: tuple[NonLiveEvaluationEvidence, ...] = ()
 
 
 def assess_portfolio_guardrails(
@@ -81,7 +87,7 @@ def assess_portfolio_guardrails(
         default=0.0,
     )
 
-    reasons = _build_violation_reasons(
+    reasons, policy_evidence = _build_violation_assessment(
         exposure_summary=exposure_summary,
         absolute_net_exposure_pct=absolute_net_exposure_pct,
         offset_exposure_pct=offset_exposure_pct,
@@ -100,10 +106,11 @@ def assess_portfolio_guardrails(
         max_strategy_concentration_pct_observed=max_strategy_concentration_pct_observed,
         max_symbol_concentration_pct_observed=max_symbol_concentration_pct_observed,
         max_position_concentration_pct_observed=max_position_concentration_pct_observed,
+        policy_evidence=policy_evidence,
     )
 
 
-def _build_violation_reasons(
+def _build_violation_assessment(
     *,
     exposure_summary: PortfolioExposureSummary,
     absolute_net_exposure_pct: float,
@@ -112,52 +119,133 @@ def _build_violation_reasons(
     max_symbol_concentration_pct_observed: float,
     max_position_concentration_pct_observed: float,
     limits: PortfolioGuardrailLimits,
-) -> tuple[str, ...]:
+) -> tuple[tuple[str, ...], tuple[NonLiveEvaluationEvidence, ...]]:
     reasons: list[str] = []
+    policy_evidence: list[NonLiveEvaluationEvidence] = []
 
     if exposure_summary.gross_exposure_pct > limits.max_gross_exposure_pct:
-        reasons.append(
-            "guardrail_exceeded: "
-            f"type=gross_exposure_pct observed={exposure_summary.gross_exposure_pct} "
-            f"limit={limits.max_gross_exposure_pct}"
+        reasons.append(_guardrail_reason(
+            rule_code="gross_exposure_pct",
+            observed_value=exposure_summary.gross_exposure_pct,
+            limit_value=limits.max_gross_exposure_pct,
+        ))
+        policy_evidence.append(
+            _guardrail_evidence(
+                scope="portfolio",
+                rule_code="gross_exposure_pct",
+                reason_code=reasons[-1],
+                observed_value=exposure_summary.gross_exposure_pct,
+                limit_value=limits.max_gross_exposure_pct,
+            )
         )
 
     if absolute_net_exposure_pct > limits.max_abs_net_exposure_pct:
-        reasons.append(
-            "guardrail_exceeded: "
-            f"type=abs_net_exposure_pct observed={absolute_net_exposure_pct} "
-            f"limit={limits.max_abs_net_exposure_pct}"
+        reasons.append(_guardrail_reason(
+            rule_code="abs_net_exposure_pct",
+            observed_value=absolute_net_exposure_pct,
+            limit_value=limits.max_abs_net_exposure_pct,
+        ))
+        policy_evidence.append(
+            _guardrail_evidence(
+                scope="portfolio",
+                rule_code="abs_net_exposure_pct",
+                reason_code=reasons[-1],
+                observed_value=absolute_net_exposure_pct,
+                limit_value=limits.max_abs_net_exposure_pct,
+            )
         )
 
     if offset_exposure_pct > limits.max_offset_exposure_pct:
-        reasons.append(
-            "guardrail_exceeded: "
-            f"type=offset_exposure_pct observed={offset_exposure_pct} "
-            f"limit={limits.max_offset_exposure_pct}"
+        reasons.append(_guardrail_reason(
+            rule_code="offset_exposure_pct",
+            observed_value=offset_exposure_pct,
+            limit_value=limits.max_offset_exposure_pct,
+        ))
+        policy_evidence.append(
+            _guardrail_evidence(
+                scope="portfolio",
+                rule_code="offset_exposure_pct",
+                reason_code=reasons[-1],
+                observed_value=offset_exposure_pct,
+                limit_value=limits.max_offset_exposure_pct,
+            )
         )
 
     if max_strategy_concentration_pct_observed > limits.max_strategy_concentration_pct:
-        reasons.append(
-            "guardrail_exceeded: "
-            f"type=strategy_concentration_pct observed={max_strategy_concentration_pct_observed} "
-            f"limit={limits.max_strategy_concentration_pct}"
+        reasons.append(_guardrail_reason(
+            rule_code="strategy_concentration_pct",
+            observed_value=max_strategy_concentration_pct_observed,
+            limit_value=limits.max_strategy_concentration_pct,
+        ))
+        policy_evidence.append(
+            _guardrail_evidence(
+                scope="strategy",
+                rule_code="strategy_concentration_pct",
+                reason_code=reasons[-1],
+                observed_value=max_strategy_concentration_pct_observed,
+                limit_value=limits.max_strategy_concentration_pct,
+            )
         )
 
     if max_symbol_concentration_pct_observed > limits.max_symbol_concentration_pct:
-        reasons.append(
-            "guardrail_exceeded: "
-            f"type=symbol_concentration_pct observed={max_symbol_concentration_pct_observed} "
-            f"limit={limits.max_symbol_concentration_pct}"
+        reasons.append(_guardrail_reason(
+            rule_code="symbol_concentration_pct",
+            observed_value=max_symbol_concentration_pct_observed,
+            limit_value=limits.max_symbol_concentration_pct,
+        ))
+        policy_evidence.append(
+            _guardrail_evidence(
+                scope="symbol",
+                rule_code="symbol_concentration_pct",
+                reason_code=reasons[-1],
+                observed_value=max_symbol_concentration_pct_observed,
+                limit_value=limits.max_symbol_concentration_pct,
+            )
         )
 
     if max_position_concentration_pct_observed > limits.max_position_concentration_pct:
-        reasons.append(
-            "guardrail_exceeded: "
-            f"type=position_concentration_pct observed={max_position_concentration_pct_observed} "
-            f"limit={limits.max_position_concentration_pct}"
+        reasons.append(_guardrail_reason(
+            rule_code="position_concentration_pct",
+            observed_value=max_position_concentration_pct_observed,
+            limit_value=limits.max_position_concentration_pct,
+        ))
+        policy_evidence.append(
+            _guardrail_evidence(
+                scope="trade",
+                rule_code="position_concentration_pct",
+                reason_code=reasons[-1],
+                observed_value=max_position_concentration_pct_observed,
+                limit_value=limits.max_position_concentration_pct,
+            )
         )
 
-    return tuple(reasons)
+    return tuple(reasons), tuple(policy_evidence)
+
+
+def _guardrail_reason(*, rule_code: str, observed_value: float, limit_value: float) -> str:
+    return (
+        "guardrail_exceeded: "
+        f"type={rule_code} observed={observed_value} limit={limit_value}"
+    )
+
+
+def _guardrail_evidence(
+    *,
+    scope: NonLiveScope,
+    rule_code: str,
+    reason_code: str,
+    observed_value: float,
+    limit_value: float,
+) -> NonLiveEvaluationEvidence:
+    return NonLiveEvaluationEvidence(
+        decision="reject",
+        semantic="boundary",
+        scope=scope,
+        rule_code=rule_code,
+        reason_code=reason_code,
+        observed_value=observed_value,
+        limit_value=limit_value,
+    )
 
 
 def _concentration_ratio(absolute_notional: float, total_absolute_notional: float) -> float:

--- a/tests/portfolio/test_portfolio_decision_pipeline.py
+++ b/tests/portfolio/test_portfolio_decision_pipeline.py
@@ -79,6 +79,7 @@ def test_pipeline_approves_signal_and_persists_it_in_final_state() -> None:
     assert result.decisions[0].guardrail_assessment is not None
     assert result.decisions[0].intent.higher_priority_approved_signal_ids == ()
     assert result.decisions[0].intent.capital_after_signal == 50.0
+    assert result.decisions[0].policy_evidence == ()
 
 
 def test_pipeline_rejects_signal_before_exposure_checks_when_intent_is_below_minimum() -> None:
@@ -114,6 +115,7 @@ def test_pipeline_rejects_signal_before_exposure_checks_when_intent_is_below_min
     assert result.decisions[0].outcome_reasons == ("below_min_allocation",)
     assert result.decisions[0].allocation_assessment is None
     assert result.decisions[0].guardrail_assessment is None
+    assert result.decisions[0].policy_evidence == ()
 
 
 def test_pipeline_resolves_prioritization_conflicts_deterministically() -> None:
@@ -155,6 +157,7 @@ def test_pipeline_resolves_prioritization_conflicts_deterministically() -> None:
     assert result.decisions[1].constraint_categories == ("capacity",)
     assert result.decisions[1].intent.higher_priority_approved_signal_ids == ("sig-a",)
     assert result.decisions[1].outcome_reasons == ("position_limit_reached",)
+    assert result.decisions[1].policy_evidence == ()
 
 
 def test_pipeline_marks_exposure_guardrail_constraint_hits_without_mutating_state() -> None:
@@ -225,6 +228,10 @@ def test_pipeline_marks_exposure_guardrail_constraint_hits_without_mutating_stat
     )
     assert result.decisions[0].allocation_assessment is not None
     assert result.decisions[0].guardrail_assessment is not None
+    assert len(result.decisions[0].policy_evidence) == 1
+    assert result.decisions[0].policy_evidence[0].semantic == "boundary"
+    assert result.decisions[0].policy_evidence[0].scope == "portfolio"
+    assert result.decisions[0].policy_evidence[0].rule_code == "gross_exposure_pct"
 
 
 def test_pipeline_marks_concentration_constraint_hits_with_explicit_categories() -> None:
@@ -279,3 +286,8 @@ def test_pipeline_marks_concentration_constraint_hits_with_explicit_categories()
         "guardrail_exceeded: type=symbol_concentration_pct observed=1.0 limit=0.9",
         "guardrail_exceeded: type=position_concentration_pct observed=1.0 limit=0.9",
     )
+    assert [item.scope for item in result.decisions[0].policy_evidence] == [
+        "strategy",
+        "symbol",
+        "trade",
+    ]

--- a/tests/test_non_live_evaluation_contract_docs.py
+++ b/tests/test_non_live_evaluation_contract_docs.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_DOC = (
+    REPO_ROOT / "docs" / "architecture" / "risk" / "non_live_evaluation_contract.md"
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_non_live_evaluation_contract_doc_defines_canonical_semantics() -> None:
+    content = _read(CONTRACT_DOC)
+
+    assert content.startswith("# Professional Non-Live Risk and Exposure Evaluation Contract")
+    assert "NonLiveEvaluationEvidence" in content
+    assert "decision" in content
+    assert "semantic" in content
+    assert "scope" in content
+    assert "reject/cap/boundary semantics" in content
+
+
+def test_non_live_contract_doc_locks_portfolio_constraint_hit_terminology() -> None:
+    content = _read(CONTRACT_DOC)
+
+    assert "portfolio pipeline outcomes are `approved`, `rejected`, or `constraint_hit`" in content
+    assert "evidence rows are emitted only when a cap or" in content
+    assert "boundary is violated" in content
+    assert "reject edges only" not in content.lower()
+
+
+def test_non_live_evaluation_contract_doc_keeps_non_live_boundaries_explicit() -> None:
+    content = _read(CONTRACT_DOC)
+
+    assert "Out of scope:" in content
+    assert "live trading enablement" in content
+    assert "broker execution integration" in content
+    assert "external portfolio optimization subsystems" in content
+
+
+def test_risk_and_portfolio_docs_reference_canonical_non_live_contract() -> None:
+    risk_framework = _read(REPO_ROOT / "docs" / "architecture" / "risk" / "risk_framework.md")
+    portfolio_framework = _read(REPO_ROOT / "docs" / "architecture" / "risk" / "portfolio_framework.md")
+
+    assert "non_live_evaluation_contract.md" in risk_framework
+    assert "policy_evidence" in risk_framework
+    assert "risk evaluator outcomes are `approved` or `rejected`" in risk_framework
+    assert "non_live_evaluation_contract.md" in portfolio_framework
+    assert "policy_evidence" in portfolio_framework
+    assert "approved`, `rejected`, or `constraint_hit`" in portfolio_framework
+    assert "reject edges only" not in portfolio_framework.lower()
+
+
+def test_ops_policy_doc_references_structured_non_live_evidence_surface() -> None:
+    policy_doc = _read(
+        REPO_ROOT
+        / "docs"
+        / "operations"
+        / "runtime"
+        / "signal_to_paper_execution_policy.md"
+    )
+
+    assert "RiskEvaluationResponse.policy_evidence" in policy_doc
+    assert "CapitalAllocationAssessment.policy_evidence" in policy_doc
+    assert "PortfolioGuardrailAssessment.policy_evidence" in policy_doc
+    assert "non_live_evaluation_contract.md" in policy_doc
+    assert "approved`, `rejected`, or `constraint_hit`" in policy_doc
+    assert "approved outcomes emit an empty evidence tuple" in policy_doc
+    assert "reject edges only" not in policy_doc.lower()

--- a/tests/test_phase43_portfolio_simulation_contract.py
+++ b/tests/test_phase43_portfolio_simulation_contract.py
@@ -81,6 +81,10 @@ def test_phase43_capital_allocation_contract_enforces_global_and_strategy_caps()
         "global_cap_exceeded: total_absolute_notional=300.0 global_cap_notional=250.0",
         "strategy_cap_exceeded: strategy_id=alpha",
     )
+    assert [item.rule_code for item in assessment.policy_evidence] == [
+        "global_cap_notional",
+        "strategy_cap_notional",
+    ]
 
 
 def test_phase43_exposure_handling_contract_reports_deterministic_multi_position_metrics() -> None:


### PR DESCRIPTION
closes #993

## Summary
- formalize the canonical non-live evaluation contract for deterministic risk and portfolio evidence
- align portfolio pipeline terminology with approved/rejected/constraint_hit semantics
- tighten documentation and regression coverage for evidence emission boundaries

## Scope
- canonical non-live evaluation contract documentation
- portfolio decision pipeline evidence semantics
- non-live contract documentation regression tests

## Validation
- python -m pytest
- 1092 passed, 4 warnings

## Active Issue
- #993