### PR TITLE
[QUEUED][BACKTEST][06] Add deterministic realism sensitivity matrix to backtest evidence outputs

### DIFF
--- a/docs/testing/backtesting/p56_bounded_backtest_realism_assumptions.md
+++ b/docs/testing/backtesting/p56_bounded_backtest_realism_assumptions.md
@@ -1,7 +1,9 @@
 # P56-BT Bounded Backtest Realism Assumptions
 
 ## Goal
-Document and validate currently implemented realism-sensitive assumptions in the deterministic backtest path without introducing a new backtesting subsystem.
+Document and validate currently implemented realism-sensitive assumptions in the deterministic
+backtest path, including a bounded deterministic realism sensitivity matrix, without introducing a
+new backtesting subsystem.
 
 ## Scope Boundary
 This contract covers only the current deterministic backtest implementation.
@@ -28,6 +30,23 @@ Trader validation status for this implementation remains `trader_validation_not_
 - Signals are translated to deterministic market orders with deterministic ordering.
 - Snapshot processing and order processing are deterministic for identical inputs.
 
+## Deterministic Realism Sensitivity Matrix (Bounded)
+Backtest evidence now includes one fixed bounded realism-profile matrix computed from the same
+snapshot inputs:
+
+- `configured_baseline`: run-config assumptions exactly as declared in `run_config`.
+- `cost_free_reference`: same fill timing as baseline with `slippage_bps=0` and `commission_per_order=0`.
+- `bounded_cost_stress`: same fill timing with deterministic bounded stress costs
+  (`slippage_bps>=25`, `commission_per_order>=2.50`, capped by existing assumption limits).
+
+For each profile the evidence persists:
+- profile assumptions
+- profile cost-aware summary
+- profile cost-aware metrics
+- `delta_vs_baseline` for summary and metrics fields
+
+The matrix is deterministic for identical inputs and assumption values.
+
 ## Explicit Realism Gaps (Not Modeled)
 - Market hours/session calendars, halts, auctions, and after-hours restrictions.
 - Broker routing, venue selection, rejects, cancels, and broker-specific policies.
@@ -36,7 +55,10 @@ Trader validation status for this implementation remains `trader_validation_not_
 ## Evidence Interpretation Boundary
 - Backtest output is bounded evidence for deterministic replay under declared assumptions.
 - It supports controlled review of what the model did on supplied snapshots under fixed cost/fill rules.
-- This implementation improves technical realism only; it does not validate trader readiness, live tradability, or execution quality in production markets.
+- This implementation improves technical realism only; it does not validate trader readiness, live
+  tradability, or execution quality in production markets.
+- Sensitivity outputs are technical-only comparison evidence and must not be interpreted as live
+  readiness, broker-readiness, or trader validation.
 
 Unsupported claims:
 - live-trading readiness or approval

--- a/src/cilly_trading/engine/backtest_execution_contract.py
+++ b/src/cilly_trading/engine/backtest_execution_contract.py
@@ -22,10 +22,16 @@ from cilly_trading.engine.strategy_lifecycle.model import StrategyLifecycleState
 SUPPORTED_RUN_CONTRACT_VERSION = "1.0.0"
 BASELINE_VERSION = "1.0.0"
 REALISM_BOUNDARY_VERSION = "1.0.0"
+REALISM_SENSITIVITY_MATRIX_VERSION = "1.0.0"
 DEFAULT_ACTION_TO_SIDE: dict[str, Literal["BUY", "SELL"]] = {"BUY": "BUY", "SELL": "SELL"}
 MAX_SLIPPAGE_BPS = 250
 MAX_COMMISSION_PER_ORDER = Decimal("25")
 DEFAULT_STARTING_EQUITY = Decimal("100000")
+REALISM_PROFILE_BASELINE_ID = "configured_baseline"
+REALISM_PROFILE_COST_FREE_ID = "cost_free_reference"
+REALISM_PROFILE_COST_STRESS_ID = "bounded_cost_stress"
+REALISM_PROFILE_COST_STRESS_SLIPPAGE_BPS = 25
+REALISM_PROFILE_COST_STRESS_COMMISSION_PER_ORDER = Decimal("2.50")
 
 
 @dataclass(frozen=True)
@@ -655,6 +661,144 @@ def build_cost_slippage_metrics_baseline(
         },
         "trades": [],
     }
+
+
+def build_realism_sensitivity_matrix(
+    *,
+    ordered_snapshots: Sequence[Mapping[str, Any]],
+    run_id: str,
+    strategy_name: str,
+    run_contract: BacktestRunContract,
+) -> dict[str, Any]:
+    """Build deterministic bounded realism sensitivity metrics from one snapshot set."""
+
+    profile_definitions = _build_realism_profile_assumptions(
+        execution_assumptions=run_contract.execution_assumptions
+    )
+
+    baseline_summary: Mapping[str, Any] | None = None
+    baseline_metrics: Mapping[str, Any] | None = None
+    profiles: list[dict[str, Any]] = []
+    for profile_id, profile_name, profile_description, profile_assumptions in profile_definitions:
+        profile_contract = BacktestRunContract(
+            contract_version=run_contract.contract_version,
+            signal_translation=run_contract.signal_translation,
+            execution_assumptions=profile_assumptions,
+        )
+        profile_flow = simulate_execution_flow(
+            snapshots=ordered_snapshots,
+            run_id=run_id,
+            strategy_name=strategy_name,
+            run_contract=profile_contract,
+        )
+        profile_baseline = build_cost_slippage_metrics_baseline(
+            ordered_snapshots=ordered_snapshots,
+            fills=profile_flow.fills,
+            execution_assumptions=profile_assumptions,
+        )
+        profile_summary = dict(profile_baseline["summary"])
+        profile_metrics = dict(profile_baseline["metrics"]["cost_aware"])
+        if profile_id == REALISM_PROFILE_BASELINE_ID:
+            baseline_summary = profile_summary
+            baseline_metrics = profile_metrics
+
+        profiles.append(
+            {
+                "profile_id": profile_id,
+                "profile_name": profile_name,
+                "profile_description": profile_description,
+                "assumptions": profile_assumptions.to_payload(),
+                "summary": profile_summary,
+                "metrics": profile_metrics,
+            }
+        )
+
+    if baseline_summary is None or baseline_metrics is None:
+        raise ValueError("Configured baseline realism profile is required")
+
+    for profile in profiles:
+        profile["delta_vs_baseline"] = {
+            "summary": _build_numeric_delta_map(
+                current=profile["summary"],
+                baseline=baseline_summary,
+            ),
+            "metrics": _build_numeric_delta_map(
+                current=profile["metrics"],
+                baseline=baseline_metrics,
+            ),
+        }
+
+    return {
+        "matrix_version": REALISM_SENSITIVITY_MATRIX_VERSION,
+        "deterministic": True,
+        "baseline_profile_id": REALISM_PROFILE_BASELINE_ID,
+        "profile_order": [profile["profile_id"] for profile in profiles],
+        "profiles": profiles,
+    }
+
+
+def _build_realism_profile_assumptions(
+    *,
+    execution_assumptions: BacktestExecutionAssumptions,
+) -> tuple[
+    tuple[str, str, str, BacktestExecutionAssumptions],
+    tuple[str, str, str, BacktestExecutionAssumptions],
+    tuple[str, str, str, BacktestExecutionAssumptions],
+]:
+    fill_timing = execution_assumptions.fill_timing
+    stress_slippage_bps = max(
+        execution_assumptions.slippage_bps,
+        REALISM_PROFILE_COST_STRESS_SLIPPAGE_BPS,
+    )
+    stress_commission = max(
+        execution_assumptions.commission_per_order,
+        REALISM_PROFILE_COST_STRESS_COMMISSION_PER_ORDER,
+    )
+    return (
+        (
+            REALISM_PROFILE_BASELINE_ID,
+            "Configured baseline",
+            "Run-config execution assumptions without sensitivity overrides.",
+            execution_assumptions,
+        ),
+        (
+            REALISM_PROFILE_COST_FREE_ID,
+            "Cost-free reference",
+            "Deterministic reference with zero slippage and zero commission.",
+            BacktestExecutionAssumptions(
+                fill_timing=fill_timing,
+                slippage_bps=0,
+                commission_per_order=Decimal("0"),
+            ),
+        ),
+        (
+            REALISM_PROFILE_COST_STRESS_ID,
+            "Bounded cost stress",
+            "Deterministic bounded stress with elevated fixed slippage and commission.",
+            BacktestExecutionAssumptions(
+                fill_timing=fill_timing,
+                slippage_bps=stress_slippage_bps,
+                commission_per_order=stress_commission,
+            ),
+        ),
+    )
+
+
+def _build_numeric_delta_map(
+    *,
+    current: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+) -> dict[str, float | None]:
+    deltas: dict[str, float | None] = {}
+    ordered_keys = sorted(set(current.keys()) | set(baseline.keys()))
+    for key in ordered_keys:
+        current_value = current.get(key)
+        baseline_value = baseline.get(key)
+        if isinstance(current_value, (int, float)) and isinstance(baseline_value, (int, float)):
+            deltas[key] = _round_metric(float(current_value) - float(baseline_value))
+        else:
+            deltas[key] = None
+    return deltas
 
 
 def _snapshot_fill_reference_price(snapshot: Mapping[str, Any]) -> Decimal | None:

--- a/src/cilly_trading/engine/backtest_handoff_contract.py
+++ b/src/cilly_trading/engine/backtest_handoff_contract.py
@@ -44,6 +44,7 @@ PHASE_43_REQUIRED_FIELDS: tuple[str, ...] = (
     "metrics_baseline.assumptions",
     "metrics_baseline.summary",
     "metrics_baseline.metrics.cost_aware",
+    "metrics_baseline.realism_sensitivity_matrix",
 )
 
 PHASE_44_REQUIRED_FIELDS: tuple[str, ...] = (
@@ -74,6 +75,7 @@ PROFESSIONAL_REVIEW_REQUIRED_VISIBLE_FIELDS: tuple[str, ...] = (
     "summary.end_equity",
     "metrics_baseline.summary",
     "metrics_baseline.metrics.cost_aware",
+    "metrics_baseline.realism_sensitivity_matrix",
     "phase_handoff.acceptance_gates.technically_valid_backtest_artifact",
     "phase_handoff.acceptance_gates.phase_43_portfolio_simulation_ready",
     "phase_handoff.acceptance_gates.phase_44_paper_trading_readiness_evidence_ready",
@@ -83,6 +85,7 @@ PROFESSIONAL_REVIEW_COMPARISON_AXES: tuple[str, ...] = (
     "snapshot window and count",
     "strategy identity and params",
     "execution assumptions and baseline assumption alignment",
+    "deterministic realism sensitivity profile matrix",
     "modeled vs unmodeled realism boundary",
     "cost-aware outcome summary and deltas",
     "phase handoff gate outcomes",
@@ -103,6 +106,7 @@ TRADER_AUTHORITATIVE_FIELDS: tuple[str, ...] = (
     "metrics_baseline.summary",
     "metrics_baseline.metrics.cost_aware",
     "metrics_baseline.metrics.deltas",
+    "metrics_baseline.realism_sensitivity_matrix",
 )
 
 ARTIFACT_LINEAGE_REQUIRED_FIELDS: tuple[str, ...] = (

--- a/src/cilly_trading/engine/backtest_runner.py
+++ b/src/cilly_trading/engine/backtest_runner.py
@@ -10,6 +10,7 @@ from cilly_trading.engine.backtest_execution_contract import (
     BacktestRunContract,
     build_backtest_realism_boundary,
     build_cost_slippage_metrics_baseline,
+    build_realism_sensitivity_matrix,
     serialize_fills,
     serialize_orders,
     serialize_positions,
@@ -248,6 +249,13 @@ class BacktestRunner:
             fills=flow_result.fills,
             execution_assumptions=config.run_contract.execution_assumptions,
         )
+        realism_sensitivity_matrix = build_realism_sensitivity_matrix(
+            ordered_snapshots=processed_snapshots,
+            run_id=config.run_id,
+            strategy_name=config.strategy_name,
+            run_contract=config.run_contract,
+        )
+        metrics_baseline["realism_sensitivity_matrix"] = realism_sensitivity_matrix
 
         payload = {
             "artifact_version": "1",

--- a/tests/cilly_trading/engine/test_backtest_execution_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_execution_contract.py
@@ -12,6 +12,7 @@ from cilly_trading.engine.backtest_execution_contract import (
     BacktestSignalTranslationConfig,
     build_backtest_realism_boundary,
     build_cost_slippage_metrics_baseline,
+    build_realism_sensitivity_matrix,
     serialize_fills,
     serialize_orders,
     serialize_positions,
@@ -332,3 +333,92 @@ def test_negative_configuration_invalid_signal_payload_fails(tmp_path: Path) -> 
             strategy_factory=lambda: _NoopStrategy(),
             config=BacktestRunnerConfig(output_dir=tmp_path / "out"),
         )
+
+
+def test_realism_sensitivity_matrix_contract_schema_contains_profiles_metrics_and_deltas() -> None:
+    snapshots = sort_snapshots(_sample_flow_snapshots())
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=10,
+            commission_per_order=Decimal("1.00"),
+            fill_timing="next_snapshot",
+        )
+    )
+
+    matrix = build_realism_sensitivity_matrix(
+        ordered_snapshots=snapshots,
+        run_id="run-matrix",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    assert matrix["matrix_version"] == "1.0.0"
+    assert matrix["deterministic"] is True
+    assert matrix["baseline_profile_id"] == "configured_baseline"
+    assert matrix["profile_order"] == [
+        "configured_baseline",
+        "cost_free_reference",
+        "bounded_cost_stress",
+    ]
+    assert len(matrix["profiles"]) == 3
+
+    for profile in matrix["profiles"]:
+        assert "profile_id" in profile
+        assert "assumptions" in profile
+        assert "summary" in profile
+        assert "metrics" in profile
+        assert "delta_vs_baseline" in profile
+        assert "summary" in profile["delta_vs_baseline"]
+        assert "metrics" in profile["delta_vs_baseline"]
+
+
+def test_realism_sensitivity_matrix_is_deterministic_for_identical_inputs() -> None:
+    snapshots = sort_snapshots(_sample_flow_snapshots())
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=10,
+            commission_per_order=Decimal("1.00"),
+            fill_timing="next_snapshot",
+        )
+    )
+
+    first = build_realism_sensitivity_matrix(
+        ordered_snapshots=snapshots,
+        run_id="run-matrix-repro",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+    second = build_realism_sensitivity_matrix(
+        ordered_snapshots=snapshots,
+        run_id="run-matrix-repro",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    assert first == second
+
+
+def test_realism_sensitivity_matrix_delta_calculation_consistency() -> None:
+    snapshots = sort_snapshots(_sample_flow_snapshots())
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=10,
+            commission_per_order=Decimal("1.00"),
+            fill_timing="next_snapshot",
+        )
+    )
+    matrix = build_realism_sensitivity_matrix(
+        ordered_snapshots=snapshots,
+        run_id="run-matrix-deltas",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    profiles = {profile["profile_id"]: profile for profile in matrix["profiles"]}
+    baseline = profiles["configured_baseline"]
+    no_cost = profiles["cost_free_reference"]
+
+    assert baseline["delta_vs_baseline"]["summary"]["ending_equity_cost_aware"] == 0.0
+    assert baseline["delta_vs_baseline"]["metrics"]["total_return"] == 0.0
+    assert no_cost["delta_vs_baseline"]["summary"]["ending_equity_cost_aware"] == pytest.approx(2.33)
+    assert no_cost["delta_vs_baseline"]["summary"]["total_transaction_cost"] == pytest.approx(-2.33)

--- a/tests/cilly_trading/engine/test_backtest_handoff_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_handoff_contract.py
@@ -93,6 +93,17 @@ def _base_payload() -> dict[str, Any]:
                 "cost_aware": {"total_return": 0.00001},
                 "deltas": {"total_return": 0.0},
             },
+            "realism_sensitivity_matrix": {
+                "matrix_version": "1.0.0",
+                "deterministic": True,
+                "baseline_profile_id": "configured_baseline",
+                "profile_order": [
+                    "configured_baseline",
+                    "cost_free_reference",
+                    "bounded_cost_stress",
+                ],
+                "profiles": [],
+            },
             "trades": [],
         },
     }
@@ -121,6 +132,7 @@ def test_build_professional_review_contract_returns_canonical_payload() -> None:
             "summary.end_equity",
             "metrics_baseline.summary",
             "metrics_baseline.metrics.cost_aware",
+            "metrics_baseline.realism_sensitivity_matrix",
             "phase_handoff.acceptance_gates.technically_valid_backtest_artifact",
             "phase_handoff.acceptance_gates.phase_43_portfolio_simulation_ready",
             "phase_handoff.acceptance_gates.phase_44_paper_trading_readiness_evidence_ready",
@@ -129,6 +141,7 @@ def test_build_professional_review_contract_returns_canonical_payload() -> None:
             "snapshot window and count",
             "strategy identity and params",
             "execution assumptions and baseline assumption alignment",
+            "deterministic realism sensitivity profile matrix",
             "modeled vs unmodeled realism boundary",
             "cost-aware outcome summary and deltas",
             "phase handoff gate outcomes",
@@ -166,6 +179,8 @@ def test_phase_handoff_contract_reports_passed_gates_for_complete_payload() -> N
     assert review_contract == canonical_review_contract
     assert "run.run_id" in review_contract["required_visible_evidence"]
     assert "metrics_baseline.metrics.cost_aware" in review_contract["required_visible_evidence"]
+    assert "metrics_baseline.realism_sensitivity_matrix" in review_contract["required_visible_evidence"]
+    assert "deterministic realism sensitivity profile matrix" in review_contract["comparison_axes"]
     assert "phase handoff gate outcomes" in review_contract["comparison_axes"]
     assert "must remain separated" in review_contract["readiness_non_inference_statement"]
     assert (
@@ -239,6 +254,7 @@ def test_phase_handoff_contract_reports_passed_gates_for_complete_payload() -> N
             "metrics_baseline.assumptions",
             "metrics_baseline.summary",
             "metrics_baseline.metrics.cost_aware",
+            "metrics_baseline.realism_sensitivity_matrix",
         ],
         "artifact_lineage_complete": True,
         "artifact_lineage_required_fields": handoff["artifact_lineage"]["required_fields"],
@@ -287,6 +303,7 @@ def test_phase_handoff_contract_reports_passed_gates_for_complete_payload() -> N
             "metrics_baseline.assumptions",
             "metrics_baseline.summary",
             "metrics_baseline.metrics.cost_aware",
+            "metrics_baseline.realism_sensitivity_matrix",
             "orders",
             "fills",
             "positions",

--- a/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
+++ b/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
@@ -6,6 +6,7 @@ from cilly_trading.engine.backtest_execution_contract import (
     BacktestExecutionAssumptions,
     BacktestRunContract,
     build_cost_slippage_metrics_baseline,
+    build_realism_sensitivity_matrix,
     simulate_execution_flow,
     sort_snapshots,
 )
@@ -168,4 +169,59 @@ def test_p56_bt_replay_is_deterministic_and_cost_sensitive_to_assumptions() -> N
     assert (
         higher_cost_baseline["summary"]["ending_equity_cost_aware"]
         < baseline_first["summary"]["ending_equity_cost_aware"]
+    )
+
+
+def test_p56_bt_realism_profile_matrix_is_deterministic_and_replay_stable() -> None:
+    snapshots = sort_snapshots(
+        [
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {
+                "id": "s2",
+                "timestamp": "2024-01-02T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "101",
+                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {"id": "s3", "timestamp": "2024-01-03T00:00:00Z", "symbol": "AAPL", "open": "102"},
+        ]
+    )
+    run_contract = BacktestRunContract(
+        execution_assumptions=BacktestExecutionAssumptions(
+            slippage_bps=10,
+            commission_per_order=Decimal("1.25"),
+            fill_timing="next_snapshot",
+        )
+    )
+
+    first = build_realism_sensitivity_matrix(
+        ordered_snapshots=snapshots,
+        run_id="p56-bt-matrix",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+    second = build_realism_sensitivity_matrix(
+        ordered_snapshots=snapshots,
+        run_id="p56-bt-matrix",
+        strategy_name="REFERENCE",
+        run_contract=run_contract,
+    )
+
+    assert first == second
+    assert first["profile_order"] == [
+        "configured_baseline",
+        "cost_free_reference",
+        "bounded_cost_stress",
+    ]
+    profiles = {profile["profile_id"]: profile for profile in first["profiles"]}
+    assert profiles["configured_baseline"]["delta_vs_baseline"]["summary"]["total_transaction_cost"] == 0.0
+    assert profiles["cost_free_reference"]["summary"]["total_transaction_cost"] == 0.0
+    assert profiles["bounded_cost_stress"]["summary"]["total_transaction_cost"] >= (
+        profiles["configured_baseline"]["summary"]["total_transaction_cost"]
     )

--- a/tests/test_api_backtest_entry_read.py
+++ b/tests/test_api_backtest_entry_read.py
@@ -65,6 +65,14 @@ def test_backtest_entry_read_route_exposes_bounded_non_live_contract(
         assert "technical availability" in payload["boundary"]["technical_availability_statement"]
         assert "not trader validation" in payload["boundary"]["trader_validation_statement"]
         assert "not operational readiness" in payload["boundary"]["operational_readiness_statement"]
+        assert (
+            "metrics_baseline.realism_sensitivity_matrix"
+            in payload["boundary"]["review_required_evidence"]
+        )
+        assert (
+            "deterministic realism sensitivity profile matrix"
+            in payload["boundary"]["review_comparison_axes"]
+        )
         evidence = payload["boundary"]["strategy_readiness_evidence"]
         assert "bounded API/UI evidence surfacing scope" in evidence["bounded_scope"]
         assert evidence["technical"]["gate"] == "technical_implementation"

--- a/tests/test_backtest_evidence_docs.py
+++ b/tests/test_backtest_evidence_docs.py
@@ -96,3 +96,21 @@ def test_backtest_schema_and_execution_docs_define_realism_disclosures() -> None
     assert "This model is non-live and non-broker by design." in execution_content
     assert "does not support live-trading readiness claims" in execution_content
     assert "does not constitute trader validation" in execution_content
+
+
+def test_p56_doc_defines_deterministic_realism_sensitivity_matrix_with_bounded_wording() -> None:
+    content = (
+        REPO_ROOT
+        / "docs"
+        / "testing"
+        / "backtesting"
+        / "p56_bounded_backtest_realism_assumptions.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Deterministic Realism Sensitivity Matrix (Bounded)" in content
+    assert "`configured_baseline`" in content
+    assert "`cost_free_reference`" in content
+    assert "`bounded_cost_stress`" in content
+    assert "`delta_vs_baseline`" in content
+    assert "technical-only comparison evidence" in content
+    assert "must not be interpreted as live" in content


### PR DESCRIPTION
Closes #999

## Summary
- Added a fixed bounded deterministic realism-profile matrix to backtest evidence.
- Persisted per-profile assumptions, cost-aware metrics, and `delta_vs_baseline` outputs.
- Kept interpretation technical-only and non-live, without simulator expansion.
- Extended deterministic replay, schema, delta-consistency, and docs tests.

## Scope
- Changes are limited to issue-allowed files and deterministic backtest evidence surfaces only.

## Test command
```powershell
.\.venv\Scripts\python.exe -m pytest
Test result
1108 passed
4 warnings
0 failures
