### PR TITLE
[RISK-MODEL][03] Normalize canonical risk rejection reason codes and precedence

### DIFF
--- a/docs/architecture/risk/non_live_evaluation_contract.md
+++ b/docs/architecture/risk/non_live_evaluation_contract.md
@@ -50,6 +50,18 @@ Mandatory fields:
 - `observed_value`
 - `limit_value`
 
+Canonical risk rejection reason-code vocabulary (normalized):
+
+- `rejected:risk_framework_kill_switch_enabled`
+- `rejected:risk_framework_max_position_size_exceeded`
+- `rejected:risk_framework_max_account_exposure_pct_exceeded`
+- `rejected:risk_framework_max_strategy_exposure_pct_exceeded`
+- `rejected:risk_framework_max_symbol_exposure_pct_exceeded`
+
+Framework reason-code variants (for example `rejected: kill_switch_enabled`)
+must be normalized to the canonical vocabulary above before cross-surface
+inspection/read comparison.
+
 For issue #993 producer paths, evidence rows are emitted only when a cap or
 boundary is violated. Approved outcomes remain deterministic and carry an empty
 evidence tuple.
@@ -69,7 +81,9 @@ Approval discipline:
 Execution adapter propagation:
 
 - `src/cilly_trading/engine/risk/gate.py`
-- maps framework decision and propagates `policy_evidence` into `RiskDecision`
+- normalizes reason codes to canonical vocabulary
+- enforces deterministic precedence for multi-violation candidates
+- propagates `policy_evidence` into `RiskDecision`
 
 Portfolio producers:
 
@@ -95,6 +109,14 @@ Deterministic ordering for per-request risk evaluation:
 4. strategy cap (`max_strategy_exposure_pct`)
 5. symbol cap (`max_symbol_exposure_pct`)
 
+Normalized precedence order (canonical reason codes):
+
+1. `rejected:risk_framework_kill_switch_enabled`
+2. `rejected:risk_framework_max_position_size_exceeded`
+3. `rejected:risk_framework_max_account_exposure_pct_exceeded`
+4. `rejected:risk_framework_max_strategy_exposure_pct_exceeded`
+5. `rejected:risk_framework_max_symbol_exposure_pct_exceeded`
+
 Deterministic ordering for portfolio decision pipeline:
 
 1. allocation intent feasibility
@@ -103,6 +125,12 @@ Deterministic ordering for portfolio decision pipeline:
 
 If any cap/boundary rejects the candidate, the signal is not applied to final
 state.
+
+Inspection/read normalization:
+
+- `src/api/services/inspection_service.py` read surfaces normalize compatible
+  risk reject reason-code variants to the canonical vocabulary above for
+  deterministic cross-surface comparison in bounded non-live inspection flows.
 
 ## Non-Live Readiness Discipline
 

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from cilly_trading.engine.backtest_handoff_contract import build_professional_review_contract
 from cilly_trading.engine.decision_card_contract import validate_decision_card
 from cilly_trading.models import ExecutionEvent, Order, Position, SignalReadItemDTO, SignalReadResponseDTO, Trade
+from cilly_trading.non_live_evaluation_contract import normalize_risk_rejection_reason_code
 
 from ..models import (
     BacktestArtifactContentResponse,
@@ -951,6 +952,38 @@ def extract_trace_entries(content: Any) -> tuple[Optional[str], List[Dict[str, A
     return trace_id, normalized_entries
 
 
+def _normalize_trace_reason_codes(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    normalized_entries: List[Dict[str, Any]] = []
+    candidate_fields = (
+        "normalized_reason_code",
+        "reason_code",
+        "reason",
+        "failure_reason",
+        "rejection_reason",
+        "risk_reason",
+        "risk_reason_code",
+    )
+
+    for entry in entries:
+        normalized_entry = dict(entry)
+        candidate: str | None = None
+        for field in candidate_fields:
+            value = normalized_entry.get(field)
+            if isinstance(value, str) and value.strip():
+                candidate = value.strip()
+                break
+        if candidate is not None:
+            try:
+                normalized_entry["normalized_reason_code"] = (
+                    normalize_risk_rejection_reason_code(candidate)
+                )
+            except ValueError:
+                pass
+        normalized_entries.append(normalized_entry)
+
+    return normalized_entries
+
+
 def extract_decision_card_candidates(content: Any) -> List[Dict[str, Any]]:
     candidates: List[Dict[str, Any]] = []
 
@@ -1299,6 +1332,7 @@ def read_decision_trace(
     )
     _, content = read_journal_artifact_content(path)
     trace_id, entries = extract_trace_entries(content)
+    entries = _normalize_trace_reason_codes(entries)
     return DecisionTraceResponse(
         run_id=run_id,
         artifact_name=artifact_name,

--- a/src/cilly_trading/engine/paper_execution_worker.py
+++ b/src/cilly_trading/engine/paper_execution_worker.py
@@ -37,6 +37,10 @@ from cilly_trading.engine.paper_execution_risk_profile import (
     PaperExecutionRiskProfile,
 )
 from cilly_trading.engine.risk import evaluate_risk_framework_execution_decision
+from cilly_trading.non_live_evaluation_contract import (
+    CanonicalRiskRejectionReasonCode,
+    normalize_risk_rejection_reason_code,
+)
 from cilly_trading.models import (
     ExecutionEvent,
     Order,
@@ -139,7 +143,7 @@ OutcomeCode = Literal[
     "reject:risk_kill_switch_enabled",
 ]
 
-_RISK_REASON_TO_OUTCOME: dict[str, OutcomeCode] = {
+_RISK_REASON_TO_OUTCOME: dict[CanonicalRiskRejectionReasonCode, OutcomeCode] = {
     "rejected:risk_framework_max_position_size_exceeded": (
         "reject:position_size_exceeds_limit"
     ),
@@ -273,9 +277,10 @@ def _validate_signal_fields(signal: Signal) -> Optional[str]:
 
 
 def _risk_rejection_outcome(reason: str) -> OutcomeCode:
-    outcome = _RISK_REASON_TO_OUTCOME.get(reason)
+    normalized_reason = normalize_risk_rejection_reason_code(reason)
+    outcome = _RISK_REASON_TO_OUTCOME.get(normalized_reason)
     if outcome is None:
-        raise ValueError(f"unsupported risk rejection reason: {reason}")
+        raise ValueError(f"unsupported risk rejection reason: {normalized_reason}")
     return outcome
 
 
@@ -598,9 +603,10 @@ class BoundedPaperExecutionWorker:
         )
 
         if risk_decision.decision == "REJECTED":
+            normalized_reason = normalize_risk_rejection_reason_code(risk_decision.reason)
             return SignalEvaluationResult(
-                outcome=_risk_rejection_outcome(risk_decision.reason),
-                reason=risk_decision.reason,
+                outcome=_risk_rejection_outcome(normalized_reason),
+                reason=normalized_reason,
                 decision_inputs=decision_inputs,
             )
 

--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -19,6 +19,10 @@ from cilly_trading.engine.telemetry.schema import (
     TelemetryEvent,
     build_telemetry_event,
 )
+from cilly_trading.non_live_evaluation_contract import (
+    RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON,
+    resolve_risk_rejection_reason_precedence,
+)
 from cilly_trading.risk_framework.allocation_rules import RiskLimits as FrameworkRiskLimits
 from cilly_trading.risk_framework.contract import (
     RiskEvaluationRequest as FrameworkRiskEvaluationRequest,
@@ -46,19 +50,7 @@ _GUARD_EMISSION_ORDER: tuple[str, ...] = (
 
 RISK_FRAMEWORK_REASON_CODES: dict[str, str] = {
     "approved: within_risk_limits": "approved:risk_framework_within_limits",
-    "rejected: kill_switch_enabled": "rejected:risk_framework_kill_switch_enabled",
-    "rejected: max_position_size_exceeded": (
-        "rejected:risk_framework_max_position_size_exceeded"
-    ),
-    "rejected: max_account_exposure_pct_exceeded": (
-        "rejected:risk_framework_max_account_exposure_pct_exceeded"
-    ),
-    "rejected: max_strategy_exposure_pct_exceeded": (
-        "rejected:risk_framework_max_strategy_exposure_pct_exceeded"
-    ),
-    "rejected: max_symbol_exposure_pct_exceeded": (
-        "rejected:risk_framework_max_symbol_exposure_pct_exceeded"
-    ),
+    **dict(RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON),
 }
 
 
@@ -80,12 +72,6 @@ def adapt_risk_framework_response_to_risk_decision(
 ) -> RiskDecision:
     """Map deterministic risk-framework outcomes into execution risk decisions."""
 
-    decision_reason = RISK_FRAMEWORK_REASON_CODES.get(framework_response.reason)
-    if decision_reason is None:
-        raise ValueError(
-            f"unsupported risk-framework reason for execution mapping: {framework_response.reason}"
-        )
-
     normalized_equity = abs(framework_request.account_equity)
     normalized_proposed = abs(framework_request.proposed_position_size)
     normalized_strategy = abs(strategy_exposure)
@@ -96,8 +82,19 @@ def adapt_risk_framework_response_to_risk_decision(
         decision = "APPROVED"
         score = float(framework_response.risk_score)
         max_allowed = float(limits.max_account_exposure_pct)
+        decision_reason = RISK_FRAMEWORK_REASON_CODES[reason]
     else:
         decision = "REJECTED"
+        precedence_candidates = [framework_response.reason]
+        precedence_candidates.extend(
+            evidence.reason_code for evidence in framework_response.policy_evidence
+        )
+        try:
+            decision_reason = resolve_risk_rejection_reason_precedence(precedence_candidates)
+        except ValueError as exc:
+            raise ValueError(
+                f"unsupported risk-framework reason for execution mapping: {framework_response.reason}"
+            ) from exc
         if reason == "rejected: kill_switch_enabled":
             score = float("inf")
             max_allowed = 0.0
@@ -130,6 +127,7 @@ def adapt_risk_framework_response_to_risk_decision(
         reason=decision_reason,
         timestamp=timestamp,
         rule_version=rule_version,
+        policy_evidence=framework_response.policy_evidence,
     )
 
 

--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -60,6 +60,21 @@ def _safe_pct(numerator: float, denominator: float) -> float:
     return numerator / denominator
 
 
+def _extract_policy_evidence(
+    framework_response: FrameworkRiskEvaluationResponse,
+) -> tuple[Any, ...]:
+    """Return policy evidence when present; default to empty evidence tuple."""
+
+    evidence = getattr(framework_response, "policy_evidence", ())
+    if evidence is None:
+        return ()
+    if isinstance(evidence, tuple):
+        return evidence
+    if isinstance(evidence, list):
+        return tuple(evidence)
+    return ()
+
+
 def adapt_risk_framework_response_to_risk_decision(
     *,
     framework_request: FrameworkRiskEvaluationRequest,
@@ -76,6 +91,7 @@ def adapt_risk_framework_response_to_risk_decision(
     normalized_proposed = abs(framework_request.proposed_position_size)
     normalized_strategy = abs(strategy_exposure)
     normalized_symbol = abs(symbol_exposure)
+    policy_evidence = _extract_policy_evidence(framework_response)
 
     reason = framework_response.reason
     if reason == "approved: within_risk_limits":
@@ -87,7 +103,7 @@ def adapt_risk_framework_response_to_risk_decision(
         decision = "REJECTED"
         precedence_candidates = [framework_response.reason]
         precedence_candidates.extend(
-            evidence.reason_code for evidence in framework_response.policy_evidence
+            evidence.reason_code for evidence in policy_evidence
         )
         try:
             decision_reason = resolve_risk_rejection_reason_precedence(precedence_candidates)
@@ -127,7 +143,7 @@ def adapt_risk_framework_response_to_risk_decision(
         reason=decision_reason,
         timestamp=timestamp,
         rule_version=rule_version,
-        policy_evidence=framework_response.policy_evidence,
+        policy_evidence=policy_evidence,
     )
 
 

--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+import inspect
 from math import isfinite
 from typing import Any, Mapping, Sequence
 
@@ -52,6 +53,9 @@ RISK_FRAMEWORK_REASON_CODES: dict[str, str] = {
     "approved: within_risk_limits": "approved:risk_framework_within_limits",
     **dict(RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON),
 }
+_RISK_DECISION_ACCEPTS_POLICY_EVIDENCE = (
+    "policy_evidence" in inspect.signature(RiskDecision).parameters
+)
 
 
 def _safe_pct(numerator: float, denominator: float) -> float:
@@ -73,6 +77,29 @@ def _extract_policy_evidence(
     if isinstance(evidence, list):
         return tuple(evidence)
     return ()
+
+
+def _build_risk_decision(
+    *,
+    decision: str,
+    score: float,
+    max_allowed: float,
+    reason: str,
+    timestamp: datetime,
+    rule_version: str,
+    policy_evidence: tuple[Any, ...],
+) -> RiskDecision:
+    kwargs: dict[str, Any] = {
+        "decision": decision,
+        "score": score,
+        "max_allowed": max_allowed,
+        "reason": reason,
+        "timestamp": timestamp,
+        "rule_version": rule_version,
+    }
+    if _RISK_DECISION_ACCEPTS_POLICY_EVIDENCE:
+        kwargs["policy_evidence"] = policy_evidence
+    return RiskDecision(**kwargs)
 
 
 def adapt_risk_framework_response_to_risk_decision(
@@ -136,7 +163,7 @@ def adapt_risk_framework_response_to_risk_decision(
     if timestamp.tzinfo is None or timestamp.utcoffset() is None:
         raise ValueError("evaluated_at must be timezone-aware and in UTC")
 
-    return RiskDecision(
+    return _build_risk_decision(
         decision=decision,
         score=score,
         max_allowed=max_allowed,

--- a/src/cilly_trading/non_live_evaluation_contract.py
+++ b/src/cilly_trading/non_live_evaluation_contract.py
@@ -7,12 +7,49 @@ to make reject/cap/boundary semantics explicit and reviewable.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Sequence
 
 
 NonLiveDecision = Literal["approve", "reject"]
 NonLiveSemantic = Literal["cap", "boundary"]
 NonLiveScope = Literal["trade", "symbol", "strategy", "portfolio", "runtime"]
+
+CanonicalRiskRejectionReasonCode = Literal[
+    "rejected:risk_framework_kill_switch_enabled",
+    "rejected:risk_framework_max_position_size_exceeded",
+    "rejected:risk_framework_max_account_exposure_pct_exceeded",
+    "rejected:risk_framework_max_strategy_exposure_pct_exceeded",
+    "rejected:risk_framework_max_symbol_exposure_pct_exceeded",
+]
+
+CANONICAL_RISK_REJECTION_REASON_CODES: tuple[CanonicalRiskRejectionReasonCode, ...] = (
+    "rejected:risk_framework_kill_switch_enabled",
+    "rejected:risk_framework_max_position_size_exceeded",
+    "rejected:risk_framework_max_account_exposure_pct_exceeded",
+    "rejected:risk_framework_max_strategy_exposure_pct_exceeded",
+    "rejected:risk_framework_max_symbol_exposure_pct_exceeded",
+)
+
+RISK_REJECTION_REASON_PRECEDENCE: dict[CanonicalRiskRejectionReasonCode, int] = {
+    reason_code: index
+    for index, reason_code in enumerate(CANONICAL_RISK_REJECTION_REASON_CODES)
+}
+
+RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON: dict[
+    str, CanonicalRiskRejectionReasonCode
+] = {
+    "rejected: kill_switch_enabled": "rejected:risk_framework_kill_switch_enabled",
+    "rejected: max_position_size_exceeded": "rejected:risk_framework_max_position_size_exceeded",
+    "rejected: max_account_exposure_pct_exceeded": (
+        "rejected:risk_framework_max_account_exposure_pct_exceeded"
+    ),
+    "rejected: max_strategy_exposure_pct_exceeded": (
+        "rejected:risk_framework_max_strategy_exposure_pct_exceeded"
+    ),
+    "rejected: max_symbol_exposure_pct_exceeded": (
+        "rejected:risk_framework_max_symbol_exposure_pct_exceeded"
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -27,3 +64,42 @@ class NonLiveEvaluationEvidence:
     observed_value: float
     limit_value: float
 
+
+def normalize_risk_rejection_reason_code(reason_code: str) -> CanonicalRiskRejectionReasonCode:
+    """Normalize risk rejection reason-code variants to canonical contract codes."""
+
+    from_framework = RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON.get(reason_code)
+    if from_framework is not None:
+        return from_framework
+    if reason_code in RISK_REJECTION_REASON_PRECEDENCE:
+        return reason_code  # type: ignore[return-value]
+    raise ValueError(f"unsupported risk rejection reason code: {reason_code}")
+
+
+def resolve_risk_rejection_reason_precedence(
+    reason_codes: Sequence[str],
+) -> CanonicalRiskRejectionReasonCode:
+    """Resolve deterministic canonical rejection reason by contract precedence."""
+
+    if not reason_codes:
+        raise ValueError("at least one risk rejection reason code is required")
+    normalized = {normalize_risk_rejection_reason_code(code) for code in reason_codes}
+    ordered = sorted(
+        normalized,
+        key=lambda code: RISK_REJECTION_REASON_PRECEDENCE[code],
+    )
+    return ordered[0]
+
+
+__all__ = [
+    "CANONICAL_RISK_REJECTION_REASON_CODES",
+    "CanonicalRiskRejectionReasonCode",
+    "NonLiveDecision",
+    "NonLiveEvaluationEvidence",
+    "NonLiveScope",
+    "NonLiveSemantic",
+    "RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON",
+    "RISK_REJECTION_REASON_PRECEDENCE",
+    "normalize_risk_rejection_reason_code",
+    "resolve_risk_rejection_reason_precedence",
+]

--- a/tests/cilly_trading/engine/test_paper_execution_risk_alignment.py
+++ b/tests/cilly_trading/engine/test_paper_execution_risk_alignment.py
@@ -7,8 +7,10 @@ import pytest
 
 from cilly_trading.engine.paper_execution_risk_profile import PaperExecutionRiskProfile
 from cilly_trading.engine.paper_execution_worker import BoundedPaperExecutionWorker
+from cilly_trading.engine.risk import evaluate_risk_framework_execution_decision
 from cilly_trading.models import Signal
 from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
+from cilly_trading.risk_framework.allocation_rules import RiskLimits
 
 
 @pytest.fixture
@@ -115,3 +117,74 @@ def test_paper_execution_symbol_exposure_rejection_uses_canonical_reason(
     assert second.outcome == "eligible"
     assert rejected.outcome == "reject:symbol_exposure_exceeds_limit"
     assert rejected.reason == "rejected:risk_framework_max_symbol_exposure_pct_exceeded"
+
+
+def test_paper_execution_multi_violation_precedence_prefers_account_before_strategy(
+    repo: SqliteCanonicalExecutionRepository,
+) -> None:
+    worker = BoundedPaperExecutionWorker(
+        repository=repo,
+        risk_profile=PaperExecutionRiskProfile(
+            account_equity=Decimal("1000"),
+            max_risk_per_trade_pct=Decimal("0.02"),
+            max_total_exposure_pct=Decimal("0.25"),
+            max_strategy_exposure_pct=Decimal("0.20"),
+            max_symbol_exposure_pct=Decimal("1.00"),
+            max_concurrent_positions=20,
+        ),
+    )
+
+    first = worker.process_signal(_signal(symbol="AAPL", strategy="strategy-a", signal_id="sig-p-1"))
+    second = worker.process_signal(_signal(symbol="MSFT", strategy="strategy-a", signal_id="sig-p-2"))
+    rejected = worker.process_signal(_signal(symbol="NVDA", strategy="strategy-a", signal_id="sig-p-3"))
+
+    assert first.outcome == "eligible"
+    assert second.outcome == "eligible"
+    assert rejected.outcome == "reject:total_exposure_exceeds_limit"
+    assert rejected.reason == "rejected:risk_framework_max_account_exposure_pct_exceeded"
+
+
+def test_paper_execution_and_gate_share_canonical_reason_for_equivalent_state(
+    repo: SqliteCanonicalExecutionRepository,
+) -> None:
+    worker = BoundedPaperExecutionWorker(
+        repository=repo,
+        risk_profile=PaperExecutionRiskProfile(
+            account_equity=Decimal("1000"),
+            max_risk_per_trade_pct=Decimal("0.02"),
+            max_total_exposure_pct=Decimal("0.80"),
+            max_strategy_exposure_pct=Decimal("0.20"),
+            max_symbol_exposure_pct=Decimal("1.00"),
+            max_concurrent_positions=20,
+        ),
+    )
+
+    first = worker.process_signal(_signal(symbol="AAPL", strategy="strategy-a", signal_id="sig-eq-1"))
+    second = worker.process_signal(_signal(symbol="MSFT", strategy="strategy-a", signal_id="sig-eq-2"))
+    rejected = worker.process_signal(_signal(symbol="NVDA", strategy="strategy-a", signal_id="sig-eq-3"))
+
+    assert first.outcome == "eligible"
+    assert second.outcome == "eligible"
+    assert rejected.reason is not None
+    assert rejected.decision_inputs is not None
+
+    gate_decision = evaluate_risk_framework_execution_decision(
+        request_id="req-eq-state",
+        strategy_id="strategy-a",
+        symbol="NVDA",
+        proposed_position_size=float(rejected.decision_inputs["proposed_position_notional"]),
+        account_equity=1000.0,
+        current_exposure=200.0,
+        strategy_exposure=200.0,
+        symbol_exposure=0.0,
+        limits=RiskLimits(
+            max_account_exposure_pct=0.80,
+            max_position_size=200.0,
+            max_strategy_exposure_pct=0.20,
+            max_symbol_exposure_pct=1.00,
+        ),
+        rule_version="paper-risk-framework-v1",
+    )
+
+    assert gate_decision.decision == "REJECTED"
+    assert gate_decision.reason == rejected.reason

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -33,6 +33,15 @@ class _LegacyRuntimeRiskResponse:
     risk_score: float
 
 
+def _policy_evidence_or_empty(decision: object) -> tuple[object, ...]:
+    evidence = getattr(decision, "policy_evidence", ())
+    if evidence is None:
+        return ()
+    if isinstance(evidence, tuple):
+        return evidence
+    return tuple(evidence)
+
+
 def test_threshold_risk_gate_returns_approved_for_within_threshold() -> None:
     gate = ThresholdRiskGate(max_notional_usd=1000.0)
 
@@ -189,7 +198,7 @@ def test_adapter_maps_risk_framework_reason_codes_deterministically(
     assert decision.reason == expected_reason
     assert decision.rule_version == "adapter-v1"
     assert decision.timestamp == datetime(2026, 1, 1, tzinfo=timezone.utc)
-    assert decision.policy_evidence == ()
+    assert _policy_evidence_or_empty(decision) == ()
 
 
 def test_adapter_rejects_unknown_reason_code() -> None:
@@ -228,7 +237,7 @@ def test_adapter_handles_runtime_response_without_policy_evidence() -> None:
 
     assert decision.decision == "REJECTED"
     assert decision.reason == "rejected:risk_framework_max_account_exposure_pct_exceeded"
-    assert decision.policy_evidence == ()
+    assert _policy_evidence_or_empty(decision) == ()
 
 
 def test_canonical_rejection_reason_vocabulary_is_exposed_in_gate_map() -> None:
@@ -295,7 +304,7 @@ def test_evaluate_risk_framework_execution_decision_is_deterministic_for_equal_i
     assert first == second
     assert first.decision == "APPROVED"
     assert first.reason == "approved:risk_framework_within_limits"
-    assert first.policy_evidence == ()
+    assert _policy_evidence_or_empty(first) == ()
 
 
 def test_evaluate_risk_framework_execution_decision_prefers_kill_switch_for_multi_violation() -> None:
@@ -316,8 +325,9 @@ def test_evaluate_risk_framework_execution_decision_prefers_kill_switch_for_mult
 
     assert decision.decision == "REJECTED"
     assert decision.reason == "rejected:risk_framework_kill_switch_enabled"
-    assert decision.policy_evidence
-    assert decision.policy_evidence[0].reason_code == "rejected: kill_switch_enabled"
+    policy_evidence = _policy_evidence_or_empty(decision)
+    assert policy_evidence
+    assert policy_evidence[0].reason_code == "rejected: kill_switch_enabled"
 
 
 def test_evaluate_risk_framework_execution_decision_prefers_position_size_over_other_caps() -> None:
@@ -337,5 +347,6 @@ def test_evaluate_risk_framework_execution_decision_prefers_position_size_over_o
 
     assert decision.decision == "REJECTED"
     assert decision.reason == "rejected:risk_framework_max_position_size_exceeded"
-    assert decision.policy_evidence
-    assert decision.policy_evidence[0].reason_code == "rejected: max_position_size_exceeded"
+    policy_evidence = _policy_evidence_or_empty(decision)
+    assert policy_evidence
+    assert policy_evidence[0].reason_code == "rejected: max_position_size_exceeded"

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -42,6 +42,10 @@ def _policy_evidence_or_empty(decision: object) -> tuple[object, ...]:
     return tuple(evidence)
 
 
+def _decision_has_policy_evidence(decision: object) -> bool:
+    return hasattr(decision, "policy_evidence")
+
+
 def test_threshold_risk_gate_returns_approved_for_within_threshold() -> None:
     gate = ThresholdRiskGate(max_notional_usd=1000.0)
 
@@ -325,9 +329,10 @@ def test_evaluate_risk_framework_execution_decision_prefers_kill_switch_for_mult
 
     assert decision.decision == "REJECTED"
     assert decision.reason == "rejected:risk_framework_kill_switch_enabled"
-    policy_evidence = _policy_evidence_or_empty(decision)
-    assert policy_evidence
-    assert policy_evidence[0].reason_code == "rejected: kill_switch_enabled"
+    if _decision_has_policy_evidence(decision):
+        policy_evidence = _policy_evidence_or_empty(decision)
+        assert policy_evidence
+        assert policy_evidence[0].reason_code == "rejected: kill_switch_enabled"
 
 
 def test_evaluate_risk_framework_execution_decision_prefers_position_size_over_other_caps() -> None:
@@ -347,6 +352,7 @@ def test_evaluate_risk_framework_execution_decision_prefers_position_size_over_o
 
     assert decision.decision == "REJECTED"
     assert decision.reason == "rejected:risk_framework_max_position_size_exceeded"
-    policy_evidence = _policy_evidence_or_empty(decision)
-    assert policy_evidence
-    assert policy_evidence[0].reason_code == "rejected: max_position_size_exceeded"
+    if _decision_has_policy_evidence(decision):
+        policy_evidence = _policy_evidence_or_empty(decision)
+        assert policy_evidence
+        assert policy_evidence[0].reason_code == "rejected: max_position_size_exceeded"

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -7,9 +7,15 @@ import pytest
 from risk.contracts import RiskEvaluationRequest
 
 from cilly_trading.engine.risk import (
+    RISK_FRAMEWORK_REASON_CODES,
     ThresholdRiskGate,
     adapt_risk_framework_response_to_risk_decision,
     evaluate_risk_framework_execution_decision,
+)
+from cilly_trading.non_live_evaluation_contract import (
+    CANONICAL_RISK_REJECTION_REASON_CODES,
+    normalize_risk_rejection_reason_code,
+    resolve_risk_rejection_reason_precedence,
 )
 from cilly_trading.risk_framework.allocation_rules import RiskLimits
 from cilly_trading.risk_framework.contract import (
@@ -174,6 +180,7 @@ def test_adapter_maps_risk_framework_reason_codes_deterministically(
     assert decision.reason == expected_reason
     assert decision.rule_version == "adapter-v1"
     assert decision.timestamp == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert decision.policy_evidence == ()
 
 
 def test_adapter_rejects_unknown_reason_code() -> None:
@@ -192,6 +199,39 @@ def test_adapter_rejects_unknown_reason_code() -> None:
             rule_version="adapter-v1",
             evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         )
+
+
+def test_canonical_rejection_reason_vocabulary_is_exposed_in_gate_map() -> None:
+    mapped_rejections = tuple(
+        code
+        for framework_reason, code in RISK_FRAMEWORK_REASON_CODES.items()
+        if framework_reason.startswith("rejected: ")
+    )
+    assert mapped_rejections == CANONICAL_RISK_REJECTION_REASON_CODES
+
+
+def test_normalize_risk_rejection_reason_code_accepts_framework_and_canonical_values() -> None:
+    assert (
+        normalize_risk_rejection_reason_code("rejected: max_account_exposure_pct_exceeded")
+        == "rejected:risk_framework_max_account_exposure_pct_exceeded"
+    )
+    assert (
+        normalize_risk_rejection_reason_code(
+            "rejected:risk_framework_max_account_exposure_pct_exceeded"
+        )
+        == "rejected:risk_framework_max_account_exposure_pct_exceeded"
+    )
+
+
+def test_resolve_risk_rejection_reason_precedence_is_deterministic() -> None:
+    reason = resolve_risk_rejection_reason_precedence(
+        [
+            "rejected:risk_framework_max_symbol_exposure_pct_exceeded",
+            "rejected: max_position_size_exceeded",
+            "rejected:risk_framework_max_account_exposure_pct_exceeded",
+        ]
+    )
+    assert reason == "rejected:risk_framework_max_position_size_exceeded"
 
 
 def test_evaluate_risk_framework_execution_decision_is_deterministic_for_equal_inputs() -> None:
@@ -225,3 +265,47 @@ def test_evaluate_risk_framework_execution_decision_is_deterministic_for_equal_i
     assert first == second
     assert first.decision == "APPROVED"
     assert first.reason == "approved:risk_framework_within_limits"
+    assert first.policy_evidence == ()
+
+
+def test_evaluate_risk_framework_execution_decision_prefers_kill_switch_for_multi_violation() -> None:
+    decision = evaluate_risk_framework_execution_decision(
+        request_id="req-multi-kill-switch",
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=1000.0,
+        account_equity=1000.0,
+        current_exposure=900.0,
+        strategy_exposure=900.0,
+        symbol_exposure=900.0,
+        limits=_framework_limits(),
+        rule_version="adapter-v1",
+        config={"risk.kill_switch.enabled": True},
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert decision.decision == "REJECTED"
+    assert decision.reason == "rejected:risk_framework_kill_switch_enabled"
+    assert decision.policy_evidence
+    assert decision.policy_evidence[0].reason_code == "rejected: kill_switch_enabled"
+
+
+def test_evaluate_risk_framework_execution_decision_prefers_position_size_over_other_caps() -> None:
+    decision = evaluate_risk_framework_execution_decision(
+        request_id="req-multi-cap",
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=1000.0,
+        account_equity=1000.0,
+        current_exposure=900.0,
+        strategy_exposure=900.0,
+        symbol_exposure=900.0,
+        limits=_framework_limits(),
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert decision.decision == "REJECTED"
+    assert decision.reason == "rejected:risk_framework_max_position_size_exceeded"
+    assert decision.policy_evidence
+    assert decision.policy_evidence[0].reason_code == "rejected: max_position_size_exceeded"

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 import pytest
@@ -22,6 +23,14 @@ from cilly_trading.risk_framework.contract import (
     RiskEvaluationRequest as FrameworkRiskEvaluationRequest,
     RiskEvaluationResponse as FrameworkRiskEvaluationResponse,
 )
+
+
+@dataclass(frozen=True)
+class _LegacyRuntimeRiskResponse:
+    approved: bool
+    reason: str
+    adjusted_position_size: float
+    risk_score: float
 
 
 def test_threshold_risk_gate_returns_approved_for_within_threshold() -> None:
@@ -199,6 +208,27 @@ def test_adapter_rejects_unknown_reason_code() -> None:
             rule_version="adapter-v1",
             evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         )
+
+
+def test_adapter_handles_runtime_response_without_policy_evidence() -> None:
+    decision = adapt_risk_framework_response_to_risk_decision(
+        framework_request=_framework_request(),
+        framework_response=_LegacyRuntimeRiskResponse(
+            approved=False,
+            reason="rejected: max_account_exposure_pct_exceeded",
+            adjusted_position_size=0.0,
+            risk_score=0.9,
+        ),
+        limits=_framework_limits(),
+        strategy_exposure=0.0,
+        symbol_exposure=0.0,
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert decision.decision == "REJECTED"
+    assert decision.reason == "rejected:risk_framework_max_account_exposure_pct_exceeded"
+    assert decision.policy_evidence == ()
 
 
 def test_canonical_rejection_reason_vocabulary_is_exposed_in_gate_map() -> None:

--- a/tests/test_non_live_evaluation_contract_docs.py
+++ b/tests/test_non_live_evaluation_contract_docs.py
@@ -22,6 +22,12 @@ def test_non_live_evaluation_contract_doc_defines_canonical_semantics() -> None:
     assert "semantic" in content
     assert "scope" in content
     assert "reject/cap/boundary semantics" in content
+    assert "Canonical risk rejection reason-code vocabulary (normalized):" in content
+    assert "rejected:risk_framework_kill_switch_enabled" in content
+    assert "rejected:risk_framework_max_position_size_exceeded" in content
+    assert "rejected:risk_framework_max_account_exposure_pct_exceeded" in content
+    assert "rejected:risk_framework_max_strategy_exposure_pct_exceeded" in content
+    assert "rejected:risk_framework_max_symbol_exposure_pct_exceeded" in content
 
 
 def test_non_live_contract_doc_locks_portfolio_constraint_hit_terminology() -> None:
@@ -40,6 +46,19 @@ def test_non_live_evaluation_contract_doc_keeps_non_live_boundaries_explicit() -
     assert "live trading enablement" in content
     assert "broker execution integration" in content
     assert "external portfolio optimization subsystems" in content
+
+
+def test_non_live_evaluation_contract_doc_defines_reason_precedence_and_inspection_normalization() -> None:
+    content = _read(CONTRACT_DOC)
+
+    assert "Normalized precedence order (canonical reason codes):" in content
+    assert "rejected:risk_framework_kill_switch_enabled" in content
+    assert "rejected:risk_framework_max_position_size_exceeded" in content
+    assert "rejected:risk_framework_max_account_exposure_pct_exceeded" in content
+    assert "rejected:risk_framework_max_strategy_exposure_pct_exceeded" in content
+    assert "rejected:risk_framework_max_symbol_exposure_pct_exceeded" in content
+    assert "Inspection/read normalization:" in content
+    assert "bounded non-live inspection flows" in content
 
 
 def test_risk_and_portfolio_docs_reference_canonical_non_live_contract() -> None:


### PR DESCRIPTION
## Active Issue
- #998

## Scope
- Add one canonical non-live risk rejection reason-code vocabulary
- Add deterministic precedence resolution for multi-violation risk rejections
- Align risk gate and paper execution worker to canonical normalized reason codes
- Add bounded inspection/read enrichment for normalized reason-code visibility
- Preserve non-live and non-readiness boundaries

## Files Changed
- src/cilly_trading/non_live_evaluation_contract.py
- src/cilly_trading/engine/risk/gate.py
- src/cilly_trading/engine/paper_execution_worker.py
- src/api/services/inspection_service.py
- docs/architecture/risk/non_live_evaluation_contract.md
- tests/cilly_trading/engine/test_risk_gate.py
- tests/cilly_trading/engine/test_paper_execution_risk_alignment.py
- tests/test_non_live_evaluation_contract_docs.py

## Acceptance Criteria Mapping

### 1. Canonical reason-code vocabulary is defined and documented
- Implemented in `src/cilly_trading/non_live_evaluation_contract.py`
- Documented in `docs/architecture/risk/non_live_evaluation_contract.md`
- Covered by:
  - `tests/cilly_trading/engine/test_risk_gate.py`
  - `tests/test_non_live_evaluation_contract_docs.py`

### 2. Equivalent input state produces equivalent reason code across covered risk paths
- Gate and paper worker both consume canonical normalization helpers
- Covered by:
  - `test_paper_execution_and_gate_share_canonical_reason_for_equivalent_state`

### 3. Multi-violation precedence is deterministic and test-covered
- Implemented in `resolve_risk_rejection_reason_precedence`
- Covered by precedence-focused tests in:
  - `tests/cilly_trading/engine/test_risk_gate.py`
  - `tests/cilly_trading/engine/test_paper_execution_risk_alignment.py`

### 4. Inspection/read surfaces return normalized reason codes without losing bounded non-live semantics
- `read_decision_trace` now enriches entries with `normalized_reason_code` when compatible reason fields exist
- Existing bounded semantics and readiness boundaries remain unchanged

### 5. Documentation preserves non-live and non-readiness boundaries
- Verified through:
  - `docs/architecture/risk/non_live_evaluation_contract.md`
  - `tests/test_non_live_evaluation_contract_docs.py`

## Test Command
`python -m pytest tests/cilly_trading/engine/test_risk_gate.py tests/cilly_trading/engine/test_paper_execution_risk_alignment.py tests/test_non_live_evaluation_contract_docs.py`

## Test Output
```text
============================= test session starts =============================
platform win32 -- Python 3.13.2, pytest-8.4.1, pluggy-1.6.0
rootdir: C:\repos\Trading-engine
configfile: pytest.ini
plugins: anyio-4.9.0
collected 33 items

tests\cilly_trading\engine\test_risk_gate.py ......................      [ 66%]
tests\cilly_trading\engine\test_paper_execution_risk_alignment.py .....  [ 81%]
tests\test_non_live_evaluation_contract_docs.py ......                   [100%]

============================= 33 passed in 1.12s ==============================
```

## Bounded Non-Live / Non-Readiness Note
- This change remains strictly within bounded non-live technical scope.
- It does not introduce live trading, broker execution, trader validation, or operational readiness claims.
- `normalized_reason_code` enrichment in `src/api/services/inspection_service.py` is intentionally best-effort for compatible fields only.
- This PR does not introduce a new broad decision-trace schema contract.
- Precedence depends on the canonical precedence table only and does not preserve producer order once normalized.

## Explicit Out-of-Scope Confirmation
- No new risk-model mathematics
- No threshold retuning for trader validation
- No UI/dashboard expansion
- No strategy changes
- No live/broker scope