### PR TITLE
[QUEUED][SIGNAL-VALIDATION][04] Add bounded comparison-group threshold profiles for qualification calibration (#1000)

### DIFF
--- a/.github_pr_999.md
+++ b/.github_pr_999.md
@@ -1,0 +1,18 @@
+Closes #999
+
+## Summary
+- Added a fixed bounded deterministic realism-profile matrix to backtest evidence.
+- Persisted per-profile assumptions, cost-aware metrics, and `delta_vs_baseline` outputs.
+- Kept interpretation technical-only and non-live, without simulator expansion.
+- Extended deterministic replay, schema, delta-consistency, and docs tests.
+
+## Scope
+- Changes are limited to issue-allowed files and deterministic backtest evidence surfaces only.
+
+## Test command
+```powershell
+.\.venv\Scripts\python.exe -m pytest
+Test result
+1108 passed
+4 warnings
+0 failures

--- a/docs/governance/score-semantics-cross-strategy.md
+++ b/docs/governance/score-semantics-cross-strategy.md
@@ -62,12 +62,28 @@ The confidence tier is the primary bounded interpretation:
 
 No stronger claim than these bounded tier definitions is supported.
 
+## 4.1 Comparison-Group Threshold Profile Calibration
+
+Qualification thresholds are calibrated through deterministic threshold profiles keyed
+by strategy `comparison_group`.
+
+- Each strategy resolves one bounded threshold profile identifier from registry metadata.
+- The applied profile governs confidence/qualification aggregate and minimum-component
+  threshold checks for that strategy evaluation.
+- Profile calibration does not change cross-group score meaning: strategies in different
+  comparison groups remain not directly comparable by score.
+
+Threshold-profile calibration is bounded contract behavior for within-group qualification
+consistency only and does not create cross-group ranking authority.
+
 ## 5. Runtime and Documentation Alignment Rule
 
 All runtime wording and documentation must remain consistent with this governance contract:
 
 - `confidence_reason` text must reference bounded evidence semantics and must not
   claim precise probability, cross-strategy equality, or live-trading readiness.
+- qualification evidence must include the applied threshold profile identifier used
+  for deterministic confidence and qualification resolution.
 - `qualification.summary` text must stay within paper-trading scope.
 - `rationale.final_explanation` must explicitly deny live-trading approval implication.
 

--- a/docs/governance/signal-quality-bounded-contract.md
+++ b/docs/governance/signal-quality-bounded-contract.md
@@ -66,6 +66,18 @@ win-rate, and expected-value evidence:
 These action semantics are bounded to paper evaluation and must not be interpreted as
 live-trading authorization.
 
+## Comparison-Group Threshold Profile Boundary
+
+Qualification calibration is deterministic and bounded by strategy `comparison_group`
+threshold profiles.
+
+- threshold profiles are resolved from governed strategy metadata comparison groups
+- the applied profile identifier is emitted in qualification evidence output
+- calibrated thresholds remain bounded implementation semantics, not probability claims
+
+Cross-group non-comparability remains explicit: threshold profile calibration does not
+make decision-card scores directly comparable across different comparison groups.
+
 ## Deterministic Ranking Boundary
 
 For setup-stage candidates that meet the configured score floor, ranking is deterministic:

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -90,6 +90,21 @@ CLAIM_BOUNDARY_FORBIDDEN_PHRASES: tuple[str, ...] = (
 )
 
 
+def _qualification_thresholds_from_metadata(metadata: dict[str, Any]) -> tuple[float, float]:
+    """Resolve qualification aggregate thresholds from metadata fallback to contract defaults."""
+    thresholds = metadata.get("qualification_thresholds")
+    if not isinstance(thresholds, dict):
+        return QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD, QUALIFICATION_HIGH_AGGREGATE_THRESHOLD
+    medium = thresholds.get("medium_aggregate")
+    high = thresholds.get("high_aggregate")
+    try:
+        medium_value = float(medium)
+        high_value = float(high)
+    except (TypeError, ValueError):
+        return QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD, QUALIFICATION_HIGH_AGGREGATE_THRESHOLD
+    return medium_value, high_value
+
+
 def _contains_forbidden_claim_phrase(value: str) -> str | None:
     normalized = value.casefold()
     for phrase in CLAIM_BOUNDARY_FORBIDDEN_PHRASES:
@@ -459,21 +474,23 @@ class DecisionCard(BaseModel):
         return self
 
     def _expected_qualification_state(self) -> QualificationState:
+        medium_threshold, high_threshold = _qualification_thresholds_from_metadata(self.metadata)
         if self.hard_gates.has_blocking_failure:
             return "reject"
         if (
             self.score.confidence_tier == "low"
-            or self.score.aggregate_score < QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD
+            or self.score.aggregate_score < medium_threshold
         ):
             return "watch"
         if (
             self.score.confidence_tier == "high"
-            and self.score.aggregate_score >= QUALIFICATION_HIGH_AGGREGATE_THRESHOLD
+            and self.score.aggregate_score >= high_threshold
         ):
             return "paper_approved"
         return "paper_candidate"
 
     def _expected_decision_action(self) -> DecisionAction:
+        medium_threshold, _ = _qualification_thresholds_from_metadata(self.metadata)
         if self.hard_gates.has_blocking_failure:
             return "ignore"
         if self.score.expected_value < 0.0:
@@ -485,7 +502,7 @@ class DecisionCard(BaseModel):
             return "exit"
         if (
             self.score.confidence_tier == "low"
-            or self.score.aggregate_score < QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD
+            or self.score.aggregate_score < medium_threshold
             or self.qualification.state in {"reject", "watch"}
         ):
             return "ignore"

--- a/src/cilly_trading/engine/qualification_engine.py
+++ b/src/cilly_trading/engine/qualification_engine.py
@@ -23,6 +23,10 @@ from cilly_trading.engine.decision_card_contract import (
     QualificationState,
     validate_decision_card,
 )
+from cilly_trading.strategies.registry import (
+    get_registered_strategy_metadata,
+    resolve_qualification_threshold_profile,
+)
 
 DecisionActionState = QualificationState
 
@@ -100,6 +104,7 @@ class QualificationEngineInput:
 
 def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard:
     """Evaluate hard gates, component scores, and output a deterministic decision card."""
+    threshold_profile = _resolve_threshold_profile(strategy_id=input_data.strategy_id)
     hard_gate_evaluation = HardGateEvaluation(
         policy_version=input_data.hard_gate_policy_version,
         gates=list(input_data.hard_gates),
@@ -118,6 +123,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
     confidence_tier = assign_confidence_tier(
         aggregate_score=aggregate_score,
         component_scores=integrated_component_scores,
+        confidence_thresholds=threshold_profile["thresholds"],
     )
     confidence_reason = _confidence_reason(confidence_tier=confidence_tier, aggregate_score=aggregate_score)
     win_rate = compute_bounded_win_rate(component_scores=integrated_component_scores)
@@ -129,6 +135,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         hard_gate_evaluation=hard_gate_evaluation,
         aggregate_score=aggregate_score,
         confidence_tier=confidence_tier,
+        confidence_thresholds=threshold_profile["thresholds"],
     )
     action = resolve_decision_action(
         hard_gate_evaluation=hard_gate_evaluation,
@@ -137,6 +144,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         qualification_state=state,
         win_rate=win_rate,
         expected_value=expected_value,
+        confidence_thresholds=threshold_profile["thresholds"],
     )
     payload = {
         "contract_version": DECISION_CARD_CONTRACT_VERSION,
@@ -176,6 +184,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
                 base_aggregate_score=base_aggregate_score,
                 aggregate_score=aggregate_score,
                 confidence_tier=confidence_tier,
+                threshold_profile=threshold_profile,
                 win_rate=win_rate,
                 expected_value=expected_value,
                 action=action,
@@ -193,12 +202,30 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             input_data=input_data,
             base_aggregate_score=base_aggregate_score,
             sentiment_resolution=sentiment_resolution,
+            threshold_profile=threshold_profile,
             win_rate=win_rate,
             expected_value=expected_value,
             action=action,
         ),
     }
     return validate_decision_card(payload)
+
+
+def _resolve_threshold_profile(*, strategy_id: str) -> dict[str, object]:
+    metadata_by_strategy = get_registered_strategy_metadata()
+    strategy_metadata = metadata_by_strategy.get(strategy_id, {})
+    comparison_group = strategy_metadata.get("comparison_group")
+    profile = resolve_qualification_threshold_profile(comparison_group=comparison_group)
+    return {
+        "comparison_group": comparison_group if isinstance(comparison_group, str) else "default",
+        "profile_id": str(profile["profile_id"]),
+        "thresholds": {
+            "high_aggregate": float(profile["high_aggregate"]),
+            "high_min_component": float(profile["high_min_component"]),
+            "medium_aggregate": float(profile["medium_aggregate"]),
+            "medium_min_component": float(profile["medium_min_component"]),
+        },
+    }
 
 
 def compute_aggregate_score(*, component_scores: list[ComponentScore]) -> float:
@@ -321,17 +348,19 @@ def assign_confidence_tier(
     *,
     aggregate_score: float,
     component_scores: list[ComponentScore],
+    confidence_thresholds: dict[str, float] | None = None,
 ) -> DecisionConfidenceTier:
     """Assign deterministic confidence tier from bounded aggregate and minimum component score."""
+    thresholds = confidence_thresholds or CONFIDENCE_THRESHOLDS
     min_component = min(float(component.score) for component in component_scores)
     if (
-        aggregate_score >= CONFIDENCE_THRESHOLDS["high_aggregate"]
-        and min_component >= CONFIDENCE_THRESHOLDS["high_min_component"]
+        aggregate_score >= thresholds["high_aggregate"]
+        and min_component >= thresholds["high_min_component"]
     ):
         return "high"
     if (
-        aggregate_score >= CONFIDENCE_THRESHOLDS["medium_aggregate"]
-        and min_component >= CONFIDENCE_THRESHOLDS["medium_min_component"]
+        aggregate_score >= thresholds["medium_aggregate"]
+        and min_component >= thresholds["medium_min_component"]
     ):
         return "medium"
     return "low"
@@ -370,21 +399,23 @@ def resolve_qualification_state(
     hard_gate_evaluation: HardGateEvaluation,
     aggregate_score: float,
     confidence_tier: DecisionConfidenceTier,
+    confidence_thresholds: dict[str, float] | None = None,
 ) -> tuple[DecisionActionState, QualificationColor, str]:
     """Resolve action-state and traffic-light output deterministically."""
+    thresholds = confidence_thresholds or CONFIDENCE_THRESHOLDS
     if hard_gate_evaluation.has_blocking_failure:
         return (
             "reject",
             "red",
             "Blocking hard gate failed; opportunity is rejected for paper-trading qualification.",
         )
-    if confidence_tier == "low" or aggregate_score < CONFIDENCE_THRESHOLDS["medium_aggregate"]:
+    if confidence_tier == "low" or aggregate_score < thresholds["medium_aggregate"]:
         return (
             "watch",
             "yellow",
             "Opportunity remains on watch for paper-trading pending stronger confidence or score.",
         )
-    if confidence_tier == "high" and aggregate_score >= CONFIDENCE_THRESHOLDS["high_aggregate"]:
+    if confidence_tier == "high" and aggregate_score >= thresholds["high_aggregate"]:
         return (
             "paper_approved",
             "green",
@@ -405,15 +436,17 @@ def resolve_decision_action(
     qualification_state: DecisionActionState,
     win_rate: float,
     expected_value: float,
+    confidence_thresholds: dict[str, float] | None = None,
 ) -> DecisionAction:
     """Resolve deterministic paper-evaluation action from bounded evidence fields."""
+    thresholds = confidence_thresholds or CONFIDENCE_THRESHOLDS
     if hard_gate_evaluation.has_blocking_failure:
         return "ignore"
     if expected_value < 0.0:
         return "exit"
     if qualification_state in {"paper_candidate", "paper_approved"} and win_rate <= ACTION_EXIT_WIN_RATE_MAX:
         return "exit"
-    if confidence_tier == "low" or aggregate_score < CONFIDENCE_THRESHOLDS["medium_aggregate"]:
+    if confidence_tier == "low" or aggregate_score < thresholds["medium_aggregate"]:
         return "ignore"
     if qualification_state in {"paper_candidate", "paper_approved"} and win_rate >= ACTION_ENTRY_WIN_RATE_MIN:
         return "entry"
@@ -460,6 +493,7 @@ def _score_explanations(
     base_aggregate_score: float,
     aggregate_score: float,
     confidence_tier: DecisionConfidenceTier,
+    threshold_profile: dict[str, object],
     win_rate: float,
     expected_value: float,
     action: DecisionAction,
@@ -474,6 +508,15 @@ def _score_explanations(
     return [
         f"Backtest input path is {'explicitly integrated' if backtest_input_applied else 'not provided; component value is used as-is'}.",
         f"Portfolio-fit input path is {'explicitly integrated' if portfolio_fit_input_applied else 'not provided; component value is used as-is'}.",
+        (
+            "Qualification threshold profile applied: "
+            f"{threshold_profile['profile_id']} "
+            f"(comparison_group={threshold_profile['comparison_group']}, "
+            f"high_aggregate={threshold_profile['thresholds']['high_aggregate']:.4f}, "
+            f"high_min_component={threshold_profile['thresholds']['high_min_component']:.4f}, "
+            f"medium_aggregate={threshold_profile['thresholds']['medium_aggregate']:.4f}, "
+            f"medium_min_component={threshold_profile['thresholds']['medium_min_component']:.4f})."
+        ),
         f"Bounded weighted aggregate score={base_aggregate_score:.4f} using fixed category weights.",
         (
             "Bounded win-rate formula: "
@@ -507,6 +550,7 @@ def _build_metadata(
     input_data: QualificationEngineInput,
     base_aggregate_score: float,
     sentiment_resolution: SentimentOverlayResolution,
+    threshold_profile: dict[str, object],
     win_rate: float,
     expected_value: float,
     action: DecisionAction,
@@ -515,6 +559,9 @@ def _build_metadata(
     metadata["base_aggregate_score"] = base_aggregate_score
     metadata["backtest_input_applied"] = input_data.backtest_evidence is not None
     metadata["portfolio_fit_input_applied"] = input_data.portfolio_fit_input is not None
+    metadata["comparison_group"] = threshold_profile["comparison_group"]
+    metadata["qualification_threshold_profile_id"] = threshold_profile["profile_id"]
+    metadata["qualification_thresholds"] = dict(threshold_profile["thresholds"])
     metadata["sentiment_overlay_status"] = sentiment_resolution.status
     metadata["sentiment_overlay_points"] = sentiment_resolution.points
     metadata["sentiment_overlay_cap_points"] = sentiment_resolution.cap_points
@@ -550,6 +597,7 @@ __all__ = [
     "compute_bounded_win_rate",
     "compute_aggregate_score",
     "evaluate_qualification",
+    "resolve_qualification_threshold_profile",
     "resolve_decision_action",
     "resolve_qualification_state",
 ]

--- a/src/cilly_trading/strategies/registry.py
+++ b/src/cilly_trading/strategies/registry.py
@@ -37,6 +37,40 @@ CROSS_STRATEGY_SCORE_NON_COMPARABILITY_NOTE = (
     "only strategies within the same comparison group may be meaningfully compared by score."
 )
 
+DEFAULT_COMPARISON_GROUP = "default"
+QUALIFICATION_THRESHOLD_PROFILE_DEFAULT_ID = "qualification-threshold.default.v1"
+
+QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP: dict[str, dict[str, float | str]] = {
+    "default": {
+        "profile_id": QUALIFICATION_THRESHOLD_PROFILE_DEFAULT_ID,
+        "high_aggregate": 80.0,
+        "high_min_component": 70.0,
+        "medium_aggregate": 60.0,
+        "medium_min_component": 50.0,
+    },
+    "mean-reversion": {
+        "profile_id": "qualification-threshold.mean-reversion.v1",
+        "high_aggregate": 80.0,
+        "high_min_component": 70.0,
+        "medium_aggregate": 60.0,
+        "medium_min_component": 50.0,
+    },
+    "reference-control": {
+        "profile_id": "qualification-threshold.reference-control.v1",
+        "high_aggregate": 79.0,
+        "high_min_component": 69.0,
+        "medium_aggregate": 59.0,
+        "medium_min_component": 49.0,
+    },
+    "trend-following": {
+        "profile_id": "qualification-threshold.trend-following.v1",
+        "high_aggregate": 82.0,
+        "high_min_component": 68.0,
+        "medium_aggregate": 62.0,
+        "medium_min_component": 52.0,
+    },
+}
+
 
 class StrategyNotRegisteredError(KeyError):
     """Raised when an unknown strategy key is requested."""
@@ -219,3 +253,17 @@ def run_registry_smoke() -> list[str]:
 
     initialize_default_registry()
     return [entry.key for entry in get_registered_strategies()]
+
+
+def resolve_qualification_threshold_profile(
+    *, comparison_group: str | None
+) -> dict[str, float | str]:
+    """Resolve deterministic threshold profile for a comparison group."""
+
+    normalized_group = (
+        comparison_group.strip() if isinstance(comparison_group, str) and comparison_group.strip() else DEFAULT_COMPARISON_GROUP
+    )
+    profile = QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP.get(normalized_group)
+    if profile is None:
+        profile = QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP[DEFAULT_COMPARISON_GROUP]
+    return dict(profile)

--- a/tests/cilly_trading/engine/test_qualification_engine.py
+++ b/tests/cilly_trading/engine/test_qualification_engine.py
@@ -17,6 +17,7 @@ from cilly_trading.engine.qualification_engine import (
     compute_aggregate_score,
     evaluate_qualification,
 )
+from cilly_trading.strategies.registry import get_registered_strategy_metadata
 
 
 def _base_component_scores() -> list[ComponentScore]:
@@ -80,12 +81,13 @@ def _engine_input(
     backtest_evidence: BacktestEvidenceInput | None = None,
     portfolio_fit_input: PortfolioFitInput | None = None,
     sentiment_overlay: SentimentOverlayInput | None = None,
+    strategy_id: str = "RSI2",
 ) -> QualificationEngineInput:
     return QualificationEngineInput(
         decision_card_id="dc_20260324_AAPL_RSI2",
         generated_at_utc="2026-03-24T08:10:00Z",
         symbol="AAPL",
-        strategy_id="RSI2",
+        strategy_id=strategy_id,
         hard_gates=list(hard_gates or _base_hard_gates()),
         component_scores=list(component_scores or _base_component_scores()),
         backtest_evidence=backtest_evidence,
@@ -327,3 +329,40 @@ def test_low_confidence_reason_references_upstream_evidence_quality() -> None:
     confidence_reason = card.score.confidence_reason.casefold()
     assert "upstream evidence quality" in confidence_reason
     assert "limited" in confidence_reason
+
+
+def test_qualification_profile_resolution_by_strategy_comparison_group() -> None:
+    metadata_by_strategy = get_registered_strategy_metadata()
+
+    reference = evaluate_qualification(_engine_input(strategy_id="REFERENCE"))
+    assert reference.metadata["comparison_group"] == metadata_by_strategy["REFERENCE"]["comparison_group"]
+    assert reference.metadata["qualification_threshold_profile_id"] == (
+        "qualification-threshold.reference-control.v1"
+    )
+    assert "Qualification threshold profile applied:" in " ".join(reference.rationale.score_explanations)
+
+    turtle = evaluate_qualification(_engine_input(strategy_id="TURTLE"))
+    assert turtle.metadata["comparison_group"] == metadata_by_strategy["TURTLE"]["comparison_group"]
+    assert turtle.metadata["qualification_threshold_profile_id"] == (
+        "qualification-threshold.trend-following.v1"
+    )
+
+
+def test_regression_identical_inputs_are_deterministic_across_groups() -> None:
+    reference_input = _engine_input(strategy_id="REFERENCE")
+    first_reference = evaluate_qualification(reference_input)
+    second_reference = evaluate_qualification(reference_input)
+    assert first_reference.action == second_reference.action
+    assert first_reference.score.aggregate_score == second_reference.score.aggregate_score
+    assert first_reference.metadata["qualification_threshold_profile_id"] == (
+        second_reference.metadata["qualification_threshold_profile_id"]
+    )
+
+    turtle_input = _engine_input(strategy_id="TURTLE")
+    first_turtle = evaluate_qualification(turtle_input)
+    second_turtle = evaluate_qualification(turtle_input)
+    assert first_turtle.action == second_turtle.action
+    assert first_turtle.score.aggregate_score == second_turtle.score.aggregate_score
+    assert first_turtle.metadata["qualification_threshold_profile_id"] == (
+        second_turtle.metadata["qualification_threshold_profile_id"]
+    )

--- a/tests/decision/test_decision_integration_layer.py
+++ b/tests/decision/test_decision_integration_layer.py
@@ -130,6 +130,8 @@ def test_evidence_semantics_and_contract_boundary_remain_explicit() -> None:
 
     confidence_reason = card.score.confidence_reason.casefold()
     assert any(term in confidence_reason for term in ("aggregate", "component", "threshold", "evidence"))
+    assert card.metadata["qualification_threshold_profile_id"] == "qualification-threshold.mean-reversion.v1"
+    assert "Qualification threshold profile applied:" in " ".join(card.rationale.score_explanations)
     assert "does not imply live-trading approval" in card.rationale.final_explanation.casefold()
     assert [component.category for component in card.score.component_scores] == [
         "backtest_quality",

--- a/tests/test_sig_p47_score_semantics.py
+++ b/tests/test_sig_p47_score_semantics.py
@@ -21,8 +21,10 @@ from cilly_trading.engine.qualification_engine import (
 )
 from cilly_trading.strategies.registry import (
     CROSS_STRATEGY_SCORE_NON_COMPARABILITY_NOTE,
+    QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP,
     get_registered_strategy_metadata,
     reset_registry,
+    resolve_qualification_threshold_profile,
 )
 
 
@@ -99,6 +101,19 @@ def test_rsi2_is_in_mean_reversion_group() -> None:
 def test_turtle_is_in_trend_following_group() -> None:
     metadata = get_registered_strategy_metadata()
     assert metadata["TURTLE"]["comparison_group"] == "trend-following"
+
+
+def test_comparison_group_threshold_profiles_are_defined_and_deterministic() -> None:
+    assert "mean-reversion" in QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP
+    assert "trend-following" in QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP
+    assert "reference-control" in QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP
+
+    first = resolve_qualification_threshold_profile(comparison_group="mean-reversion")
+    second = resolve_qualification_threshold_profile(comparison_group="mean-reversion")
+    assert first == second
+    assert first["profile_id"] == "qualification-threshold.mean-reversion.v1"
+    assert first["high_aggregate"] >= first["medium_aggregate"]
+    assert first["high_min_component"] >= first["medium_min_component"]
 
 
 # ---------------------------------------------------------------------------
@@ -252,6 +267,14 @@ def test_score_semantics_governance_doc_defines_precision_boundaries() -> None:
     assert "CONFIDENCE_TIER_PRECISION_DISCLAIMER" in content
 
 
+def test_score_semantics_governance_doc_mentions_calibrated_threshold_profiles() -> None:
+    content = GOVERNANCE_DOC.read_text(encoding="utf-8")
+
+    assert "threshold profile" in content.casefold()
+    assert "comparison_group" in content
+    assert "not directly comparable" in content
+
+
 def test_score_semantics_governance_doc_defines_non_goals() -> None:
     content = GOVERNANCE_DOC.read_text(encoding="utf-8")
 
@@ -284,3 +307,12 @@ def test_sig_p47_phase_doc_lists_out_of_scope_reminders() -> None:
     assert "Out-of-Scope" in content
     assert "live trading" in content
     assert "new strategies" in content
+
+
+def test_signal_quality_contract_doc_mentions_calibrated_threshold_profiles() -> None:
+    content = (REPO_ROOT / "docs" / "governance" / "signal-quality-bounded-contract.md").read_text(
+        encoding="utf-8"
+    )
+    assert "threshold profile" in content.casefold()
+    assert "comparison_group" in content
+    assert "non-comparability" in content.casefold()


### PR DESCRIPTION
Closes #1000

## Summary
- Introduced deterministic qualification threshold profiles keyed by strategy `comparison_group`.
- Wired profile resolution into qualification flow and applied profile thresholds for confidence, qualification state, and action resolution.
- Exposed applied profile identifier and thresholds in qualification evidence metadata.
- Preserved cross-group non-comparability boundaries and existing bounded formula semantics.
- Updated governance docs and added contract/regression coverage for calibrated semantics.

## Changes
- `src/cilly_trading/strategies/registry.py`
  - Added `QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP`
  - Added `resolve_qualification_threshold_profile(...)`
- `src/cilly_trading/engine/qualification_engine.py`
  - Resolve profile from strategy `comparison_group`
  - Apply profile thresholds to confidence/state/action
  - Emit `qualification_threshold_profile_id` and threshold evidence
- `src/cilly_trading/engine/decision_card_contract.py`
  - Validation now reads threshold aggregates from metadata when provided to keep deterministic contract checks aligned
- Docs:
  - `docs/governance/score-semantics-cross-strategy.md`
  - `docs/governance/signal-quality-bounded-contract.md`
- Tests:
  - `tests/test_sig_p47_score_semantics.py`
  - `tests/cilly_trading/engine/test_qualification_engine.py`
  - `tests/decision/test_decision_integration_layer.py`

## Validation
- `python -m pytest`
- Result: `1113 passed, 4 warnings`
