### PR TITLE
[OPS-RUNTIME][03] Migrate FastAPI runtime lifecycle hooks to lifespan handlers

### DIFF
--- a/docs/governance/qualification-claim-evidence-discipline.md
+++ b/docs/governance/qualification-claim-evidence-discipline.md
@@ -57,7 +57,41 @@ Determinism rule:
 - identical inputs must produce identical case classifications and ordering
 - classification must be machine-evaluable from explicit output evidence fields only (no manual interpretation)
 
-## 5. Runtime and Documentation Alignment Rule
+## 5. Deterministic Bounded Decision-to-Paper Usefulness Audit
+
+Canonical contract id/version:
+
+- `decision_evidence_to_paper_outcome_usefulness.paper_audit.v1`
+- version `1.0.0`
+
+Covered cases:
+
+- only decision cards that explicitly declare `metadata.bounded_decision_to_paper_match`
+- contract v1 is bounded to covered `entry` decisions only
+- the explicit match contract is one exact `paper_trade_id`
+
+Deterministic matching rule:
+
+- resolve the exact `paper_trade_id`
+- the matched paper trade must share the same `symbol` and `strategy_id` as the decision card
+- the matched paper trade must open at or after `generated_at_utc`
+- if any of those checks fail, the usefulness signal is out of contract and must be classified as misleading
+
+Usefulness classification semantics:
+
+- `explanatory`: the covered entry decision matches a subsequent closed paper trade with a favorable bounded outcome
+- `weak`: the covered entry decision has no resolved match, remains open, or closes flat
+- `misleading`: the covered entry decision matches an invalid or adverse bounded paper outcome
+
+Claim boundary:
+
+- usefulness is bounded to non-live explanatory review only
+- it is not trader validation
+- it is not profitability forecasting
+- it is not live-trading readiness
+- it is not operational readiness
+
+## 6. Runtime and Documentation Alignment Rule
 
 Documentation and runtime wording must enforce the same boundary:
 
@@ -65,7 +99,7 @@ Documentation and runtime wording must enforce the same boundary:
 - inspection API wording mirrors the same boundary
 - qualification outputs explicitly state they do not imply live-trading approval
 
-## 6. Validation Rule
+## 7. Validation Rule
 
 Where claim-boundary enforcement exists in runtime contracts, validation must fail closed for unsupported claim language.
 Validation is required for:
@@ -74,7 +108,7 @@ Validation is required for:
 - qualification summary text
 - rationale summary/final explanation text
 
-## 7. Non-Goals
+## 8. Non-Goals
 
 This governance contract does not grant:
 

--- a/docs/governance/qualification-claim-evidence-discipline.md
+++ b/docs/governance/qualification-claim-evidence-discipline.md
@@ -30,9 +30,34 @@ The following claim classes are unsupported in qualification outputs and must be
 - production readiness claims
 - broker execution readiness claims
 - trader-validation claims
+- paper profitability or edge claims
 - guaranteed/certain outcome claims
 
-## 4. Runtime and Documentation Alignment Rule
+## 4. Deterministic Bounded Trader-Relevance Review Contract
+
+Canonical contract id/version:
+
+- `bounded_trader_relevance.paper_review.v1`
+- version `1.0.0`
+
+Paper-review cases (deterministic and ordered by case id):
+
+- `qualification_state_relevance`: verify qualification-state output is evidence-explained and explicitly paper-scoped
+- `decision_action_relevance`: verify action output is evidence-explained with bounded decision metrics
+- `boundary_scope_relevance`: verify explicit boundary wording for trader_validation separation, paper profitability separation, and live-readiness separation
+
+Case status semantics:
+
+- `aligned`: all required evidence signals for the case are present
+- `weak`: some required evidence signals are present, but at least one is missing
+- `missing`: no required evidence signals are present
+
+Determinism rule:
+
+- identical inputs must produce identical case classifications and ordering
+- classification must be machine-evaluable from explicit output evidence fields only (no manual interpretation)
+
+## 5. Runtime and Documentation Alignment Rule
 
 Documentation and runtime wording must enforce the same boundary:
 
@@ -40,7 +65,7 @@ Documentation and runtime wording must enforce the same boundary:
 - inspection API wording mirrors the same boundary
 - qualification outputs explicitly state they do not imply live-trading approval
 
-## 5. Validation Rule
+## 6. Validation Rule
 
 Where claim-boundary enforcement exists in runtime contracts, validation must fail closed for unsupported claim language.
 Validation is required for:
@@ -49,7 +74,7 @@ Validation is required for:
 - qualification summary text
 - rationale summary/final explanation text
 
-## 6. Non-Goals
+## 7. Non-Goals
 
 This governance contract does not grant:
 

--- a/docs/governance/score-semantics-cross-strategy.md
+++ b/docs/governance/score-semantics-cross-strategy.md
@@ -76,6 +76,23 @@ by strategy `comparison_group`.
 Threshold-profile calibration is bounded contract behavior for within-group qualification
 consistency only and does not create cross-group ranking authority.
 
+## 4.2 Qualification-Profile Robustness Audit Boundary
+
+Qualification-profile robustness is audited through one fixed deterministic slice set
+using existing qualification evidence dimensions only.
+
+- one covered slice reproduces current-evidence qualification output
+- bounded failure-envelope slices degrade signal/backtest and risk/execution evidence
+  with fixed deterministic deltas
+- one regime slice is resolved deterministically from strategy `comparison_group`
+- audit output records explicit `stable`, `weak`, and `failing` behavior by slice
+
+This robustness audit does not perform probabilistic regime detection, threshold
+recalibration, or scope expansion beyond bounded decision-support review.
+
+Weak or failing slices limit interpretation outside covered conditions. They do not
+create live-trading approval, trader_validation completion, or profitability claims.
+
 ## 5. Runtime and Documentation Alignment Rule
 
 All runtime wording and documentation must remain consistent with this governance contract:
@@ -92,6 +109,8 @@ wording templates that runtime qualification uses:
 
 - `CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY`: the bounded non-comparability statement
 - `CONFIDENCE_TIER_PRECISION_DISCLAIMER`: the bounded precision statement
+- `QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY`: the bounded robustness
+  interpretation limit for covered versus weak/failing slices
 
 ## 6. Non-Goals
 
@@ -100,3 +119,4 @@ This governance contract does not grant:
 - cross-strategy ranking authority
 - live trading approval or broker execution approval
 - forecast or probability certification
+- robustness claims outside covered conditions

--- a/docs/governance/signal-quality-bounded-contract.md
+++ b/docs/governance/signal-quality-bounded-contract.md
@@ -78,6 +78,23 @@ threshold profiles.
 Cross-group non-comparability remains explicit: threshold profile calibration does not
 make decision-card scores directly comparable across different comparison groups.
 
+## Qualification-Profile Robustness Boundary
+
+Qualification-profile robustness is evaluated through one fixed deterministic bounded
+audit slice set:
+
+- `covered.current_evidence.v1`
+- `failure_envelope.evidence_decay.v1`
+- `failure_envelope.execution_stress.v1`
+- one comparison-group regime slice resolved deterministically from registry metadata
+
+The audit uses only existing component-score evidence dimensions and governed threshold
+profiles. It records explicit `stable`, `weak`, and `failing` slice behavior in bounded
+audit output.
+
+Weak or failing slices limit interpretation outside covered conditions and do not expand
+live-trading approval, paper profitability, or trader_validation claims.
+
 ## Deterministic Ranking Boundary
 
 For setup-stage candidates that meet the configured score floor, ranking is deterministic:
@@ -135,6 +152,10 @@ This contract supports only bounded implementation claims. It explicitly support
 "Classification: technically good, traderically weak" for current state.
 
 It does not claim trader readiness, and it provides no live-trading readiness, execution approval, or profitability guarantee.
+
+Robustness audit findings remain non-live interpretation only: stable slices stay bounded
+to covered conditions, and weak/failing slices reduce interpretive confidence rather than
+expanding claims.
 
 ## Validation Surfaces
 

--- a/docs/governance/strategy-readiness-gates.md
+++ b/docs/governance/strategy-readiness-gates.md
@@ -136,6 +136,7 @@ Decision-evidence status boundary for qualification outputs:
 
 - qualification and action outputs may include `technical_implementation_status` as technical-only evidence metadata
 - qualification and action outputs may include `trader_validation_status` as independent trader-validation metadata
+- qualification and action outputs may include bounded trader-relevance validation case outputs (`aligned` | `weak` | `missing`) for deterministic paper-review evidence checks
 - technical and trader-validation statuses must remain explicit, separate fields
 - default bounded interpretation for current paper-evaluation action evidence:
   - technical implementation status may be `technical_in_progress`
@@ -146,6 +147,7 @@ Non-live and governance boundary for this scope:
 
 - no live-trading readiness or authorization claim
 - no broker-connectivity or execution-enablement claim
+- no paper profitability or edge claim
 - no production-readiness claim
 - no replacement of governance gates with inferred UI/API status
 

--- a/docs/operations/runtime/p53-automated-review-operations.md
+++ b/docs/operations/runtime/p53-automated-review-operations.md
@@ -160,6 +160,31 @@ Interpretation boundary:
 - Keep raw evidence markers (`PASS`, `FAIL`, `ERROR`) unchanged; apply the review
   semantics below on top of those markers.
 
+### Daily Runtime Operator Action Boundary
+
+When the daily bounded runtime summary is produced through OPS-P63 or OPS-P64,
+record operator next-action semantics explicitly in the artifact with:
+
+- `operator_action_contract_version`
+- `operator_action_contract.action_category`
+- `operator_action_contract.action_code`
+- `operator_action_contract.action_summary`
+- `operator_action_contract.escalation_boundary`
+
+Bounded action categories for daily runtime use:
+
+- `informational`: record bounded evidence and continue the next scheduled bounded run
+- `review_required`: inspect bounded no-eligible evidence and confirm the outcome without retrying solely to force activity
+- `retry_required`: correct a pre-execution failure and rerun only when bounded paper execution has not started
+- `blocking`: stop continuation claims for the affected run and investigate before any rerun or staged-evaluation claim
+
+Boundary reminder:
+
+- these action categories are bounded operator guidance only
+- they do not imply operational readiness
+- they do not imply broker readiness
+- they do not imply production readiness
+
 ### Decision-Support Review Semantics
 
 Use one review classification per bounded review package:

--- a/docs/operations/runtime/p60-signal-to-paper-operator-path.md
+++ b/docs/operations/runtime/p60-signal-to-paper-operator-path.md
@@ -177,6 +177,30 @@ Alternatively, run the existing P53 post-run reconciliation script:
 python scripts/run_post_run_reconciliation.py --db-path /path/to/cilly_trading.db
 ```
 
+## Decision Evidence Usefulness Audit
+
+Covered decision cards may expose one bounded usefulness audit through
+`/decision-cards` metadata:
+
+- `metadata.bounded_decision_to_paper_match`
+- `metadata.bounded_decision_to_paper_usefulness_audit`
+
+The canonical matching rule is exact and deterministic:
+
+1. resolve one explicit `paper_trade_id`
+2. require the matched trade to share the same `symbol` and `strategy_id`
+3. require the matched trade to open at or after the decision-card timestamp
+
+The audit classifications are:
+
+- `explanatory`
+- `weak`
+- `misleading`
+
+This audit is bounded to non-live usefulness only. It does not imply trader
+validation, profitability forecasting, live-trading readiness, or operational
+readiness.
+
 ## Gap Analysis
 
 ### Previously Missing (addressed by P60)
@@ -298,6 +322,8 @@ Under bounded staging conditions, this confirms:
 - `/paper/trades` and `/paper/positions` reflect canonical created state
 - reconciliation remains consistent (`ok: true`, `mismatches: 0`) in non-empty
   state
+- covered decision cards can later be reviewed against exact matched
+  paper-trade outcomes for bounded usefulness
 - immediate repeat execution remains bounded and duplicate-entry safe
 - no duplicate paper trades are created on immediate re-run
 
@@ -307,5 +333,7 @@ This OPS-P62 record is bounded staging evidence only. It does not claim:
 - live-trading readiness
 - broker integration readiness
 - production readiness
+- trader validation
+- profitability forecasting
 - strategy calibration completeness
 - portfolio or risk optimization completeness

--- a/docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md
+++ b/docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md
@@ -219,6 +219,8 @@ The daily summary artifact includes explicit bounded run-quality fields:
 - `run_quality_status`
 - `run_quality_classification_version`
 - `run_quality_inputs`
+- `operator_action_contract_version`
+- `operator_action_contract`
 
 Deterministic classification rules use existing runtime summary inputs only:
 
@@ -240,6 +242,47 @@ Bounded interpretation:
 - `no_eligible` is valid non-error completion in bounded runtime evidence
 - `run_quality_status` is operator-facing evidence quality only
 - classification does not widen runtime scope and does not imply live readiness
+
+### Deterministic Operator Action Contract (Daily Summary)
+
+The daily summary artifact records one deterministic next-action contract for
+each classified `run_quality_status`.
+
+Recorded action fields:
+
+- `operator_action_contract_version`
+- `operator_action_contract.action_category`
+- `operator_action_contract.action_code`
+- `operator_action_contract.action_summary`
+- `operator_action_contract.escalation_boundary`
+
+Deterministic summary-state mapping:
+
+| `run_quality_status` | `action_category` | Deterministic bounded operator interpretation |
+| --- | --- | --- |
+| `healthy` | `informational` | Record the bounded daily runtime evidence and continue the next scheduled bounded run. |
+| `no_eligible` | `review_required` | Review the bounded no-eligible outcome, confirm skip reasons and inputs, and record the run without retrying solely to force activity. |
+| `degraded` | `blocking` | Stop continuation claims for that run, investigate the degraded evidence, and open or update follow-up before the next bounded decision. |
+
+Operator-facing category wording:
+
+- `healthy` is informational
+- `no_eligible` is review-required
+- `degraded` is blocking
+
+Fail-fast bounded runner guidance:
+
+- pre-execution failures are retry-required
+- execution or post-execution failures are blocking
+- retry-required applies only when the daily command path fails before bounded paper execution starts
+- blocking applies once execution starts or when reconciliation/evidence is incomplete, so the operator does not blindly rerun a partially completed daily workflow
+
+Escalation boundary:
+
+- the action contract is bounded operator guidance only
+- it does not imply operational readiness
+- it does not imply broker readiness
+- it does not imply production readiness
 
 ## Daily Sequential Command Sequence (Bounded Staging)
 

--- a/docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md
+++ b/docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md
@@ -86,6 +86,8 @@ The runner is fail-fast:
   - `detail`
   - `steps_completed`
   - `step_order`
+  - `operator_action_contract_version`
+  - `operator_action_contract`
 - it returns step-specific non-zero exit codes
 
 Bounded execution note:
@@ -103,6 +105,8 @@ On success, the runner emits bounded JSON summary output to stdout with:
 - `run_quality_status`
 - `run_quality_classification_version`
 - `run_quality_inputs`
+- `operator_action_contract_version`
+- `operator_action_contract`
 - `steps_completed`
 - `verification_surfaces` evidence file paths
 - `summary_file` path
@@ -123,7 +127,30 @@ Deterministic run-quality interpretation:
 Determinism contract:
 
 - same run summary inputs always produce the same `run_quality_status`
+- the same `run_quality_status` always produces the same `operator_action_contract`
 - classification is bounded evidence quality only and remains non-live
+
+Deterministic operator action contract:
+
+| `run_quality_status` | `action_category` | Deterministic bounded operator interpretation |
+| --- | --- | --- |
+| `healthy` | `informational` | Record the bounded daily runtime evidence and continue the next scheduled bounded run. |
+| `no_eligible` | `review_required` | Review the bounded no-eligible outcome, confirm skip reasons and inputs, and record the run without retrying solely to force activity. |
+| `degraded` | `blocking` | Stop continuation claims for that run, investigate the degraded evidence, and open or update follow-up before the next bounded decision. |
+
+Operator-facing category wording:
+
+- `healthy` is informational
+- `no_eligible` is review-required
+- `degraded` is blocking
+
+Fail-fast operator action boundary:
+
+- pre-execution failures are retry-required
+- execution or post-execution failures are blocking
+- pre-execution retry applies only before bounded paper execution starts
+- once execution has started, the operator must stop and investigate before any rerun decision
+- this bounded action contract does not imply operational readiness
 
 ## Verification Surfaces Remain Usable
 

--- a/docs/operations/runtime/phase-44-paper-operator-workflow.md
+++ b/docs/operations/runtime/phase-44-paper-operator-workflow.md
@@ -12,12 +12,14 @@ Phase 44 is bounded to one operator verification workflow:
 2. Inspect canonical trading-core lifecycle entities (orders, execution events, trades, positions).
 3. Inspect paper-facing account/trade/position views derived from canonical entities.
 4. Reconcile canonical and paper-facing state and require zero mismatches.
-5. Treat the result as bounded paper-runtime coherence evidence only.
+5. Inspect covered decision-card usefulness audit outputs against exact matched paper trades.
+6. Treat the result as bounded paper-runtime coherence evidence only.
 
 ## Workflow Boundary
 This workflow is read-only, operator-facing, and validation-oriented.
 
 In scope:
+- covered decision-to-paper usefulness audit for explicit paper-trade matches
 - deterministic paper lifecycle evidence
 - canonical inspection surfaces for order lifecycle state
 - paper inspection and reconciliation surfaces derived from canonical entities
@@ -38,6 +40,7 @@ Out of scope:
 - `tests/cilly_trading/engine/test_paper_order_lifecycle.py`
 
 ### Canonical inspection surfaces
+- `GET /decision-cards`
 - `GET /trading-core/orders`
 - `GET /trading-core/execution-events`
 - `GET /trading-core/trades`
@@ -57,6 +60,7 @@ Out of scope:
 4. Inspect canonical trade and position state via `GET /trading-core/trades` and `GET /trading-core/positions`.
 5. Inspect paper-facing trade, position, and account projections via `GET /paper/trades`, `GET /paper/positions`, and `GET /paper/account`.
 6. Reconcile the workflow state via `GET /paper/reconciliation` and require `ok: true` and `summary.mismatches: 0`.
+7. Inspect `/decision-cards` and review `metadata.bounded_decision_to_paper_usefulness_audit` for any covered cases.
 
 ## Minimum Operator Evidence
 The bounded Phase 44 workflow claim requires all of the following evidence:
@@ -65,6 +69,7 @@ The bounded Phase 44 workflow claim requires all of the following evidence:
 - Paper inspection and reconciliation contract coverage is passing (`tests/test_api_paper_inspection_read.py`).
 - Reconciliation returns `ok: true` and `summary.mismatches: 0` for valid lifecycle data.
 - Paper inspection views are derived from canonical trading-core entities, not legacy trade payload authority.
+- Covered decision-card usefulness audit remains bounded to non-live explanatory review and exact paper-trade matches only.
 - Full repository regression gate remains green (`python -m pytest`).
 
 ## Phase 24 vs Phase 44 Boundary
@@ -141,6 +146,7 @@ Each bounded long-run paper operator review must produce the following artifacts
 | R5 | Canonical trade count | `GET /trading-core/trades` | `total` matches `GET /paper/trades` `total` |
 | R6 | Canonical position count | `GET /trading-core/positions` | `total` matches `GET /paper/positions` `total` |
 | R7 | Workflow contract state | `GET /paper/workflow` | `validation.ok: true` |
+| R8 | Covered decision usefulness audit | `GET /decision-cards` | Covered cases expose `metadata.bounded_decision_to_paper_usefulness_audit` only in bounded non-live scope |
 
 All R1–R7 artifacts must be captured in the sequence listed above. R1 must be captured and confirmed clean before R2–R7 are treated as valid review evidence.
 

--- a/scripts/run_daily_bounded_paper_runtime.py
+++ b/scripts/run_daily_bounded_paper_runtime.py
@@ -54,6 +54,104 @@ EXIT_CODE_RECONCILIATION_FAILED = 13
 EXIT_CODE_EVIDENCE_FAILED = 14
 
 RUN_QUALITY_CLASSIFICATION_VERSION = 1
+OPERATOR_ACTION_CONTRACT_VERSION = 1
+
+RUN_QUALITY_OPERATOR_ACTION_CONTRACTS: dict[str, dict[str, str]] = {
+    "healthy": {
+        "action_category": "informational",
+        "action_code": "record_and_continue",
+        "action_summary": (
+            "Record the bounded daily runtime evidence and continue the next scheduled bounded run."
+        ),
+        "escalation_boundary": (
+            "No escalation from this state alone. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+    "no_eligible": {
+        "action_category": "review_required",
+        "action_code": "review_no_eligible_and_record",
+        "action_summary": (
+            "Review the bounded no-eligible outcome, confirm skip reasons and inputs, and record the run without retrying solely to force activity."
+        ),
+        "escalation_boundary": (
+            "Escalate only when adjacent bounded evidence is contradictory or the no-eligible pattern is unexpected for the stated inputs. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+    "degraded": {
+        "action_category": "blocking",
+        "action_code": "stop_and_open_follow_up",
+        "action_summary": (
+            "Treat the bounded run as blocked for continuation claims, investigate the degraded evidence, and open or update follow-up before the next bounded decision."
+        ),
+        "escalation_boundary": (
+            "Do not continue staged evaluation claims from this run until the degraded cause is resolved. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+}
+
+FAILED_STEP_OPERATOR_ACTION_CONTRACTS: dict[str, dict[str, str]] = {
+    "snapshot_ingestion": {
+        "action_category": "retry_required",
+        "action_code": "fix_pre_execution_failure_and_rerun",
+        "action_summary": (
+            "Correct the pre-execution failure cause and rerun the bounded daily workflow."
+        ),
+        "escalation_boundary": (
+            "Retry is bounded to failures before paper execution starts. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+    "analysis_signal_generation": {
+        "action_category": "retry_required",
+        "action_code": "fix_pre_execution_failure_and_rerun",
+        "action_summary": (
+            "Correct the pre-execution failure cause and rerun the bounded daily workflow."
+        ),
+        "escalation_boundary": (
+            "Retry is bounded to failures before paper execution starts. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+    "bounded_paper_execution_cycle": {
+        "action_category": "blocking",
+        "action_code": "stop_and_investigate_before_rerun",
+        "action_summary": (
+            "Stop and investigate the bounded execution failure before any rerun decision."
+        ),
+        "escalation_boundary": (
+            "Do not rerun the full workflow blindly after execution has started. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+    "reconciliation": {
+        "action_category": "blocking",
+        "action_code": "stop_and_investigate_before_rerun",
+        "action_summary": (
+            "Stop and investigate the bounded reconciliation failure before any rerun decision."
+        ),
+        "escalation_boundary": (
+            "Do not continue staged evaluation claims until reconciliation is resolved. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+    "evidence_capture": {
+        "action_category": "blocking",
+        "action_code": "stop_and_investigate_before_rerun",
+        "action_summary": (
+            "Stop and investigate the missing or failed bounded evidence capture before any rerun decision."
+        ),
+        "escalation_boundary": (
+            "Do not rerun the full workflow blindly after execution-stage evidence has already been produced. Do not treat bounded paper evidence as live, broker, or production readiness."
+        ),
+    },
+}
+
+DEFAULT_FAILED_STEP_OPERATOR_ACTION_CONTRACT: dict[str, str] = {
+    "action_category": "blocking",
+    "action_code": "stop_and_investigate_before_rerun",
+    "action_summary": (
+        "Stop and investigate the bounded runtime failure before any rerun decision."
+    ),
+    "escalation_boundary": (
+        "Do not treat bounded paper evidence as live, broker, or production readiness."
+    ),
+}
 
 
 class DailyRuntimeStepError(RuntimeError):
@@ -261,6 +359,8 @@ def _build_error_payload(
         "status": "failed",
         "step_order": list(STEP_ORDER),
         "steps_completed": steps_completed,
+        "operator_action_contract_version": OPERATOR_ACTION_CONTRACT_VERSION,
+        "operator_action_contract": _build_failed_step_action_contract(step),
     }
     if ingestion_run_id is not None:
         payload["ingestion_run_id"] = ingestion_run_id
@@ -344,6 +444,8 @@ def _classify_run_quality(
         run_quality_status = "degraded"
 
     return {
+        "operator_action_contract": _build_run_quality_action_contract(run_quality_status),
+        "operator_action_contract_version": OPERATOR_ACTION_CONTRACT_VERSION,
         "run_quality_classification_version": RUN_QUALITY_CLASSIFICATION_VERSION,
         "run_quality_status": run_quality_status,
         "run_quality_inputs": {
@@ -354,6 +456,21 @@ def _classify_run_quality(
             "reconciliation_ok": reconciliation_ok,
         },
     }
+
+
+def _build_run_quality_action_contract(run_quality_status: str) -> dict[str, str]:
+    contract = RUN_QUALITY_OPERATOR_ACTION_CONTRACTS.get(run_quality_status)
+    if contract is None:
+        raise ValueError(f"unsupported run_quality_status for operator action contract: {run_quality_status}")
+    return dict(contract)
+
+
+def _build_failed_step_action_contract(step: str) -> dict[str, str]:
+    contract = FAILED_STEP_OPERATOR_ACTION_CONTRACTS.get(
+        step,
+        DEFAULT_FAILED_STEP_OPERATOR_ACTION_CONTRACT,
+    )
+    return dict(contract)
 
 
 def run_daily_bounded_paper_runtime(

--- a/src/api/composition/runtime_lifecycle.py
+++ b/src/api/composition/runtime_lifecycle.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Callable
+from typing import AsyncIterator, Callable
 
 from fastapi import FastAPI
 
@@ -23,13 +24,11 @@ def register_runtime_lifecycle(
     app: FastAPI,
     deps: RuntimeLifecycleDependencies,
 ) -> tuple[Callable[[], None], Callable[[], None]]:
-    @app.on_event("startup")
     def _startup_runtime() -> None:
         deps.start_runtime()
         deps.set_runtime_guard_active(True)
         deps.start_scheduled_analysis_runner()
 
-    @app.on_event("shutdown")
     def _shutdown_runtime() -> None:
         deps.shutdown_scheduled_analysis_runner()
         deps.set_runtime_guard_active(False)
@@ -37,5 +36,15 @@ def register_runtime_lifecycle(
             deps.shutdown_runtime()
         except deps.lifecycle_transition_error:
             deps.logger.exception("Engine runtime shutdown failed")
+
+    @asynccontextmanager
+    async def _runtime_lifespan(_: FastAPI) -> AsyncIterator[None]:
+        _startup_runtime()
+        try:
+            yield
+        finally:
+            _shutdown_runtime()
+
+    app.router.lifespan_context = _runtime_lifespan
 
     return _startup_runtime, _shutdown_runtime

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -15,6 +15,7 @@ from cilly_trading.engine.decision_card_contract import (
     ACTION_EXIT_WIN_RATE_MAX,
     QUALIFICATION_HIGH_AGGREGATE_THRESHOLD,
     QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD,
+    evaluate_bounded_trader_relevance_cases,
     validate_decision_card,
 )
 from cilly_trading.models import ExecutionEvent, Order, Position, SignalReadItemDTO, SignalReadResponseDTO, Trade
@@ -565,9 +566,11 @@ def _build_signal_decision_surface_boundary() -> SignalDecisionSurfaceBoundaryRe
             "professional non-live qualification criteria over stage, score, confirmation-rule, and entry-zone evidence",
             "explicit qualification evidence with rationale including score contribution and stage assessment",
             "explicit missing criteria and blocking-condition visibility",
+            "deterministic bounded trader-relevance case evaluation for qualification and action outputs",
         ],
         out_of_scope=[
             "trader validation outcomes",
+            "paper profitability or edge claims",
             "operational readiness outcomes",
             "live trading and broker execution decisions",
         ],
@@ -714,6 +717,37 @@ def _build_signal_decision_surface_item(signal: Dict[str, Any]) -> SignalDecisio
         action = "entry"
     else:
         action = "ignore"
+
+    boundary_statement = (
+        "Boundary evidence: this deterministic decision output is bounded trader-relevance validation only; "
+        "it is not trader_validation evidence, not paper profitability evidence, and not live-trading readiness evidence."
+    )
+    trader_relevance_validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state=qualification_state,
+        action=action,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        qualification_summary=(
+            "Qualification output remains explicitly bounded to paper-trading scope for technical review."
+        ),
+        rationale_summary=rationale_summary,
+        final_explanation=boundary_statement,
+        qualification_evidence=qualification_evidence + [boundary_statement],
+        missing_criteria=missing_criteria,
+        blocking_conditions=blocking_conditions,
+    )
+    trader_relevance_case_status = ", ".join(
+        f"{item.case_id}={item.evidence_status}"
+        for item in trader_relevance_validation.evaluations
+    )
+    qualification_evidence.append(
+        "Bounded trader-relevance case review "
+        f"(contract={trader_relevance_validation.contract_id}, "
+        f"version={trader_relevance_validation.contract_version}, "
+        f"overall={trader_relevance_validation.overall_status}): "
+        f"{trader_relevance_case_status}."
+    )
+    qualification_evidence.append(boundary_statement)
 
     return SignalDecisionSurfaceItemResponse(
         symbol=str(signal.get("symbol") or ""),

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -337,10 +337,12 @@ def read_paper_operator_workflow(
         boundary=PaperOperatorWorkflowBoundaryResponse(
             workflow_id="phase44_bounded_paper_operator",
             description=(
-                "One read-only portfolio-to-paper handoff contract that validates bounded "
-                "paper-readiness inputs across canonical inspection and reconciliation surfaces."
+                "One read-only decision-to-paper and portfolio-to-paper handoff contract that "
+                "validates bounded paper-readiness inputs across canonical inspection and "
+                "reconciliation surfaces."
             ),
             in_scope=[
+                "covered decision-card usefulness audit against explicit matched paper-trade outcomes",
                 "explicit portfolio-to-paper handoff inputs from canonical orders, execution events, trades, and positions",
                 "paper-facing account, trade, and position views derived from canonical portfolio evidence",
                 "reconciliation validation with mismatch accounting",
@@ -395,9 +397,22 @@ def read_paper_operator_workflow(
                     f"{reconciliation.summary.mismatches}."
                 ),
             ),
+            PaperOperatorWorkflowStepResponse(
+                step=6,
+                action=(
+                    "Inspect covered decision cards for bounded usefulness classifications against "
+                    "explicit matched paper-trade outcomes."
+                ),
+                endpoint="GET /decision-cards",
+                expected_result=(
+                    "Covered decision-card outputs expose bounded usefulness classifications in "
+                    "metadata without trader-validation or readiness claims."
+                ),
+            ),
         ],
         surfaces=PaperOperatorWorkflowSurfaceResponse(
             canonical_inspection=[
+                "/decision-cards",
                 "/trading-core/orders",
                 "/trading-core/execution-events",
                 "/trading-core/trades",
@@ -1174,6 +1189,20 @@ def build_decision_card_inspection_items(
                 continue
             seen.add(dedupe_key)
 
+            metadata = dict(card.metadata)
+            usefulness_audit = paper_inspection_service.build_bounded_decision_to_paper_usefulness_audit(
+                canonical_execution_repo=paper_inspection_service.resolve_runtime_canonical_execution_repo(),
+                decision_card_id=card.decision_card_id,
+                generated_at_utc=card.generated_at_utc,
+                symbol=card.symbol,
+                strategy_id=card.strategy_id,
+                action=card.action,
+                qualification_state=card.qualification.state,
+                match_reference=metadata.get("bounded_decision_to_paper_match"),
+            )
+            if usefulness_audit is not None:
+                metadata["bounded_decision_to_paper_usefulness_audit"] = usefulness_audit
+
             items.append(
                 DecisionCardInspectionItemResponse(
                     run_id=run_id,
@@ -1206,7 +1235,7 @@ def build_decision_card_inspection_items(
                     gate_explanations=list(card.rationale.gate_explanations),
                     score_explanations=list(card.rationale.score_explanations),
                     final_explanation=card.rationale.final_explanation,
-                    metadata=dict(card.metadata),
+                    metadata=metadata,
                 )
             )
 

--- a/src/api/services/paper_inspection_service.py
+++ b/src/api/services/paper_inspection_service.py
@@ -8,11 +8,17 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Any, Literal, Optional, Sequence
 
 from fastapi import HTTPException
+from pydantic import ValidationError
 
+from cilly_trading.engine.decision_card_contract import (
+    BoundedDecisionToPaperUsefulnessMatchReference,
+    evaluate_bounded_decision_to_paper_usefulness_audit,
+)
 from cilly_trading.models import ExecutionEvent, Order, Position, Trade
 
 
@@ -732,3 +738,171 @@ def build_bounded_paper_simulation_state(
         portfolio_positions=tuple(portfolio_positions),
         reconciliation_mismatches=tuple(mismatches),
     )
+
+
+def resolve_runtime_canonical_execution_repo() -> Any | None:
+    try:
+        import api.main as api_main
+    except Exception:
+        return None
+    return getattr(api_main, "canonical_execution_repo", None)
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    return datetime.fromisoformat(normalized)
+
+
+def _format_decimal(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _build_paper_trade_outcome_payload(
+    *,
+    trade: Trade,
+    expected_symbol: str,
+    expected_strategy_id: str,
+    decision_generated_at_utc: str,
+) -> tuple[Literal["matched", "open", "invalid"], dict[str, Any]]:
+    try:
+        decision_at = _parse_iso_datetime(decision_generated_at_utc)
+        opened_at = _parse_iso_datetime(trade.opened_at)
+    except ValueError:
+        return (
+            "invalid",
+            {
+                "trade_id": trade.trade_id,
+                "position_id": trade.position_id,
+                "symbol": trade.symbol,
+                "strategy_id": trade.strategy_id,
+                "trade_status": trade.status,
+                "opened_at_utc": trade.opened_at,
+                "closed_at_utc": trade.closed_at,
+                "outcome_direction": "invalid",
+                "realized_pnl": _format_decimal(trade.realized_pnl),
+                "unrealized_pnl": _format_decimal(trade.unrealized_pnl),
+                "outcome_summary": (
+                    "Matched paper trade could not satisfy deterministic timestamp parsing for bounded "
+                    "decision-to-paper usefulness review."
+                ),
+            },
+        )
+
+    if trade.symbol != expected_symbol or trade.strategy_id != expected_strategy_id or opened_at < decision_at:
+        return (
+            "invalid",
+            {
+                "trade_id": trade.trade_id,
+                "position_id": trade.position_id,
+                "symbol": trade.symbol,
+                "strategy_id": trade.strategy_id,
+                "trade_status": trade.status,
+                "opened_at_utc": trade.opened_at,
+                "closed_at_utc": trade.closed_at,
+                "outcome_direction": "invalid",
+                "realized_pnl": _format_decimal(trade.realized_pnl),
+                "unrealized_pnl": _format_decimal(trade.unrealized_pnl),
+                "outcome_summary": (
+                    "Matched paper trade violates the explicit symbol, strategy, or subsequent-timing "
+                    "comparison contract."
+                ),
+            },
+        )
+
+    if trade.status == "open":
+        return (
+            "open",
+            {
+                "trade_id": trade.trade_id,
+                "position_id": trade.position_id,
+                "symbol": trade.symbol,
+                "strategy_id": trade.strategy_id,
+                "trade_status": trade.status,
+                "opened_at_utc": trade.opened_at,
+                "closed_at_utc": trade.closed_at,
+                "outcome_direction": "open",
+                "realized_pnl": _format_decimal(trade.realized_pnl),
+                "unrealized_pnl": _format_decimal(trade.unrealized_pnl),
+                "outcome_summary": (
+                    "Matched paper trade remains open, so the bounded non-live outcome is not yet closed."
+                ),
+            },
+        )
+
+    realized_pnl = trade.realized_pnl or Decimal("0")
+    if realized_pnl > Decimal("0"):
+        outcome_direction = "favorable"
+    elif realized_pnl < Decimal("0"):
+        outcome_direction = "adverse"
+    else:
+        outcome_direction = "flat"
+    return (
+        "matched",
+        {
+            "trade_id": trade.trade_id,
+            "position_id": trade.position_id,
+            "symbol": trade.symbol,
+            "strategy_id": trade.strategy_id,
+            "trade_status": trade.status,
+            "opened_at_utc": trade.opened_at,
+            "closed_at_utc": trade.closed_at,
+            "outcome_direction": outcome_direction,
+            "realized_pnl": _format_decimal(trade.realized_pnl),
+            "unrealized_pnl": _format_decimal(trade.unrealized_pnl),
+            "outcome_summary": (
+                "Matched paper trade closed and produced a deterministic bounded paper outcome for "
+                "decision-to-paper usefulness review."
+            ),
+        },
+    )
+
+
+def build_bounded_decision_to_paper_usefulness_audit(
+    *,
+    canonical_execution_repo: Any | None,
+    decision_card_id: str,
+    generated_at_utc: str,
+    symbol: str,
+    strategy_id: str,
+    action: str,
+    qualification_state: str,
+    match_reference: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(match_reference, dict):
+        return None
+
+    try:
+        normalized_match_reference = BoundedDecisionToPaperUsefulnessMatchReference.model_validate(
+            match_reference
+        )
+    except ValidationError:
+        return None
+
+    trade: Trade | None = None
+    if canonical_execution_repo is not None:
+        try:
+            trade = canonical_execution_repo.get_trade(normalized_match_reference.paper_trade_id)
+        except Exception:
+            trade = None
+
+    match_status: Literal["matched", "open", "missing", "invalid"] = "missing"
+    matched_outcome: dict[str, Any] | None = None
+    if trade is not None:
+        match_status, matched_outcome = _build_paper_trade_outcome_payload(
+            trade=trade,
+            expected_symbol=symbol,
+            expected_strategy_id=strategy_id,
+            decision_generated_at_utc=generated_at_utc,
+        )
+
+    audit = evaluate_bounded_decision_to_paper_usefulness_audit(
+        covered_case_id=decision_card_id,
+        action=action,
+        qualification_state=qualification_state,
+        match_status=match_status,
+        match_reference=normalized_match_reference.model_dump(mode="python"),
+        matched_outcome=matched_outcome,
+    )
+    return audit.model_dump(mode="python")

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 DECISION_CARD_CONTRACT_VERSION = "2.0.0"
+BOUNDED_TRADER_RELEVANCE_CONTRACT_ID = "bounded_trader_relevance.paper_review.v1"
+BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION = "1.0.0"
 QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD = 60.0
 QUALIFICATION_HIGH_AGGREGATE_THRESHOLD = 80.0
 ACTION_EXIT_WIN_RATE_MAX = 0.50
@@ -44,6 +46,12 @@ HardGateStatus = Literal["pass", "fail"]
 QualificationState = Literal["reject", "watch", "paper_candidate", "paper_approved"]
 QualificationColor = Literal["green", "yellow", "red"]
 DecisionAction = Literal["entry", "exit", "ignore"]
+PaperReviewCaseId = Literal[
+    "qualification_state_relevance",
+    "decision_action_relevance",
+    "boundary_scope_relevance",
+]
+TraderRelevanceEvidenceStatus = Literal["aligned", "weak", "missing"]
 
 REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
     "signal_quality",
@@ -88,6 +96,40 @@ CLAIM_BOUNDARY_FORBIDDEN_PHRASES: tuple[str, ...] = (
     "live approval",
     "production readiness",
 )
+
+PAPER_REVIEW_CASE_DEFINITIONS: dict[PaperReviewCaseId, dict[str, Any]] = {
+    "qualification_state_relevance": {
+        "review_question": (
+            "Does the output expose deterministic evidence that explains why the qualification state was resolved?"
+        ),
+        "required_evidence": (
+            "qualification_state",
+            "paper_scope_summary",
+            "state_explanation_evidence",
+        ),
+    },
+    "decision_action_relevance": {
+        "review_question": (
+            "Does the output expose deterministic evidence that explains why action is entry/exit/ignore?"
+        ),
+        "required_evidence": (
+            "action",
+            "bounded_decision_metrics",
+            "action_rule_trace",
+        ),
+    },
+    "boundary_scope_relevance": {
+        "review_question": (
+            "Does the output explicitly keep bounded trader-relevance validation separate from trader_validation, "
+            "paper profitability, and live-readiness claims?"
+        ),
+        "required_evidence": (
+            "trader_validation_boundary",
+            "paper_profitability_boundary",
+            "live_readiness_boundary",
+        ),
+    },
+}
 
 
 def _qualification_thresholds_from_metadata(metadata: dict[str, Any]) -> tuple[float, float]:
@@ -178,6 +220,26 @@ def _derive_decision_action_from_fields(
     return "ignore"
 
 
+def _collect_non_empty_texts(values: list[str | None]) -> list[str]:
+    return [value.strip() for value in values if isinstance(value, str) and value.strip()]
+
+
+def _contains_any_phrase(*, texts: list[str], phrases: tuple[str, ...]) -> bool:
+    lowered = [text.casefold() for text in texts]
+    return any(phrase in text for text in lowered for phrase in phrases)
+
+
+def _classify_trader_relevance_status(
+    checks: dict[str, bool],
+) -> TraderRelevanceEvidenceStatus:
+    true_count = sum(1 for ok in checks.values() if ok)
+    if true_count == len(checks):
+        return "aligned"
+    if true_count == 0:
+        return "missing"
+    return "weak"
+
+
 class HardGateResult(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -203,6 +265,163 @@ class HardGateResult(BaseModel):
         if self.status == "pass" and self.failure_reason is not None:
             raise ValueError("Passing hard gates must not define failure_reason")
         return self
+
+
+class BoundedTraderRelevanceCaseEvaluation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    case_id: PaperReviewCaseId
+    review_question: str = Field(min_length=16)
+    evidence_status: TraderRelevanceEvidenceStatus
+    required_evidence: list[str] = Field(min_length=1)
+    observed_evidence: list[str]
+    evidence_summary: str = Field(min_length=16)
+
+
+class BoundedTraderRelevanceValidation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_id: str = BOUNDED_TRADER_RELEVANCE_CONTRACT_ID
+    contract_version: str = BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION
+    overall_status: TraderRelevanceEvidenceStatus
+    evaluations: list[BoundedTraderRelevanceCaseEvaluation] = Field(min_length=1)
+
+    @field_validator("contract_id")
+    @classmethod
+    def _validate_contract_id(cls, value: str) -> str:
+        if value != BOUNDED_TRADER_RELEVANCE_CONTRACT_ID:
+            raise ValueError(f"Unsupported bounded trader relevance contract_id: {value}")
+        return value
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION:
+            raise ValueError(f"Unsupported bounded trader relevance contract_version: {value}")
+        return value
+
+    @field_validator("evaluations")
+    @classmethod
+    def _validate_evaluations(cls, value: list[BoundedTraderRelevanceCaseEvaluation]) -> list[BoundedTraderRelevanceCaseEvaluation]:
+        case_ids = [item.case_id for item in value]
+        required_case_ids = sorted(PAPER_REVIEW_CASE_DEFINITIONS.keys())
+        if sorted(case_ids) != required_case_ids:
+            raise ValueError(
+                "Bounded trader relevance evaluations must cover all canonical paper-review cases"
+            )
+        return sorted(value, key=lambda item: item.case_id)
+
+
+def evaluate_bounded_trader_relevance_cases(
+    *,
+    qualification_state: str | None,
+    action: str | None,
+    win_rate: float | None,
+    expected_value: float | None,
+    qualification_summary: str | None,
+    rationale_summary: str | None = None,
+    final_explanation: str | None = None,
+    gate_explanations: list[str] | None = None,
+    score_explanations: list[str] | None = None,
+    qualification_evidence: list[str] | None = None,
+    missing_criteria: list[str] | None = None,
+    blocking_conditions: list[str] | None = None,
+) -> BoundedTraderRelevanceValidation:
+    normalized_gate_explanations = list(gate_explanations or [])
+    normalized_score_explanations = list(score_explanations or [])
+    normalized_qualification_evidence = list(qualification_evidence or [])
+    normalized_missing_criteria = list(missing_criteria or [])
+    normalized_blocking_conditions = list(blocking_conditions or [])
+
+    all_texts = _collect_non_empty_texts(
+        [
+            qualification_summary,
+            rationale_summary,
+            final_explanation,
+            *normalized_gate_explanations,
+            *normalized_score_explanations,
+            *normalized_qualification_evidence,
+            *normalized_missing_criteria,
+            *normalized_blocking_conditions,
+        ]
+    )
+    qualification_summary_text = (qualification_summary or "").strip()
+
+    case_checks: dict[PaperReviewCaseId, dict[str, bool]] = {
+        "qualification_state_relevance": {
+            "qualification_state": bool(qualification_state and str(qualification_state).strip()),
+            "paper_scope_summary": "paper" in qualification_summary_text.casefold(),
+            "state_explanation_evidence": bool(
+                normalized_gate_explanations
+                or normalized_qualification_evidence
+                or normalized_missing_criteria
+                or normalized_blocking_conditions
+            ),
+        },
+        "decision_action_relevance": {
+            "action": bool(action and str(action).strip()),
+            "bounded_decision_metrics": (win_rate is not None and expected_value is not None),
+            "action_rule_trace": _contains_any_phrase(
+                texts=normalized_score_explanations + normalized_qualification_evidence,
+                phrases=("action", "entry", "exit", "ignore", "expected value", "win_rate", "win-rate"),
+            ),
+        },
+        "boundary_scope_relevance": {
+            "trader_validation_boundary": _contains_any_phrase(
+                texts=all_texts,
+                phrases=("trader_validation", "trader validation"),
+            ),
+            "paper_profitability_boundary": _contains_any_phrase(
+                texts=all_texts,
+                phrases=("paper profitability", "profitability", "edge claim", "profit claim"),
+            ),
+            "live_readiness_boundary": _contains_any_phrase(
+                texts=all_texts,
+                phrases=(
+                    "live-trading approval",
+                    "live trading readiness",
+                    "live readiness",
+                    "operational readiness",
+                    "broker execution readiness",
+                ),
+            ),
+        },
+    }
+
+    evaluations: list[BoundedTraderRelevanceCaseEvaluation] = []
+    statuses: list[TraderRelevanceEvidenceStatus] = []
+    for case_id in sorted(PAPER_REVIEW_CASE_DEFINITIONS.keys()):
+        checks = case_checks[case_id]
+        status = _classify_trader_relevance_status(checks=checks)
+        statuses.append(status)
+        observed = sorted(signal for signal, ok in checks.items() if ok)
+        required = list(PAPER_REVIEW_CASE_DEFINITIONS[case_id]["required_evidence"])
+        summary = (
+            f"Deterministic case={case_id} classified as {status}; "
+            f"observed={','.join(observed) if observed else 'none'}."
+        )
+        evaluations.append(
+            BoundedTraderRelevanceCaseEvaluation(
+                case_id=case_id,
+                review_question=str(PAPER_REVIEW_CASE_DEFINITIONS[case_id]["review_question"]),
+                evidence_status=status,
+                required_evidence=required,
+                observed_evidence=observed,
+                evidence_summary=summary,
+            )
+        )
+
+    if "missing" in statuses:
+        overall_status: TraderRelevanceEvidenceStatus = "missing"
+    elif "weak" in statuses:
+        overall_status = "weak"
+    else:
+        overall_status = "aligned"
+
+    return BoundedTraderRelevanceValidation(
+        overall_status=overall_status,
+        evaluations=evaluations,
+    )
 
 
 class HardGateEvaluation(BaseModel):
@@ -538,6 +757,9 @@ def serialize_decision_card(card: DecisionCard) -> str:
 
 __all__ = [
     "DECISION_CARD_CONTRACT_VERSION",
+    "BOUNDED_TRADER_RELEVANCE_CONTRACT_ID",
+    "BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION",
+    "PAPER_REVIEW_CASE_DEFINITIONS",
     "CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY",
     "CONFIDENCE_TIER_PRECISION_DISCLAIMER",
     "UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND",
@@ -547,6 +769,8 @@ __all__ = [
     "ACTION_ENTRY_WIN_RATE_MIN",
     "ACTION_EXIT_WIN_RATE_MAX",
     "QUALIFICATION_COLOR_BY_STATE",
+    "BoundedTraderRelevanceCaseEvaluation",
+    "BoundedTraderRelevanceValidation",
     "ComponentScore",
     "DecisionAction",
     "DecisionCard",
@@ -555,6 +779,7 @@ __all__ = [
     "HardGateResult",
     "Qualification",
     "ScoreEvaluation",
+    "evaluate_bounded_trader_relevance_cases",
     "serialize_decision_card",
     "validate_decision_card",
 ]

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -34,6 +34,14 @@ UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND = (
     "limited or low-quality upstream evidence limits confidence regardless of thresholds."
 )
 
+QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_ID = "qualification_profile_robustness.paper_audit.v1"
+QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_VERSION = "1.0.0"
+QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY = (
+    "Qualification-profile robustness audit is bounded to deterministic covered, failure-envelope, "
+    "and regime slices. Weak or failing slices limit interpretation outside covered conditions and "
+    "do not expand live-trading approval, paper profitability, or trader_validation claims."
+)
+
 DecisionComponentCategory = Literal[
     "signal_quality",
     "backtest_quality",
@@ -52,6 +60,8 @@ PaperReviewCaseId = Literal[
     "boundary_scope_relevance",
 ]
 TraderRelevanceEvidenceStatus = Literal["aligned", "weak", "missing"]
+QualificationProfileRobustnessStatus = Literal["stable", "weak", "failing"]
+QualificationProfileRobustnessSliceType = Literal["covered", "failure_envelope", "regime_slice"]
 
 REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
     "signal_quality",
@@ -424,6 +434,114 @@ def evaluate_bounded_trader_relevance_cases(
     )
 
 
+class QualificationProfileRobustnessSliceResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    slice_id: str = Field(min_length=1)
+    slice_type: QualificationProfileRobustnessSliceType
+    deterministic_rank: int = Field(ge=1)
+    description: str = Field(min_length=16)
+    behavior_status: QualificationProfileRobustnessStatus
+    qualification_state: QualificationState
+    action: DecisionAction
+    confidence_tier: DecisionConfidenceTier
+    aggregate_score: float = Field(ge=0.0, le=100.0)
+    base_aggregate_score: float = Field(ge=0.0, le=100.0)
+    win_rate: float = Field(ge=0.0, le=1.0)
+    expected_value: float = Field(ge=-1.0, le=1.0)
+    has_blocking_failure: bool = False
+    applied_adjustments: list[str] = Field(min_length=1)
+    finding: str = Field(min_length=24)
+
+    @field_validator("applied_adjustments")
+    @classmethod
+    def _normalize_adjustments(cls, value: list[str]) -> list[str]:
+        normalized = [item.strip() for item in value if item and item.strip()]
+        if not normalized:
+            raise ValueError("Robustness slice must include at least one adjustment entry")
+        return normalized
+
+
+class QualificationProfileRobustnessAudit(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_id: str = QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_ID
+    contract_version: str = QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_VERSION
+    comparison_group: str = Field(min_length=1)
+    threshold_profile_id: str = Field(min_length=1)
+    stable_slice_ids: list[str] = Field(default_factory=list)
+    weak_slice_ids: list[str] = Field(default_factory=list)
+    failing_slice_ids: list[str] = Field(default_factory=list)
+    slice_results: list[QualificationProfileRobustnessSliceResult] = Field(min_length=1)
+    audit_summary: str = Field(min_length=24)
+    interpretation_limit: str = Field(min_length=24)
+
+    @field_validator("contract_id")
+    @classmethod
+    def _validate_contract_id(cls, value: str) -> str:
+        if value != QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_ID:
+            raise ValueError(f"Unsupported qualification-profile robustness contract_id: {value}")
+        return value
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_VERSION:
+            raise ValueError(
+                f"Unsupported qualification-profile robustness contract_version: {value}"
+            )
+        return value
+
+    @field_validator("stable_slice_ids", "weak_slice_ids", "failing_slice_ids")
+    @classmethod
+    def _normalize_slice_id_lists(cls, value: list[str]) -> list[str]:
+        normalized = sorted({item.strip() for item in value if item and item.strip()})
+        return normalized
+
+    @field_validator("slice_results")
+    @classmethod
+    def _validate_slice_results(
+        cls, value: list[QualificationProfileRobustnessSliceResult]
+    ) -> list[QualificationProfileRobustnessSliceResult]:
+        ordered = sorted(value, key=lambda item: (item.deterministic_rank, item.slice_id))
+        slice_ids = [item.slice_id for item in ordered]
+        if len(slice_ids) != len(set(slice_ids)):
+            raise ValueError("Robustness audit slice_results must use unique slice identifiers")
+        return ordered
+
+    @model_validator(mode="after")
+    def _validate_summary_alignment(self) -> "QualificationProfileRobustnessAudit":
+        expected_by_status = {
+            "stable": sorted(
+                item.slice_id for item in self.slice_results if item.behavior_status == "stable"
+            ),
+            "weak": sorted(
+                item.slice_id for item in self.slice_results if item.behavior_status == "weak"
+            ),
+            "failing": sorted(
+                item.slice_id for item in self.slice_results if item.behavior_status == "failing"
+            ),
+        }
+        if self.stable_slice_ids != expected_by_status["stable"]:
+            raise ValueError("stable_slice_ids must match slice_results behavior_status=stable")
+        if self.weak_slice_ids != expected_by_status["weak"]:
+            raise ValueError("weak_slice_ids must match slice_results behavior_status=weak")
+        if self.failing_slice_ids != expected_by_status["failing"]:
+            raise ValueError("failing_slice_ids must match slice_results behavior_status=failing")
+        phrase = _contains_forbidden_claim_phrase(self.audit_summary)
+        if phrase is not None:
+            raise ValueError(f"audit_summary contains unsupported claim language: {phrase}")
+        phrase = _contains_forbidden_claim_phrase(self.interpretation_limit)
+        if phrase is not None:
+            raise ValueError(f"interpretation_limit contains unsupported claim language: {phrase}")
+        if "covered conditions" not in self.interpretation_limit.casefold():
+            raise ValueError(
+                "interpretation_limit must explain how robustness findings limit interpretation "
+                "outside covered conditions"
+            )
+        return self
+
+
 class HardGateEvaluation(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -670,7 +788,17 @@ class DecisionCard(BaseModel):
         for key in value:
             if not isinstance(key, str):
                 raise ValueError("metadata keys must be strings")
-        return dict(sorted(value.items()))
+        normalized = dict(sorted(value.items()))
+        robustness_audit = normalized.get("qualification_profile_robustness_audit")
+        if robustness_audit is not None:
+            if not isinstance(robustness_audit, dict):
+                raise ValueError("qualification_profile_robustness_audit metadata must be an object")
+            normalized["qualification_profile_robustness_audit"] = (
+                QualificationProfileRobustnessAudit.model_validate(robustness_audit).model_dump(
+                    mode="python"
+                )
+            )
+        return normalized
 
     @model_validator(mode="after")
     def _validate_qualification_semantics(self) -> "DecisionCard":
@@ -762,6 +890,9 @@ __all__ = [
     "PAPER_REVIEW_CASE_DEFINITIONS",
     "CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY",
     "CONFIDENCE_TIER_PRECISION_DISCLAIMER",
+    "QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_ID",
+    "QUALIFICATION_PROFILE_ROBUSTNESS_CONTRACT_VERSION",
+    "QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY",
     "UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND",
     "QUALIFICATION_HIGH_AGGREGATE_THRESHOLD",
     "QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD",
@@ -777,6 +908,8 @@ __all__ = [
     "DecisionRationale",
     "HardGateEvaluation",
     "HardGateResult",
+    "QualificationProfileRobustnessAudit",
+    "QualificationProfileRobustnessSliceResult",
     "Qualification",
     "ScoreEvaluation",
     "evaluate_bounded_trader_relevance_cases",

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -41,6 +41,15 @@ QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY = (
     "and regime slices. Weak or failing slices limit interpretation outside covered conditions and "
     "do not expand live-trading approval, paper profitability, or trader_validation claims."
 )
+DECISION_TO_PAPER_USEFULNESS_CONTRACT_ID = (
+    "decision_evidence_to_paper_outcome_usefulness.paper_audit.v1"
+)
+DECISION_TO_PAPER_USEFULNESS_CONTRACT_VERSION = "1.0.0"
+DECISION_TO_PAPER_USEFULNESS_INTERPRETATION_BOUNDARY = (
+    "Decision-to-paper usefulness audit is bounded to non-live explanatory value for covered entry "
+    "decisions with explicit paper_trade_id matches. It does not imply trader validation, "
+    "profitability forecasting, live-trading readiness, or operational readiness."
+)
 
 DecisionComponentCategory = Literal[
     "signal_quality",
@@ -62,6 +71,10 @@ PaperReviewCaseId = Literal[
 TraderRelevanceEvidenceStatus = Literal["aligned", "weak", "missing"]
 QualificationProfileRobustnessStatus = Literal["stable", "weak", "failing"]
 QualificationProfileRobustnessSliceType = Literal["covered", "failure_envelope", "regime_slice"]
+DecisionToPaperUsefulnessClassification = Literal["explanatory", "weak", "misleading"]
+DecisionToPaperUsefulnessMatchStatus = Literal["matched", "open", "missing", "invalid"]
+DecisionToPaperUsefulnessMatchMode = Literal["paper_trade_id"]
+PaperTradeOutcomeDirection = Literal["favorable", "flat", "adverse", "open", "invalid"]
 
 REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
     "signal_quality",
@@ -320,6 +333,177 @@ class BoundedTraderRelevanceValidation(BaseModel):
                 "Bounded trader relevance evaluations must cover all canonical paper-review cases"
             )
         return sorted(value, key=lambda item: item.case_id)
+
+
+class BoundedDecisionToPaperUsefulnessMatchReference(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    match_mode: DecisionToPaperUsefulnessMatchMode
+    paper_trade_id: str = Field(min_length=1)
+
+
+class BoundedPaperTradeOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    trade_id: str = Field(min_length=1)
+    position_id: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    strategy_id: str = Field(min_length=1)
+    trade_status: Literal["open", "closed"]
+    opened_at_utc: str = Field(min_length=1)
+    closed_at_utc: str | None = None
+    outcome_direction: PaperTradeOutcomeDirection
+    realized_pnl: str | None = None
+    unrealized_pnl: str | None = None
+    outcome_summary: str = Field(min_length=24)
+
+
+class BoundedDecisionToPaperUsefulnessAudit(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_id: str = DECISION_TO_PAPER_USEFULNESS_CONTRACT_ID
+    contract_version: str = DECISION_TO_PAPER_USEFULNESS_CONTRACT_VERSION
+    covered_case_id: str = Field(min_length=1)
+    match_reference: BoundedDecisionToPaperUsefulnessMatchReference
+    match_status: DecisionToPaperUsefulnessMatchStatus
+    matched_outcome: BoundedPaperTradeOutcome | None = None
+    usefulness_classification: DecisionToPaperUsefulnessClassification
+    usefulness_reason: str = Field(min_length=24)
+    interpretation_limit: str = Field(min_length=24)
+
+    @field_validator("contract_id")
+    @classmethod
+    def _validate_contract_id(cls, value: str) -> str:
+        if value != DECISION_TO_PAPER_USEFULNESS_CONTRACT_ID:
+            raise ValueError(f"Unsupported decision-to-paper usefulness contract_id: {value}")
+        return value
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != DECISION_TO_PAPER_USEFULNESS_CONTRACT_VERSION:
+            raise ValueError(
+                f"Unsupported decision-to-paper usefulness contract_version: {value}"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _validate_match_alignment(self) -> "BoundedDecisionToPaperUsefulnessAudit":
+        if self.match_status in {"matched", "open", "invalid"} and self.matched_outcome is None:
+            raise ValueError(
+                "matched_outcome is required when match_status is matched, open, or invalid"
+            )
+        if self.match_status == "missing" and self.matched_outcome is not None:
+            raise ValueError("matched_outcome must be omitted when match_status is missing")
+        lowered_limit = self.interpretation_limit.casefold()
+        required_phrases = (
+            "non-live",
+            "trader validation",
+            "profitability forecasting",
+            "live-trading readiness",
+            "operational readiness",
+        )
+        if not all(phrase in lowered_limit for phrase in required_phrases):
+            raise ValueError(
+                "interpretation_limit must keep non-live usefulness separate from trader validation, "
+                "profitability forecasting, and readiness claims"
+            )
+        return self
+
+
+def _classify_decision_to_paper_usefulness(
+    *,
+    action: str,
+    qualification_state: str,
+    match_status: DecisionToPaperUsefulnessMatchStatus,
+    matched_outcome: BoundedPaperTradeOutcome | None,
+) -> tuple[DecisionToPaperUsefulnessClassification, str]:
+    if action != "entry":
+        return (
+            "weak",
+            "Contract v1 remains bounded to covered entry decisions, so non-entry decisions stay outside "
+            "strong usefulness interpretation.",
+        )
+    if qualification_state not in {"paper_candidate", "paper_approved"}:
+        return (
+            "weak",
+            "Entry usefulness remains weak because the decision did not resolve to a covered paper-entry "
+            "qualification state.",
+        )
+    if match_status == "missing":
+        return (
+            "weak",
+            "Covered entry decision has no resolved matched paper trade, so usefulness remains unproven in "
+            "bounded non-live review.",
+        )
+    if match_status == "invalid":
+        return (
+            "misleading",
+            "Matched paper trade violates the explicit symbol, strategy, or timing comparison contract, so "
+            "the usefulness signal is misleading.",
+        )
+    if match_status == "open":
+        return (
+            "weak",
+            "Matched paper trade remains open, so bounded usefulness is not yet resolved to an explanatory "
+            "or misleading closed outcome.",
+        )
+    if matched_outcome is None:
+        return (
+            "weak",
+            "Matched paper outcome is unavailable, so bounded usefulness remains weak.",
+        )
+    if matched_outcome.outcome_direction == "favorable":
+        return (
+            "explanatory",
+            "Covered entry decision matched a subsequent closed paper trade with favorable bounded outcome, "
+            "so the surfaced evidence is explanatory in non-live review.",
+        )
+    if matched_outcome.outcome_direction == "flat":
+        return (
+            "weak",
+            "Covered entry decision matched a closed flat paper trade, so the surfaced evidence remains weak "
+            "for bounded usefulness.",
+        )
+    return (
+        "misleading",
+        "Covered entry decision matched a subsequent closed paper trade with adverse bounded outcome, so the "
+        "surfaced evidence is misleading in non-live review.",
+    )
+
+
+def evaluate_bounded_decision_to_paper_usefulness_audit(
+    *,
+    covered_case_id: str,
+    action: str,
+    qualification_state: str,
+    match_status: DecisionToPaperUsefulnessMatchStatus,
+    match_reference: dict[str, Any],
+    matched_outcome: dict[str, Any] | None = None,
+) -> BoundedDecisionToPaperUsefulnessAudit:
+    normalized_match_reference = BoundedDecisionToPaperUsefulnessMatchReference.model_validate(
+        match_reference
+    )
+    normalized_matched_outcome = (
+        BoundedPaperTradeOutcome.model_validate(matched_outcome)
+        if matched_outcome is not None
+        else None
+    )
+    usefulness_classification, usefulness_reason = _classify_decision_to_paper_usefulness(
+        action=action,
+        qualification_state=qualification_state,
+        match_status=match_status,
+        matched_outcome=normalized_matched_outcome,
+    )
+    return BoundedDecisionToPaperUsefulnessAudit(
+        covered_case_id=covered_case_id,
+        match_reference=normalized_match_reference,
+        match_status=match_status,
+        matched_outcome=normalized_matched_outcome,
+        usefulness_classification=usefulness_classification,
+        usefulness_reason=usefulness_reason,
+        interpretation_limit=DECISION_TO_PAPER_USEFULNESS_INTERPRETATION_BOUNDARY,
+    )
 
 
 def evaluate_bounded_trader_relevance_cases(
@@ -887,6 +1071,9 @@ __all__ = [
     "DECISION_CARD_CONTRACT_VERSION",
     "BOUNDED_TRADER_RELEVANCE_CONTRACT_ID",
     "BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION",
+    "DECISION_TO_PAPER_USEFULNESS_CONTRACT_ID",
+    "DECISION_TO_PAPER_USEFULNESS_CONTRACT_VERSION",
+    "DECISION_TO_PAPER_USEFULNESS_INTERPRETATION_BOUNDARY",
     "PAPER_REVIEW_CASE_DEFINITIONS",
     "CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY",
     "CONFIDENCE_TIER_PRECISION_DISCLAIMER",
@@ -900,6 +1087,9 @@ __all__ = [
     "ACTION_ENTRY_WIN_RATE_MIN",
     "ACTION_EXIT_WIN_RATE_MAX",
     "QUALIFICATION_COLOR_BY_STATE",
+    "BoundedDecisionToPaperUsefulnessAudit",
+    "BoundedDecisionToPaperUsefulnessMatchReference",
+    "BoundedPaperTradeOutcome",
     "BoundedTraderRelevanceCaseEvaluation",
     "BoundedTraderRelevanceValidation",
     "ComponentScore",
@@ -912,6 +1102,7 @@ __all__ = [
     "QualificationProfileRobustnessSliceResult",
     "Qualification",
     "ScoreEvaluation",
+    "evaluate_bounded_decision_to_paper_usefulness_audit",
     "evaluate_bounded_trader_relevance_cases",
     "serialize_decision_card",
     "validate_decision_card",

--- a/src/cilly_trading/engine/qualification_engine.py
+++ b/src/cilly_trading/engine/qualification_engine.py
@@ -9,6 +9,7 @@ from cilly_trading.engine.decision_card_contract import (
     ACTION_ENTRY_WIN_RATE_MIN,
     ACTION_EXIT_WIN_RATE_MAX,
     DECISION_CARD_CONTRACT_VERSION,
+    BoundedTraderRelevanceValidation,
     CONFIDENCE_TIER_PRECISION_DISCLAIMER,
     UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND,
     REQUIRED_COMPONENT_CATEGORIES,
@@ -21,6 +22,7 @@ from cilly_trading.engine.decision_card_contract import (
     HardGateResult,
     QualificationColor,
     QualificationState,
+    evaluate_bounded_trader_relevance_cases,
     validate_decision_card,
 )
 from cilly_trading.strategies.registry import (
@@ -146,6 +148,40 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         expected_value=expected_value,
         confidence_thresholds=threshold_profile["thresholds"],
     )
+    gate_explanations = _gate_explanations(hard_gate_evaluation=hard_gate_evaluation)
+    score_explanations = _score_explanations(
+        component_scores=integrated_component_scores,
+        base_aggregate_score=base_aggregate_score,
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+        threshold_profile=threshold_profile,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        action=action,
+        sentiment_resolution=sentiment_resolution,
+        backtest_input_applied=input_data.backtest_evidence is not None,
+        portfolio_fit_input_applied=input_data.portfolio_fit_input is not None,
+    )
+    rationale_summary = (
+        "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules."
+    )
+    final_explanation = (
+        "Decision action and qualification are deterministic technical implementation evidence "
+        "and does not imply live-trading approval, paper profitability, or trader_validation gate completion. "
+        "Validation gate status remains explicitly separate and defaults to trader_validation_not_started "
+        "unless governed evidence is recorded."
+    )
+    trader_relevance_validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state=state,
+        action=action,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        qualification_summary=qualification_summary,
+        rationale_summary=rationale_summary,
+        final_explanation=final_explanation,
+        gate_explanations=gate_explanations,
+        score_explanations=score_explanations,
+    )
     payload = {
         "contract_version": DECISION_CARD_CONTRACT_VERSION,
         "decision_card_id": input_data.decision_card_id,
@@ -177,26 +213,10 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             "summary": qualification_summary,
         },
         "rationale": {
-            "summary": "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules.",
-            "gate_explanations": _gate_explanations(hard_gate_evaluation=hard_gate_evaluation),
-            "score_explanations": _score_explanations(
-                component_scores=integrated_component_scores,
-                base_aggregate_score=base_aggregate_score,
-                aggregate_score=aggregate_score,
-                confidence_tier=confidence_tier,
-                threshold_profile=threshold_profile,
-                win_rate=win_rate,
-                expected_value=expected_value,
-                action=action,
-                sentiment_resolution=sentiment_resolution,
-                backtest_input_applied=input_data.backtest_evidence is not None,
-                portfolio_fit_input_applied=input_data.portfolio_fit_input is not None,
-            ),
-            "final_explanation": (
-                "Decision action and qualification are deterministic technical implementation evidence "
-                "and does not imply live-trading approval. Validation gate status remains explicitly "
-                "separate and defaults to trader_validation_not_started unless governed evidence is recorded."
-            ),
+            "summary": rationale_summary,
+            "gate_explanations": gate_explanations,
+            "score_explanations": score_explanations,
+            "final_explanation": final_explanation,
         },
         "metadata": _build_metadata(
             input_data=input_data,
@@ -206,6 +226,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             win_rate=win_rate,
             expected_value=expected_value,
             action=action,
+            trader_relevance_validation=trader_relevance_validation,
         ),
     }
     return validate_decision_card(payload)
@@ -554,6 +575,7 @@ def _build_metadata(
     win_rate: float,
     expected_value: float,
     action: DecisionAction,
+    trader_relevance_validation: BoundedTraderRelevanceValidation,
 ) -> dict[str, object]:
     metadata = dict(input_data.metadata or {})
     metadata["base_aggregate_score"] = base_aggregate_score
@@ -572,6 +594,7 @@ def _build_metadata(
     metadata["expected_value"] = expected_value
     metadata["decision_action"] = action
     metadata["decision_action_policy_version"] = "paper-action.v1"
+    metadata["bounded_trader_relevance_validation"] = trader_relevance_validation.model_dump(mode="python")
     metadata["technical_implementation_status"] = metadata.get(
         "technical_implementation_status", "technical_in_progress"
     )

--- a/src/cilly_trading/engine/qualification_engine.py
+++ b/src/cilly_trading/engine/qualification_engine.py
@@ -11,6 +11,7 @@ from cilly_trading.engine.decision_card_contract import (
     DECISION_CARD_CONTRACT_VERSION,
     BoundedTraderRelevanceValidation,
     CONFIDENCE_TIER_PRECISION_DISCLAIMER,
+    QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY,
     UPSTREAM_EVIDENCE_QUALITY_CONFIDENCE_BOUND,
     REQUIRED_COMPONENT_CATEGORIES,
     ComponentScore,
@@ -21,12 +22,15 @@ from cilly_trading.engine.decision_card_contract import (
     HardGateEvaluation,
     HardGateResult,
     QualificationColor,
+    QualificationProfileRobustnessAudit,
+    QualificationProfileRobustnessSliceResult,
     QualificationState,
     evaluate_bounded_trader_relevance_cases,
     validate_decision_card,
 )
 from cilly_trading.strategies.registry import (
     get_registered_strategy_metadata,
+    resolve_qualification_profile_robustness_slices,
     resolve_qualification_threshold_profile,
 )
 
@@ -55,6 +59,17 @@ EXPECTED_VALUE_REWARD_MULTIPLIER_MIN = 0.50
 EXPECTED_VALUE_REWARD_MULTIPLIER_MAX = 1.50
 EXPECTED_VALUE_MIN = -1.0
 EXPECTED_VALUE_MAX = 1.0
+QUALIFICATION_STATE_RANKS: dict[QualificationState, int] = {
+    "reject": 0,
+    "watch": 1,
+    "paper_candidate": 2,
+    "paper_approved": 3,
+}
+CONFIDENCE_TIER_RANKS: dict[DecisionConfidenceTier, int] = {
+    "low": 0,
+    "medium": 1,
+    "high": 2,
+}
 
 
 @dataclass(frozen=True)
@@ -87,6 +102,18 @@ class SentimentOverlayResolution:
     cap_points: float
     reason: str
     sentiment_score: float | None = None
+
+
+@dataclass(frozen=True)
+class QualificationProfileSnapshot:
+    qualification_state: QualificationState
+    action: DecisionAction
+    confidence_tier: DecisionConfidenceTier
+    aggregate_score: float
+    base_aggregate_score: float
+    win_rate: float
+    expected_value: float
+    has_blocking_failure: bool
 
 
 @dataclass(frozen=True)
@@ -148,6 +175,24 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         expected_value=expected_value,
         confidence_thresholds=threshold_profile["thresholds"],
     )
+    robustness_audit = _evaluate_qualification_profile_robustness_audit(
+        generated_at_utc=input_data.generated_at_utc,
+        hard_gates=hard_gate_evaluation.gates,
+        hard_gate_policy_version=input_data.hard_gate_policy_version,
+        component_scores=integrated_component_scores,
+        sentiment_overlay=input_data.sentiment_overlay,
+        threshold_profile=threshold_profile,
+        baseline_snapshot=QualificationProfileSnapshot(
+            qualification_state=state,
+            action=action,
+            confidence_tier=confidence_tier,
+            aggregate_score=aggregate_score,
+            base_aggregate_score=base_aggregate_score,
+            win_rate=win_rate,
+            expected_value=expected_value,
+            has_blocking_failure=hard_gate_evaluation.has_blocking_failure,
+        ),
+    )
     gate_explanations = _gate_explanations(hard_gate_evaluation=hard_gate_evaluation)
     score_explanations = _score_explanations(
         component_scores=integrated_component_scores,
@@ -161,6 +206,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         sentiment_resolution=sentiment_resolution,
         backtest_input_applied=input_data.backtest_evidence is not None,
         portfolio_fit_input_applied=input_data.portfolio_fit_input is not None,
+        robustness_audit=robustness_audit,
     )
     rationale_summary = (
         "Qualification is resolved from explicit hard gates, bounded scores, and confidence rules."
@@ -169,7 +215,8 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
         "Decision action and qualification are deterministic technical implementation evidence "
         "and does not imply live-trading approval, paper profitability, or trader_validation gate completion. "
         "Validation gate status remains explicitly separate and defaults to trader_validation_not_started "
-        "unless governed evidence is recorded."
+        "unless governed evidence is recorded. "
+        f"{robustness_audit.interpretation_limit}"
     )
     trader_relevance_validation = evaluate_bounded_trader_relevance_cases(
         qualification_state=state,
@@ -227,6 +274,7 @@ def evaluate_qualification(input_data: QualificationEngineInput) -> DecisionCard
             expected_value=expected_value,
             action=action,
             trader_relevance_validation=trader_relevance_validation,
+            robustness_audit=robustness_audit,
         ),
     }
     return validate_decision_card(payload)
@@ -521,6 +569,7 @@ def _score_explanations(
     sentiment_resolution: SentimentOverlayResolution,
     backtest_input_applied: bool,
     portfolio_fit_input_applied: bool,
+    robustness_audit: QualificationProfileRobustnessAudit,
 ) -> list[str]:
     ordered = sorted(component_scores, key=lambda component: component.category)
     component_summary = ", ".join(
@@ -563,7 +612,246 @@ def _score_explanations(
             f"qualified win_rate >= {ACTION_ENTRY_WIN_RATE_MIN:.2f} with non-negative expected value -> entry; "
             f"else ignore. Resolved action={action}."
         ),
+        f"Qualification-profile robustness audit: {robustness_audit.audit_summary}",
+        f"Robustness interpretation boundary: {robustness_audit.interpretation_limit}",
     ]
+
+
+def _evaluate_qualification_profile_robustness_audit(
+    *,
+    generated_at_utc: str,
+    hard_gates: list[HardGateResult],
+    hard_gate_policy_version: str,
+    component_scores: list[ComponentScore],
+    sentiment_overlay: SentimentOverlayInput | None,
+    threshold_profile: dict[str, object],
+    baseline_snapshot: QualificationProfileSnapshot,
+) -> QualificationProfileRobustnessAudit:
+    comparison_group = str(threshold_profile["comparison_group"])
+    slice_definitions = resolve_qualification_profile_robustness_slices(
+        comparison_group=comparison_group
+    )
+    slice_results: list[QualificationProfileRobustnessSliceResult] = []
+    for slice_definition in slice_definitions:
+        adjusted_snapshot = _resolve_qualification_profile_snapshot(
+            generated_at_utc=generated_at_utc,
+            hard_gates=hard_gates,
+            hard_gate_policy_version=hard_gate_policy_version,
+            component_scores=component_scores,
+            sentiment_overlay=sentiment_overlay,
+            threshold_profile=threshold_profile,
+            component_score_adjustments=dict(slice_definition["component_score_adjustments"]),
+        )
+        behavior_status = _classify_robustness_behavior(
+            baseline_snapshot=baseline_snapshot,
+            slice_snapshot=adjusted_snapshot,
+            slice_type=str(slice_definition["slice_type"]),
+        )
+        slice_results.append(
+            QualificationProfileRobustnessSliceResult(
+                slice_id=str(slice_definition["slice_id"]),
+                slice_type=str(slice_definition["slice_type"]),
+                deterministic_rank=int(slice_definition["deterministic_rank"]),
+                description=str(slice_definition["description"]),
+                behavior_status=behavior_status,
+                qualification_state=adjusted_snapshot.qualification_state,
+                action=adjusted_snapshot.action,
+                confidence_tier=adjusted_snapshot.confidence_tier,
+                aggregate_score=adjusted_snapshot.aggregate_score,
+                base_aggregate_score=adjusted_snapshot.base_aggregate_score,
+                win_rate=adjusted_snapshot.win_rate,
+                expected_value=adjusted_snapshot.expected_value,
+                has_blocking_failure=adjusted_snapshot.has_blocking_failure,
+                applied_adjustments=_robustness_adjustment_entries(
+                    component_score_adjustments=dict(slice_definition["component_score_adjustments"])
+                ),
+                finding=_robustness_finding(
+                    baseline_snapshot=baseline_snapshot,
+                    slice_snapshot=adjusted_snapshot,
+                    behavior_status=behavior_status,
+                ),
+            )
+        )
+
+    stable_slice_ids = sorted(
+        item.slice_id for item in slice_results if item.behavior_status == "stable"
+    )
+    weak_slice_ids = sorted(item.slice_id for item in slice_results if item.behavior_status == "weak")
+    failing_slice_ids = sorted(
+        item.slice_id for item in slice_results if item.behavior_status == "failing"
+    )
+    audit_summary = (
+        f"Deterministic qualification-profile robustness audit covered {len(slice_results)} slices "
+        f"for comparison_group={comparison_group}: stable={_format_slice_ids(stable_slice_ids)}; "
+        f"weak={_format_slice_ids(weak_slice_ids)}; failing={_format_slice_ids(failing_slice_ids)}."
+    )
+    return QualificationProfileRobustnessAudit(
+        comparison_group=comparison_group,
+        threshold_profile_id=str(threshold_profile["profile_id"]),
+        stable_slice_ids=stable_slice_ids,
+        weak_slice_ids=weak_slice_ids,
+        failing_slice_ids=failing_slice_ids,
+        slice_results=slice_results,
+        audit_summary=audit_summary,
+        interpretation_limit=QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY,
+    )
+
+
+def _resolve_qualification_profile_snapshot(
+    *,
+    generated_at_utc: str,
+    hard_gates: list[HardGateResult],
+    hard_gate_policy_version: str,
+    component_scores: list[ComponentScore],
+    sentiment_overlay: SentimentOverlayInput | None,
+    threshold_profile: dict[str, object],
+    component_score_adjustments: dict[str, float],
+) -> QualificationProfileSnapshot:
+    adjusted_components = _apply_robustness_component_adjustments(
+        component_scores=component_scores,
+        component_score_adjustments=component_score_adjustments,
+    )
+    hard_gate_evaluation = HardGateEvaluation(
+        policy_version=hard_gate_policy_version,
+        gates=list(hard_gates),
+    )
+    base_aggregate_score = compute_aggregate_score(component_scores=adjusted_components)
+    sentiment_resolution = _resolve_sentiment_overlay(
+        sentiment_overlay=sentiment_overlay,
+        generated_at_utc=generated_at_utc,
+        component_scores=adjusted_components,
+    )
+    aggregate_score = _apply_sentiment_overlay(
+        base_aggregate_score=base_aggregate_score,
+        sentiment_resolution=sentiment_resolution,
+    )
+    confidence_tier = assign_confidence_tier(
+        aggregate_score=aggregate_score,
+        component_scores=adjusted_components,
+        confidence_thresholds=threshold_profile["thresholds"],
+    )
+    win_rate = compute_bounded_win_rate(component_scores=adjusted_components)
+    expected_value = compute_bounded_expected_value(
+        component_scores=adjusted_components,
+        win_rate=win_rate,
+    )
+    qualification_state, _, _ = resolve_qualification_state(
+        hard_gate_evaluation=hard_gate_evaluation,
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+        confidence_thresholds=threshold_profile["thresholds"],
+    )
+    action = resolve_decision_action(
+        hard_gate_evaluation=hard_gate_evaluation,
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+        qualification_state=qualification_state,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        confidence_thresholds=threshold_profile["thresholds"],
+    )
+    return QualificationProfileSnapshot(
+        qualification_state=qualification_state,
+        action=action,
+        confidence_tier=confidence_tier,
+        aggregate_score=aggregate_score,
+        base_aggregate_score=base_aggregate_score,
+        win_rate=win_rate,
+        expected_value=expected_value,
+        has_blocking_failure=hard_gate_evaluation.has_blocking_failure,
+    )
+
+
+def _apply_robustness_component_adjustments(
+    *,
+    component_scores: list[ComponentScore],
+    component_score_adjustments: dict[str, float],
+) -> list[ComponentScore]:
+    adjusted_components: list[ComponentScore] = []
+    for component in component_scores:
+        delta = float(component_score_adjustments.get(component.category, 0.0))
+        adjusted_components.append(
+            ComponentScore(
+                category=component.category,
+                score=_clamp_audit_component_score(float(component.score) + delta),
+                rationale=component.rationale,
+                evidence=list(component.evidence),
+            )
+        )
+    return adjusted_components
+
+
+def _clamp_audit_component_score(value: float) -> float:
+    return max(0.0, min(100.0, round(float(value), 4)))
+
+
+def _classify_robustness_behavior(
+    *,
+    baseline_snapshot: QualificationProfileSnapshot,
+    slice_snapshot: QualificationProfileSnapshot,
+    slice_type: str,
+) -> str:
+    if slice_type == "covered":
+        return "stable"
+    if slice_snapshot.has_blocking_failure or slice_snapshot.qualification_state == "reject":
+        return "failing"
+    baseline_state_rank = QUALIFICATION_STATE_RANKS[baseline_snapshot.qualification_state]
+    slice_state_rank = QUALIFICATION_STATE_RANKS[slice_snapshot.qualification_state]
+    baseline_confidence_rank = CONFIDENCE_TIER_RANKS[baseline_snapshot.confidence_tier]
+    slice_confidence_rank = CONFIDENCE_TIER_RANKS[slice_snapshot.confidence_tier]
+    if baseline_snapshot.action == "entry" and slice_snapshot.action in {"ignore", "exit"}:
+        return "failing"
+    if slice_state_rank < (baseline_state_rank - 1):
+        return "failing"
+    if (
+        slice_state_rank >= baseline_state_rank
+        and slice_snapshot.action == baseline_snapshot.action
+        and slice_confidence_rank >= baseline_confidence_rank
+    ):
+        return "stable"
+    return "weak"
+
+
+def _robustness_adjustment_entries(*, component_score_adjustments: dict[str, float]) -> list[str]:
+    if not component_score_adjustments:
+        return ["component_score_adjustments=none"]
+    return [
+        f"{category} delta={float(delta):.4f}"
+        for category, delta in sorted(component_score_adjustments.items())
+    ]
+
+
+def _robustness_finding(
+    *,
+    baseline_snapshot: QualificationProfileSnapshot,
+    slice_snapshot: QualificationProfileSnapshot,
+    behavior_status: str,
+) -> str:
+    baseline_label = (
+        f"{baseline_snapshot.qualification_state}/{baseline_snapshot.action}/"
+        f"{baseline_snapshot.confidence_tier}"
+    )
+    slice_label = (
+        f"{slice_snapshot.qualification_state}/{slice_snapshot.action}/"
+        f"{slice_snapshot.confidence_tier}"
+    )
+    if behavior_status == "stable":
+        lead = "Slice remained stable relative to covered current evidence."
+        boundary = "Interpretation remains bounded to covered conditions only."
+    elif behavior_status == "weak":
+        lead = "Slice degraded profile support relative to covered current evidence."
+        boundary = "This instability limits interpretation outside covered conditions."
+    else:
+        lead = "Slice produced failing profile behavior relative to covered current evidence."
+        boundary = "Do not generalize stability outside covered conditions from this slice."
+    return (
+        f"{lead} Baseline={baseline_label}; slice={slice_label}; "
+        f"aggregate={slice_snapshot.aggregate_score:.4f}; {boundary}"
+    )
+
+
+def _format_slice_ids(slice_ids: list[str]) -> str:
+    return ",".join(slice_ids) if slice_ids else "none"
 
 
 def _build_metadata(
@@ -576,6 +864,7 @@ def _build_metadata(
     expected_value: float,
     action: DecisionAction,
     trader_relevance_validation: BoundedTraderRelevanceValidation,
+    robustness_audit: QualificationProfileRobustnessAudit,
 ) -> dict[str, object]:
     metadata = dict(input_data.metadata or {})
     metadata["base_aggregate_score"] = base_aggregate_score
@@ -595,6 +884,7 @@ def _build_metadata(
     metadata["decision_action"] = action
     metadata["decision_action_policy_version"] = "paper-action.v1"
     metadata["bounded_trader_relevance_validation"] = trader_relevance_validation.model_dump(mode="python")
+    metadata["qualification_profile_robustness_audit"] = robustness_audit.model_dump(mode="python")
     metadata["technical_implementation_status"] = metadata.get(
         "technical_implementation_status", "technical_in_progress"
     )

--- a/src/cilly_trading/strategies/registry.py
+++ b/src/cilly_trading/strategies/registry.py
@@ -71,6 +71,101 @@ QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP: dict[str, dict[str, float 
     },
 }
 
+QUALIFICATION_PROFILE_ROBUSTNESS_BASE_SLICES: tuple[dict[str, Any], ...] = (
+    {
+        "slice_id": "covered.current_evidence.v1",
+        "slice_type": "covered",
+        "deterministic_rank": 1,
+        "description": (
+            "Covered current-evidence slice resolves the qualification profile without adverse adjustments."
+        ),
+        "component_score_adjustments": {},
+    },
+    {
+        "slice_id": "failure_envelope.evidence_decay.v1",
+        "slice_type": "failure_envelope",
+        "deterministic_rank": 2,
+        "description": (
+            "Failure-envelope slice degrades signal and backtest evidence by fixed bounded deltas."
+        ),
+        "component_score_adjustments": {
+            "backtest_quality": -18.0,
+            "signal_quality": -18.0,
+        },
+    },
+    {
+        "slice_id": "failure_envelope.execution_stress.v1",
+        "slice_type": "failure_envelope",
+        "deterministic_rank": 3,
+        "description": (
+            "Failure-envelope slice degrades risk and execution evidence by fixed bounded deltas."
+        ),
+        "component_score_adjustments": {
+            "execution_readiness": -35.0,
+            "risk_alignment": -40.0,
+        },
+    },
+)
+
+QUALIFICATION_PROFILE_ROBUSTNESS_REGIME_SLICE_BY_COMPARISON_GROUP: dict[str, dict[str, Any]] = {
+    "default": {
+        "slice_id": "regime_slice.default_headwind.v1",
+        "slice_type": "regime_slice",
+        "deterministic_rank": 4,
+        "description": (
+            "Default regime slice applies a bounded mixed headwind across signal, portfolio-fit, "
+            "and execution evidence."
+        ),
+        "component_score_adjustments": {
+            "execution_readiness": -8.0,
+            "portfolio_fit": -10.0,
+            "signal_quality": -12.0,
+        },
+    },
+    "mean-reversion": {
+        "slice_id": "regime_slice.mean_reversion_headwind.v1",
+        "slice_type": "regime_slice",
+        "deterministic_rank": 4,
+        "description": (
+            "Mean-reversion regime slice applies a bounded headwind to reversal signal, backtest, "
+            "and portfolio-fit evidence."
+        ),
+        "component_score_adjustments": {
+            "backtest_quality": -14.0,
+            "portfolio_fit": -10.0,
+            "signal_quality": -22.0,
+        },
+    },
+    "reference-control": {
+        "slice_id": "regime_slice.reference_control_headwind.v1",
+        "slice_type": "regime_slice",
+        "deterministic_rank": 4,
+        "description": (
+            "Reference-control regime slice applies a bounded stability check across signal, "
+            "backtest, and execution evidence."
+        ),
+        "component_score_adjustments": {
+            "backtest_quality": -10.0,
+            "execution_readiness": -8.0,
+            "signal_quality": -10.0,
+        },
+    },
+    "trend-following": {
+        "slice_id": "regime_slice.trend_following_headwind.v1",
+        "slice_type": "regime_slice",
+        "deterministic_rank": 4,
+        "description": (
+            "Trend-following regime slice applies a bounded chop/headwind adjustment to signal, "
+            "backtest, and risk evidence."
+        ),
+        "component_score_adjustments": {
+            "backtest_quality": -12.0,
+            "risk_alignment": -8.0,
+            "signal_quality": -18.0,
+        },
+    },
+}
+
 
 class StrategyNotRegisteredError(KeyError):
     """Raised when an unknown strategy key is requested."""
@@ -95,6 +190,14 @@ class RegisteredStrategy:
 
 
 _REGISTRY: dict[str, RegisteredStrategy] = {}
+
+
+def _normalize_comparison_group(comparison_group: str | None) -> str:
+    return (
+        comparison_group.strip()
+        if isinstance(comparison_group, str) and comparison_group.strip()
+        else DEFAULT_COMPARISON_GROUP
+    )
 
 
 def _normalize_key(strategy_key: str) -> str:
@@ -260,10 +363,45 @@ def resolve_qualification_threshold_profile(
 ) -> dict[str, float | str]:
     """Resolve deterministic threshold profile for a comparison group."""
 
-    normalized_group = (
-        comparison_group.strip() if isinstance(comparison_group, str) and comparison_group.strip() else DEFAULT_COMPARISON_GROUP
-    )
+    normalized_group = _normalize_comparison_group(comparison_group)
     profile = QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP.get(normalized_group)
     if profile is None:
         profile = QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP[DEFAULT_COMPARISON_GROUP]
     return dict(profile)
+
+
+def resolve_qualification_profile_robustness_slices(
+    *, comparison_group: str | None
+) -> list[dict[str, Any]]:
+    """Resolve deterministic bounded robustness slices for a comparison group."""
+
+    normalized_group = _normalize_comparison_group(comparison_group)
+    regime_slice = QUALIFICATION_PROFILE_ROBUSTNESS_REGIME_SLICE_BY_COMPARISON_GROUP.get(
+        normalized_group
+    )
+    if regime_slice is None:
+        regime_slice = QUALIFICATION_PROFILE_ROBUSTNESS_REGIME_SLICE_BY_COMPARISON_GROUP[
+            DEFAULT_COMPARISON_GROUP
+        ]
+
+    resolved_slices: list[dict[str, Any]] = []
+    for slice_definition in (*QUALIFICATION_PROFILE_ROBUSTNESS_BASE_SLICES, regime_slice):
+        adjustments = {
+            str(category): float(delta)
+            for category, delta in dict(
+                slice_definition.get("component_score_adjustments", {})
+            ).items()
+        }
+        resolved_slices.append(
+            {
+                "slice_id": str(slice_definition["slice_id"]),
+                "slice_type": str(slice_definition["slice_type"]),
+                "deterministic_rank": int(slice_definition["deterministic_rank"]),
+                "description": str(slice_definition["description"]),
+                "component_score_adjustments": dict(sorted(adjustments.items())),
+            }
+        )
+    return sorted(
+        resolved_slices,
+        key=lambda item: (int(item["deterministic_rank"]), str(item["slice_id"])),
+    )

--- a/tests/cilly_trading/engine/test_qualification_engine.py
+++ b/tests/cilly_trading/engine/test_qualification_engine.py
@@ -371,6 +371,99 @@ def test_regression_identical_inputs_are_deterministic_across_groups() -> None:
     )
 
 
+def test_qualification_profile_robustness_audit_identifies_stable_weak_and_failing_slices() -> None:
+    card = evaluate_qualification(_engine_input())
+    audit = card.metadata["qualification_profile_robustness_audit"]
+    by_slice_id = {item["slice_id"]: item for item in audit["slice_results"]}
+
+    assert audit["comparison_group"] == "mean-reversion"
+    assert audit["threshold_profile_id"] == "qualification-threshold.mean-reversion.v1"
+    assert audit["stable_slice_ids"] == ["covered.current_evidence.v1"]
+    assert audit["weak_slice_ids"] == [
+        "failure_envelope.evidence_decay.v1",
+        "regime_slice.mean_reversion_headwind.v1",
+    ]
+    assert audit["failing_slice_ids"] == ["failure_envelope.execution_stress.v1"]
+
+    assert by_slice_id["covered.current_evidence.v1"]["behavior_status"] == "stable"
+    assert by_slice_id["covered.current_evidence.v1"]["qualification_state"] == "paper_approved"
+    assert by_slice_id["covered.current_evidence.v1"]["action"] == "entry"
+
+    assert by_slice_id["failure_envelope.evidence_decay.v1"]["behavior_status"] == "weak"
+    assert by_slice_id["failure_envelope.evidence_decay.v1"]["qualification_state"] == "paper_candidate"
+    assert by_slice_id["failure_envelope.evidence_decay.v1"]["action"] == "entry"
+    assert by_slice_id["failure_envelope.evidence_decay.v1"]["aggregate_score"] == 74.25
+
+    assert by_slice_id["failure_envelope.execution_stress.v1"]["behavior_status"] == "failing"
+    assert by_slice_id["failure_envelope.execution_stress.v1"]["qualification_state"] == "watch"
+    assert by_slice_id["failure_envelope.execution_stress.v1"]["action"] == "ignore"
+    assert by_slice_id["failure_envelope.execution_stress.v1"]["aggregate_score"] == 72.65
+
+    assert by_slice_id["regime_slice.mean_reversion_headwind.v1"]["behavior_status"] == "weak"
+    assert by_slice_id["regime_slice.mean_reversion_headwind.v1"]["qualification_state"] == (
+        "paper_candidate"
+    )
+    assert by_slice_id["regime_slice.mean_reversion_headwind.v1"]["action"] == "entry"
+    assert by_slice_id["regime_slice.mean_reversion_headwind.v1"]["aggregate_score"] == 72.55
+    assert "covered conditions" in audit["interpretation_limit"]
+
+
+def test_qualification_profile_robustness_audit_is_deterministic_for_identical_inputs() -> None:
+    card_a = evaluate_qualification(_engine_input())
+    card_b = evaluate_qualification(_engine_input())
+
+    audit_a = card_a.metadata["qualification_profile_robustness_audit"]
+    audit_b = card_b.metadata["qualification_profile_robustness_audit"]
+
+    assert audit_a == audit_b
+    assert sorted(audit_a.keys()) == [
+        "audit_summary",
+        "comparison_group",
+        "contract_id",
+        "contract_version",
+        "failing_slice_ids",
+        "interpretation_limit",
+        "slice_results",
+        "stable_slice_ids",
+        "threshold_profile_id",
+        "weak_slice_ids",
+    ]
+    for item in audit_a["slice_results"]:
+        assert sorted(item.keys()) == [
+            "action",
+            "aggregate_score",
+            "applied_adjustments",
+            "base_aggregate_score",
+            "behavior_status",
+            "confidence_tier",
+            "description",
+            "deterministic_rank",
+            "expected_value",
+            "finding",
+            "has_blocking_failure",
+            "qualification_state",
+            "slice_id",
+            "slice_type",
+            "win_rate",
+        ]
+
+
+def test_qualification_profile_robustness_audit_resolves_group_specific_regime_slice_ids() -> None:
+    reference = evaluate_qualification(_engine_input(strategy_id="REFERENCE"))
+    reference_slice_ids = [
+        item["slice_id"]
+        for item in reference.metadata["qualification_profile_robustness_audit"]["slice_results"]
+    ]
+    assert reference_slice_ids[-1] == "regime_slice.reference_control_headwind.v1"
+
+    turtle = evaluate_qualification(_engine_input(strategy_id="TURTLE"))
+    turtle_slice_ids = [
+        item["slice_id"]
+        for item in turtle.metadata["qualification_profile_robustness_audit"]["slice_results"]
+    ]
+    assert turtle_slice_ids[-1] == "regime_slice.trend_following_headwind.v1"
+
+
 def test_bounded_trader_relevance_validation_is_aligned_for_complete_qualification_output() -> None:
     card = evaluate_qualification(_engine_input())
     validation = card.metadata["bounded_trader_relevance_validation"]

--- a/tests/cilly_trading/engine/test_qualification_engine.py
+++ b/tests/cilly_trading/engine/test_qualification_engine.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import pytest
 
 from cilly_trading.engine.decision_card_contract import (
+    BOUNDED_TRADER_RELEVANCE_CONTRACT_ID,
+    BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION,
     DECISION_CARD_CONTRACT_VERSION,
     ComponentScore,
     HardGateResult,
+    evaluate_bounded_trader_relevance_cases,
 )
 from cilly_trading.engine.qualification_engine import (
     BacktestEvidenceInput,
@@ -366,3 +369,84 @@ def test_regression_identical_inputs_are_deterministic_across_groups() -> None:
     assert first_turtle.metadata["qualification_threshold_profile_id"] == (
         second_turtle.metadata["qualification_threshold_profile_id"]
     )
+
+
+def test_bounded_trader_relevance_validation_is_aligned_for_complete_qualification_output() -> None:
+    card = evaluate_qualification(_engine_input())
+    validation = card.metadata["bounded_trader_relevance_validation"]
+
+    assert validation["contract_id"] == BOUNDED_TRADER_RELEVANCE_CONTRACT_ID
+    assert validation["contract_version"] == BOUNDED_TRADER_RELEVANCE_CONTRACT_VERSION
+    assert validation["overall_status"] == "aligned"
+    assert [item["case_id"] for item in validation["evaluations"]] == [
+        "boundary_scope_relevance",
+        "decision_action_relevance",
+        "qualification_state_relevance",
+    ]
+    assert all(item["evidence_status"] == "aligned" for item in validation["evaluations"])
+
+
+def test_bounded_trader_relevance_validation_supports_weak_path_deterministically() -> None:
+    validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state="watch",
+        action="ignore",
+        win_rate=0.42,
+        expected_value=None,
+        qualification_summary="Qualification output remains bounded to paper scope.",
+        rationale_summary="Partial technical evidence exists.",
+        final_explanation="Boundary mentions trader_validation and live-trading readiness only.",
+        qualification_evidence=["No explicit action rule trace is included yet."],
+        missing_criteria=["Missing deterministic expected-value evidence."],
+        blocking_conditions=[],
+    )
+
+    assert validation.overall_status == "weak"
+    by_case = {item.case_id: item.evidence_status for item in validation.evaluations}
+    assert by_case == {
+        "boundary_scope_relevance": "weak",
+        "decision_action_relevance": "weak",
+        "qualification_state_relevance": "aligned",
+    }
+
+
+def test_bounded_trader_relevance_validation_supports_missing_path_deterministically() -> None:
+    validation = evaluate_bounded_trader_relevance_cases(
+        qualification_state=None,
+        action=None,
+        win_rate=None,
+        expected_value=None,
+        qualification_summary="",
+        rationale_summary="",
+        final_explanation="",
+        qualification_evidence=[],
+        missing_criteria=[],
+        blocking_conditions=[],
+    )
+
+    assert validation.overall_status == "missing"
+    assert all(item.evidence_status == "missing" for item in validation.evaluations)
+
+
+def test_bounded_trader_relevance_validation_schema_is_stable_for_identical_inputs() -> None:
+    card_a = evaluate_qualification(_engine_input())
+    card_b = evaluate_qualification(_engine_input())
+
+    validation_a = card_a.metadata["bounded_trader_relevance_validation"]
+    validation_b = card_b.metadata["bounded_trader_relevance_validation"]
+
+    assert validation_a == validation_b
+    assert sorted(validation_a.keys()) == [
+        "contract_id",
+        "contract_version",
+        "evaluations",
+        "overall_status",
+    ]
+    for item in validation_a["evaluations"]:
+        assert sorted(item.keys()) == [
+            "case_id",
+            "evidence_status",
+            "evidence_summary",
+            "observed_evidence",
+            "required_evidence",
+            "review_question",
+        ]

--- a/tests/decision/test_decision_integration_layer.py
+++ b/tests/decision/test_decision_integration_layer.py
@@ -142,6 +142,27 @@ def test_evidence_semantics_and_contract_boundary_remain_explicit() -> None:
     ]
 
 
+def test_robustness_audit_and_boundary_language_are_integrated_into_decision_card() -> None:
+    card = evaluate_qualification(_engine_input())
+    audit = card.metadata["qualification_profile_robustness_audit"]
+    score_explanations = " ".join(card.rationale.score_explanations)
+
+    assert audit["stable_slice_ids"] == ["covered.current_evidence.v1"]
+    assert audit["failing_slice_ids"] == ["failure_envelope.execution_stress.v1"]
+    assert "Qualification-profile robustness audit:" in score_explanations
+    assert audit["audit_summary"] in score_explanations
+    assert audit["interpretation_limit"] in score_explanations
+
+    final_explanation = card.rationale.final_explanation.casefold()
+    assert "covered conditions" in final_explanation
+    assert "weak or failing slices limit interpretation outside covered conditions" in (
+        final_explanation
+    )
+    assert "live-trading approval" in final_explanation
+    assert "paper profitability" in final_explanation
+    assert "trader_validation" in final_explanation
+
+
 def test_stale_sentiment_overlay_is_explicitly_neutral_and_bounded() -> None:
     card = evaluate_qualification(
         _engine_input(

--- a/tests/test_api_decision_card_inspection_read.py
+++ b/tests/test_api_decision_card_inspection_read.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
 from fastapi.testclient import TestClient
 
 import api.main as api_main
+from cilly_trading.models import Trade
 from cilly_trading.engine.decision_card_contract import REQUIRED_COMPONENT_CATEGORIES
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
 from tests.utils.json_schema_validator import validate_json_schema
 
 READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
@@ -19,6 +22,44 @@ def _write_artifact(root: Path, run_id: str, artifact_name: str, payload: Any) -
     (run_dir / artifact_name).write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _repo(tmp_path: Path) -> SqliteCanonicalExecutionRepository:
+    return SqliteCanonicalExecutionRepository(db_path=tmp_path / "decision-card-inspection.db")
+
+
+def _trade(
+    trade_id: str,
+    *,
+    strategy_id: str,
+    symbol: str,
+    status: str,
+    opened_at: str,
+    closed_at: str | None,
+    realized_pnl: str | None,
+    unrealized_pnl: str | None,
+) -> Trade:
+    return Trade.model_validate(
+        {
+            "trade_id": trade_id,
+            "position_id": f"pos-{trade_id}",
+            "strategy_id": strategy_id,
+            "symbol": symbol,
+            "direction": "long",
+            "status": status,
+            "opened_at": opened_at,
+            "closed_at": closed_at,
+            "quantity_opened": Decimal("1"),
+            "quantity_closed": Decimal("1") if status == "closed" else Decimal("0"),
+            "average_entry_price": Decimal("100"),
+            "average_exit_price": Decimal("101") if status == "closed" else None,
+            "realized_pnl": Decimal(realized_pnl) if realized_pnl is not None else None,
+            "unrealized_pnl": Decimal(unrealized_pnl) if unrealized_pnl is not None else None,
+            "opening_order_ids": [f"ord-{trade_id}"],
+            "closing_order_ids": [f"ord-{trade_id}"] if status == "closed" else [],
+            "execution_event_ids": [f"evt-{trade_id}"],
+        }
+    )
+
+
 def _decision_card_payload(
     *,
     decision_card_id: str,
@@ -26,6 +67,7 @@ def _decision_card_payload(
     symbol: str,
     strategy_id: str,
     qualification_state: str,
+    paper_trade_id: str | None = None,
 ) -> dict[str, Any]:
     color_by_state = {
         "reject": "red",
@@ -82,7 +124,7 @@ def _decision_card_payload(
     elif qualification_state == "paper_approved":
         qualification_summary = "Opportunity is approved for bounded paper-trading only."
 
-    return {
+    payload = {
         "contract_version": "2.0.0",
         "decision_card_id": decision_card_id,
         "generated_at_utc": generated_at_utc,
@@ -151,11 +193,24 @@ def _decision_card_payload(
             "source": "qualification_engine",
         },
     }
+    if paper_trade_id is not None:
+        payload["metadata"]["bounded_decision_to_paper_match"] = {
+            "match_mode": "paper_trade_id",
+            "paper_trade_id": paper_trade_id,
+        }
+    return payload
 
 
-def _client(monkeypatch, artifacts_root: Path) -> TestClient:
+def _client(
+    monkeypatch,
+    artifacts_root: Path,
+    repo: SqliteCanonicalExecutionRepository | None = None,
+) -> TestClient:
+    if repo is None:
+        repo = _repo(artifacts_root.parent)
     monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
     monkeypatch.setattr(api_main, "JOURNAL_ARTIFACTS_ROOT", artifacts_root)
+    monkeypatch.setattr(api_main, "canonical_execution_repo", repo)
     return TestClient(api_main.app)
 
 
@@ -353,3 +408,117 @@ def test_decision_card_inspection_regression_ignores_non_contract_artifacts(
     payload = response.json()
     assert payload["total"] == 1
     assert [item["decision_card_id"] for item in payload["items"]] == ["dc-010"]
+
+
+def test_decision_card_inspection_persists_deterministic_bounded_usefulness_audit(
+    monkeypatch, tmp_path: Path
+) -> None:
+    artifacts_root = tmp_path / "runs" / "phase6"
+    repo = _repo(tmp_path)
+    repo.save_trade(
+        _trade(
+            "trade-exp",
+            strategy_id="RSI2",
+            symbol="AAPL",
+            status="closed",
+            opened_at="2026-03-24T08:05:00Z",
+            closed_at="2026-03-24T08:45:00Z",
+            realized_pnl="1.50",
+            unrealized_pnl=None,
+        )
+    )
+    repo.save_trade(
+        _trade(
+            "trade-weak",
+            strategy_id="RSI2",
+            symbol="MSFT",
+            status="open",
+            opened_at="2026-03-24T09:05:00Z",
+            closed_at=None,
+            realized_pnl=None,
+            unrealized_pnl="0.25",
+        )
+    )
+    repo.save_trade(
+        _trade(
+            "trade-misleading",
+            strategy_id="TURTLE",
+            symbol="NVDA",
+            status="closed",
+            opened_at="2026-03-24T10:05:00Z",
+            closed_at="2026-03-24T10:35:00Z",
+            realized_pnl="-2.00",
+            unrealized_pnl=None,
+        )
+    )
+
+    _write_artifact(
+        artifacts_root,
+        run_id="run-usefulness",
+        artifact_name="dc-exp.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-exp",
+            generated_at_utc="2026-03-24T08:00:00Z",
+            symbol="AAPL",
+            strategy_id="RSI2",
+            qualification_state="paper_approved",
+            paper_trade_id="trade-exp",
+        ),
+    )
+    _write_artifact(
+        artifacts_root,
+        run_id="run-usefulness",
+        artifact_name="dc-weak.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-weak",
+            generated_at_utc="2026-03-24T09:00:00Z",
+            symbol="MSFT",
+            strategy_id="RSI2",
+            qualification_state="paper_approved",
+            paper_trade_id="trade-weak",
+        ),
+    )
+    _write_artifact(
+        artifacts_root,
+        run_id="run-usefulness",
+        artifact_name="dc-misleading.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-misleading",
+            generated_at_utc="2026-03-24T10:00:00Z",
+            symbol="NVDA",
+            strategy_id="TURTLE",
+            qualification_state="paper_approved",
+            paper_trade_id="trade-misleading",
+        ),
+    )
+
+    with _client(monkeypatch, artifacts_root, repo=repo) as client:
+        first = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+        second = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+
+    by_id = {item["decision_card_id"]: item for item in first.json()["items"]}
+
+    explanatory_audit = by_id["dc-exp"]["metadata"]["bounded_decision_to_paper_usefulness_audit"]
+    assert explanatory_audit["contract_id"] == "decision_evidence_to_paper_outcome_usefulness.paper_audit.v1"
+    assert explanatory_audit["match_reference"] == {
+        "match_mode": "paper_trade_id",
+        "paper_trade_id": "trade-exp",
+    }
+    assert explanatory_audit["match_status"] == "matched"
+    assert explanatory_audit["usefulness_classification"] == "explanatory"
+    assert explanatory_audit["matched_outcome"]["outcome_direction"] == "favorable"
+    assert "non-live" in explanatory_audit["interpretation_limit"]
+
+    weak_audit = by_id["dc-weak"]["metadata"]["bounded_decision_to_paper_usefulness_audit"]
+    assert weak_audit["match_status"] == "open"
+    assert weak_audit["usefulness_classification"] == "weak"
+    assert weak_audit["matched_outcome"]["outcome_direction"] == "open"
+
+    misleading_audit = by_id["dc-misleading"]["metadata"]["bounded_decision_to_paper_usefulness_audit"]
+    assert misleading_audit["match_status"] == "matched"
+    assert misleading_audit["usefulness_classification"] == "misleading"
+    assert misleading_audit["matched_outcome"]["outcome_direction"] == "adverse"

--- a/tests/test_api_paper_inspection_read.py
+++ b/tests/test_api_paper_inspection_read.py
@@ -420,10 +420,12 @@ def test_paper_workflow_contract_is_explicit_and_aligned_to_surfaces(
 
     assert payload["boundary"]["workflow_id"] == "phase44_bounded_paper_operator"
     assert payload["boundary"]["description"] == (
-        "One read-only portfolio-to-paper handoff contract that validates bounded "
-        "paper-readiness inputs across canonical inspection and reconciliation surfaces."
+        "One read-only decision-to-paper and portfolio-to-paper handoff contract that "
+        "validates bounded paper-readiness inputs across canonical inspection and "
+        "reconciliation surfaces."
     )
     assert payload["boundary"]["in_scope"] == [
+        "covered decision-card usefulness audit against explicit matched paper-trade outcomes",
         "explicit portfolio-to-paper handoff inputs from canonical orders, execution events, trades, and positions",
         "paper-facing account, trade, and position views derived from canonical portfolio evidence",
         "reconciliation validation with mismatch accounting",
@@ -467,9 +469,16 @@ def test_paper_workflow_contract_is_explicit_and_aligned_to_surfaces(
             "endpoint": "GET /paper/reconciliation",
             "expected_result": "Paper-readiness reconciliation ok=true mismatches=0.",
         },
+        {
+            "step": 6,
+            "action": "Inspect covered decision cards for bounded usefulness classifications against explicit matched paper-trade outcomes.",
+            "endpoint": "GET /decision-cards",
+            "expected_result": "Covered decision-card outputs expose bounded usefulness classifications in metadata without trader-validation or readiness claims.",
+        },
     ]
     assert payload["surfaces"] == {
         "canonical_inspection": [
+            "/decision-cards",
             "/trading-core/orders",
             "/trading-core/execution-events",
             "/trading-core/trades",

--- a/tests/test_api_signal_decision_surface.py
+++ b/tests/test_api_signal_decision_surface.py
@@ -203,6 +203,16 @@ def test_signal_decision_surface_returns_bounded_technical_states(tmp_path: Path
     assert payload["items"][2]["expected_value"] == 1.0
     assert "score" in payload["items"][2]["score_contribution"].lower()
     assert "stage" in payload["items"][1]["stage_assessment"].lower()
+    assert any(
+        "bounded trader-relevance case review" in entry.lower()
+        for entry in payload["items"][2]["qualification_evidence"]
+    )
+    assert any(
+        "boundary evidence" in entry.lower()
+        and "not trader_validation evidence" in entry.lower()
+        and "not paper profitability evidence" in entry.lower()
+        for entry in payload["items"][2]["qualification_evidence"]
+    )
 
 
 def test_signal_decision_surface_covers_threshold_and_entry_zone_edge_cases(
@@ -248,6 +258,13 @@ def test_signal_decision_surface_covers_threshold_and_entry_zone_edge_cases(
     assert by_symbol["EDGE_CANDIDATE"]["missing_criteria"] == []
     assert by_symbol["EDGE_CANDIDATE"]["blocking_conditions"] == []
     assert by_symbol["EDGE_CANDIDATE"]["qualification_evidence"]
+    edge_candidate_review = next(
+        entry
+        for entry in by_symbol["EDGE_CANDIDATE"]["qualification_evidence"]
+        if "Bounded trader-relevance case review" in entry
+    )
+    assert "decision_action_relevance=aligned" in edge_candidate_review
+    assert "qualification_state_relevance=aligned" in edge_candidate_review
 
     assert by_symbol["EDGE_BLOCK"]["decision_state"] == "watch"
     assert by_symbol["EDGE_BLOCK"]["qualification_state"] == "watch"

--- a/tests/test_non_live_evaluation_contract_docs.py
+++ b/tests/test_non_live_evaluation_contract_docs.py
@@ -12,6 +12,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_DOC = (
     REPO_ROOT / "docs" / "architecture" / "risk" / "non_live_evaluation_contract.md"
 )
+GOVERNANCE_DOC = (
+    REPO_ROOT / "docs" / "governance" / "qualification-claim-evidence-discipline.md"
+)
+PHASE44_DOC = (
+    REPO_ROOT / "docs" / "operations" / "runtime" / "phase-44-paper-operator-workflow.md"
+)
 
 
 def _read(path: Path) -> str:
@@ -163,3 +169,28 @@ def test_ops_policy_doc_references_structured_non_live_evidence_surface() -> Non
     assert "approved`, `rejected`, or `constraint_hit`" in policy_doc
     assert "approved outcomes emit an empty evidence tuple" in policy_doc
     assert "reject edges only" not in policy_doc.lower()
+
+
+def test_usefulness_governance_doc_defines_exact_non_live_decision_to_paper_contract() -> None:
+    content = _read(GOVERNANCE_DOC)
+
+    assert "Deterministic Bounded Decision-to-Paper Usefulness Audit" in content
+    assert "decision_evidence_to_paper_outcome_usefulness.paper_audit.v1" in content
+    assert "metadata.bounded_decision_to_paper_match" in content
+    assert "paper_trade_id" in content
+    assert "`explanatory`" in content
+    assert "`weak`" in content
+    assert "`misleading`" in content
+
+
+def test_usefulness_docs_keep_non_live_claim_boundaries_explicit() -> None:
+    governance = _read(GOVERNANCE_DOC)
+    phase44 = _read(PHASE44_DOC)
+
+    assert "it is not trader validation" in governance
+    assert "it is not profitability forecasting" in governance
+    assert "it is not live-trading readiness" in governance
+    assert "it is not operational readiness" in governance
+    assert "metadata.bounded_decision_to_paper_usefulness_audit" in phase44
+    assert "non-live explanatory review" in phase44
+    assert "exact paper-trade matches only" in phase44

--- a/tests/test_ops_p60_signal_to_paper_operator_path.py
+++ b/tests/test_ops_p60_signal_to_paper_operator_path.py
@@ -108,6 +108,18 @@ def test_p60_post_execution_verification_documented() -> None:
     assert "/paper/reconciliation" in content
 
 
+def test_p60_decision_usefulness_audit_is_documented() -> None:
+    content = _read(P60_DOC_PATH)
+
+    assert "## Decision Evidence Usefulness Audit" in content
+    assert "metadata.bounded_decision_to_paper_match" in content
+    assert "metadata.bounded_decision_to_paper_usefulness_audit" in content
+    assert "paper_trade_id" in content
+    assert "`explanatory`" in content
+    assert "`weak`" in content
+    assert "`misleading`" in content
+
+
 # ---------------------------------------------------------------------------
 # AC3: Gap analysis is explicit without overclaim
 # ---------------------------------------------------------------------------
@@ -156,6 +168,15 @@ def test_p60_non_live_boundary_is_explicit() -> None:
     assert "No broker APIs are called." in content
     assert "No real capital is at risk." in content
     assert "does not imply live-trading readiness" in content
+
+
+def test_p60_usefulness_audit_keeps_claim_boundary_explicit() -> None:
+    content = _read(P60_DOC_PATH)
+
+    assert "This audit is bounded to non-live usefulness only." in content
+    assert "does not imply trader" in content
+    assert "profitability forecasting" in content
+    assert "operational" in content
 
 
 def test_p60_script_contains_non_live_boundary() -> None:

--- a/tests/test_ops_p63_daily_bounded_paper_runtime_workflow.py
+++ b/tests/test_ops_p63_daily_bounded_paper_runtime_workflow.py
@@ -105,8 +105,22 @@ def test_p63_doc_defines_deterministic_run_quality_classification() -> None:
     assert "run_quality_status" in content
     assert "run_quality_classification_version" in content
     assert "run_quality_inputs" in content
+    assert "operator_action_contract_version" in content
+    assert "operator_action_contract" in content
     assert "`healthy`" in content
     assert "`no_eligible`" in content
     assert "`degraded`" in content
     assert "Deterministic classification rules use existing runtime summary inputs only" in content
 
+
+def test_p63_doc_defines_bounded_operator_action_categories_and_boundaries() -> None:
+    content = _read(P63_DOC)
+
+    assert "Deterministic Operator Action Contract (Daily Summary)" in content
+    assert "informational" in content
+    assert "review-required" in content
+    assert "retry-required" in content
+    assert "blocking" in content
+    assert "pre-execution failures are retry-required" in content
+    assert "execution or post-execution failures are blocking" in content
+    assert "does not imply operational readiness" in content

--- a/tests/test_ops_p64_one_command_bounded_daily_paper_runtime_runner.py
+++ b/tests/test_ops_p64_one_command_bounded_daily_paper_runtime_runner.py
@@ -56,6 +56,8 @@ def test_p64_doc_defines_bounded_failure_behavior() -> None:
     assert "failed_step" in content
     assert "steps_completed" in content
     assert "step_order" in content
+    assert "operator_action_contract_version" in content
+    assert "operator_action_contract" in content
 
 
 def test_p64_doc_defines_deterministic_run_quality_contract() -> None:
@@ -64,6 +66,8 @@ def test_p64_doc_defines_deterministic_run_quality_contract() -> None:
     assert "run_quality_status" in content
     assert "run_quality_classification_version" in content
     assert "run_quality_inputs" in content
+    assert "operator_action_contract_version" in content
+    assert "operator_action_contract" in content
     assert "`healthy`" in content
     assert "`no_eligible`" in content
     assert "`degraded`" in content
@@ -87,6 +91,18 @@ def test_p64_doc_has_explicit_non_live_claim_boundary() -> None:
     assert "no live orders are placed" in content
     assert "no broker APIs are called" in content
     assert "no production-readiness claim is made" in content
+
+
+def test_p64_doc_defines_bounded_operator_action_categories_and_fail_fast_boundaries() -> None:
+    content = _read(P64_DOC)
+
+    assert "informational" in content
+    assert "review-required" in content
+    assert "retry-required" in content
+    assert "blocking" in content
+    assert "pre-execution failures are retry-required" in content
+    assert "execution or post-execution failures are blocking" in content
+    assert "does not imply operational readiness" in content
 
 
 def test_p64_script_references_ops_p63_order_and_failure_mode() -> None:

--- a/tests/test_qualification_claim_boundary_docs.py
+++ b/tests/test_qualification_claim_boundary_docs.py
@@ -24,7 +24,21 @@ def test_governance_doc_defines_evidence_hierarchy_and_forbidden_claim_classes()
     assert "live-trading readiness/approval claims" in content
     assert "broker execution readiness claims" in content
     assert "trader-validation claims" in content
+    assert "paper profitability or edge claims" in content
     assert "guaranteed/certain outcome claims" in content
+
+
+def test_governance_doc_defines_deterministic_bounded_trader_relevance_contract() -> None:
+    content = GOVERNANCE_DOC.read_text(encoding="utf-8")
+
+    assert "Deterministic Bounded Trader-Relevance Review Contract" in content
+    assert "bounded_trader_relevance.paper_review.v1" in content
+    assert "qualification_state_relevance" in content
+    assert "decision_action_relevance" in content
+    assert "boundary_scope_relevance" in content
+    assert "aligned" in content
+    assert "weak" in content
+    assert "missing" in content
 
 
 def test_decision_card_contract_doc_declares_claim_boundary_wording_requirements() -> None:

--- a/tests/test_run_daily_bounded_paper_runtime_script.py
+++ b/tests/test_run_daily_bounded_paper_runtime_script.py
@@ -144,6 +144,13 @@ def test_daily_runner_executes_ops_p63_order_and_writes_run_record(
     assert payload["status"] == "ok"
     assert payload["run_quality_status"] == "no_eligible"
     assert payload["run_quality_classification_version"] == 1
+    assert payload["operator_action_contract_version"] == 1
+    assert payload["operator_action_contract"] == {
+        "action_category": "review_required",
+        "action_code": "review_no_eligible_and_record",
+        "action_summary": "Review the bounded no-eligible outcome, confirm skip reasons and inputs, and record the run without retrying solely to force activity.",
+        "escalation_boundary": "Escalate only when adjacent bounded evidence is contradictory or the no-eligible pattern is unexpected for the stated inputs. Do not treat bounded paper evidence as live, broker, or production readiness.",
+    }
     assert payload["run_quality_inputs"] == {
         "execution_eligible": 0,
         "execution_returncode": 1,
@@ -176,6 +183,8 @@ def test_daily_runner_executes_ops_p63_order_and_writes_run_record(
     summary_file_payload = json.loads(Path(payload["summary_file"]).read_text(encoding="utf-8"))
     assert summary_file_payload["run_quality_status"] == payload["run_quality_status"]
     assert summary_file_payload["run_quality_classification_version"] == payload["run_quality_classification_version"]
+    assert summary_file_payload["operator_action_contract_version"] == payload["operator_action_contract_version"]
+    assert summary_file_payload["operator_action_contract"] == payload["operator_action_contract"]
     assert summary_file_payload["run_quality_inputs"] == payload["run_quality_inputs"]
 
 
@@ -198,10 +207,34 @@ def test_run_quality_classification_state_transitions_are_deterministic() -> Non
         execution_step={"returncode": 0, "payload": {"status": "pass", "eligible": 3}},
         reconciliation_step={"payload": {"ok": False, "mismatches": 2}},
     )
+    healthy_repeat = module._classify_run_quality(
+        execution_step={"returncode": 0, "payload": {"status": "pass", "eligible": 3}},
+        reconciliation_step={"payload": {"ok": True, "mismatches": 0}},
+    )
 
     assert healthy["run_quality_status"] == "healthy"
+    assert healthy["operator_action_contract_version"] == 1
+    assert healthy["operator_action_contract"] == {
+        "action_category": "informational",
+        "action_code": "record_and_continue",
+        "action_summary": "Record the bounded daily runtime evidence and continue the next scheduled bounded run.",
+        "escalation_boundary": "No escalation from this state alone. Do not treat bounded paper evidence as live, broker, or production readiness.",
+    }
     assert no_eligible["run_quality_status"] == "no_eligible"
+    assert no_eligible["operator_action_contract"] == {
+        "action_category": "review_required",
+        "action_code": "review_no_eligible_and_record",
+        "action_summary": "Review the bounded no-eligible outcome, confirm skip reasons and inputs, and record the run without retrying solely to force activity.",
+        "escalation_boundary": "Escalate only when adjacent bounded evidence is contradictory or the no-eligible pattern is unexpected for the stated inputs. Do not treat bounded paper evidence as live, broker, or production readiness.",
+    }
     assert degraded["run_quality_status"] == "degraded"
+    assert degraded["operator_action_contract"] == {
+        "action_category": "blocking",
+        "action_code": "stop_and_open_follow_up",
+        "action_summary": "Treat the bounded run as blocked for continuation claims, investigate the degraded evidence, and open or update follow-up before the next bounded decision.",
+        "escalation_boundary": "Do not continue staged evaluation claims from this run until the degraded cause is resolved. Do not treat bounded paper evidence as live, broker, or production readiness.",
+    }
+    assert healthy == healthy_repeat
     assert degraded == degraded_repeat
 
 
@@ -259,6 +292,13 @@ def test_daily_runner_stops_after_analysis_failure(
     payload = json.loads(capsys.readouterr().err)
     assert payload["status"] == "failed"
     assert payload["failed_step"] == "analysis_signal_generation"
+    assert payload["operator_action_contract_version"] == 1
+    assert payload["operator_action_contract"] == {
+        "action_category": "retry_required",
+        "action_code": "fix_pre_execution_failure_and_rerun",
+        "action_summary": "Correct the pre-execution failure cause and rerun the bounded daily workflow.",
+        "escalation_boundary": "Retry is bounded to failures before paper execution starts. Do not treat bounded paper evidence as live, broker, or production readiness.",
+    }
     assert payload["steps_completed"] == ["snapshot_ingestion"]
     assert executed_scripts == ["run_snapshot_ingestion.py"]
 
@@ -330,6 +370,13 @@ def test_daily_runner_stops_after_execution_failure(
     payload = json.loads(capsys.readouterr().err)
     assert payload["status"] == "failed"
     assert payload["failed_step"] == "bounded_paper_execution_cycle"
+    assert payload["operator_action_contract_version"] == 1
+    assert payload["operator_action_contract"] == {
+        "action_category": "blocking",
+        "action_code": "stop_and_investigate_before_rerun",
+        "action_summary": "Stop and investigate the bounded execution failure before any rerun decision.",
+        "escalation_boundary": "Do not rerun the full workflow blindly after execution has started. Do not treat bounded paper evidence as live, broker, or production readiness.",
+    }
     assert payload["steps_completed"] == [
         "snapshot_ingestion",
         "analysis_signal_generation",

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -187,6 +187,97 @@ def test_scheduled_runner_is_started_on_api_startup_and_stopped_on_shutdown(monk
     assert calls == ["start_scheduler", "stop_scheduler"]
 
 
+def test_runtime_lifecycle_registration_uses_lifespan_handlers() -> None:
+    assert api_main.app.router.on_startup == []
+    assert api_main.app.router.on_shutdown == []
+
+
+def test_runtime_lifecycle_side_effect_order_remains_deterministic(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(api_main, "ENGINE_RUNTIME_GUARD_ACTIVE", False)
+
+    def _start_runtime() -> str:
+        calls.append(f"start_runtime:guard={api_main.ENGINE_RUNTIME_GUARD_ACTIVE}")
+        return "running"
+
+    def _start_scheduler() -> str:
+        calls.append(f"start_scheduler:guard={api_main.ENGINE_RUNTIME_GUARD_ACTIVE}")
+        return "running"
+
+    def _stop_scheduler() -> str:
+        calls.append(f"stop_scheduler:guard={api_main.ENGINE_RUNTIME_GUARD_ACTIVE}")
+        return "stopped"
+
+    def _shutdown_runtime() -> str:
+        calls.append(f"shutdown_runtime:guard={api_main.ENGINE_RUNTIME_GUARD_ACTIVE}")
+        return "stopped"
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", _start_runtime)
+    monkeypatch.setattr(api_main, "start_scheduled_analysis_runner", _start_scheduler)
+    monkeypatch.setattr(api_main, "shutdown_scheduled_analysis_runner", _stop_scheduler)
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", _shutdown_runtime)
+
+    with TestClient(api_main.app):
+        assert calls == [
+            "start_runtime:guard=False",
+            "start_scheduler:guard=True",
+        ]
+
+    assert calls == [
+        "start_runtime:guard=False",
+        "start_scheduler:guard=True",
+        "stop_scheduler:guard=True",
+        "shutdown_runtime:guard=False",
+    ]
+
+
+def test_runtime_guard_toggles_across_lifecycle(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "ENGINE_RUNTIME_GUARD_ACTIVE", False)
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "start_scheduled_analysis_runner", lambda: "running")
+    monkeypatch.setattr(api_main, "shutdown_scheduled_analysis_runner", lambda: "stopped")
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
+
+    with TestClient(api_main.app):
+        assert api_main.ENGINE_RUNTIME_GUARD_ACTIVE is True
+
+    assert api_main.ENGINE_RUNTIME_GUARD_ACTIVE is False
+
+
+def test_shutdown_lifecycle_transition_error_is_logged_and_swallowed(monkeypatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "start_scheduled_analysis_runner", lambda: "running")
+    monkeypatch.setattr(
+        api_main,
+        "shutdown_scheduled_analysis_runner",
+        lambda: calls.append("stop_scheduler") or "stopped",
+    )
+
+    def _shutdown_runtime() -> str:
+        calls.append("shutdown_runtime")
+        raise api_main.LifecycleTransitionError("Cannot shutdown runtime from state 'ready'.")
+
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", _shutdown_runtime)
+    monkeypatch.setattr(
+        api_main.logger,
+        "exception",
+        lambda message, *args, **kwargs: calls.append(f"log:{message}"),
+    )
+
+    with TestClient(api_main.app):
+        pass
+
+    assert calls == [
+        "stop_scheduler",
+        "shutdown_runtime",
+        "log:Engine runtime shutdown failed",
+    ]
+    assert api_main.ENGINE_RUNTIME_GUARD_ACTIVE is False
+
+
 def test_watchlist_persistence_survives_api_restart(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "restart-safe.db"
 

--- a/tests/test_sig_p47_score_semantics.py
+++ b/tests/test_sig_p47_score_semantics.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from cilly_trading.engine.decision_card_contract import (
     CONFIDENCE_TIER_PRECISION_DISCLAIMER,
     CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY,
+    QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY,
     ComponentScore,
     HardGateResult,
 )
@@ -23,7 +24,7 @@ from cilly_trading.strategies.registry import (
     CROSS_STRATEGY_SCORE_NON_COMPARABILITY_NOTE,
     QUALIFICATION_THRESHOLD_PROFILES_BY_COMPARISON_GROUP,
     get_registered_strategy_metadata,
-    reset_registry,
+    resolve_qualification_profile_robustness_slices,
     resolve_qualification_threshold_profile,
 )
 
@@ -114,6 +115,27 @@ def test_comparison_group_threshold_profiles_are_defined_and_deterministic() -> 
     assert first["profile_id"] == "qualification-threshold.mean-reversion.v1"
     assert first["high_aggregate"] >= first["medium_aggregate"]
     assert first["high_min_component"] >= first["medium_min_component"]
+
+
+def test_comparison_group_robustness_slices_are_defined_and_deterministic() -> None:
+    first = resolve_qualification_profile_robustness_slices(comparison_group="mean-reversion")
+    second = resolve_qualification_profile_robustness_slices(comparison_group="mean-reversion")
+
+    assert first == second
+    assert [item["deterministic_rank"] for item in first] == [1, 2, 3, 4]
+    assert [item["slice_id"] for item in first] == [
+        "covered.current_evidence.v1",
+        "failure_envelope.evidence_decay.v1",
+        "failure_envelope.execution_stress.v1",
+        "regime_slice.mean_reversion_headwind.v1",
+    ]
+    assert all(isinstance(item["component_score_adjustments"], dict) for item in first)
+    assert (
+        resolve_qualification_profile_robustness_slices(comparison_group="trend-following")[-1][
+            "slice_id"
+        ]
+        == "regime_slice.trend_following_headwind.v1"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -275,6 +297,17 @@ def test_score_semantics_governance_doc_mentions_calibrated_threshold_profiles()
     assert "not directly comparable" in content
 
 
+def test_score_semantics_governance_doc_mentions_bounded_robustness_audit() -> None:
+    content = GOVERNANCE_DOC.read_text(encoding="utf-8")
+
+    assert "Qualification-Profile Robustness Audit Boundary" in content
+    assert "stable" in content
+    assert "weak" in content
+    assert "failing" in content
+    assert "covered conditions" in content
+    assert "QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY" in content
+
+
 def test_score_semantics_governance_doc_defines_non_goals() -> None:
     content = GOVERNANCE_DOC.read_text(encoding="utf-8")
 
@@ -316,3 +349,27 @@ def test_signal_quality_contract_doc_mentions_calibrated_threshold_profiles() ->
     assert "threshold profile" in content.casefold()
     assert "comparison_group" in content
     assert "non-comparability" in content.casefold()
+
+
+def test_signal_quality_contract_doc_mentions_bounded_robustness_claim_limits() -> None:
+    content = (REPO_ROOT / "docs" / "governance" / "signal-quality-bounded-contract.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Qualification-Profile Robustness Boundary" in content
+    assert "covered.current_evidence.v1" in content
+    assert "failure_envelope.execution_stress.v1" in content
+    assert "stable" in content
+    assert "weak" in content
+    assert "failing" in content
+    assert "covered conditions" in content
+    assert "trader_validation" in content
+
+
+def test_qualification_profile_robustness_boundary_constant_is_defined() -> None:
+    boundary = QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY.casefold()
+
+    assert isinstance(QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY, str)
+    assert "covered conditions" in boundary
+    assert "weak or failing slices" in boundary
+    assert "paper profitability" in boundary

--- a/tests/test_strategy_readiness_gates_docs.py
+++ b/tests/test_strategy_readiness_gates_docs.py
@@ -54,7 +54,9 @@ def test_strategy_readiness_gates_define_bounded_api_ui_evidence_surface_scope()
     assert "GET /backtest/artifacts/{run_id}/{artifact_name}" in content
     assert "must not collapse these states into a single inferred readiness claim" in content
     assert "no live-trading readiness or authorization claim" in content
+    assert "no paper profitability or edge claim" in content
     assert "no production-readiness claim" in content
+    assert "bounded trader-relevance validation" in content
 
 
 def test_docs_index_references_strategy_readiness_gates_contract() -> None:


### PR DESCRIPTION
## Summary
- Replaced deprecated @app.on_event(startup) / @app.on_event(shutdown) lifecycle registration with FastAPI lifespan handlers in API runtime composition.
- Preserved lifecycle side-effect order exactly:
  - startup: runtime start -> guard activation -> scheduler start
  - shutdown: scheduler stop -> guard deactivation -> runtime stop
- Preserved shutdown exception handling semantics for LifecycleTransitionError (log-and-swallow).
- Added lifecycle regression coverage for:
  - deprecated hook removal (on_startup / on_shutdown empty)
  - deterministic startup/shutdown ordering parity
  - runtime guard toggling
  - scheduler lifecycle wiring and shutdown error handling parity

## Validation
- Ran full repository test suite successfully:
  - C:\repos\Trading-engine\.venv\Scripts\python.exe -m pytest
  - 1140 passed

Closes #1017