### PR TITLE
[DO NOW][RISK-HARDENING] Strengthen bounded trade- and portfolio-level risk evaluation under explicit evidence discipline (#1039)

### DIFF
--- a/docs/architecture/risk/non_live_evaluation_contract.md
+++ b/docs/architecture/risk/non_live_evaluation_contract.md
@@ -87,6 +87,11 @@ Execution adapter propagation:
 - normalizes reason codes to canonical vocabulary
 - enforces deterministic precedence for multi-violation candidates
 - propagates `policy_evidence` into `RiskDecision`
+- evaluates covered trade/symbol/strategy/portfolio/runtime evidence through one
+  deterministic rejection path
+- fails closed when covered required evidence is contradictory or malformed
+- preserves bounded compatibility by mapping legacy reason-only rejects to one
+  deterministic synthetic evidence row when explicit evidence rows are absent
 
 Portfolio producers:
 
@@ -144,6 +149,9 @@ Cross-surface deterministic contract:
 - equivalent bounded non-live input state must emit the same canonical reject
   reason code across risk gate and paper execution worker surfaces.
 - deterministic precedence is mandatory when multiple constraints are violated.
+- contradictory covered evidence for an approved decision is fail-closed.
+- contradictory or malformed covered evidence for a rejected decision is
+  fail-closed.
 - inspection/read surfaces provide best-effort single-field normalization to
   `normalized_reason_code` without multi-reason precedence selection.
 - this contract is technical non-live evidence only and is not live-trading or broker-readiness evidence.

--- a/src/cilly_trading/engine/risk/__init__.py
+++ b/src/cilly_trading/engine/risk/__init__.py
@@ -8,6 +8,7 @@ from .authority import (
 from .gate import (
     RISK_FRAMEWORK_REASON_CODES,
     RiskApprovalMissingError,
+    RiskEvidenceDisciplineError,
     RiskRejectedError,
     ThresholdRiskGate,
     adapt_risk_framework_response_to_risk_decision,
@@ -24,6 +25,7 @@ __all__ = [
     "BOUNDED_RISK_FRAMEWORK_AUTHORITY_ID",
     "RISK_FRAMEWORK_REASON_CODES",
     "RiskApprovalMissingError",
+    "RiskEvidenceDisciplineError",
     "RiskRejectedError",
     "ThresholdRiskGate",
     "adapt_risk_framework_response_to_risk_decision",

--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -21,7 +21,9 @@ from cilly_trading.engine.telemetry.schema import (
     build_telemetry_event,
 )
 from cilly_trading.non_live_evaluation_contract import (
+    NonLiveEvaluationEvidence,
     RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON,
+    normalize_risk_rejection_reason_code,
     resolve_risk_rejection_reason_precedence,
 )
 from cilly_trading.risk_framework.allocation_rules import RiskLimits as FrameworkRiskLimits
@@ -56,6 +58,39 @@ RISK_FRAMEWORK_REASON_CODES: dict[str, str] = {
 _RISK_DECISION_ACCEPTS_POLICY_EVIDENCE = (
     "policy_evidence" in inspect.signature(RiskDecision).parameters
 )
+_COVERED_EVIDENCE_SCOPES: frozenset[str] = frozenset(
+    {
+        "trade",
+        "symbol",
+        "strategy",
+        "portfolio",
+        "runtime",
+    }
+)
+
+_RISK_REASON_TO_EVIDENCE_METADATA: dict[str, tuple[str, str, str]] = {
+    "rejected: kill_switch_enabled": ("boundary", "runtime", "kill_switch_enabled"),
+    "rejected: max_position_size_exceeded": ("cap", "trade", "max_position_size"),
+    "rejected: max_account_exposure_pct_exceeded": (
+        "cap",
+        "portfolio",
+        "max_account_exposure_pct",
+    ),
+    "rejected: max_strategy_exposure_pct_exceeded": (
+        "cap",
+        "strategy",
+        "max_strategy_exposure_pct",
+    ),
+    "rejected: max_symbol_exposure_pct_exceeded": (
+        "cap",
+        "symbol",
+        "max_symbol_exposure_pct",
+    ),
+}
+
+
+class RiskEvidenceDisciplineError(ValueError):
+    """Raised when bounded risk evidence is missing or contradictory."""
 
 
 def _safe_pct(numerator: float, denominator: float) -> float:
@@ -77,6 +112,62 @@ def _extract_policy_evidence(
     if isinstance(evidence, list):
         return tuple(evidence)
     return ()
+
+
+def _read_evidence_field(evidence: object, field_name: str) -> object | None:
+    if isinstance(evidence, Mapping):
+        return evidence.get(field_name)
+    return getattr(evidence, field_name, None)
+
+
+def _collect_covered_rejection_reason_codes(
+    policy_evidence: tuple[Any, ...],
+) -> tuple[str, ...]:
+    rejection_reason_codes: list[str] = []
+    for evidence in policy_evidence:
+        scope = _read_evidence_field(evidence, "scope")
+        if scope not in _COVERED_EVIDENCE_SCOPES:
+            continue
+        decision = _read_evidence_field(evidence, "decision")
+        if decision not in {"approve", "reject"}:
+            raise RiskEvidenceDisciplineError(
+                "covered risk policy evidence must declare decision='approve' or decision='reject'"
+            )
+        reason_code = _read_evidence_field(evidence, "reason_code")
+        if not isinstance(reason_code, str) or not reason_code:
+            raise RiskEvidenceDisciplineError(
+                "covered risk policy evidence must include non-empty reason_code"
+            )
+        if decision == "approve":
+            raise RiskEvidenceDisciplineError(
+                "covered risk policy evidence contradicts rejection discipline: decision='approve'"
+            )
+        normalize_risk_rejection_reason_code(reason_code)
+        rejection_reason_codes.append(reason_code)
+    return tuple(rejection_reason_codes)
+
+
+def _build_synthetic_rejection_evidence(
+    *,
+    reason_code: str,
+    observed_value: float,
+    limit_value: float,
+) -> NonLiveEvaluationEvidence:
+    metadata = _RISK_REASON_TO_EVIDENCE_METADATA.get(reason_code)
+    if metadata is None:
+        raise RiskEvidenceDisciplineError(
+            f"cannot synthesize bounded risk evidence for unsupported reason code: {reason_code}"
+        )
+    semantic, scope, rule_code = metadata
+    return NonLiveEvaluationEvidence(
+        decision="reject",
+        semantic=semantic,  # type: ignore[arg-type]
+        scope=scope,  # type: ignore[arg-type]
+        rule_code=rule_code,
+        reason_code=reason_code,
+        observed_value=observed_value,
+        limit_value=limit_value,
+    )
 
 
 def _build_risk_decision(
@@ -122,17 +213,29 @@ def adapt_risk_framework_response_to_risk_decision(
 
     reason = framework_response.reason
     if reason == "approved: within_risk_limits":
+        if _collect_covered_rejection_reason_codes(policy_evidence):
+            raise RiskEvidenceDisciplineError(
+                "approved risk decision contains covered rejection evidence rows"
+            )
         decision = "APPROVED"
         score = float(framework_response.risk_score)
         max_allowed = float(limits.max_account_exposure_pct)
         decision_reason = RISK_FRAMEWORK_REASON_CODES[reason]
     else:
         decision = "REJECTED"
-        precedence_candidates = [framework_response.reason]
-        precedence_candidates.extend(
-            evidence.reason_code for evidence in policy_evidence
-        )
         try:
+            normalize_risk_rejection_reason_code(reason)
+        except ValueError as exc:
+            raise ValueError(
+                f"unsupported risk-framework reason for execution mapping: {framework_response.reason}"
+            ) from exc
+        evidence_reason_codes = _collect_covered_rejection_reason_codes(policy_evidence)
+        if not evidence_reason_codes:
+            # Compatibility mapping for bounded non-live producers that still emit
+            # reason-only rejects without explicit policy evidence rows.
+            evidence_reason_codes = (reason,)
+        try:
+            precedence_candidates = [reason, *evidence_reason_codes]
             decision_reason = resolve_risk_rejection_reason_precedence(precedence_candidates)
         except ValueError as exc:
             raise ValueError(
@@ -155,6 +258,14 @@ def adapt_risk_framework_response_to_risk_decision(
             max_allowed = float(limits.max_symbol_exposure_pct)
         else:  # pragma: no cover - guarded by reason map above
             raise ValueError(f"unsupported risk-framework reason: {reason}")
+        if not _collect_covered_rejection_reason_codes(policy_evidence):
+            policy_evidence = (
+                _build_synthetic_rejection_evidence(
+                    reason_code=reason,
+                    observed_value=score,
+                    limit_value=max_allowed,
+                ),
+            )
 
     if framework_response.approved != (decision == "APPROVED"):
         raise ValueError("risk-framework approval flag conflicts with mapped execution decision")
@@ -386,6 +497,7 @@ def _emit_guard_trigger_log(*, guard_type: str, payload: Mapping[str, Any]) -> N
 
 __all__ = [
     "RISK_FRAMEWORK_REASON_CODES",
+    "RiskEvidenceDisciplineError",
     "RiskApprovalMissingError",
     "RiskRejectedError",
     "ThresholdRiskGate",

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -9,12 +9,14 @@ from risk.contracts import RiskEvaluationRequest
 
 from cilly_trading.engine.risk import (
     RISK_FRAMEWORK_REASON_CODES,
+    RiskEvidenceDisciplineError,
     ThresholdRiskGate,
     adapt_risk_framework_response_to_risk_decision,
     evaluate_risk_framework_execution_decision,
 )
 from cilly_trading.non_live_evaluation_contract import (
     CANONICAL_RISK_REJECTION_REASON_CODES,
+    NonLiveEvaluationEvidence,
     normalize_risk_rejection_reason_code,
     resolve_risk_rejection_reason_precedence,
 )
@@ -31,6 +33,15 @@ class _LegacyRuntimeRiskResponse:
     reason: str
     adjusted_position_size: float
     risk_score: float
+
+
+@dataclass(frozen=True)
+class _RuntimeRiskResponseWithEvidence:
+    approved: bool
+    reason: str
+    adjusted_position_size: float
+    risk_score: float
+    policy_evidence: tuple[object, ...]
 
 
 def _policy_evidence_or_empty(decision: object) -> tuple[object, ...]:
@@ -241,7 +252,152 @@ def test_adapter_handles_runtime_response_without_policy_evidence() -> None:
 
     assert decision.decision == "REJECTED"
     assert decision.reason == "rejected:risk_framework_max_account_exposure_pct_exceeded"
-    assert _policy_evidence_or_empty(decision) == ()
+    if _decision_has_policy_evidence(decision):
+        policy_evidence = _policy_evidence_or_empty(decision)
+        assert len(policy_evidence) == 1
+        assert policy_evidence[0].reason_code == "rejected: max_account_exposure_pct_exceeded"
+        assert policy_evidence[0].scope == "portfolio"
+    else:
+        assert _policy_evidence_or_empty(decision) == ()
+
+
+def test_adapter_rejects_contradictory_evidence_when_response_is_approved() -> None:
+    with pytest.raises(
+        RiskEvidenceDisciplineError,
+        match="approved risk decision contains covered rejection evidence rows",
+    ):
+        adapt_risk_framework_response_to_risk_decision(
+            framework_request=_framework_request(),
+            framework_response=_RuntimeRiskResponseWithEvidence(
+                approved=True,
+                reason="approved: within_risk_limits",
+                adjusted_position_size=400.0,
+                risk_score=0.6,
+                policy_evidence=(
+                    NonLiveEvaluationEvidence(
+                        decision="reject",
+                        semantic="cap",
+                        scope="trade",
+                        rule_code="max_position_size",
+                        reason_code="rejected: max_position_size_exceeded",
+                        observed_value=600.0,
+                        limit_value=500.0,
+                    ),
+                ),
+            ),
+            limits=_framework_limits(),
+            strategy_exposure=200.0,
+            symbol_exposure=100.0,
+            rule_version="adapter-v1",
+            evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_adapter_rejects_contradictory_approve_evidence_when_response_is_rejected() -> None:
+    with pytest.raises(
+        RiskEvidenceDisciplineError,
+        match="decision='approve'",
+    ):
+        adapt_risk_framework_response_to_risk_decision(
+            framework_request=_framework_request(),
+            framework_response=_RuntimeRiskResponseWithEvidence(
+                approved=False,
+                reason="rejected: max_position_size_exceeded",
+                adjusted_position_size=500.0,
+                risk_score=0.8,
+                policy_evidence=(
+                    {
+                        "decision": "approve",
+                        "scope": "trade",
+                        "reason_code": "rejected: max_position_size_exceeded",
+                    },
+                ),
+            ),
+            limits=_framework_limits(),
+            strategy_exposure=200.0,
+            symbol_exposure=100.0,
+            rule_version="adapter-v1",
+            evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_adapter_fails_closed_when_covered_evidence_reason_code_is_missing() -> None:
+    with pytest.raises(
+        RiskEvidenceDisciplineError,
+        match="must include non-empty reason_code",
+    ):
+        adapt_risk_framework_response_to_risk_decision(
+            framework_request=_framework_request(),
+            framework_response=_RuntimeRiskResponseWithEvidence(
+                approved=False,
+                reason="rejected: max_position_size_exceeded",
+                adjusted_position_size=500.0,
+                risk_score=0.8,
+                policy_evidence=(
+                    {
+                        "decision": "reject",
+                        "scope": "trade",
+                        "reason_code": "",
+                    },
+                ),
+            ),
+            limits=_framework_limits(),
+            strategy_exposure=200.0,
+            symbol_exposure=100.0,
+            rule_version="adapter-v1",
+            evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_adapter_precedence_is_deterministic_for_multi_violation_evidence_rows() -> None:
+    framework_response = _RuntimeRiskResponseWithEvidence(
+        approved=False,
+        reason="rejected: max_symbol_exposure_pct_exceeded",
+        adjusted_position_size=200.0,
+        risk_score=0.7,
+        policy_evidence=(
+            NonLiveEvaluationEvidence(
+                decision="reject",
+                semantic="cap",
+                scope="portfolio",
+                rule_code="max_account_exposure_pct",
+                reason_code="rejected: max_account_exposure_pct_exceeded",
+                observed_value=0.91,
+                limit_value=0.80,
+            ),
+            NonLiveEvaluationEvidence(
+                decision="reject",
+                semantic="cap",
+                scope="trade",
+                rule_code="max_position_size",
+                reason_code="rejected: max_position_size_exceeded",
+                observed_value=900.0,
+                limit_value=500.0,
+            ),
+        ),
+    )
+
+    first = adapt_risk_framework_response_to_risk_decision(
+        framework_request=_framework_request(),
+        framework_response=framework_response,
+        limits=_framework_limits(),
+        strategy_exposure=200.0,
+        symbol_exposure=100.0,
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    second = adapt_risk_framework_response_to_risk_decision(
+        framework_request=_framework_request(),
+        framework_response=framework_response,
+        limits=_framework_limits(),
+        strategy_exposure=200.0,
+        symbol_exposure=100.0,
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert first == second
+    assert first.reason == "rejected:risk_framework_max_position_size_exceeded"
 
 
 def test_canonical_rejection_reason_vocabulary_is_exposed_in_gate_map() -> None:

--- a/tests/test_non_live_evaluation_contract_docs.py
+++ b/tests/test_non_live_evaluation_contract_docs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from cilly_trading.non_live_evaluation_contract import (
     CANONICAL_RISK_REJECTION_REASON_CODES,
     RISK_REJECTION_REASON_PRECEDENCE,
@@ -15,6 +17,10 @@ from tests.utils.consumer_contract_helpers import (
 CONTRACT_DOC = "docs/architecture/risk/non_live_evaluation_contract.md"
 GOVERNANCE_DOC = "docs/governance/qualification-claim-evidence-discipline.md"
 PHASE44_DOC = "docs/operations/runtime/phase-44-paper-operator-workflow.md"
+
+
+def _read(path: Path) -> str:
+    return read_repo_text(path.as_posix())
 
 
 def _extract_bullet_codes_after_heading(content: str, heading: str) -> list[str]:
@@ -149,7 +155,7 @@ def test_non_live_contract_doc_explicitly_locks_cross_surface_determinism_bounda
 
 
 def test_non_live_contract_doc_locks_fail_closed_evidence_discipline_and_legacy_mapping() -> None:
-    content = _read(CONTRACT_DOC)
+    content = _read(Path(CONTRACT_DOC))
 
     assert "deterministic rejection path" in content
     assert "fails closed when covered required evidence is contradictory or malformed" in content

--- a/tests/test_non_live_evaluation_contract_docs.py
+++ b/tests/test_non_live_evaluation_contract_docs.py
@@ -148,6 +148,17 @@ def test_non_live_contract_doc_explicitly_locks_cross_surface_determinism_bounda
     )
 
 
+def test_non_live_contract_doc_locks_fail_closed_evidence_discipline_and_legacy_mapping() -> None:
+    content = _read(CONTRACT_DOC)
+
+    assert "deterministic rejection path" in content
+    assert "fails closed when covered required evidence is contradictory or malformed" in content
+    assert "legacy reason-only rejects" in content
+    assert "deterministic synthetic evidence row" in content
+    assert "technical non-live evidence only" in content
+    assert "not live-trading or broker-readiness evidence" in content
+
+
 def test_risk_and_portfolio_docs_reference_canonical_non_live_contract() -> None:
     risk_framework = read_repo_text("docs/architecture/risk/risk_framework.md")
     portfolio_framework = read_repo_text("docs/architecture/risk/portfolio_framework.md")


### PR DESCRIPTION
﻿Closes #1039

## Summary
This PR hardens bounded non-live risk evaluation evidence handling under one deterministic adapter path, with explicit fail-closed behavior for contradictory or malformed covered evidence and deterministic compatibility mapping for legacy reason-only reject responses.

## What Changed
- Added covered evidence-discipline enforcement in engine/risk/gate.py
- Exported RiskEvidenceDisciplineError via engine/risk/__init__.py
- Added deterministic regression tests in tests/cilly_trading/engine/test_risk_gate.py
- Updated docs/architecture/risk/non_live_evaluation_contract.md
- Added doc contract coverage in tests/test_non_live_evaluation_contract_docs.py

## Acceptance Criteria Trace
- One deterministic covered evidence path: implemented and tested.
- Missing or contradictory evidence fail-closed: implemented and tested.
- Stable reason-code semantics for identical inputs: covered by regression tests.
- Existing bounded non-live surfaces compatible or mapped: documented and tested.
- Non-live boundaries preserved: documented and tested.

## Validation
- .\.venv\Scripts\python.exe -m pytest
- 1152 passed
