### PR TITLE
[DO NOW][STRATEGY-READINESS][03] Validate bounded trader relevance of qualification and decision outputs against paper-review cases

### DIFF
--- a/docs/governance/qualification-claim-evidence-discipline.md
+++ b/docs/governance/qualification-claim-evidence-discipline.md
@@ -30,9 +30,34 @@ The following claim classes are unsupported in qualification outputs and must be
 - production readiness claims
 - broker execution readiness claims
 - trader-validation claims
+- paper profitability or edge claims
 - guaranteed/certain outcome claims
 
-## 4. Runtime and Documentation Alignment Rule
+## 4. Deterministic Bounded Trader-Relevance Review Contract
+
+Canonical contract id/version:
+
+- `bounded_trader_relevance.paper_review.v1`
+- version `1.0.0`
+
+Paper-review cases (deterministic and ordered by case id):
+
+- `qualification_state_relevance`: verify qualification-state output is evidence-explained and explicitly paper-scoped
+- `decision_action_relevance`: verify action output is evidence-explained with bounded decision metrics
+- `boundary_scope_relevance`: verify explicit boundary wording for trader_validation separation, paper profitability separation, and live-readiness separation
+
+Case status semantics:
+
+- `aligned`: all required evidence signals for the case are present
+- `weak`: some required evidence signals are present, but at least one is missing
+- `missing`: no required evidence signals are present
+
+Determinism rule:
+
+- identical inputs must produce identical case classifications and ordering
+- classification must be machine-evaluable from explicit output evidence fields only (no manual interpretation)
+
+## 5. Runtime and Documentation Alignment Rule
 
 Documentation and runtime wording must enforce the same boundary:
 
@@ -40,7 +65,7 @@ Documentation and runtime wording must enforce the same boundary:
 - inspection API wording mirrors the same boundary
 - qualification outputs explicitly state they do not imply live-trading approval
 
-## 5. Validation Rule
+## 6. Validation Rule
 
 Where claim-boundary enforcement exists in runtime contracts, validation must fail closed for unsupported claim language.
 Validation is required for:
@@ -49,7 +74,7 @@ Validation is required for:
 - qualification summary text
 - rationale summary/final explanation text
 
-## 6. Non-Goals
+## 7. Non-Goals
 
 This governance contract does not grant:
 

--- a/docs/governance/strategy-readiness-gates.md
+++ b/docs/governance/strategy-readiness-gates.md
@@ -136,6 +136,7 @@ Decision-evidence status boundary for qualification outputs:
 
 - qualification and action outputs may include `technical_implementation_status` as technical-only evidence metadata
 - qualification and action outputs may include `trader_validation_status` as independent trader-validation metadata
+- qualification and action outputs may include bounded trader-relevance validation case outputs (`aligned` | `weak` | `missing`) for deterministic paper-review evidence checks
 - technical and trader-validation statuses must remain explicit, separate fields
 - default bounded interpretation for current paper-evaluation action evidence:
   - technical implementation status may be `technical_in_progress`
@@ -146,6 +147,7 @@ Non-live and governance boundary for this scope:
 
 - no live-trading readiness or authorization claim
 - no broker-connectivity or execution-enablement claim
+- no paper profitability or edge claim
 - no production-readiness claim
 - no replacement of governance gates with inferred UI/API status
 

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -15,6 +15,7 @@ from cilly_trading.engine.decision_card_contract import (
     ACTION_EXIT_WIN_RATE_MAX,
     QUALIFICATION_HIGH_AGGREGATE_THRESHOLD,
     QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD,
+    evaluate_bounded_trader_relevance_cases,
     validate_decision_card,
 )
 from cilly_trading.models import ExecutionEvent, Order, Position, SignalReadItemDTO, SignalReadResponseDTO, Trade
@@ -565,9 +566,11 @@ def _build_signal_decision_surface_boundary() -> SignalDecisionSurfaceBoundaryRe
             "professional non-live qualification criteria over stage, score, confirmation-rule, and entry-zone evidence",
             "explicit qualification evidence with rationale including score contribution and stage assessment",
             "explicit missing criteria and blocking-condition visibility",
+            "deterministic bounded trader-relevance case evaluation for qualification and action outputs",
         ],
         out_of_scope=[
             "trader validation outcomes",
+            "paper profitability or edge claims",
             "operational readiness outcomes",
             "live trading and broker execution decisions",
         ],
@@ -714,6 +717,37 @@ def _build_signal_decision_surface_item(signal: Dict[str, Any]) -> SignalDecisio
         action = "entry"
     else:
         action = "ignore"
+
+    boundary_statement = (
+        "Boundary evidence: this deterministic decision output is bounded trader-relevance validation only; "
+        "it is not trader_validation evidence, not paper profitability evidence, and not live-trading readiness evidence."
+    )
+    trader_relevance_validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state=qualification_state,
+        action=action,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        qualification_summary=(
+            "Qualification output remains explicitly bounded to paper-trading scope for technical review."
+        ),
+        rationale_summary=rationale_summary,
+        final_explanation=boundary_statement,
+        qualification_evidence=qualification_evidence + [boundary_statement],
+        missing_criteria=missing_criteria,
+        blocking_conditions=blocking_conditions,
+    )
+    trader_relevance_case_status = ", ".join(
+        f"{item.case_id}={item.evidence_status}"
+        for item in trader_relevance_validation.evaluations
+    )
+    qualification_evidence.append(
+        "Bounded trader-relevance case review "
+        f"(contract={trader_relevance_validation.contract_id}, "
+        f"version={trader_relevance_validation.contract_version}, "
+        f"overall={trader_relevance_validation.overall_status}): "
+        f"{trader_relevance_case_status}."
+    )
+    qualification_evidence.append(boundary_statement)
 
     return SignalDecisionSurfaceItemResponse(
         symbol=str(signal.get("symbol") or ""),

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 DECISION_CARD_CONTRACT_VERSION = "2.0.0"
+BOUNDED_TRADER_RELEVANCE_CONTRACT_ID = "bounded_trader_relevance.paper_review.v1"
+BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION = "1.0.0"
 QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD = 60.0
 QUALIFICATION_HIGH_AGGREGATE_THRESHOLD = 80.0
 ACTION_EXIT_WIN_RATE_MAX = 0.50
@@ -44,6 +46,12 @@ HardGateStatus = Literal["pass", "fail"]
 QualificationState = Literal["reject", "watch", "paper_candidate", "paper_approved"]
 QualificationColor = Literal["green", "yellow", "red"]
 DecisionAction = Literal["entry", "exit", "ignore"]
+PaperReviewCaseId = Literal[
+    "qualification_state_relevance",
+    "decision_action_relevance",
+    "boundary_scope_relevance",
+]
+TraderRelevanceEvidenceStatus = Literal["aligned", "weak", "missing"]
 
 REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
     "signal_quality",
@@ -88,6 +96,40 @@ CLAIM_BOUNDARY_FORBIDDEN_PHRASES: tuple[str, ...] = (
     "live approval",
     "production readiness",
 )
+
+PAPER_REVIEW_CASE_DEFINITIONS: dict[PaperReviewCaseId, dict[str, Any]] = {
+    "qualification_state_relevance": {
+        "review_question": (
+            "Does the output expose deterministic evidence that explains why the qualification state was resolved?"
+        ),
+        "required_evidence": (
+            "qualification_state",
+            "paper_scope_summary",
+            "state_explanation_evidence",
+        ),
+    },
+    "decision_action_relevance": {
+        "review_question": (
+            "Does the output expose deterministic evidence that explains why action is entry/exit/ignore?"
+        ),
+        "required_evidence": (
+            "action",
+            "bounded_decision_metrics",
+            "action_rule_trace",
+        ),
+    },
+    "boundary_scope_relevance": {
+        "review_question": (
+            "Does the output explicitly keep bounded trader-relevance validation separate from trader_validation, "
+            "paper profitability, and live-readiness claims?"
+        ),
+        "required_evidence": (
+            "trader_validation_boundary",
+            "paper_profitability_boundary",
+            "live_readiness_boundary",
+        ),
+    },
+}
 
 
 def _qualification_thresholds_from_metadata(metadata: dict[str, Any]) -> tuple[float, float]:
@@ -178,6 +220,26 @@ def _derive_decision_action_from_fields(
     return "ignore"
 
 
+def _collect_non_empty_texts(values: list[str | None]) -> list[str]:
+    return [value.strip() for value in values if isinstance(value, str) and value.strip()]
+
+
+def _contains_any_phrase(*, texts: list[str], phrases: tuple[str, ...]) -> bool:
+    lowered = [text.casefold() for text in texts]
+    return any(phrase in text for text in lowered for phrase in phrases)
+
+
+def _classify_trader_relevance_status(
+    checks: dict[str, bool],
+) -> TraderRelevanceEvidenceStatus:
+    true_count = sum(1 for ok in checks.values() if ok)
+    if true_count == len(checks):
+        return "aligned"
+    if true_count == 0:
+        return "missing"
+    return "weak"
+
+
 class HardGateResult(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -203,6 +265,163 @@ class HardGateResult(BaseModel):
         if self.status == "pass" and self.failure_reason is not None:
             raise ValueError("Passing hard gates must not define failure_reason")
         return self
+
+
+class BoundedTraderRelevanceCaseEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: PaperReviewCaseId
+    review_question: str = Field(min_length=16)
+    evidence_status: TraderRelevanceEvidenceStatus
+    required_evidence: list[str] = Field(min_length=1)
+    observed_evidence: list[str]
+    evidence_summary: str = Field(min_length=16)
+
+
+class BoundedTraderRelevanceValidation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_id: str = BOUNDED_TRADER_RELEVANCE_CONTRACT_ID
+    contract_version: str = BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION
+    overall_status: TraderRelevanceEvidenceStatus
+    evaluations: list[BoundedTraderRelevanceCaseEvaluation] = Field(min_length=1)
+
+    @field_validator("contract_id")
+    @classmethod
+    def _validate_contract_id(cls, value: str) -> str:
+        if value != BOUNDED_TRADER_RELEVANCE_CONTRACT_ID:
+            raise ValueError(f"Unsupported bounded trader relevance contract_id: {value}")
+        return value
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION:
+            raise ValueError(f"Unsupported bounded trader relevance contract_version: {value}")
+        return value
+
+    @field_validator("evaluations")
+    @classmethod
+    def _validate_evaluations(cls, value: list[BoundedTraderRelevanceCaseEvaluation]) -> list[BoundedTraderRelevanceCaseEvaluation]:
+        case_ids = [item.case_id for item in value]
+        required_case_ids = sorted(PAPER_REVIEW_CASE_DEFINITIONS.keys())
+        if sorted(case_ids) != required_case_ids:
+            raise ValueError(
+                "Bounded trader relevance evaluations must cover all canonical paper-review cases"
+            )
+        return sorted(value, key=lambda item: item.case_id)
+
+
+def evaluate_bounded_trader_relevance_cases(
+    *,
+    qualification_state: str | None,
+    action: str | None,
+    win_rate: float | None,
+    expected_value: float | None,
+    qualification_summary: str | None,
+    rationale_summary: str | None = None,
+    final_explanation: str | None = None,
+    gate_explanations: list[str] | None = None,
+    score_explanations: list[str] | None = None,
+    qualification_evidence: list[str] | None = None,
+    missing_criteria: list[str] | None = None,
+    blocking_conditions: list[str] | None = None,
+) -> BoundedTraderRelevanceValidation:
+    normalized_gate_explanations = list(gate_explanations or [])
+    normalized_score_explanations = list(score_explanations or [])
+    normalized_qualification_evidence = list(qualification_evidence or [])
+    normalized_missing_criteria = list(missing_criteria or [])
+    normalized_blocking_conditions = list(blocking_conditions or [])
+
+    all_texts = _collect_non_empty_texts(
+        [
+            qualification_summary,
+            rationale_summary,
+            final_explanation,
+            *normalized_gate_explanations,
+            *normalized_score_explanations,
+            *normalized_qualification_evidence,
+            *normalized_missing_criteria,
+            *normalized_blocking_conditions,
+        ]
+    )
+    qualification_summary_text = (qualification_summary or "").strip()
+
+    case_checks: dict[PaperReviewCaseId, dict[str, bool]] = {
+        "qualification_state_relevance": {
+            "qualification_state": bool(qualification_state and str(qualification_state).strip()),
+            "paper_scope_summary": "paper" in qualification_summary_text.casefold(),
+            "state_explanation_evidence": bool(
+                normalized_gate_explanations
+                or normalized_qualification_evidence
+                or normalized_missing_criteria
+                or normalized_blocking_conditions
+            ),
+        },
+        "decision_action_relevance": {
+            "action": bool(action and str(action).strip()),
+            "bounded_decision_metrics": (win_rate is not None and expected_value is not None),
+            "action_rule_trace": _contains_any_phrase(
+                texts=normalized_score_explanations + normalized_qualification_evidence,
+                phrases=("action", "entry", "exit", "ignore", "expected value", "win_rate", "win-rate"),
+            ),
+        },
+        "boundary_scope_relevance": {
+            "trader_validation_boundary": _contains_any_phrase(
+                texts=all_texts,
+                phrases=("trader_validation", "trader validation"),
+            ),
+            "paper_profitability_boundary": _contains_any_phrase(
+                texts=all_texts,
+                phrases=("paper profitability", "profitability", "edge claim", "profit claim"),
+            ),
+            "live_readiness_boundary": _contains_any_phrase(
+                texts=all_texts,
+                phrases=(
+                    "live-trading approval",
+                    "live trading readiness",
+                    "live readiness",
+                    "operational readiness",
+                    "broker execution readiness",
+                ),
+            ),
+        },
+    }
+
+    evaluations: list[BoundedTraderRelevanceCaseEvaluation] = []
+    statuses: list[TraderRelevanceEvidenceStatus] = []
+    for case_id in sorted(PAPER_REVIEW_CASE_DEFINITIONS.keys()):
+        checks = case_checks[case_id]
+        status = _classify_trader_relevance_status(checks=checks)
+        statuses.append(status)
+        observed = sorted(signal for signal, ok in checks.items() if ok)
+        required = list(PAPER_REVIEW_CASE_DEFINITIONS[case_id]["required_evidence"])
+        summary = (
+            f"Deterministic case={case_id} classified as {status}; "
+            f"observed={','.join(observed) if observed else 'none'}."
+        )
+        evaluations.append(
+            BoundedTraderRelevanceCaseEvaluation(
+                case_id=case_id,
+                review_question=str(PAPER_REVIEW_CASE_DEFINITIONS[case_id]["review_question"]),
+                evidence_status=status,
+                required_evidence=required,
+                observed_evidence=observed,
+                evidence_summary=summary,
+            )
+        )
+
+    if "missing" in statuses:
+        overall_status: TraderRelevanceEvidenceStatus = "missing"
+    elif "weak" in statuses:
+        overall_status = "weak"
+    else:
+        overall_status = "aligned"
+
+    return BoundedTraderRelevanceValidation(
+        overall_status=overall_status,
+        evaluations=evaluations,
+    )
 
 
 class HardGateEvaluation(BaseModel):
@@ -538,6 +757,9 @@ def serialize_decision_card(card: DecisionCard) -> str:
 
 __all__ = [
     "DECISION_CARD_CONTRACT_VERSION",
+    "BOUNDED_TRADER_RELEVANCE_CONTRACT_ID",
+    "BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION",
+    "PAPER_REVIEW_CASE_DEFINITIONS",
     "CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY",
     "CONFIDENCE_TIER_PRECISION_DISCLAIMER",
     "UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND",
@@ -547,6 +769,8 @@ __all__ = [
     "ACTION_ENTRY_WIN_RATE_MIN",
     "ACTION_EXIT_WIN_RATE_MAX",
     "QUALIFICATION_COLOR_BY_STATE",
+    "BoundedTraderRelevanceCaseEvaluation",
+    "BoundedTraderRelevanceValidation",
     "ComponentScore",
     "DecisionAction",
     "DecisionCard",
@@ -555,6 +779,7 @@ __all__ = [
     "HardGateResult",
     "Qualification",
     "ScoreEvaluation",
+    "evaluate_bounded_trader_relevance_cases",
     "serialize_decision_card",
     "validate_decision_card",
 ]

--- a/src/cilly_trading/engine/qualification_engine.py
+++ b/src/cilly_trading/engine/qualification_engine.py
@@ -9,6 +9,7 @@ from cilly_trading.engine.decision_card_contract import (
     ACTION_ENTRY_WIN_RATE_MIN,
     ACTION_EXIT_WIN_RATE_MAX,
     DECISION_CARD_CONTRACT_VERSION,
+    BoundedTraderRelevanceValidation,
     CONFIDENCE_TIER_PRECISION_DISCLAIMER,
     UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND,
     REQUIRED_COMPONENT_CATEGORIES,
@@ -21,6 +22,7 @@ from cilly_trading.engine.decision_card_contract import (
     HardGateResult,
     QualificationColor,
     QualificationState,
+    evaluate_bounded_trader_relevance_cases,
     validate_decision_card,
 )
 from cilly_trading.strategies.registry import (
@@ -146,6 +148,40 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         expected_value=expected_value,
         confidence_thresholds=threshold_profile["thresholds"],
     )
+    gate_explanations = _gate_explanations(hard_gate_evaluation=hard_gate_evaluation)
+    score_explanations = _score_explanations(
+        component_scores=integrated_component_scores,
+        base_aggregate_score=base_aggregate_score,
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+        threshold_profile=threshold_profile,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        action=action,
+        sentiment_resolution=sentiment_resolution,
+        backtest_input_applied=input_data.backtest_evidence is not None,
+        portfolio_fit_input_applied=input_data.portfolio_fit_input is not None,
+    )
+    rationale_summary = (
+        "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules."
+    )
+    final_explanation = (
+        "Decision action and qualification are deterministic technical implementation evidence "
+        "and does not imply live-trading approval, paper profitability, or trader_validation gate completion. "
+        "Validation gate status remains explicitly separate and defaults to trader_validation_not_started "
+        "unless governed evidence is recorded."
+    )
+    trader_relevance_validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state=state,
+        action=action,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        qualification_summary=qualification_summary,
+        rationale_summary=rationale_summary,
+        final_explanation=final_explanation,
+        gate_explanations=gate_explanations,
+        score_explanations=score_explanations,
+    )
     payload = {
         "contract_version": DECISION_CARD_CONTRACT_VERSION,
         "decision_card_id": input_data.decision_card_id,
@@ -177,26 +213,10 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             "summary": qualification_summary,
         },
         "rationale": {
-            "summary": "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules.",
-            "gate_explanations": _gate_explanations(hard_gate_evaluation=hard_gate_evaluation),
-            "score_explanations": _score_explanations(
-                component_scores=integrated_component_scores,
-                base_aggregate_score=base_aggregate_score,
-                aggregate_score=aggregate_score,
-                confidence_tier=confidence_tier,
-                threshold_profile=threshold_profile,
-                win_rate=win_rate,
-                expected_value=expected_value,
-                action=action,
-                sentiment_resolution=sentiment_resolution,
-                backtest_input_applied=input_data.backtest_evidence is not None,
-                portfolio_fit_input_applied=input_data.portfolio_fit_input is not None,
-            ),
-            "final_explanation": (
-                "Decision action and qualification are deterministic technical implementation evidence "
-                "and does not imply live-trading approval. Validation gate status remains explicitly "
-                "separate and defaults to trader_validation_not_started unless governed evidence is recorded."
-            ),
+            "summary": rationale_summary,
+            "gate_explanations": gate_explanations,
+            "score_explanations": score_explanations,
+            "final_explanation": final_explanation,
         },
         "metadata": _build_metadata(
             input_data=input_data,
@@ -206,6 +226,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             win_rate=win_rate,
             expected_value=expected_value,
             action=action,
+            trader_relevance_validation=trader_relevance_validation,
         ),
     }
     return validate_decision_card(payload)
@@ -554,6 +575,7 @@ def _build_metadata(
     win_rate: float,
     expected_value: float,
     action: DecisionAction,
+    trader_relevance_validation: BoundedTraderRelevanceValidation,
 ) -> dict[str, object]:
     metadata = dict(input_data.metadata or {})
     metadata["base_aggregate_score"] = base_aggregate_score
@@ -572,6 +594,7 @@ def _build_metadata(
     metadata["expected_value"] = expected_value
     metadata["decision_action"] = action
     metadata["decision_action_policy_version"] = "paper-action.v1"
+    metadata["bounded_trader_relevance_validation"] = trader_relevance_validation.model_dump(mode="python")
     metadata["technical_implementation_status"] = metadata.get(
         "technical_implementation_status", "technical_in_progress"
     )

--- a/tests/cilly_trading/engine/test_qualification_engine.py
+++ b/tests/cilly_trading/engine/test_qualification_engine.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import pytest
 
 from cilly_trading.engine.decision_card_contract import (
+    BOUNDED_TRADER_RELEVANCE_CONTRACT_ID,
+    BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION,
     DECISION_CARD_CONTRACT_VERSION,
     ComponentScore,
     HardGateResult,
+    evaluate_bounded_trader_relevance_cases,
 )
 from cilly_trading.engine.qualification_engine import (
     BacktestEvidenceInput,
@@ -366,3 +369,84 @@ def test_regression_identical_inputs_are_deterministic_across_groups() -> None:
     assert first_turtle.metadata["qualification_threshold_profile_id"] == (
         second_turtle.metadata["qualification_threshold_profile_id"]
     )
+
+
+def test_bounded_trader_relevance_validation_is_aligned_for_complete_qualification_output() -> None:
+    card = evaluate_qualification(_engine_input())
+    validation = card.metadata["bounded_trader_relevance_validation"]
+
+    assert validation["contract_id"] == BOUNDED_TRADER_RELEVANCE_CONTRACT_ID
+    assert validation["contract_version"] == BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION
+    assert validation["overall_status"] == "aligned"
+    assert [item["case_id"] for item in validation["evaluations"]] == [
+        "boundary_scope_relevance",
+        "decision_action_relevance",
+        "qualification_state_relevance",
+    ]
+    assert all(item["evidence_status"] == "aligned" for item in validation["evaluations"])
+
+
+def test_bounded_trader_relevance_validation_supports_weak_path_deterministically() -> None:
+    validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state="watch",
+        action="ignore",
+        win_rate=0.42,
+        expected_value=None,
+        qualification_summary="Qualification output remains bounded to paper scope.",
+        rationale_summary="Partial technical evidence exists.",
+        final_explanation="Boundary mentions trader_validation and live-trading readiness only.",
+        qualification_evidence=["No explicit action rule trace is included yet."],
+        missing_criteria=["Missing deterministic expected-value evidence."],
+        blocking_conditions=[],
+    )
+
+    assert validation.overall_status == "weak"
+    by_case = {item.case_id: item.evidence_status for item in validation.evaluations}
+    assert by_case == {
+        "boundary_scope_relevance": "weak",
+        "decision_action_relevance": "weak",
+        "qualification_state_relevance": "aligned",
+    }
+
+
+def test_bounded_trader_relevance_validation_supports_missing_path_deterministically() -> None:
+    validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state=None,
+        action=None,
+        win_rate=None,
+        expected_value=None,
+        qualification_summary="",
+        rationale_summary="",
+        final_explanation="",
+        qualification_evidence=[],
+        missing_criteria=[],
+        blocking_conditions=[],
+    )
+
+    assert validation.overall_status == "missing"
+    assert all(item.evidence_status == "missing" for item in validation.evaluations)
+
+
+def test_bounded_trader_relevance_validation_schema_is_stable_for_identical_inputs() -> None:
+    card_a = evaluate_qualification(_engine_input())
+    card_b = evaluate_qualification(_engine_input())
+
+    validation_a = card_a.metadata["bounded_trader_relevance_validation"]
+    validation_b = card_b.metadata["bounded_trader_relevance_validation"]
+
+    assert validation_a == validation_b
+    assert sorted(validation_a.keys()) == [
+        "contract_id",
+        "contract_version",
+        "evaluations",
+        "overall_status",
+    ]
+    for item in validation_a["evaluations"]:
+        assert sorted(item.keys()) == [
+            "case_id",
+            "evidence_status",
+            "evidence_summary",
+            "observed_evidence",
+            "required_evidence",
+            "review_question",
+        ]

--- a/tests/test_api_signal_decision_surface.py
+++ b/tests/test_api_signal_decision_surface.py
@@ -203,6 +203,16 @@ def test_signal_decision_surface_returns_bounded_technical_states(tmp_path: Path
     assert payload["items"][2]["expected_value"] == 1.0
     assert "score" in payload["items"][2]["score_contribution"].lower()
     assert "stage" in payload["items"][1]["stage_assessment"].lower()
+    assert any(
+        "bounded trader-relevance case review" in entry.lower()
+        for entry in payload["items"][2]["qualification_evidence"]
+    )
+    assert any(
+        "boundary evidence" in entry.lower()
+        and "not trader_validation evidence" in entry.lower()
+        and "not paper profitability evidence" in entry.lower()
+        for entry in payload["items"][2]["qualification_evidence"]
+    )
 
 
 def test_signal_decision_surface_covers_threshold_and_entry_zone_edge_cases(
@@ -248,6 +258,13 @@ def test_signal_decision_surface_covers_threshold_and_entry_zone_edge_cases(
     assert by_symbol["EDGE_CANDIDATE"]["missing_criteria"] == []
     assert by_symbol["EDGE_CANDIDATE"]["blocking_conditions"] == []
     assert by_symbol["EDGE_CANDIDATE"]["qualification_evidence"]
+    edge_candidate_review = next(
+        entry
+        for entry in by_symbol["EDGE_CANDIDATE"]["qualification_evidence"]
+        if "Bounded trader-relevance case review" in entry
+    )
+    assert "decision_action_relevance=aligned" in edge_candidate_review
+    assert "qualification_state_relevance=aligned" in edge_candidate_review
 
     assert by_symbol["EDGE_BLOCK"]["decision_state"] == "watch"
     assert by_symbol["EDGE_BLOCK"]["qualification_state"] == "watch"

--- a/tests/test_qualification_claim_boundary_docs.py
+++ b/tests/test_qualification_claim_boundary_docs.py
@@ -24,7 +24,21 @@ def test_governance_doc_defines_evidence_hierarchy_and_forbidden_claim_classes()
     assert "live-trading readiness/approval claims" in content
     assert "broker execution readiness claims" in content
     assert "trader-validation claims" in content
+    assert "paper profitability or edge claims" in content
     assert "guaranteed/certain outcome claims" in content
+
+
+def test_governance_doc_defines_deterministic_bounded_trader_relevance_contract() -> None:
+    content = GOVERNANCE_DOC.read_text(encoding="utf-8")
+
+    assert "Deterministic Bounded Trader-Relevance Review Contract" in content
+    assert "bounded_trader_relevance.paper_review.v1" in content
+    assert "qualification_state_relevance" in content
+    assert "decision_action_relevance" in content
+    assert "boundary_scope_relevance" in content
+    assert "aligned" in content
+    assert "weak" in content
+    assert "missing" in content
 
 
 def test_decision_card_contract_doc_declares_claim_boundary_wording_requirements() -> None:

--- a/tests/test_strategy_readiness_gates_docs.py
+++ b/tests/test_strategy_readiness_gates_docs.py
@@ -54,7 +54,9 @@ def test_strategy_readiness_gates_define_bounded_api_ui_evidence_surface_scope()
     assert "GET /backtest/artifacts/{run_id}/{artifact_name}" in content
     assert "must not collapse these states into a single inferred readiness claim" in content
     assert "no live-trading readiness or authorization claim" in content
+    assert "no paper profitability or edge claim" in content
     assert "no production-readiness claim" in content
+    assert "bounded trader-relevance validation" in content
 
 
 def test_docs_index_references_strategy_readiness_gates_contract() -> None:


### PR DESCRIPTION
SUMMARY

Implemented issue #1009 by adding deterministic bounded trader-relevance validation for qualification and decision outputs against canonical paper-review cases.

What changed

1. Added canonical bounded trader-relevance paper-review contract
- Introduced contract id/version:
  - bounded_trader_relevance.paper_review.v1
  - version 1.0.0
- Added canonical paper-review cases:
  - qualification_state_relevance
  - decision_action_relevance
  - boundary_scope_relevance
- Added deterministic case status semantics:
  - aligned
  - weak
  - missing

2. Added runtime evaluation for qualification outputs
- Implemented evaluate_bounded_trader_relevance_cases(...) in the decision-card contract layer.
- Qualification engine now computes bounded trader-relevance validation for generated decision cards.
- Validation output is persisted under:
  - metadata.bounded_trader_relevance_validation

3. Extended signal decision surface with bounded trader-relevance evidence
- /signals/decision-surface now evaluates qualification/action outputs against the same bounded paper-review cases.
- Surface output now includes explicit trader-relevance case-review evidence and boundary wording.
- Qualification/action output remains explicitly separated from trader_validation, paper profitability, and live-readiness claims.

4. Tightened governance/docs alignment
- Added deterministic bounded trader-relevance review contract wording to governance docs.
- Updated strategy-readiness governance docs to explicitly include bounded trader-relevance validation in the API/UI evidence boundary.
- Maintained non-inference discipline across technical implementation, trader validation, and operational readiness.

5. Added regression and boundary coverage
- Added tests for:
  - aligned validation path
  - weak validation path
  - missing validation path
  - schema stability for identical inputs
  - API surface visibility of bounded trader-relevance review evidence
  - doc/runtime wording alignment

Acceptance criteria coverage

- Qualification outputs are now validated against deterministic paper-review cases.
- Decision outputs (action, bounded metrics) are now validated against deterministic paper-review cases.
- Boundary-scope validation explicitly checks separation from trader_validation, paper profitability, and live/live-readiness claims.
- Validation outputs are machine-evaluable, deterministic, and stable for identical inputs.
- API/UI surface exposes bounded trader-relevance evidence without implying readiness claims.

Validation

- Exact test command:
  .\.venv\Scripts\python -m pytest

- Result:
  1121 passed, 4 warnings