### PR TITLE
Reconcile onboarding and snapshot docs with bounded repo reality

### DIFF
--- a/docs/getting-started/repo-snapshot.md
+++ b/docs/getting-started/repo-snapshot.md
@@ -1,59 +1,129 @@
-# Repository Snapshot – Neutral Analysis for Onboarding
+# Repository Snapshot - Neutral Analysis for Onboarding
 
 ## Purpose of the Repository
 
-This repository describes a trading analysis engine intended to support a website-based trading analysis tool with deterministic strategy outputs, persistence, and an API layer. The project targets market data ingestion, indicator calculation, strategy-based signal generation, and storage of results for retrieval through an API. The scope explicitly excludes live trading, broker integrations, order execution, portfolio management, backtesting frameworks, and AI-based signal generation in the current MVP definition. The deterministic smoke-run is implemented and documented in the runbook/spec.
+This repository describes a bounded, non-live trading analysis engine intended
+to support deterministic strategy analysis, snapshot-first data ingestion,
+persistence, bounded evidence generation, and API inspection surfaces. Current
+materials cover market data ingestion, indicator calculation, strategy-based
+signal generation, deterministic smoke-run behavior, bounded backtest evidence,
+portfolio/paper inspection surfaces, and bounded paper-runtime operations.
+
+The repository remains explicitly non-live. Current documentation and runtime
+boundaries do not authorize live trading, broker integrations, real-capital
+order execution, production-readiness claims, trader-validation claims, or
+AI-based signal generation.
 
 ## High-Level Project State
 
-Current materials include detailed scope, architecture, workflow, and deterministic contracts captured in markdown files. The documentation defines what the MVP should cover and what it excludes, while the deterministic smoke-run is defined and implemented. An engine-level deterministic paper-trading simulator artifact is implemented and test-verified. This simulator does not provide live trading, broker integration, or a production operator runtime entrypoint.
+Current materials include detailed scope, architecture, workflow, runtime, and
+deterministic contracts captured in markdown files. The documentation defines
+bounded implementation evidence and the limits of that evidence. Where evidence
+is partial, the wording remains conservative and defers phase status authority
+to `ROADMAP_MASTER.md`.
+
+Verified current surfaces include:
+
+- deterministic smoke-run execution and documentation
+- snapshot-first analysis through local API paths
+- bounded backtest evidence contracts and tests
+- bounded portfolio and paper inspection read surfaces
+- bounded daily paper-runtime workflow and one-command runner documentation
+- roadmap traceability and documentation-alignment governance for Phase 25 and
+  Phase 26
+
+These surfaces do not imply live-trading readiness, broker readiness, production
+readiness, or trader validation.
 
 ## Repository Structure Overview
 
 Top-level directories include:
 
-- `docs/`: Documentation for scope, architecture, governance, runbooks, and specifications (including the smoke-run spec and MVP documents).
-- `src/`: Core source code directory (implementation details are not described here).
-- `tests/`: Test suite directory.
+- `docs/`: Documentation for scope, architecture, governance, operations,
+  testing, runtime contracts, and specifications.
+- `src/`: Core source code directory. Implementation details are not described
+  in this snapshot.
+- `tests/`: Test suite directory, including documentation and bounded contract
+  tests.
 - `fixtures/`: Deterministic fixture and sample snapshot data.
-- `scripts/`: Utility or helper scripts.
+- `scripts/`: Bounded utility and operator helper scripts.
 
-Documentation, governance, and specifications primarily live in `docs/`, including the runbook, governance rules, MVP scope, and deterministic smoke-run specification.
+Documentation, governance, and specifications primarily live in `docs/`,
+including runbooks, governance rules, MVP scope, runtime contracts, testing
+contracts, and deterministic smoke-run specifications.
 
 ## Governance & Workflow Model
 
-Work is structured around a single active Issue with an explicit execution workflow. The runbook defines a staged process: define the issue and acceptance criteria, execute implementation, verify with tests, pass a review gate, and close the issue with a PR linked to the issue. Codex B implements the active Issue, while Codex A provides a review gate decision after tests and before merge. Test-gated execution mode defines non-negotiable requirements such as green CI, issue linkage in the PR, and Codex A review authority, with stop conditions and merge authority described in governance documents.
+Work is structured around a single active issue with explicit acceptance
+criteria, allowed files, and test expectations. The runbook defines a staged
+process: define the issue and acceptance criteria, execute implementation,
+verify with tests, pass a review gate, and close the issue with a PR linked to
+the issue. Codex B implements the active issue, while Codex A provides a review
+gate decision after tests and before merge.
+
+Roadmap authority is split conservatively:
+
+- `ROADMAP_MASTER.md` governs canonical phase maturity/status labels.
+- `docs/architecture/roadmap/execution_roadmap.md` governs audited phase
+  meaning and taxonomy.
+- Secondary documents are evidence-bearing or explanatory unless their status
+  claims are reflected in the authoritative roadmap surfaces.
 
 ## Key Documents
 
-- `docs/operations/runbook.md`: Working SOP that defines the end-to-end workflow, review gate, Definition of Done, and the local deterministic smoke-run execution steps. It also documents that an engine-level deterministic paper-trading simulator artifact exists without introducing live trading, broker integrations, or a production operator runtime entrypoint.
-- `docs/testing/smoke-run.md`: Deterministic smoke-run specification with exact fixtures, output, and exit codes.
-- `docs/architecture/mvp-spec.md`: Product scope and exclusions for MVP v1, including explicit exclusions such as live trading, broker integrations, backtesting, and AI-based signal generation.
-- `docs/architecture/mvp-v1.md`: Detailed MVP v1 system overview and component breakdown (engine, persistence, API, and trading desk) with scope and non-goals.
-- `docs/getting-started/local-run.md`: Local development steps and API usage expectations, including the note that there is no CLI entrypoint and that the API is used directly.
-- `docs/governance/*`: Governance documents for execution modes, test-gated execution requirements, and stop conditions/merge authority.
+- `docs/operations/runbook.md`: Working SOP that defines the end-to-end
+  workflow, review gate, Definition of Done, and deterministic smoke-run
+  execution steps. It also points bounded paper-runtime operation to the
+  dedicated OPS-P63 and OPS-P64 runtime documents.
+- `docs/testing/smoke-run.md`: Deterministic smoke-run specification with exact
+  fixtures, output, and exit codes.
+- `docs/architecture/mvp-spec.md`: MVP scope and exclusions. Treat this as a
+  scoped MVP document rather than a blanket denial of later bounded evidence.
+- `docs/architecture/mvp-v1.md`: MVP v1 system overview and component
+  breakdown with scope and non-goals.
+- `docs/getting-started/local-run.md`: Canonical local development startup and
+  API usage path.
+- `docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md`: Daily
+  bounded paper-runtime workflow.
+- `docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md`:
+  One-command bounded daily paper-runtime runner contract.
+- `docs/architecture/governance/*` and `docs/governance/*`: Governance
+  documents for execution modes, claim boundaries, readiness separation, and
+  review authority.
 
 ## Entry Points for a New Developer
 
 A new developer can start with:
 
-1. `README.md` for the high-level orientation and pointers to core documents.
-2. `docs/architecture/mvp-spec.md` and `docs/architecture/mvp-v1.md` for scope, architecture, and MVP boundaries.
-3. `docs/operations/runbook.md` and `docs/governance/*` for workflow, review gates, and test/merge rules.
-4. `docs/getting-started/local-run.md` for how the API is invoked in local development.
-5. `docs/testing/smoke-run.md` to understand the deterministic smoke-run contract and its implementation details.
+1. `README.md` for high-level orientation and pointers to core documents.
+2. `docs/getting-started/getting-started.md` for local setup.
+3. `docs/getting-started/local-run.md` for local API startup and snapshot-first
+   analysis flow.
+4. `docs/testing/index.md` and `docs/testing/smoke-run.md` for repository tests
+   and deterministic smoke-run behavior.
+5. `docs/operations/runbook.md` for issue workflow, review gates, and Definition
+   of Done.
+6. `docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md` and
+   `docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md`
+   for bounded paper-runtime operation.
+7. `ROADMAP_MASTER.md` for canonical phase maturity/status labels.
 
-They should not expect a production operator CLI/entrypoint for paper-trading simulation, and they should not expect a live trading workflow. The deterministic paper-trading simulator exists as an engine-level, test-verified artifact only, with no broker connectivity or real-capital execution path. There is no CLI entrypoint documented; API usage via `uvicorn` is the described path, and the smoke-run is executed via the documented local command. The documentation provides the scope and operational workflow; implementation specifics are in `src/` and `api/` and are outside the scope of this snapshot.
+They should not expect a live trading workflow, broker connectivity,
+real-capital order execution, production-readiness guarantee, or trader
+validation evidence from the current repository. Bounded paper-runtime commands
+and read surfaces exist for local/staging evidence workflows only.
 
-## Known Gaps / Non-Implemented Areas
+## Known Gaps / Explicit Boundaries
 
-The following components are explicitly absent or described as not implemented in the current repository state:
+The following remain explicit boundaries in the current repository state:
 
-- A production operator CLI/runtime entrypoint for paper-trading simulation (the engine-level deterministic simulator artifact exists and is test-verified).
-- Live trading, broker integrations, or order execution.
-- Backtesting frameworks.
-- AI-based signal generation or automated decision-making.
-- A CLI entrypoint for running the engine; API-only invocation is documented.
+- No live trading workflow is authorized.
+- No broker integration or real-capital execution path is authorized.
+- Bounded paper-runtime evidence does not imply production readiness,
+  operational readiness, trader validation, or profitability.
+- Backtest and portfolio evidence remains bounded and must not be read as
+  broker, live-trading, or production-readiness approval.
+- AI-based signal generation or automated discretionary decision-making is not
+  part of the current bounded implementation claim.
 
-Deterministic smoke-run execution is implemented and documented in the runbook/spec.
-These are documented as out of scope or not yet implemented, and are part of the current state rather than defects.
+These boundaries are part of the current governed state rather than defects.

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -138,10 +138,28 @@ python -m pytest
 - A red check blocks merge until tests pass.
 
 ### Run Paper Trading (Simulation)
-No production operator CLI/runtime entrypoint is documented for paper-trading simulation in this runbook. The repository contains an engine-level deterministic simulator module (`src/cilly_trading/engine/paper_trading.py`) that is test-verified, but no owner-facing run command is defined here. It does not provide live trading or broker integration, and no real orders are used.
+Bounded paper-runtime operation is documented in dedicated runtime contracts,
+not inline in this SOP. The current owner-facing bounded command path is the
+OPS-P64 daily runner, which orchestrates the OPS-P63 workflow through existing
+snapshot ingestion, analysis, bounded paper execution, reconciliation, and
+evidence-capture steps.
+
+Local OPS-P64 invocation:
+
+```bash
+python scripts/run_daily_bounded_paper_runtime.py \
+  --db-path cilly_trading.db \
+  --base-url http://127.0.0.1:18000
+```
+
+This command remains bounded and non-live. It does not provide live trading,
+broker integration, real-capital execution, production-readiness evidence,
+trader-validation evidence, or profitability claims.
 
 Reference:
 - [paper_trading.md](paper-trading.md)
+- [runtime/p63-daily-bounded-paper-runtime-workflow.md](runtime/p63-daily-bounded-paper-runtime-workflow.md)
+- [runtime/p64-one-command-bounded-daily-paper-runtime-runner.md](runtime/p64-one-command-bounded-daily-paper-runtime-runner.md)
 
 **Datum:** 2026-03-29
 **Thema:** Bounded Staging Prep – Host vorbereitet

--- a/tests/test_onboarding_snapshot_docs.py
+++ b/tests/test_onboarding_snapshot_docs.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from tests.utils.consumer_contract_helpers import (
+    assert_contains_all,
+    read_repo_text,
+)
+
+
+REPO_SNAPSHOT_DOC = "docs/getting-started/repo-snapshot.md"
+RUNBOOK_DOC = "docs/operations/runbook.md"
+
+
+def test_repo_snapshot_reflects_current_bounded_evidence_without_readiness_inference() -> None:
+    content = read_repo_text(REPO_SNAPSHOT_DOC)
+
+    assert_contains_all(
+        content,
+        "bounded backtest evidence contracts and tests",
+        "bounded portfolio and paper inspection read surfaces",
+        "bounded daily paper-runtime workflow and one-command runner documentation",
+        "Phase 25",
+        "Phase 26",
+        "These surfaces do not imply live-trading readiness, broker readiness, production",
+    )
+
+
+def test_repo_snapshot_removes_stale_absence_claims_for_bounded_surfaces() -> None:
+    content = read_repo_text(REPO_SNAPSHOT_DOC)
+
+    stale_claims = [
+        "Backtesting frameworks.",
+        "Portfolio management.",
+        "There is no CLI entrypoint documented",
+        "no owner-facing run command",
+    ]
+    for stale_claim in stale_claims:
+        assert stale_claim not in content
+
+
+def test_runbook_points_paper_runtime_to_bounded_ops_p63_p64_contracts() -> None:
+    content = read_repo_text(RUNBOOK_DOC)
+
+    assert_contains_all(
+        content,
+        "OPS-P64 daily runner",
+        "scripts/run_daily_bounded_paper_runtime.py",
+        "runtime/p63-daily-bounded-paper-runtime-workflow.md",
+        "runtime/p64-one-command-bounded-daily-paper-runtime-runner.md",
+        "This command remains bounded and non-live.",
+    )
+    assert "no owner-facing run command is defined here" not in content


### PR DESCRIPTION
﻿## Summary
- Reconciles repository snapshot onboarding docs with current bounded implementation evidence.
- Updates the operations runbook paper-runtime section to point to OPS-P63/OPS-P64 bounded runtime contracts.
- Adds regression coverage for stale absence/readiness claims in onboarding snapshot docs.

## Tests
- python -m pytest -q

Closes #1042
