### PR TITLE
Add bounded non-live risk-budget evidence

### DIFF
--- a/docs/architecture/risk/bounded_risk_framework_authority_contract.md
+++ b/docs/architecture/risk/bounded_risk_framework_authority_contract.md
@@ -78,10 +78,17 @@ Approved outcome reason code:
 Canonical rejection reason codes (precedence order):
 
 1. `rejected:risk_framework_kill_switch_enabled`
-2. `rejected:risk_framework_max_position_size_exceeded`
-3. `rejected:risk_framework_max_account_exposure_pct_exceeded`
-4. `rejected:risk_framework_max_strategy_exposure_pct_exceeded`
-5. `rejected:risk_framework_max_symbol_exposure_pct_exceeded`
+2. `rejected:risk_framework_stop_loss_evidence_missing`
+3. `rejected:risk_framework_stop_loss_evidence_invalid`
+4. `rejected:risk_framework_position_size_exceeds_stop_loss_budget`
+5. `rejected:risk_framework_max_trade_risk_exceeded`
+6. `rejected:risk_framework_strategy_risk_budget_exceeded`
+7. `rejected:risk_framework_symbol_risk_budget_exceeded`
+8. `rejected:risk_framework_portfolio_risk_budget_exceeded`
+9. `rejected:risk_framework_max_position_size_exceeded`
+10. `rejected:risk_framework_max_account_exposure_pct_exceeded`
+11. `rejected:risk_framework_max_strategy_exposure_pct_exceeded`
+12. `rejected:risk_framework_max_symbol_exposure_pct_exceeded`
 
 The canonical guard-type vocabulary for risk-gate guard triggers is:
 
@@ -106,8 +113,10 @@ properties for risk-boundary evaluation:
   the canonical reason code is selected by the precedence order above
 - timezone-aware UTC `evaluated_at` is required; naive timestamps are
   rejected
-- approved outcomes carry an empty `policy_evidence` tuple
-- rejected outcomes carry exactly one canonical cap/boundary evidence row
+- exposure-only approved outcomes carry an empty `policy_evidence` tuple
+- bounded risk-budget approved outcomes carry deterministic trade, strategy,
+  symbol, and portfolio evidence rows
+- rejected outcomes carry canonical cap/boundary evidence rows
 
 Identical covered inputs are defined as the full tuple of:
 
@@ -136,6 +145,10 @@ required bounded evidence is incomplete or contradictory:
 - non-finite or unbounded threshold / notional inputs at the threshold gate
   -> raise `ValueError`
 - naive (non-UTC, non-timezone-aware) `evaluated_at` -> raise `ValueError`
+- missing stop-loss evidence when bounded risk evidence is required ->
+  deterministic rejection
+- contradictory stop-loss evidence when bounded risk evidence is required ->
+  deterministic rejection
 
 Fail-closed means that absence, ambiguity, or contradiction of bounded
 evidence never silently degrades to an APPROVED execution decision.

--- a/docs/architecture/risk/contract.md
+++ b/docs/architecture/risk/contract.md
@@ -22,6 +22,12 @@ Frozen dataclass fields:
 - `proposed_position_size: float`
 - `account_equity: float`
 - `current_exposure: float`
+- `entry_price: Optional[float] = None`
+- `stop_loss_price: Optional[float] = None`
+- `strategy_risk_used: float = 0.0`
+- `symbol_risk_used: float = 0.0`
+- `portfolio_risk_used: float = 0.0`
+- `require_bounded_risk_evidence: bool = False`
 
 ### `RiskEvaluationResponse`
 Frozen dataclass fields:
@@ -29,6 +35,13 @@ Frozen dataclass fields:
 - `reason: str`
 - `adjusted_position_size: Optional[float]`
 - `risk_score: float`
+- `policy_evidence: tuple[NonLiveEvaluationEvidence, ...] = ()`
+
+The optional bounded-risk request fields support deterministic stop-loss,
+position-sizing, trade-risk, strategy-risk, symbol-risk, and portfolio-risk
+evidence for non-live evaluation only. Missing or contradictory required
+bounded evidence fails closed. These fields do not introduce live trading,
+broker execution, trader-validation, or operational-readiness claims.
 
 ### `RiskEvaluator` (optional protocol)
 Method signature:
@@ -38,3 +51,6 @@ Method signature:
 - Policy/risk business logic
 - Runtime orchestration
 - Execution integration
+- Live trading
+- Broker integration
+- Trader validation

--- a/docs/architecture/risk/non_live_evaluation_contract.md
+++ b/docs/architecture/risk/non_live_evaluation_contract.md
@@ -56,6 +56,13 @@ Mandatory fields:
 Canonical risk rejection reason-code vocabulary (normalized):
 
 - `rejected:risk_framework_kill_switch_enabled`
+- `rejected:risk_framework_stop_loss_evidence_missing`
+- `rejected:risk_framework_stop_loss_evidence_invalid`
+- `rejected:risk_framework_position_size_exceeds_stop_loss_budget`
+- `rejected:risk_framework_max_trade_risk_exceeded`
+- `rejected:risk_framework_strategy_risk_budget_exceeded`
+- `rejected:risk_framework_symbol_risk_budget_exceeded`
+- `rejected:risk_framework_portfolio_risk_budget_exceeded`
 - `rejected:risk_framework_max_position_size_exceeded`
 - `rejected:risk_framework_max_account_exposure_pct_exceeded`
 - `rejected:risk_framework_max_strategy_exposure_pct_exceeded`
@@ -66,8 +73,10 @@ must be normalized to the canonical vocabulary above before cross-surface
 inspection/read comparison.
 
 For issue #993 producer paths, evidence rows are emitted only when a cap or
-boundary is violated. Approved outcomes remain deterministic and carry an empty
-evidence tuple.
+boundary is violated. For issue #1047 bounded risk-budget paths, approved
+outcomes emit deterministic bounded evidence rows for stop-loss position
+sizing, trade risk, strategy risk, symbol risk, and portfolio risk when bounded
+risk evidence is required.
 
 ## Runtime and Portfolio Producers
 
@@ -78,8 +87,11 @@ Risk producer:
 
 Approval discipline:
 
-- approved risk outcomes (`approved: within_risk_limits`) emit no evidence rows
-- reject outcomes emit one canonical reject/cap/boundary evidence row
+- exposure-only approved risk outcomes (`approved: within_risk_limits`) emit no
+  evidence rows
+- bounded risk-budget approved outcomes emit deterministic approve evidence
+  rows for trade, strategy, symbol, and portfolio risk scope
+- reject outcomes emit canonical reject/cap/boundary evidence rows
 
 Execution adapter propagation:
 
@@ -112,18 +124,31 @@ Portfolio discipline:
 Deterministic ordering for per-request risk evaluation:
 
 1. runtime boundary (`kill_switch_enabled`)
-2. trade cap (`max_position_size`)
-3. portfolio cap (`max_account_exposure_pct`)
-4. strategy cap (`max_strategy_exposure_pct`)
-5. symbol cap (`max_symbol_exposure_pct`)
+2. stop-loss evidence missing or invalid
+3. bounded stop-loss position sizing
+4. per-trade stop-loss risk budget
+5. strategy risk budget
+6. symbol risk budget
+7. portfolio risk budget
+8. trade cap (`max_position_size`)
+9. portfolio cap (`max_account_exposure_pct`)
+10. strategy cap (`max_strategy_exposure_pct`)
+11. symbol cap (`max_symbol_exposure_pct`)
 
 Normalized precedence order (canonical reason codes):
 
-1. `rejected:risk_framework_kill_switch_enabled`
-2. `rejected:risk_framework_max_position_size_exceeded`
-3. `rejected:risk_framework_max_account_exposure_pct_exceeded`
-4. `rejected:risk_framework_max_strategy_exposure_pct_exceeded`
-5. `rejected:risk_framework_max_symbol_exposure_pct_exceeded`
+- `rejected:risk_framework_kill_switch_enabled`
+- `rejected:risk_framework_stop_loss_evidence_missing`
+- `rejected:risk_framework_stop_loss_evidence_invalid`
+- `rejected:risk_framework_position_size_exceeds_stop_loss_budget`
+- `rejected:risk_framework_max_trade_risk_exceeded`
+- `rejected:risk_framework_strategy_risk_budget_exceeded`
+- `rejected:risk_framework_symbol_risk_budget_exceeded`
+- `rejected:risk_framework_portfolio_risk_budget_exceeded`
+- `rejected:risk_framework_max_position_size_exceeded`
+- `rejected:risk_framework_max_account_exposure_pct_exceeded`
+- `rejected:risk_framework_max_strategy_exposure_pct_exceeded`
+- `rejected:risk_framework_max_symbol_exposure_pct_exceeded`
 
 Deterministic ordering for portfolio decision pipeline:
 

--- a/docs/architecture/risk/risk_framework.md
+++ b/docs/architecture/risk/risk_framework.md
@@ -89,8 +89,10 @@ The canonical cross-framework contract is:
 Evidence discipline for this bounded contract:
 
 - risk evaluator outcomes are `approved` or `rejected`
-- evidence rows are emitted only when a cap/boundary is violated (`rejected`)
-- approved outcomes emit an empty evidence tuple
+- exposure-only approved outcomes emit an empty evidence tuple
+- bounded risk-budget approved outcomes emit deterministic stop-loss
+  position-sizing, trade, strategy, symbol, and portfolio evidence rows
+- rejected outcomes emit canonical cap/boundary evidence rows
 
 ## 8.2) Bounded Risk-Framework Authority Contract
 This framework is governed by one canonical bounded risk-framework authority

--- a/docs/getting-started/repo-snapshot.md
+++ b/docs/getting-started/repo-snapshot.md
@@ -1,59 +1,129 @@
-# Repository Snapshot – Neutral Analysis for Onboarding
+# Repository Snapshot - Neutral Analysis for Onboarding
 
 ## Purpose of the Repository
 
-This repository describes a trading analysis engine intended to support a website-based trading analysis tool with deterministic strategy outputs, persistence, and an API layer. The project targets market data ingestion, indicator calculation, strategy-based signal generation, and storage of results for retrieval through an API. The scope explicitly excludes live trading, broker integrations, order execution, portfolio management, backtesting frameworks, and AI-based signal generation in the current MVP definition. The deterministic smoke-run is implemented and documented in the runbook/spec.
+This repository describes a bounded, non-live trading analysis engine intended
+to support deterministic strategy analysis, snapshot-first data ingestion,
+persistence, bounded evidence generation, and API inspection surfaces. Current
+materials cover market data ingestion, indicator calculation, strategy-based
+signal generation, deterministic smoke-run behavior, bounded backtest evidence,
+portfolio/paper inspection surfaces, and bounded paper-runtime operations.
+
+The repository remains explicitly non-live. Current documentation and runtime
+boundaries do not authorize live trading, broker integrations, real-capital
+order execution, production-readiness claims, trader-validation claims, or
+AI-based signal generation.
 
 ## High-Level Project State
 
-Current materials include detailed scope, architecture, workflow, and deterministic contracts captured in markdown files. The documentation defines what the MVP should cover and what it excludes, while the deterministic smoke-run is defined and implemented. An engine-level deterministic paper-trading simulator artifact is implemented and test-verified. This simulator does not provide live trading, broker integration, or a production operator runtime entrypoint.
+Current materials include detailed scope, architecture, workflow, runtime, and
+deterministic contracts captured in markdown files. The documentation defines
+bounded implementation evidence and the limits of that evidence. Where evidence
+is partial, the wording remains conservative and defers phase status authority
+to `ROADMAP_MASTER.md`.
+
+Verified current surfaces include:
+
+- deterministic smoke-run execution and documentation
+- snapshot-first analysis through local API paths
+- bounded backtest evidence contracts and tests
+- bounded portfolio and paper inspection read surfaces
+- bounded daily paper-runtime workflow and one-command runner documentation
+- roadmap traceability and documentation-alignment governance for Phase 25 and
+  Phase 26
+
+These surfaces do not imply live-trading readiness, broker readiness, production
+readiness, or trader validation.
 
 ## Repository Structure Overview
 
 Top-level directories include:
 
-- `docs/`: Documentation for scope, architecture, governance, runbooks, and specifications (including the smoke-run spec and MVP documents).
-- `src/`: Core source code directory (implementation details are not described here).
-- `tests/`: Test suite directory.
+- `docs/`: Documentation for scope, architecture, governance, operations,
+  testing, runtime contracts, and specifications.
+- `src/`: Core source code directory. Implementation details are not described
+  in this snapshot.
+- `tests/`: Test suite directory, including documentation and bounded contract
+  tests.
 - `fixtures/`: Deterministic fixture and sample snapshot data.
-- `scripts/`: Utility or helper scripts.
+- `scripts/`: Bounded utility and operator helper scripts.
 
-Documentation, governance, and specifications primarily live in `docs/`, including the runbook, governance rules, MVP scope, and deterministic smoke-run specification.
+Documentation, governance, and specifications primarily live in `docs/`,
+including runbooks, governance rules, MVP scope, runtime contracts, testing
+contracts, and deterministic smoke-run specifications.
 
 ## Governance & Workflow Model
 
-Work is structured around a single active Issue with an explicit execution workflow. The runbook defines a staged process: define the issue and acceptance criteria, execute implementation, verify with tests, pass a review gate, and close the issue with a PR linked to the issue. Codex B implements the active Issue, while Codex A provides a review gate decision after tests and before merge. Test-gated execution mode defines non-negotiable requirements such as green CI, issue linkage in the PR, and Codex A review authority, with stop conditions and merge authority described in governance documents.
+Work is structured around a single active issue with explicit acceptance
+criteria, allowed files, and test expectations. The runbook defines a staged
+process: define the issue and acceptance criteria, execute implementation,
+verify with tests, pass a review gate, and close the issue with a PR linked to
+the issue. Codex B implements the active issue, while Codex A provides a review
+gate decision after tests and before merge.
+
+Roadmap authority is split conservatively:
+
+- `ROADMAP_MASTER.md` governs canonical phase maturity/status labels.
+- `docs/architecture/roadmap/execution_roadmap.md` governs audited phase
+  meaning and taxonomy.
+- Secondary documents are evidence-bearing or explanatory unless their status
+  claims are reflected in the authoritative roadmap surfaces.
 
 ## Key Documents
 
-- `docs/operations/runbook.md`: Working SOP that defines the end-to-end workflow, review gate, Definition of Done, and the local deterministic smoke-run execution steps. It also documents that an engine-level deterministic paper-trading simulator artifact exists without introducing live trading, broker integrations, or a production operator runtime entrypoint.
-- `docs/testing/smoke-run.md`: Deterministic smoke-run specification with exact fixtures, output, and exit codes.
-- `docs/architecture/mvp-spec.md`: Product scope and exclusions for MVP v1, including explicit exclusions such as live trading, broker integrations, backtesting, and AI-based signal generation.
-- `docs/architecture/mvp-v1.md`: Detailed MVP v1 system overview and component breakdown (engine, persistence, API, and trading desk) with scope and non-goals.
-- `docs/getting-started/local-run.md`: Local development steps and API usage expectations, including the note that there is no CLI entrypoint and that the API is used directly.
-- `docs/governance/*`: Governance documents for execution modes, test-gated execution requirements, and stop conditions/merge authority.
+- `docs/operations/runbook.md`: Working SOP that defines the end-to-end
+  workflow, review gate, Definition of Done, and deterministic smoke-run
+  execution steps. It also points bounded paper-runtime operation to the
+  dedicated OPS-P63 and OPS-P64 runtime documents.
+- `docs/testing/smoke-run.md`: Deterministic smoke-run specification with exact
+  fixtures, output, and exit codes.
+- `docs/architecture/mvp-spec.md`: MVP scope and exclusions. Treat this as a
+  scoped MVP document rather than a blanket denial of later bounded evidence.
+- `docs/architecture/mvp-v1.md`: MVP v1 system overview and component
+  breakdown with scope and non-goals.
+- `docs/getting-started/local-run.md`: Canonical local development startup and
+  API usage path.
+- `docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md`: Daily
+  bounded paper-runtime workflow.
+- `docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md`:
+  One-command bounded daily paper-runtime runner contract.
+- `docs/architecture/governance/*` and `docs/governance/*`: Governance
+  documents for execution modes, claim boundaries, readiness separation, and
+  review authority.
 
 ## Entry Points for a New Developer
 
 A new developer can start with:
 
-1. `README.md` for the high-level orientation and pointers to core documents.
-2. `docs/architecture/mvp-spec.md` and `docs/architecture/mvp-v1.md` for scope, architecture, and MVP boundaries.
-3. `docs/operations/runbook.md` and `docs/governance/*` for workflow, review gates, and test/merge rules.
-4. `docs/getting-started/local-run.md` for how the API is invoked in local development.
-5. `docs/testing/smoke-run.md` to understand the deterministic smoke-run contract and its implementation details.
+1. `README.md` for high-level orientation and pointers to core documents.
+2. `docs/getting-started/getting-started.md` for local setup.
+3. `docs/getting-started/local-run.md` for local API startup and snapshot-first
+   analysis flow.
+4. `docs/testing/index.md` and `docs/testing/smoke-run.md` for repository tests
+   and deterministic smoke-run behavior.
+5. `docs/operations/runbook.md` for issue workflow, review gates, and Definition
+   of Done.
+6. `docs/operations/runtime/p63-daily-bounded-paper-runtime-workflow.md` and
+   `docs/operations/runtime/p64-one-command-bounded-daily-paper-runtime-runner.md`
+   for bounded paper-runtime operation.
+7. `ROADMAP_MASTER.md` for canonical phase maturity/status labels.
 
-They should not expect a production operator CLI/entrypoint for paper-trading simulation, and they should not expect a live trading workflow. The deterministic paper-trading simulator exists as an engine-level, test-verified artifact only, with no broker connectivity or real-capital execution path. There is no CLI entrypoint documented; API usage via `uvicorn` is the described path, and the smoke-run is executed via the documented local command. The documentation provides the scope and operational workflow; implementation specifics are in `src/` and `api/` and are outside the scope of this snapshot.
+They should not expect a live trading workflow, broker connectivity,
+real-capital order execution, production-readiness guarantee, or trader
+validation evidence from the current repository. Bounded paper-runtime commands
+and read surfaces exist for local/staging evidence workflows only.
 
-## Known Gaps / Non-Implemented Areas
+## Known Gaps / Explicit Boundaries
 
-The following components are explicitly absent or described as not implemented in the current repository state:
+The following remain explicit boundaries in the current repository state:
 
-- A production operator CLI/runtime entrypoint for paper-trading simulation (the engine-level deterministic simulator artifact exists and is test-verified).
-- Live trading, broker integrations, or order execution.
-- Backtesting frameworks.
-- AI-based signal generation or automated decision-making.
-- A CLI entrypoint for running the engine; API-only invocation is documented.
+- No live trading workflow is authorized.
+- No broker integration or real-capital execution path is authorized.
+- Bounded paper-runtime evidence does not imply production readiness,
+  operational readiness, trader validation, or profitability.
+- Backtest and portfolio evidence remains bounded and must not be read as
+  broker, live-trading, or production-readiness approval.
+- AI-based signal generation or automated discretionary decision-making is not
+  part of the current bounded implementation claim.
 
-Deterministic smoke-run execution is implemented and documented in the runbook/spec.
-These are documented as out of scope or not yet implemented, and are part of the current state rather than defects.
+These boundaries are part of the current governed state rather than defects.

--- a/docs/governance/bounded-risk-framework-authority.md
+++ b/docs/governance/bounded-risk-framework-authority.md
@@ -15,6 +15,8 @@ governance-level acknowledgement that:
 
 - the canonical bounded authority id is `risk_framework_bounded_non_live_v1`
 - it covers the currently implemented bounded risk primitives only
+- it covers bounded stop-loss, position-sizing, trade-risk, strategy-risk,
+  symbol-risk, and portfolio-risk evidence for non-live evaluation only
 - it preserves explicit non-live, non-broker, no-readiness-overclaim
   boundaries
 
@@ -26,6 +28,8 @@ In scope for this overlay:
   contract
 - governance-level restatement of bounded non-live wording boundaries
 - governance-level alignment with bounded technical risk evidence
+- governance-level acknowledgement of deterministic bounded risk-budget
+  evidence without live-trading or broker-readiness claims
 
 Out of scope for this overlay:
 

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -138,10 +138,28 @@ python -m pytest
 - A red check blocks merge until tests pass.
 
 ### Run Paper Trading (Simulation)
-No production operator CLI/runtime entrypoint is documented for paper-trading simulation in this runbook. The repository contains an engine-level deterministic simulator module (`src/cilly_trading/engine/paper_trading.py`) that is test-verified, but no owner-facing run command is defined here. It does not provide live trading or broker integration, and no real orders are used.
+Bounded paper-runtime operation is documented in dedicated runtime contracts,
+not inline in this SOP. The current owner-facing bounded command path is the
+OPS-P64 daily runner, which orchestrates the OPS-P63 workflow through existing
+snapshot ingestion, analysis, bounded paper execution, reconciliation, and
+evidence-capture steps.
+
+Local OPS-P64 invocation:
+
+```bash
+python scripts/run_daily_bounded_paper_runtime.py \
+  --db-path cilly_trading.db \
+  --base-url http://127.0.0.1:18000
+```
+
+This command remains bounded and non-live. It does not provide live trading,
+broker integration, real-capital execution, production-readiness evidence,
+trader-validation evidence, or profitability claims.
 
 Reference:
 - [paper_trading.md](paper-trading.md)
+- [runtime/p63-daily-bounded-paper-runtime-workflow.md](runtime/p63-daily-bounded-paper-runtime-workflow.md)
+- [runtime/p64-one-command-bounded-daily-paper-runtime-runner.md](runtime/p64-one-command-bounded-daily-paper-runtime-runner.md)
 
 **Datum:** 2026-03-29
 **Thema:** Bounded Staging Prep – Host vorbereitet

--- a/docs/operations/runtime/signal_to_paper_execution_policy.md
+++ b/docs/operations/runtime/signal_to_paper_execution_policy.md
@@ -258,13 +258,16 @@ Canonical contract reference:
 - `docs/architecture/risk/non_live_evaluation_contract.md`
 
 For this non-live contract, evidence rows are emitted only for violated
-cap/boundary outcomes:
+cap/boundary outcomes except when bounded risk-budget evidence is explicitly
+required:
 
-- risk evaluator outcomes are `approved` or `rejected`, and evidence is emitted
-  on `rejected` outcomes only
+- exposure-only risk evaluator outcomes are `approved` or `rejected`, and
+  evidence is emitted on `rejected` outcomes only
+- bounded risk-budget approved outcomes emit deterministic stop-loss
+  position-sizing, trade, strategy, symbol, and portfolio evidence rows
 - portfolio pipeline outcomes are `approved`, `rejected`, or `constraint_hit`,
   and evidence is emitted on cap/boundary `constraint_hit` outcomes
-- approved outcomes emit an empty evidence tuple
+- exposure-only approved outcomes emit an empty evidence tuple
 
 Issue #981 completion is technical implementation evidence only. It does not
 claim trader validation, trader approval of thresholds, live readiness, or

--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -70,6 +70,33 @@ _COVERED_EVIDENCE_SCOPES: frozenset[str] = frozenset(
 
 _RISK_REASON_TO_EVIDENCE_METADATA: dict[str, tuple[str, str, str]] = {
     "rejected: kill_switch_enabled": ("boundary", "runtime", "kill_switch_enabled"),
+    "rejected: stop_loss_evidence_missing": (
+        "boundary",
+        "trade",
+        "stop_loss_evidence_required",
+    ),
+    "rejected: stop_loss_evidence_invalid": (
+        "boundary",
+        "trade",
+        "stop_loss_evidence_valid",
+    ),
+    "rejected: position_size_exceeds_stop_loss_budget": (
+        "cap",
+        "trade",
+        "stop_loss_position_size",
+    ),
+    "rejected: max_trade_risk_exceeded": ("cap", "trade", "max_trade_risk"),
+    "rejected: strategy_risk_budget_exceeded": (
+        "cap",
+        "strategy",
+        "strategy_risk_budget",
+    ),
+    "rejected: symbol_risk_budget_exceeded": ("cap", "symbol", "symbol_risk_budget"),
+    "rejected: portfolio_risk_budget_exceeded": (
+        "cap",
+        "portfolio",
+        "portfolio_risk_budget",
+    ),
     "rejected: max_position_size_exceeded": ("cap", "trade", "max_position_size"),
     "rejected: max_account_exposure_pct_exceeded": (
         "cap",
@@ -97,6 +124,12 @@ def _safe_pct(numerator: float, denominator: float) -> float:
     if denominator == 0.0:
         return float("inf")
     return numerator / denominator
+
+
+def _risk_limit_notional(account_equity: float, limit_pct: float | None) -> float:
+    if limit_pct is None:
+        return float("inf")
+    return abs(account_equity) * limit_pct
 
 
 def _extract_policy_evidence(
@@ -139,12 +172,46 @@ def _collect_covered_rejection_reason_codes(
                 "covered risk policy evidence must include non-empty reason_code"
             )
         if decision == "approve":
-            raise RiskEvidenceDisciplineError(
-                "covered risk policy evidence contradicts rejection discipline: decision='approve'"
-            )
+            continue
         normalize_risk_rejection_reason_code(reason_code)
         rejection_reason_codes.append(reason_code)
     return tuple(rejection_reason_codes)
+
+
+def _validate_covered_policy_evidence(policy_evidence: tuple[Any, ...]) -> None:
+    for evidence in policy_evidence:
+        scope = _read_evidence_field(evidence, "scope")
+        if scope not in _COVERED_EVIDENCE_SCOPES:
+            continue
+        decision = _read_evidence_field(evidence, "decision")
+        if decision not in {"approve", "reject"}:
+            raise RiskEvidenceDisciplineError(
+                "covered risk policy evidence must declare decision='approve' or decision='reject'"
+            )
+        reason_code = _read_evidence_field(evidence, "reason_code")
+        if not isinstance(reason_code, str) or not reason_code:
+            raise RiskEvidenceDisciplineError(
+                "covered risk policy evidence must include non-empty reason_code"
+            )
+        if decision == "reject":
+            normalize_risk_rejection_reason_code(reason_code)
+        elif reason_code.startswith("rejected:"):
+            raise RiskEvidenceDisciplineError(
+                "covered risk policy evidence contradicts rejection discipline: decision='approve'"
+            )
+
+
+def _first_rejection_evidence_limit(
+    policy_evidence: tuple[Any, ...],
+    reason_code: str,
+) -> float | None:
+    for evidence in policy_evidence:
+        if _read_evidence_field(evidence, "reason_code") != reason_code:
+            continue
+        limit_value = _read_evidence_field(evidence, "limit_value")
+        if isinstance(limit_value, int | float):
+            return float(limit_value)
+    return None
 
 
 def _build_synthetic_rejection_evidence(
@@ -213,6 +280,7 @@ def adapt_risk_framework_response_to_risk_decision(
 
     reason = framework_response.reason
     if reason == "approved: within_risk_limits":
+        _validate_covered_policy_evidence(policy_evidence)
         if _collect_covered_rejection_reason_codes(policy_evidence):
             raise RiskEvidenceDisciplineError(
                 "approved risk decision contains covered rejection evidence rows"
@@ -229,10 +297,9 @@ def adapt_risk_framework_response_to_risk_decision(
             raise ValueError(
                 f"unsupported risk-framework reason for execution mapping: {framework_response.reason}"
             ) from exc
+        _validate_covered_policy_evidence(policy_evidence)
         evidence_reason_codes = _collect_covered_rejection_reason_codes(policy_evidence)
         if not evidence_reason_codes:
-            # Compatibility mapping for bounded non-live producers that still emit
-            # reason-only rejects without explicit policy evidence rows.
             evidence_reason_codes = (reason,)
         try:
             precedence_candidates = [reason, *evidence_reason_codes]
@@ -247,6 +314,39 @@ def adapt_risk_framework_response_to_risk_decision(
         elif reason == "rejected: max_position_size_exceeded":
             score = float(normalized_proposed)
             max_allowed = float(limits.max_position_size)
+        elif reason == "rejected: stop_loss_evidence_missing":
+            score = float("inf")
+            max_allowed = 0.0
+        elif reason == "rejected: stop_loss_evidence_invalid":
+            score = float("inf")
+            max_allowed = 0.0
+        elif reason == "rejected: position_size_exceeds_stop_loss_budget":
+            score = float(normalized_proposed)
+            max_allowed = _first_rejection_evidence_limit(policy_evidence, reason) or 0.0
+        elif reason == "rejected: max_trade_risk_exceeded":
+            score = float(framework_response.risk_score)
+            max_allowed = _risk_limit_notional(
+                normalized_equity,
+                limits.max_trade_risk_pct,
+            )
+        elif reason == "rejected: strategy_risk_budget_exceeded":
+            score = float(framework_response.risk_score)
+            max_allowed = _risk_limit_notional(
+                normalized_equity,
+                limits.max_strategy_risk_pct,
+            )
+        elif reason == "rejected: symbol_risk_budget_exceeded":
+            score = float(framework_response.risk_score)
+            max_allowed = _risk_limit_notional(
+                normalized_equity,
+                limits.max_symbol_risk_pct,
+            )
+        elif reason == "rejected: portfolio_risk_budget_exceeded":
+            score = float(framework_response.risk_score)
+            max_allowed = _risk_limit_notional(
+                normalized_equity,
+                limits.max_portfolio_risk_pct,
+            )
         elif reason == "rejected: max_account_exposure_pct_exceeded":
             score = float(framework_response.risk_score)
             max_allowed = float(limits.max_account_exposure_pct)
@@ -271,7 +371,11 @@ def adapt_risk_framework_response_to_risk_decision(
         raise ValueError("risk-framework approval flag conflicts with mapped execution decision")
 
     timestamp = evaluated_at or datetime.now(tz=timezone.utc)
-    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+    if (
+        timestamp.tzinfo is None
+        or timestamp.utcoffset() is None
+        or timestamp.utcoffset() != timezone.utc.utcoffset(timestamp)
+    ):
         raise ValueError("evaluated_at must be timezone-aware and in UTC")
 
     return _build_risk_decision(
@@ -296,6 +400,12 @@ def evaluate_risk_framework_execution_decision(
     strategy_exposure: float,
     symbol_exposure: float,
     limits: FrameworkRiskLimits,
+    entry_price: float | None = None,
+    stop_loss_price: float | None = None,
+    strategy_risk_used: float = 0.0,
+    symbol_risk_used: float = 0.0,
+    portfolio_risk_used: float = 0.0,
+    require_bounded_risk_evidence: bool = False,
     rule_version: str = "risk-framework-v1",
     config: Mapping[str, object] | None = None,
     evaluated_at: datetime | None = None,
@@ -308,6 +418,12 @@ def evaluate_risk_framework_execution_decision(
         proposed_position_size=proposed_position_size,
         account_equity=account_equity,
         current_exposure=current_exposure,
+        entry_price=entry_price,
+        stop_loss_price=stop_loss_price,
+        strategy_risk_used=strategy_risk_used,
+        symbol_risk_used=symbol_risk_used,
+        portfolio_risk_used=portfolio_risk_used,
+        require_bounded_risk_evidence=require_bounded_risk_evidence,
     )
     framework_response = evaluate_framework_risk(
         framework_request,

--- a/src/cilly_trading/non_live_evaluation_contract.py
+++ b/src/cilly_trading/non_live_evaluation_contract.py
@@ -16,6 +16,13 @@ NonLiveScope = Literal["trade", "symbol", "strategy", "portfolio", "runtime"]
 
 CanonicalRiskRejectionReasonCode = Literal[
     "rejected:risk_framework_kill_switch_enabled",
+    "rejected:risk_framework_stop_loss_evidence_missing",
+    "rejected:risk_framework_stop_loss_evidence_invalid",
+    "rejected:risk_framework_position_size_exceeds_stop_loss_budget",
+    "rejected:risk_framework_max_trade_risk_exceeded",
+    "rejected:risk_framework_strategy_risk_budget_exceeded",
+    "rejected:risk_framework_symbol_risk_budget_exceeded",
+    "rejected:risk_framework_portfolio_risk_budget_exceeded",
     "rejected:risk_framework_max_position_size_exceeded",
     "rejected:risk_framework_max_account_exposure_pct_exceeded",
     "rejected:risk_framework_max_strategy_exposure_pct_exceeded",
@@ -24,6 +31,13 @@ CanonicalRiskRejectionReasonCode = Literal[
 
 CANONICAL_RISK_REJECTION_REASON_CODES: tuple[CanonicalRiskRejectionReasonCode, ...] = (
     "rejected:risk_framework_kill_switch_enabled",
+    "rejected:risk_framework_stop_loss_evidence_missing",
+    "rejected:risk_framework_stop_loss_evidence_invalid",
+    "rejected:risk_framework_position_size_exceeds_stop_loss_budget",
+    "rejected:risk_framework_max_trade_risk_exceeded",
+    "rejected:risk_framework_strategy_risk_budget_exceeded",
+    "rejected:risk_framework_symbol_risk_budget_exceeded",
+    "rejected:risk_framework_portfolio_risk_budget_exceeded",
     "rejected:risk_framework_max_position_size_exceeded",
     "rejected:risk_framework_max_account_exposure_pct_exceeded",
     "rejected:risk_framework_max_strategy_exposure_pct_exceeded",
@@ -39,6 +53,25 @@ RISK_FRAMEWORK_REASON_TO_CANONICAL_REJECTION_REASON: dict[
     str, CanonicalRiskRejectionReasonCode
 ] = {
     "rejected: kill_switch_enabled": "rejected:risk_framework_kill_switch_enabled",
+    "rejected: stop_loss_evidence_missing": (
+        "rejected:risk_framework_stop_loss_evidence_missing"
+    ),
+    "rejected: stop_loss_evidence_invalid": (
+        "rejected:risk_framework_stop_loss_evidence_invalid"
+    ),
+    "rejected: position_size_exceeds_stop_loss_budget": (
+        "rejected:risk_framework_position_size_exceeds_stop_loss_budget"
+    ),
+    "rejected: max_trade_risk_exceeded": "rejected:risk_framework_max_trade_risk_exceeded",
+    "rejected: strategy_risk_budget_exceeded": (
+        "rejected:risk_framework_strategy_risk_budget_exceeded"
+    ),
+    "rejected: symbol_risk_budget_exceeded": (
+        "rejected:risk_framework_symbol_risk_budget_exceeded"
+    ),
+    "rejected: portfolio_risk_budget_exceeded": (
+        "rejected:risk_framework_portfolio_risk_budget_exceeded"
+    ),
     "rejected: max_position_size_exceeded": "rejected:risk_framework_max_position_size_exceeded",
     "rejected: max_account_exposure_pct_exceeded": (
         "rejected:risk_framework_max_account_exposure_pct_exceeded"

--- a/src/cilly_trading/risk_framework/allocation_rules.py
+++ b/src/cilly_trading/risk_framework/allocation_rules.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -18,9 +19,21 @@ class RiskLimits:
             after applying the proposed position.
         max_symbol_exposure_pct: Maximum symbol-level exposure percentage after
             applying the proposed position.
+        max_trade_risk_pct: Optional maximum stop-loss bounded loss percentage
+            for one proposal.
+        max_strategy_risk_pct: Optional maximum strategy-level stop-loss
+            bounded loss percentage after applying the proposed position.
+        max_symbol_risk_pct: Optional maximum symbol-level stop-loss bounded
+            loss percentage after applying the proposed position.
+        max_portfolio_risk_pct: Optional maximum portfolio-level stop-loss
+            bounded loss percentage after applying the proposed position.
     """
 
     max_account_exposure_pct: float
     max_position_size: float
     max_strategy_exposure_pct: float
     max_symbol_exposure_pct: float
+    max_trade_risk_pct: Optional[float] = None
+    max_strategy_risk_pct: Optional[float] = None
+    max_symbol_risk_pct: Optional[float] = None
+    max_portfolio_risk_pct: Optional[float] = None

--- a/src/cilly_trading/risk_framework/contract.py
+++ b/src/cilly_trading/risk_framework/contract.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Protocol
 
+from cilly_trading.non_live_evaluation_contract import NonLiveEvaluationEvidence
+
 
 @dataclass(frozen=True)
 class RiskEvaluationRequest:
@@ -20,6 +22,17 @@ class RiskEvaluationRequest:
         proposed_position_size: Requested position size before risk adjustment.
         account_equity: Current account equity used by downstream evaluators.
         current_exposure: Current account exposure before this proposal.
+        entry_price: Optional proposed entry price for bounded stop-loss risk.
+        stop_loss_price: Optional proposed stop-loss price for bounded max-risk
+            evidence.
+        strategy_risk_used: Current strategy-level bounded risk before this
+            proposal.
+        symbol_risk_used: Current symbol-level bounded risk before this
+            proposal.
+        portfolio_risk_used: Current portfolio-level bounded risk before this
+            proposal.
+        require_bounded_risk_evidence: Require stop-loss and bounded risk-budget
+            evidence to fail closed when missing or contradictory.
     """
 
     strategy_id: str
@@ -27,6 +40,12 @@ class RiskEvaluationRequest:
     proposed_position_size: float
     account_equity: float
     current_exposure: float
+    entry_price: Optional[float] = None
+    stop_loss_price: Optional[float] = None
+    strategy_risk_used: float = 0.0
+    symbol_risk_used: float = 0.0
+    portfolio_risk_used: float = 0.0
+    require_bounded_risk_evidence: bool = False
 
 
 @dataclass(frozen=True)
@@ -38,12 +57,14 @@ class RiskEvaluationResponse:
         reason: Human-readable explanation of the evaluation outcome.
         adjusted_position_size: Optional adjusted position size.
         risk_score: Numeric risk score produced by an implementation.
+        policy_evidence: Deterministic bounded non-live evidence rows.
     """
 
     approved: bool
     reason: str
     adjusted_position_size: Optional[float]
     risk_score: float
+    policy_evidence: tuple[NonLiveEvaluationEvidence, ...] = ()
 
 
 class RiskEvaluator(Protocol):

--- a/src/cilly_trading/risk_framework/risk_evaluator.py
+++ b/src/cilly_trading/risk_framework/risk_evaluator.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from math import isfinite
+
+from cilly_trading.non_live_evaluation_contract import NonLiveEvaluationEvidence
 from cilly_trading.risk_framework.allocation_rules import RiskLimits
 from cilly_trading.risk_framework.contract import RiskEvaluationRequest, RiskEvaluationResponse
 from cilly_trading.risk_framework.exposure_model import compute_exposure_metrics
@@ -13,6 +17,269 @@ def _safe_pct(numerator: float, denominator: float) -> float:
     if denominator == 0.0:
         return float("inf")
     return numerator / denominator
+
+
+@dataclass(frozen=True)
+class _RuleEvidence:
+    evidence: NonLiveEvaluationEvidence
+    violated: bool
+
+
+def _bounded_risk_required(request: RiskEvaluationRequest, limits: RiskLimits) -> bool:
+    return request.require_bounded_risk_evidence or any(
+        limit is not None
+        for limit in (
+            limits.max_trade_risk_pct,
+            limits.max_strategy_risk_pct,
+            limits.max_symbol_risk_pct,
+            limits.max_portfolio_risk_pct,
+        )
+    )
+
+
+def _risk_limit_notional(account_equity: float, limit_pct: float | None) -> float:
+    if limit_pct is None:
+        return float("inf")
+    return abs(account_equity) * limit_pct
+
+
+def _evidence(
+    *,
+    decision: str,
+    scope: str,
+    rule_code: str,
+    reason_code: str,
+    observed_value: float,
+    limit_value: float,
+) -> NonLiveEvaluationEvidence:
+    return NonLiveEvaluationEvidence(
+        decision=decision,  # type: ignore[arg-type]
+        semantic="cap",
+        scope=scope,  # type: ignore[arg-type]
+        rule_code=rule_code,
+        reason_code=reason_code,
+        observed_value=observed_value,
+        limit_value=limit_value,
+    )
+
+
+def _fail_closed_response(
+    *,
+    reason: str,
+    risk_score: float,
+    policy_evidence: tuple[NonLiveEvaluationEvidence, ...],
+) -> RiskEvaluationResponse:
+    return RiskEvaluationResponse(
+        approved=False,
+        reason=reason,
+        adjusted_position_size=0.0,
+        risk_score=risk_score,
+        policy_evidence=policy_evidence,
+    )
+
+
+def _invalid_stop_loss_evidence_response() -> tuple[
+    tuple[NonLiveEvaluationEvidence, ...], str, float
+]:
+    return (
+        (
+            _evidence(
+                decision="reject",
+                scope="trade",
+                rule_code="stop_loss_evidence_valid",
+                reason_code="rejected: stop_loss_evidence_invalid",
+                observed_value=0.0,
+                limit_value=0.0,
+            ),
+        ),
+        "rejected: stop_loss_evidence_invalid",
+        float("inf"),
+    )
+
+
+def _bounded_risk_inputs_are_finite(
+    request: RiskEvaluationRequest,
+    *,
+    limits: RiskLimits,
+) -> bool:
+    values = (
+        request.entry_price,
+        request.stop_loss_price,
+        request.proposed_position_size,
+        request.account_equity,
+        request.strategy_risk_used,
+        request.symbol_risk_used,
+        request.portfolio_risk_used,
+        limits.max_trade_risk_pct,
+        limits.max_strategy_risk_pct,
+        limits.max_symbol_risk_pct,
+        limits.max_portfolio_risk_pct,
+    )
+    return all(value is None or isfinite(value) for value in values)
+
+
+def _evaluate_bounded_risk_evidence(
+    request: RiskEvaluationRequest,
+    *,
+    limits: RiskLimits,
+) -> tuple[tuple[NonLiveEvaluationEvidence, ...], str | None, float]:
+    if not _bounded_risk_required(request, limits):
+        return (), None, 0.0
+
+    if request.entry_price is None or request.stop_loss_price is None:
+        return (
+            (
+                _evidence(
+                    decision="reject",
+                    scope="trade",
+                    rule_code="stop_loss_evidence_required",
+                    reason_code="rejected: stop_loss_evidence_missing",
+                    observed_value=0.0,
+                    limit_value=1.0,
+                ),
+            ),
+            "rejected: stop_loss_evidence_missing",
+            float("inf"),
+        )
+
+    if not _bounded_risk_inputs_are_finite(request, limits=limits):
+        return _invalid_stop_loss_evidence_response()
+
+    entry_price = abs(request.entry_price)
+    stop_loss_price = abs(request.stop_loss_price)
+    stop_loss_distance = abs(entry_price - stop_loss_price)
+    if entry_price == 0.0 or stop_loss_price == 0.0 or stop_loss_distance == 0.0:
+        return _invalid_stop_loss_evidence_response()
+
+    absolute_proposed_size = abs(request.proposed_position_size)
+    stop_loss_risk_pct = stop_loss_distance / entry_price
+    trade_risk_notional = absolute_proposed_size * stop_loss_risk_pct
+    trade_risk_budget = _risk_limit_notional(
+        request.account_equity,
+        limits.max_trade_risk_pct,
+    )
+    max_stop_loss_position_size = (
+        float("inf")
+        if limits.max_trade_risk_pct is None
+        else trade_risk_budget / stop_loss_risk_pct
+    )
+
+    rules = (
+        _RuleEvidence(
+            evidence=_evidence(
+                decision=(
+                    "reject"
+                    if absolute_proposed_size > max_stop_loss_position_size
+                    else "approve"
+                ),
+                scope="trade",
+                rule_code="stop_loss_position_size",
+                reason_code=(
+                    "rejected: position_size_exceeds_stop_loss_budget"
+                    if absolute_proposed_size > max_stop_loss_position_size
+                    else "approved: within_risk_limits"
+                ),
+                observed_value=absolute_proposed_size,
+                limit_value=max_stop_loss_position_size,
+            ),
+            violated=absolute_proposed_size > max_stop_loss_position_size,
+        ),
+        _RuleEvidence(
+            evidence=_evidence(
+                decision="reject" if trade_risk_notional > trade_risk_budget else "approve",
+                scope="trade",
+                rule_code="max_trade_risk",
+                reason_code=(
+                    "rejected: max_trade_risk_exceeded"
+                    if trade_risk_notional > trade_risk_budget
+                    else "approved: within_risk_limits"
+                ),
+                observed_value=trade_risk_notional,
+                limit_value=trade_risk_budget,
+            ),
+            violated=trade_risk_notional > trade_risk_budget,
+        ),
+        _RuleEvidence(
+            evidence=_evidence(
+                decision=(
+                    "reject"
+                    if abs(request.strategy_risk_used) + trade_risk_notional
+                    > _risk_limit_notional(request.account_equity, limits.max_strategy_risk_pct)
+                    else "approve"
+                ),
+                scope="strategy",
+                rule_code="strategy_risk_budget",
+                reason_code=(
+                    "rejected: strategy_risk_budget_exceeded"
+                    if abs(request.strategy_risk_used) + trade_risk_notional
+                    > _risk_limit_notional(request.account_equity, limits.max_strategy_risk_pct)
+                    else "approved: within_risk_limits"
+                ),
+                observed_value=abs(request.strategy_risk_used) + trade_risk_notional,
+                limit_value=_risk_limit_notional(
+                    request.account_equity,
+                    limits.max_strategy_risk_pct,
+                ),
+            ),
+            violated=abs(request.strategy_risk_used) + trade_risk_notional
+            > _risk_limit_notional(request.account_equity, limits.max_strategy_risk_pct),
+        ),
+        _RuleEvidence(
+            evidence=_evidence(
+                decision=(
+                    "reject"
+                    if abs(request.symbol_risk_used) + trade_risk_notional
+                    > _risk_limit_notional(request.account_equity, limits.max_symbol_risk_pct)
+                    else "approve"
+                ),
+                scope="symbol",
+                rule_code="symbol_risk_budget",
+                reason_code=(
+                    "rejected: symbol_risk_budget_exceeded"
+                    if abs(request.symbol_risk_used) + trade_risk_notional
+                    > _risk_limit_notional(request.account_equity, limits.max_symbol_risk_pct)
+                    else "approved: within_risk_limits"
+                ),
+                observed_value=abs(request.symbol_risk_used) + trade_risk_notional,
+                limit_value=_risk_limit_notional(
+                    request.account_equity,
+                    limits.max_symbol_risk_pct,
+                ),
+            ),
+            violated=abs(request.symbol_risk_used) + trade_risk_notional
+            > _risk_limit_notional(request.account_equity, limits.max_symbol_risk_pct),
+        ),
+        _RuleEvidence(
+            evidence=_evidence(
+                decision=(
+                    "reject"
+                    if abs(request.portfolio_risk_used) + trade_risk_notional
+                    > _risk_limit_notional(request.account_equity, limits.max_portfolio_risk_pct)
+                    else "approve"
+                ),
+                scope="portfolio",
+                rule_code="portfolio_risk_budget",
+                reason_code=(
+                    "rejected: portfolio_risk_budget_exceeded"
+                    if abs(request.portfolio_risk_used) + trade_risk_notional
+                    > _risk_limit_notional(request.account_equity, limits.max_portfolio_risk_pct)
+                    else "approved: within_risk_limits"
+                ),
+                observed_value=abs(request.portfolio_risk_used) + trade_risk_notional,
+                limit_value=_risk_limit_notional(
+                    request.account_equity,
+                    limits.max_portfolio_risk_pct,
+                ),
+            ),
+            violated=abs(request.portfolio_risk_used) + trade_risk_notional
+            > _risk_limit_notional(request.account_equity, limits.max_portfolio_risk_pct),
+        ),
+    )
+
+    for rule in rules:
+        if rule.violated:
+            return tuple(item.evidence for item in rules), rule.evidence.reason_code, trade_risk_notional
+    return tuple(item.evidence for item in rules), None, trade_risk_notional
 
 
 def evaluate_risk(
@@ -41,6 +308,17 @@ def evaluate_risk(
             reason="rejected: kill_switch_enabled",
             adjusted_position_size=0.0,
             risk_score=float("inf"),
+            policy_evidence=(
+                NonLiveEvaluationEvidence(
+                    decision="reject",
+                    semantic="boundary",
+                    scope="runtime",
+                    rule_code="kill_switch_enabled",
+                    reason_code="rejected: kill_switch_enabled",
+                    observed_value=1.0,
+                    limit_value=0.0,
+                ),
+            ),
         )
 
     absolute_equity = abs(request.account_equity)
@@ -54,6 +332,15 @@ def evaluate_risk(
         proposed_position_size=request.proposed_position_size,
     )
     risk_score = metrics.account_exposure_pct
+    policy_evidence, bounded_rejection_reason, bounded_risk_score = (
+        _evaluate_bounded_risk_evidence(request, limits=limits)
+    )
+    if bounded_rejection_reason is not None:
+        return _fail_closed_response(
+            reason=bounded_rejection_reason,
+            risk_score=bounded_risk_score,
+            policy_evidence=policy_evidence,
+        )
 
     if absolute_proposed_size > limits.max_position_size:
         return RiskEvaluationResponse(
@@ -61,6 +348,7 @@ def evaluate_risk(
             reason="rejected: max_position_size_exceeded",
             adjusted_position_size=limits.max_position_size,
             risk_score=risk_score,
+            policy_evidence=policy_evidence,
         )
 
     if metrics.account_exposure_pct > limits.max_account_exposure_pct:
@@ -71,6 +359,7 @@ def evaluate_risk(
             reason="rejected: max_account_exposure_pct_exceeded",
             adjusted_position_size=adjusted_position_size,
             risk_score=risk_score,
+            policy_evidence=policy_evidence,
         )
 
     strategy_exposure_pct = _safe_pct(
@@ -85,6 +374,7 @@ def evaluate_risk(
             reason="rejected: max_strategy_exposure_pct_exceeded",
             adjusted_position_size=adjusted_position_size,
             risk_score=risk_score,
+            policy_evidence=policy_evidence,
         )
 
     symbol_exposure_pct = _safe_pct(
@@ -99,6 +389,7 @@ def evaluate_risk(
             reason="rejected: max_symbol_exposure_pct_exceeded",
             adjusted_position_size=adjusted_position_size,
             risk_score=risk_score,
+            policy_evidence=policy_evidence,
         )
 
     return RiskEvaluationResponse(
@@ -106,4 +397,5 @@ def evaluate_risk(
         reason="approved: within_risk_limits",
         adjusted_position_size=absolute_proposed_size,
         risk_score=risk_score,
+        policy_evidence=policy_evidence,
     )

--- a/src/risk/contracts.py
+++ b/src/risk/contracts.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal, Protocol
 
+from cilly_trading.non_live_evaluation_contract import NonLiveEvaluationEvidence
+
 
 DecisionType = Literal["APPROVED", "REJECTED"]
 
@@ -44,6 +46,7 @@ class RiskDecision:
         reason: Human-readable explanation for the decision.
         timestamp: timezone-aware UTC datetime of evaluation.
         rule_version: Version identifier of the risk policy/ruleset used.
+        policy_evidence: Deterministic bounded non-live evidence rows.
     """
 
     decision: DecisionType
@@ -52,6 +55,7 @@ class RiskDecision:
     reason: str
     timestamp: datetime
     rule_version: str
+    policy_evidence: tuple[NonLiveEvaluationEvidence, ...] = ()
 
 
 class RiskGate(Protocol):

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from risk.contracts import RiskEvaluationRequest
@@ -213,7 +213,10 @@ def test_adapter_maps_risk_framework_reason_codes_deterministically(
     assert decision.reason == expected_reason
     assert decision.rule_version == "adapter-v1"
     assert decision.timestamp == datetime(2026, 1, 1, tzinfo=timezone.utc)
-    assert _policy_evidence_or_empty(decision) == ()
+    if expected_decision == "APPROVED":
+        assert _policy_evidence_or_empty(decision) == ()
+    else:
+        assert _policy_evidence_or_empty(decision)
 
 
 def test_adapter_rejects_unknown_reason_code() -> None:
@@ -465,6 +468,109 @@ def test_evaluate_risk_framework_execution_decision_is_deterministic_for_equal_i
     assert first.decision == "APPROVED"
     assert first.reason == "approved:risk_framework_within_limits"
     assert _policy_evidence_or_empty(first) == ()
+
+
+def test_adapter_rejects_non_utc_timezone_aware_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone-aware and in UTC"):
+        adapt_risk_framework_response_to_risk_decision(
+            framework_request=_framework_request(),
+            framework_response=FrameworkRiskEvaluationResponse(
+                approved=True,
+                reason="approved: within_risk_limits",
+                adjusted_position_size=400.0,
+                risk_score=0.6,
+            ),
+            limits=_framework_limits(),
+            strategy_exposure=200.0,
+            symbol_exposure=100.0,
+            rule_version="adapter-v1",
+            evaluated_at=datetime(
+                2026,
+                1,
+                1,
+                tzinfo=timezone(timedelta(hours=1)),
+            ),
+        )
+
+
+def test_evaluate_risk_framework_execution_decision_propagates_bounded_risk_evidence() -> None:
+    decision = evaluate_risk_framework_execution_decision(
+        request_id="req-bounded-approved",
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=400.0,
+        account_equity=10_000.0,
+        current_exposure=800.0,
+        strategy_exposure=200.0,
+        symbol_exposure=100.0,
+        entry_price=100.0,
+        stop_loss_price=95.0,
+        strategy_risk_used=100.0,
+        symbol_risk_used=50.0,
+        portfolio_risk_used=200.0,
+        require_bounded_risk_evidence=True,
+        limits=RiskLimits(
+            max_account_exposure_pct=0.80,
+            max_position_size=500.0,
+            max_strategy_exposure_pct=0.30,
+            max_symbol_exposure_pct=0.20,
+            max_trade_risk_pct=0.02,
+            max_strategy_risk_pct=0.05,
+            max_symbol_risk_pct=0.04,
+            max_portfolio_risk_pct=0.10,
+        ),
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    policy_evidence = _policy_evidence_or_empty(decision)
+    assert decision.decision == "APPROVED"
+    assert decision.reason == "approved:risk_framework_within_limits"
+    assert [row.rule_code for row in policy_evidence] == [
+        "stop_loss_position_size",
+        "max_trade_risk",
+        "strategy_risk_budget",
+        "symbol_risk_budget",
+        "portfolio_risk_budget",
+    ]
+    assert {row.scope for row in policy_evidence} == {
+        "trade",
+        "strategy",
+        "symbol",
+        "portfolio",
+    }
+
+
+def test_evaluate_risk_framework_execution_decision_fails_closed_for_missing_bounded_evidence() -> None:
+    decision = evaluate_risk_framework_execution_decision(
+        request_id="req-bounded-missing",
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=400.0,
+        account_equity=10_000.0,
+        current_exposure=800.0,
+        strategy_exposure=200.0,
+        symbol_exposure=100.0,
+        require_bounded_risk_evidence=True,
+        limits=RiskLimits(
+            max_account_exposure_pct=0.80,
+            max_position_size=500.0,
+            max_strategy_exposure_pct=0.30,
+            max_symbol_exposure_pct=0.20,
+            max_trade_risk_pct=0.02,
+            max_strategy_risk_pct=0.05,
+            max_symbol_risk_pct=0.04,
+            max_portfolio_risk_pct=0.10,
+        ),
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert decision.decision == "REJECTED"
+    assert decision.reason == "rejected:risk_framework_stop_loss_evidence_missing"
+    assert _policy_evidence_or_empty(decision)[0].reason_code == (
+        "rejected: stop_loss_evidence_missing"
+    )
 
 
 def test_evaluate_risk_framework_execution_decision_prefers_kill_switch_for_multi_violation() -> None:

--- a/tests/risk/test_risk_evaluator.py
+++ b/tests/risk/test_risk_evaluator.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import math
+
+import pytest
+
 from cilly_trading.risk_framework.allocation_rules import RiskLimits
 from cilly_trading.risk_framework.contract import RiskEvaluationRequest
 from cilly_trading.risk_framework.risk_evaluator import evaluate_risk
@@ -23,6 +27,19 @@ def _limits() -> RiskLimits:
         max_position_size=10_000.0,
         max_strategy_exposure_pct=0.30,
         max_symbol_exposure_pct=0.20,
+    )
+
+
+def _bounded_limits() -> RiskLimits:
+    return RiskLimits(
+        max_account_exposure_pct=0.80,
+        max_position_size=10_000.0,
+        max_strategy_exposure_pct=0.80,
+        max_symbol_exposure_pct=0.80,
+        max_trade_risk_pct=0.02,
+        max_strategy_risk_pct=0.05,
+        max_symbol_risk_pct=0.04,
+        max_portfolio_risk_pct=0.10,
     )
 
 
@@ -158,3 +175,199 @@ def test_determinism() -> None:
     )
 
     assert first == second
+
+
+def test_bounded_risk_approval_emits_trade_strategy_symbol_portfolio_evidence() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        entry_price=100.0,
+        stop_loss_price=98.0,
+        strategy_risk_used=1_000.0,
+        symbol_risk_used=500.0,
+        portfolio_risk_used=3_000.0,
+        require_bounded_risk_evidence=True,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is True
+    assert response.reason == "approved: within_risk_limits"
+    assert [row.rule_code for row in response.policy_evidence] == [
+        "stop_loss_position_size",
+        "max_trade_risk",
+        "strategy_risk_budget",
+        "symbol_risk_budget",
+        "portfolio_risk_budget",
+    ]
+    assert {row.scope for row in response.policy_evidence} == {
+        "trade",
+        "strategy",
+        "symbol",
+        "portfolio",
+    }
+    assert {row.decision for row in response.policy_evidence} == {"approve"}
+
+
+def test_bounded_risk_missing_stop_loss_fails_closed() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        require_bounded_risk_evidence=True,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: stop_loss_evidence_missing"
+    assert response.adjusted_position_size == 0.0
+    assert response.policy_evidence[0].rule_code == "stop_loss_evidence_required"
+
+
+def test_bounded_risk_contradictory_stop_loss_fails_closed() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        entry_price=100.0,
+        stop_loss_price=100.0,
+        require_bounded_risk_evidence=True,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: stop_loss_evidence_invalid"
+    assert response.policy_evidence[0].rule_code == "stop_loss_evidence_valid"
+
+
+@pytest.mark.parametrize("invalid_value", [math.nan, math.inf])
+def test_bounded_risk_non_finite_entry_price_fails_closed(invalid_value: float) -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        entry_price=invalid_value,
+        stop_loss_price=98.0,
+        require_bounded_risk_evidence=True,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: stop_loss_evidence_invalid"
+    assert response.adjusted_position_size == 0.0
+    assert response.policy_evidence[0].rule_code == "stop_loss_evidence_valid"
+
+
+@pytest.mark.parametrize("invalid_value", [math.nan, math.inf])
+def test_bounded_risk_non_finite_stop_loss_price_fails_closed(
+    invalid_value: float,
+) -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        entry_price=100.0,
+        stop_loss_price=invalid_value,
+        require_bounded_risk_evidence=True,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: stop_loss_evidence_invalid"
+    assert response.adjusted_position_size == 0.0
+    assert response.policy_evidence[0].rule_code == "stop_loss_evidence_valid"
+
+
+def test_bounded_risk_budget_rejection_precedes_exposure_rejection() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=80_000.0,
+        account_equity=100_000.0,
+        current_exposure=70_000.0,
+        entry_price=100.0,
+        stop_loss_price=90.0,
+        require_bounded_risk_evidence=True,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=70_000.0,
+        symbol_exposure=70_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: position_size_exceeds_stop_loss_budget"
+    assert response.policy_evidence[0].decision == "reject"
+
+
+def test_bounded_portfolio_risk_budget_rejection_is_deterministic() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        entry_price=100.0,
+        stop_loss_price=98.0,
+        portfolio_risk_used=9_950.0,
+        require_bounded_risk_evidence=True,
+    )
+
+    first = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+    second = evaluate_risk(
+        request,
+        limits=_bounded_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert first == second
+    assert first.approved is False
+    assert first.reason == "rejected: portfolio_risk_budget_exceeded"

--- a/tests/test_onboarding_snapshot_docs.py
+++ b/tests/test_onboarding_snapshot_docs.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from tests.utils.consumer_contract_helpers import (
+    assert_contains_all,
+    read_repo_text,
+)
+
+
+REPO_SNAPSHOT_DOC = "docs/getting-started/repo-snapshot.md"
+RUNBOOK_DOC = "docs/operations/runbook.md"
+
+
+def test_repo_snapshot_reflects_current_bounded_evidence_without_readiness_inference() -> None:
+    content = read_repo_text(REPO_SNAPSHOT_DOC)
+
+    assert_contains_all(
+        content,
+        "bounded backtest evidence contracts and tests",
+        "bounded portfolio and paper inspection read surfaces",
+        "bounded daily paper-runtime workflow and one-command runner documentation",
+        "Phase 25",
+        "Phase 26",
+        "These surfaces do not imply live-trading readiness, broker readiness, production",
+    )
+
+
+def test_repo_snapshot_removes_stale_absence_claims_for_bounded_surfaces() -> None:
+    content = read_repo_text(REPO_SNAPSHOT_DOC)
+
+    stale_claims = [
+        "Backtesting frameworks.",
+        "Portfolio management.",
+        "There is no CLI entrypoint documented",
+        "no owner-facing run command",
+    ]
+    for stale_claim in stale_claims:
+        assert stale_claim not in content
+
+
+def test_runbook_points_paper_runtime_to_bounded_ops_p63_p64_contracts() -> None:
+    content = read_repo_text(RUNBOOK_DOC)
+
+    assert_contains_all(
+        content,
+        "OPS-P64 daily runner",
+        "scripts/run_daily_bounded_paper_runtime.py",
+        "runtime/p63-daily-bounded-paper-runtime-workflow.md",
+        "runtime/p64-one-command-bounded-daily-paper-runtime-runner.md",
+        "This command remains bounded and non-live.",
+    )
+    assert "no owner-facing run command is defined here" not in content


### PR DESCRIPTION
Closes #1047

## Summary
- Adds bounded stop-loss, position-sizing, trade-risk, strategy-risk, symbol-risk, and portfolio-risk evidence to non-live risk evaluation.
- Extends canonical rejection reason vocabulary and deterministic precedence.
- Propagates bounded risk evidence through the engine risk decision contract.
- Adds fail-closed handling for missing, invalid, and non-finite bounded risk evidence.
- Enforces UTC-only evaluated_at handling in the risk adapter.
- Updates risk governance and architecture docs while preserving non-live, non-broker, non-trader-validation, and non-operational-readiness boundaries.

## Tests
- python -m pytest
- Result: 1249 passed

## Codex A Review
- Decision: APPROVED
- Classification: technically good
- Trader validation remains pending.
- Operational use remains bounded non-live/internal.