### PR TITLE
Convert MVP strategy scores into bounded calibration evidence

### DIFF
--- a/docs/governance/backtest-realism-boundary-contract.md
+++ b/docs/governance/backtest-realism-boundary-contract.md
@@ -18,6 +18,8 @@ In scope:
 
 - canonical wording for covered execution assumptions (slippage, commission, fill timing,
   price source, fill model, partial-fills policy)
+- canonical wording for deterministic bounded risk-decision evidence, including
+  missing-evidence rejection handling
 - canonical wording for the modeled vs unmodeled realism boundary already exposed by the
   deterministic backtest
 - canonical interpretation rules that prevent overreading bounded backtest output as
@@ -59,6 +61,11 @@ assumption not listed here is explicitly out of contract for backtest evidence.
 
 - Snapshots are sorted deterministically by snapshot key and id.
 - Signals are translated to deterministic market orders with deterministic ordering.
+- Signal-derived orders require deterministic risk evidence. Present risk evidence is
+  represented as an explicit risk decision; missing required risk evidence is classified
+  as `missing_required_risk_evidence` and rejects the order deterministically.
+- Rejected orders remain represented in the artifact as rejected orders and rejection
+  execution events; they do not silently disappear.
 - Identical inputs and identical run-config assumptions MUST produce identical outputs.
 
 ## Canonical Realism Boundary Disclosure
@@ -70,11 +77,15 @@ Every backtest artifact MUST carry, under `realism_boundary`, both:
 - `unmodeled_assumptions`: explicit disclosure of realism dimensions that are NOT
   modeled in the deterministic backtest:
   - market hours, exchange sessions, holidays, halts, auctions, after-hours restrictions
-  - broker routing, venue selection, rejects, cancels, broker-specific policies
+  - broker routing, venue selection, broker rejects, cancels, broker-specific policies
   - order-book depth, queue position, latency, fill probability, market impact
 
 Both lists are canonical and authoritative for what the backtest does and does not model.
 Adding new modeled dimensions requires updating this contract first.
+
+Backtest risk rejections are bounded deterministic artifact evidence only. They do not
+model broker rejects, broker routing, venue behavior, market access controls, or live
+risk management.
 
 ## Deterministic Replay Stability (Canonical)
 
@@ -85,6 +96,7 @@ artifact payloads, including:
 - `execution_assumptions`
 - `realism_boundary.modeled_assumptions`
 - `realism_boundary.unmodeled_assumptions`
+- deterministic `risk_decisions`, `rejected_orders`, and `rejection_events`
 - the cost-aware metrics baseline summary, equity curve, and metrics
 - the deterministic realism sensitivity matrix (profile order, per-profile assumptions,
   summaries, metrics, and `delta_vs_baseline`)

--- a/docs/governance/score-semantics-cross-strategy.md
+++ b/docs/governance/score-semantics-cross-strategy.md
@@ -93,6 +93,35 @@ recalibration, or scope expansion beyond bounded decision-support review.
 Weak or failing slices limit interpretation outside covered conditions. They do not
 create live-trading approval, trader_validation completion, or profitability claims.
 
+## 4.3 Per-Strategy MVP Score Calibration Boundary
+
+RSI2 and Turtle MVP aggregate scores are classified as bounded per-strategy
+calibration evidence only.
+
+The bounded strategy-score calibration audit relates:
+
+- the covered RSI2 or Turtle aggregate score
+- the ordinal `confidence_tier`
+- covered backtest-realism evidence where available
+- matched paper-trade outcomes where an explicit `paper_trade_id` link exists
+
+The audit emits explicit `stable`, `weak`, `failing`, or `limited` classification:
+
+- `stable`: covered per-strategy score evidence is supported by stable backtest-realism
+  coverage and a favorable matched paper outcome
+- `weak`: covered evidence is partial, open, flat, or otherwise not strong enough for
+  stable interpretation
+- `failing`: covered score evidence conflicts with failing realism evidence, invalid
+  paper matching, or an adverse matched paper outcome
+- `limited`: backtest-realism evidence or matched paper evidence is missing, so the
+  score remains bounded per-strategy evidence with limited calibration support
+
+This audit does not rescore strategies, optimize strategy parameters, forecast
+profitability, or validate trader judgement. Missing evidence must reduce the
+classification to weak or limited and must not inflate confidence claims.
+
+Confidence tier remains ordinal and does not represent a probability. Cross-strategy comparability remains explicitly unsupported unless governed evidence proves otherwise; current RSI2 and Turtle score calibration does not create cross-strategy ranking authority.
+
 ## 5. Runtime and Documentation Alignment Rule
 
 All runtime wording and documentation must remain consistent with this governance contract:
@@ -111,6 +140,8 @@ wording templates that runtime qualification uses:
 - `CONFIDENCE_TIER_PRECISION_DISCLAIMER`: the bounded precision statement
 - `QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY`: the bounded robustness
   interpretation limit for covered versus weak/failing slices
+- `STRATEGY_SCORE_CALIBRATION_INTERPRETATION_BOUNDARY`: the bounded per-strategy
+  score-calibration limit for RSI2/Turtle MVP score evidence
 
 ## 6. Non-Goals
 
@@ -120,3 +151,4 @@ This governance contract does not grant:
 - live trading approval or broker execution approval
 - forecast or probability certification
 - robustness claims outside covered conditions
+- trader_validation completion or profitability forecasting from MVP score calibration

--- a/docs/governance/signal-quality-bounded-contract.md
+++ b/docs/governance/signal-quality-bounded-contract.md
@@ -122,6 +122,25 @@ The calibration remains non-live and bounded:
 - missing backtest-realism evidence or missing matched paper evidence limits calibration to
   weak bounded interpretation rather than inflating confidence claims
 
+## Per-Strategy MVP Score Calibration Boundary
+
+RSI2 and Turtle MVP aggregate scores are interpreted only as bounded per-strategy
+calibration evidence. The audit relates the covered score to backtest-realism evidence
+and matched paper-trade outcomes where those evidence links exist.
+
+Classification is bounded:
+
+- `stable`: covered backtest-realism evidence and matched paper outcome support the
+  per-strategy score interpretation
+- `weak`: evidence is open, flat, partial, or otherwise not enough for stable support
+- `failing`: evidence contradicts the covered score interpretation
+- `limited`: calibration evidence is missing
+
+Confidence tier remains ordinal, not probabilistic. Cross-strategy comparability remains
+unsupported; RSI2 and Turtle score calibration does not create cross-strategy ranking
+authority. The audit remains non-live and does not imply trader validation, paper
+profitability, live-trading readiness, or operational readiness.
+
 ## Deterministic Ranking Boundary
 
 For setup-stage candidates that meet the configured score floor, ranking is deterministic:

--- a/docs/operations/runtime/backtest_realism_boundary_runtime.md
+++ b/docs/operations/runtime/backtest_realism_boundary_runtime.md
@@ -26,12 +26,14 @@ artifact payload under `realism_boundary`. The surface is composed of:
 
 - `boundary_version`: canonical version of the realism boundary contract surface.
 - `modeled_assumptions`:
+  - `bounded_risk_decisions`: required signal risk evidence, deterministic
+    approve/reject decisions, and deterministic missing-evidence rejection policy
   - `fees`: `commission_model` and `commission_per_order`
   - `slippage`: `slippage_bps` and `slippage_model`
   - `fills`: `fill_model`, `fill_timing`, `partial_fills_allowed`, `price_source`
 - `unmodeled_assumptions`:
   - `market_hours`: not modeled (sessions, halts, auctions, after-hours excluded)
-  - `broker_behavior`: not modeled (routing, rejects, cancels, broker policies excluded)
+  - `broker_behavior`: not modeled (routing, broker rejects, cancels, broker policies excluded)
   - `liquidity_and_microstructure`: not modeled (depth, queue, latency, impact excluded)
 - `evidence_boundary`:
   - `supported_interpretation`: deterministic replay under declared assumptions and
@@ -68,6 +70,17 @@ technical-only comparison evidence:
 
 The matrix MUST NOT be used as evidence of live execution behavior, broker fill
 quality, or trader-validated edge.
+
+## Bounded Risk-Decision Runtime Behavior
+
+Signal-derived backtest orders require deterministic risk evidence. The runtime
+records the resulting `risk_decisions` in the artifact. If required risk evidence
+is absent, the order is rejected with `missing_required_risk_evidence` and is
+preserved under `rejected_orders` and `rejection_events`.
+
+These rejected orders and rejection events are bounded backtest evidence only.
+They do not model broker rejects, live routing, venue behavior, liquidity,
+latency, or market access controls.
 
 ## Non-Live Boundary
 

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -1352,6 +1352,23 @@ def build_decision_card_inspection_items(
                     match_reference=match_reference,
                 )
             )
+            strategy_score_calibration_audit = (
+                paper_inspection_service.build_bounded_strategy_score_calibration_audit(
+                    canonical_execution_repo=canonical_repo,
+                    decision_card_id=card.decision_card_id,
+                    generated_at_utc=card.generated_at_utc,
+                    symbol=card.symbol,
+                    strategy_id=card.strategy_id,
+                    aggregate_score=card.score.aggregate_score,
+                    confidence_tier=card.score.confidence_tier,
+                    realism_sensitivity_matrix=realism_sensitivity_matrix,
+                    match_reference=match_reference,
+                )
+            )
+            if strategy_score_calibration_audit is not None:
+                metadata["bounded_strategy_score_calibration_audit"] = (
+                    strategy_score_calibration_audit
+                )
 
             paper_match_status, paper_trade_id = (
                 paper_inspection_service.resolve_bounded_paper_linkage_status(

--- a/src/api/services/paper_inspection_service.py
+++ b/src/api/services/paper_inspection_service.py
@@ -21,6 +21,7 @@ from cilly_trading.engine.decision_card_contract import (
     evaluate_bounded_confidence_calibration_audit,
     evaluate_bounded_decision_to_paper_usefulness_audit,
     evaluate_bounded_signal_quality_stability_audit,
+    evaluate_bounded_strategy_score_calibration_audit,
 )
 from cilly_trading.models import ExecutionEvent, Order, Position, Trade
 
@@ -1153,6 +1154,74 @@ def build_bounded_confidence_calibration_audit(
 
     audit = evaluate_bounded_confidence_calibration_audit(
         covered_case_id=decision_card_id,
+        confidence_tier=confidence_tier,
+        backtest_realism_status=backtest_realism_status,
+        backtest_realism_reason=backtest_realism_reason,
+        match_status=match_status,
+        match_reference=(
+            normalized_match_reference.model_dump(mode="python")
+            if normalized_match_reference is not None
+            else None
+        ),
+        matched_outcome=matched_outcome,
+    )
+    return audit.model_dump(mode="python")
+
+
+def build_bounded_strategy_score_calibration_audit(
+    *,
+    canonical_execution_repo: Any | None,
+    decision_card_id: str,
+    generated_at_utc: str,
+    symbol: str,
+    strategy_id: str,
+    aggregate_score: float,
+    confidence_tier: Literal["low", "medium", "high"],
+    realism_sensitivity_matrix: dict[str, Any] | None,
+    match_reference: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Build bounded per-strategy score calibration for governed MVP strategies."""
+
+    normalized_strategy_id = strategy_id.strip().upper()
+    if normalized_strategy_id not in {"RSI2", "TURTLE"}:
+        return None
+
+    backtest_realism_status, backtest_realism_reason = classify_backtest_realism_calibration_status(
+        realism_sensitivity_matrix
+    )
+
+    normalized_match_reference: BoundedDecisionToPaperUsefulnessMatchReference | None = None
+    if isinstance(match_reference, dict):
+        try:
+            normalized_match_reference = (
+                BoundedDecisionToPaperUsefulnessMatchReference.model_validate(match_reference)
+            )
+        except ValidationError:
+            normalized_match_reference = None
+
+    match_status: Literal["matched", "open", "missing", "invalid"] = "missing"
+    matched_outcome: dict[str, Any] | None = None
+    if normalized_match_reference is not None:
+        trade: Trade | None = None
+        if canonical_execution_repo is not None:
+            try:
+                trade = canonical_execution_repo.get_trade(
+                    normalized_match_reference.paper_trade_id
+                )
+            except Exception:
+                trade = None
+        if trade is not None:
+            match_status, matched_outcome = _build_paper_trade_outcome_payload(
+                trade=trade,
+                expected_symbol=symbol,
+                expected_strategy_id=normalized_strategy_id,
+                decision_generated_at_utc=generated_at_utc,
+            )
+
+    audit = evaluate_bounded_strategy_score_calibration_audit(
+        covered_case_id=decision_card_id,
+        strategy_id=normalized_strategy_id,  # type: ignore[arg-type]
+        aggregate_score=aggregate_score,
         confidence_tier=confidence_tier,
         backtest_realism_status=backtest_realism_status,
         backtest_realism_reason=backtest_realism_reason,

--- a/src/cilly_trading/engine/backtest_execution_contract.py
+++ b/src/cilly_trading/engine/backtest_execution_contract.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
+from math import isfinite
 from typing import Any, Dict, List, Literal, Mapping, Sequence
 
 from risk.contracts import RiskDecision, RiskEvaluationRequest, RiskGate
 
 from cilly_trading.metrics import compute_backtest_metrics
+from cilly_trading.models import compute_execution_event_id
 from cilly_trading.engine.pipeline.orchestrator import (
     DeterministicExecutionConfig,
     ExecutionEvent,
@@ -27,6 +29,9 @@ DEFAULT_ACTION_TO_SIDE: dict[str, Literal["BUY", "SELL"]] = {"BUY": "BUY", "SELL
 MAX_SLIPPAGE_BPS = 250
 MAX_COMMISSION_PER_ORDER = Decimal("25")
 DEFAULT_STARTING_EQUITY = Decimal("100000")
+BACKTEST_RISK_EVIDENCE_VERSION = "1.0.0"
+BACKTEST_RISK_RULE_VERSION = "deterministic-backtest-risk-v1"
+BACKTEST_RISK_DECISION_TIMESTAMP = datetime(1970, 1, 1, tzinfo=timezone.utc)
 REALISM_PROFILE_BASELINE_ID = "configured_baseline"
 REALISM_PROFILE_COST_FREE_ID = "cost_free_reference"
 REALISM_PROFILE_COST_STRESS_ID = "bounded_cost_stress"
@@ -151,6 +156,43 @@ class BacktestExecutionAssumptions:
 
 
 @dataclass(frozen=True)
+class BacktestRiskEvidenceConfig:
+    """Deterministic risk-evidence fields required for signal-derived orders."""
+
+    evidence_field: str = "risk_evidence"
+    decision_field: str = "decision"
+    score_field: str = "score"
+    max_allowed_field: str = "max_allowed"
+    reason_field: str = "reason"
+    rule_version_field: str = "rule_version"
+
+    def __post_init__(self) -> None:
+        for value in (
+            self.evidence_field,
+            self.decision_field,
+            self.score_field,
+            self.max_allowed_field,
+            self.reason_field,
+            self.rule_version_field,
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError("Risk evidence field names must be non-empty strings")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "risk_evidence_version": BACKTEST_RISK_EVIDENCE_VERSION,
+            "required": True,
+            "evidence_field": self.evidence_field,
+            "decision_field": self.decision_field,
+            "score_field": self.score_field,
+            "max_allowed_field": self.max_allowed_field,
+            "reason_field": self.reason_field,
+            "rule_version_field": self.rule_version_field,
+            "missing_evidence_policy": "reject_order",
+        }
+
+
+@dataclass(frozen=True)
 class BacktestRunContract:
     """Backtest run contract with explicit reproducibility metadata."""
 
@@ -160,6 +202,9 @@ class BacktestRunContract:
     )
     execution_assumptions: BacktestExecutionAssumptions = field(
         default_factory=BacktestExecutionAssumptions
+    )
+    risk_evidence: BacktestRiskEvidenceConfig = field(
+        default_factory=BacktestRiskEvidenceConfig
     )
 
     def __post_init__(self) -> None:
@@ -181,6 +226,7 @@ class BacktestRunContract:
             "contract_version": self.contract_version,
             "signal_translation": self.signal_translation.to_payload(),
             "execution_assumptions": self.execution_assumptions.to_payload(),
+            "risk_evidence": self.risk_evidence.to_payload(),
             "reproducibility_metadata": {
                 "run_id": run_id,
                 "strategy_name": strategy_name,
@@ -198,6 +244,9 @@ class BacktestExecutionFlowResult:
     orders: List[Order]
     fills: List[ExecutionEvent]
     positions: List[Position]
+    risk_decisions: List[dict[str, Any]]
+    rejected_orders: List[Order]
+    rejection_events: List[ExecutionEvent]
 
 
 def build_backtest_realism_boundary(
@@ -209,6 +258,12 @@ def build_backtest_realism_boundary(
     return {
         "boundary_version": REALISM_BOUNDARY_VERSION,
         "modeled_assumptions": {
+            "bounded_risk_decisions": {
+                "risk_evidence_version": BACKTEST_RISK_EVIDENCE_VERSION,
+                "evidence_source": "signal_risk_evidence",
+                "missing_evidence_policy": "deterministic_order_rejection",
+                "broker_risk_behavior": "not_modeled",
+            },
             "fees": {
                 "commission_model": "fixed_per_filled_order",
                 "commission_per_order": str(execution_assumptions.commission_per_order),
@@ -230,8 +285,9 @@ def build_backtest_realism_boundary(
                 "holidays, halts, auctions, and after-hours restrictions are excluded."
             ),
             "broker_behavior": (
-                "Not modeled. Routing, venue selection, rejects, cancels, and broker-specific "
-                "policies are excluded."
+                "Not modeled. Routing, venue selection, broker rejects, cancels, and "
+                "broker-specific policies are excluded. Backtest risk rejections are "
+                "deterministic artifact evidence only and are not broker behavior."
             ),
             "liquidity_and_microstructure": (
                 "Not modeled. Order-book depth, queue position, fill probability, latency, and "
@@ -241,10 +297,12 @@ def build_backtest_realism_boundary(
         "evidence_boundary": {
             "supported_interpretation": [
                 "Deterministic replay of supplied snapshots under the declared fill, slippage, and fee assumptions.",
+                "Deterministic bounded risk decisions for signal-derived orders when required risk evidence is present or missing.",
                 "Cost-aware metrics bounded to fixed commission and fixed basis-point slippage.",
             ],
             "unsupported_claims": [
                 "broker execution realism",
+                "broker reject realism",
                 "market-hours compliance realism",
                 "liquidity or market microstructure realism",
                 "live-trading readiness or approval",
@@ -363,6 +421,83 @@ def translate_signals_to_orders(
     return orders
 
 
+def _translate_signals_to_order_plans(
+    *,
+    ordered_snapshots: Sequence[Mapping[str, Any]],
+    run_id: str,
+    strategy_name: str,
+    signal_translation: BacktestSignalTranslationConfig,
+    risk_evidence_config: BacktestRiskEvidenceConfig,
+) -> tuple[List[Order], dict[str, Mapping[str, Any] | None]]:
+    orders: list[Order] = []
+    risk_evidence_by_order_id: dict[str, Mapping[str, Any] | None] = {}
+    sequence = 1
+    for snapshot in ordered_snapshots:
+        snapshot_key = resolve_snapshot_key(snapshot)
+        raw_signals = snapshot.get(signal_translation.signal_collection_field, [])
+        if raw_signals in (None, []):
+            continue
+        if not isinstance(raw_signals, Sequence) or isinstance(raw_signals, (str, bytes)):
+            raise ValueError("Snapshot signals must be a sequence")
+
+        normalized_signals = sorted(
+            (signal for signal in raw_signals),
+            key=lambda signal: (
+                str(signal.get(signal_translation.signal_id_field, "")),
+                str(signal.get(signal_translation.symbol_field, "")),
+            ),
+        )
+        for signal in normalized_signals:
+            if not isinstance(signal, Mapping):
+                raise ValueError("Each signal must be a mapping")
+            signal_id = signal.get(signal_translation.signal_id_field)
+            if not isinstance(signal_id, str) or not signal_id.strip():
+                raise ValueError("Signal must define a non-empty signal_id")
+            raw_action = signal.get(signal_translation.action_field)
+            if not isinstance(raw_action, str):
+                raise ValueError("Signal must define an action string")
+            action = raw_action.strip().upper()
+            side = signal_translation.action_to_side.get(action)
+            if side is None:
+                raise ValueError(f"Unsupported signal action: {action}")
+
+            symbol_value = signal.get(signal_translation.symbol_field, snapshot.get("symbol"))
+            if not isinstance(symbol_value, str) or not symbol_value.strip():
+                raise ValueError("Signal must define a non-empty symbol")
+            symbol = symbol_value.strip().upper()
+
+            quantity_value = signal.get(signal_translation.quantity_field)
+            try:
+                quantity = Decimal(str(quantity_value))
+            except Exception as exc:  # pragma: no cover - defensive parsing
+                raise ValueError("Signal quantity must be decimal-compatible") from exc
+            if quantity <= Decimal("0"):
+                raise ValueError("Signal quantity must be > 0")
+
+            order = Order(
+                order_id=f"{run_id}:{signal_id}:{sequence}",
+                strategy_id=strategy_name,
+                symbol=symbol,
+                sequence=sequence,
+                side=side,
+                order_type="market",
+                time_in_force="day",
+                status="created",
+                quantity=quantity,
+                created_at=snapshot_key,
+                position_id=f"{run_id}:{symbol}:position",
+                trade_id=f"{run_id}:{symbol}:trade",
+            )
+            raw_risk_evidence = signal.get(risk_evidence_config.evidence_field)
+            risk_evidence_by_order_id[order.order_id] = (
+                raw_risk_evidence if isinstance(raw_risk_evidence, Mapping) else None
+            )
+            orders.append(order)
+            sequence += 1
+
+    return orders, risk_evidence_by_order_id
+
+
 def simulate_execution_flow(
     *,
     snapshots: Sequence[Mapping[str, Any]],
@@ -373,15 +508,19 @@ def simulate_execution_flow(
     """Run deterministic signal->order->fill->position backtest flow."""
 
     ordered_snapshots = sort_snapshots(snapshots)
-    orders = translate_signals_to_orders(
+    orders, risk_evidence_by_order_id = _translate_signals_to_order_plans(
         ordered_snapshots=ordered_snapshots,
         run_id=run_id,
         strategy_name=strategy_name,
         signal_translation=run_contract.signal_translation,
+        risk_evidence_config=run_contract.risk_evidence,
     )
     execution_config = run_contract.execution_assumptions.to_execution_config()
     lifecycle_store = _ProductionLifecycleStore()
-    risk_gate = _ApprovedRiskGate()
+    risk_gate = _DeterministicBacktestRiskGate(
+        risk_evidence_by_order_id=risk_evidence_by_order_id,
+        risk_evidence_config=run_contract.risk_evidence,
+    )
 
     symbol_positions: dict[str, Position] = {}
     symbol_pending_orders: dict[str, list[Order]] = {}
@@ -390,7 +529,12 @@ def simulate_execution_flow(
         symbol_positions.setdefault(order.symbol, _initial_position(run_id, strategy_name, order.symbol))
 
     fills: list[ExecutionEvent] = []
+    risk_decisions: list[dict[str, Any]] = []
+    risk_decision_by_order_id: dict[str, RiskDecision] = {}
+    rejected_orders: list[Order] = []
+    rejection_events: list[ExecutionEvent] = []
     for snapshot in ordered_snapshots:
+        snapshot_key = resolve_snapshot_key(snapshot)
         snapshot_symbol = snapshot.get("symbol")
         candidate_symbols: list[str]
         if isinstance(snapshot_symbol, str) and snapshot_symbol.strip():
@@ -404,27 +548,109 @@ def simulate_execution_flow(
                 continue
 
             current_position = symbol_positions[symbol]
-            pipeline_result = run_pipeline(
-                {"orders": pending_orders, "snapshot": snapshot},
-                risk_gate=risk_gate,
-                lifecycle_store=lifecycle_store,
-                risk_request=_risk_request(run_id=run_id, strategy_name=strategy_name, symbol=symbol),
-                position=current_position,
-                execution_config=execution_config,
-            )
-            snapshot_fills = pipeline_result.fills
-            if not snapshot_fills:
-                continue
+            remaining_orders: list[Order] = []
+            for order in pending_orders:
+                risk_request = _risk_request(
+                    run_id=run_id,
+                    strategy_name=strategy_name,
+                    symbol=symbol,
+                    order=order,
+                )
+                risk_decision = risk_decision_by_order_id.get(order.order_id)
+                if risk_decision is None:
+                    risk_decision = risk_gate.evaluate(risk_request)
+                    risk_decision_by_order_id[order.order_id] = risk_decision
+                    risk_decisions.append(
+                        risk_gate.build_decision_record(
+                            request=risk_request,
+                            order=order,
+                            snapshot_key=snapshot_key,
+                            decision=risk_decision,
+                        )
+                    )
 
-            symbol_positions[symbol] = pipeline_result.position
-            filled_order_ids = {fill.order_id for fill in snapshot_fills}
-            symbol_pending_orders[symbol] = [
-                order for order in pending_orders if order.order_id not in filled_order_ids
-            ]
-            fills.extend(snapshot_fills)
+                if risk_decision.decision != "APPROVED":
+                    rejected_order = _mark_order_rejected(order)
+                    rejected_orders.append(rejected_order)
+                    rejection_events.append(
+                        _build_rejection_event(
+                            order=rejected_order,
+                            snapshot_key=snapshot_key,
+                            sequence=len(rejection_events) + 1,
+                        )
+                    )
+                    continue
+
+                if not _order_ready_for_snapshot(
+                    order=order,
+                    snapshot_key=snapshot_key,
+                    fill_timing=run_contract.execution_assumptions.fill_timing,
+                ):
+                    remaining_orders.append(order)
+                    continue
+
+                pipeline_result = run_pipeline(
+                    {"orders": [order], "snapshot": snapshot},
+                    risk_gate=risk_gate,
+                    lifecycle_store=lifecycle_store,
+                    risk_request=risk_request,
+                    position=current_position,
+                    execution_config=execution_config,
+                )
+
+                if pipeline_result.status == "rejected":
+                    rejected_order = _mark_order_rejected(order)
+                    rejected_orders.append(rejected_order)
+                    rejection_events.append(
+                        _build_rejection_event(
+                            order=rejected_order,
+                            snapshot_key=snapshot_key,
+                            sequence=len(rejection_events) + 1,
+                        )
+                    )
+                    continue
+
+                snapshot_fills = pipeline_result.fills
+                if snapshot_fills:
+                    current_position = pipeline_result.position
+                    fills.extend(snapshot_fills)
+                    continue
+
+                remaining_orders.append(order)
+
+            symbol_positions[symbol] = current_position
+            symbol_pending_orders[symbol] = remaining_orders
 
     positions = [symbol_positions[symbol] for symbol in sorted(symbol_positions.keys())]
-    return BacktestExecutionFlowResult(orders=orders, fills=fills, positions=positions)
+    return BacktestExecutionFlowResult(
+        orders=orders,
+        fills=fills,
+        positions=positions,
+        risk_decisions=sorted(
+            risk_decisions,
+            key=lambda record: (
+                str(record["snapshot_key"]),
+                str(record["order_id"]),
+                str(record["request_id"]),
+            ),
+        ),
+        rejected_orders=sorted(rejected_orders, key=lambda order: order.order_id),
+        rejection_events=sorted(
+            rejection_events,
+            key=lambda event: (event.occurred_at, event.sequence, event.order_id),
+        ),
+    )
+
+
+def _order_ready_for_snapshot(
+    *,
+    order: Order,
+    snapshot_key: str,
+    fill_timing: Literal["next_snapshot", "same_snapshot"],
+) -> bool:
+    if fill_timing == "same_snapshot":
+        return order.created_at <= snapshot_key
+    return order.created_at < snapshot_key
 
 
 def _initial_position(run_id: str, strategy_name: str, symbol: str) -> Position:
@@ -445,26 +671,167 @@ def _initial_position(run_id: str, strategy_name: str, symbol: str) -> Position:
     )
 
 
-def _risk_request(*, run_id: str, strategy_name: str, symbol: str) -> RiskEvaluationRequest:
+def _risk_request(
+    *,
+    run_id: str,
+    strategy_name: str,
+    symbol: str,
+    order: Order,
+) -> RiskEvaluationRequest:
     return RiskEvaluationRequest(
-        request_id=f"{run_id}:{strategy_name}:{symbol}:risk",
+        request_id=f"{run_id}:{order.order_id}:risk",
         strategy_id=strategy_name,
         symbol=symbol,
-        notional_usd=0.0,
-        metadata={"source": "backtest_execution_contract"},
+        notional_usd=float(order.quantity),
+        metadata={
+            "source": "backtest_execution_contract",
+            "order_id": order.order_id,
+            "guard_type": "emergency",
+        },
     )
 
 
-class _ApprovedRiskGate(RiskGate):
+class _DeterministicBacktestRiskGate(RiskGate):
+    def __init__(
+        self,
+        *,
+        risk_evidence_by_order_id: Mapping[str, Mapping[str, Any] | None],
+        risk_evidence_config: BacktestRiskEvidenceConfig,
+    ) -> None:
+        self._risk_evidence_by_order_id = dict(risk_evidence_by_order_id)
+        self._risk_evidence_config = risk_evidence_config
+        self._evidence_status_by_request_id: dict[str, str] = {}
+
     def evaluate(self, request: RiskEvaluationRequest) -> RiskDecision:
+        order_id = request.metadata.get("order_id", "")
+        evidence = self._risk_evidence_by_order_id.get(order_id)
+        if evidence is None:
+            self._evidence_status_by_request_id[request.request_id] = "missing_required_risk_evidence"
+            return RiskDecision(
+                decision="REJECTED",
+                score=0.0,
+                max_allowed=0.0,
+                reason="missing_required_risk_evidence",
+                timestamp=BACKTEST_RISK_DECISION_TIMESTAMP,
+                rule_version=BACKTEST_RISK_RULE_VERSION,
+            )
+
+        config = self._risk_evidence_config
+        try:
+            raw_decision = evidence[config.decision_field]
+            score = float(evidence[config.score_field])
+            max_allowed = float(evidence[config.max_allowed_field])
+            reason = str(evidence[config.reason_field]).strip()
+            rule_version = str(evidence[config.rule_version_field]).strip()
+        except (KeyError, TypeError, ValueError) as exc:
+            self._evidence_status_by_request_id[request.request_id] = "invalid_required_risk_evidence"
+            return RiskDecision(
+                decision="REJECTED",
+                score=0.0,
+                max_allowed=0.0,
+                reason=f"invalid_required_risk_evidence:{type(exc).__name__}",
+                timestamp=BACKTEST_RISK_DECISION_TIMESTAMP,
+                rule_version=BACKTEST_RISK_RULE_VERSION,
+            )
+
+        if not isfinite(score) or not isfinite(max_allowed):
+            self._evidence_status_by_request_id[request.request_id] = "invalid_required_risk_evidence"
+            return RiskDecision(
+                decision="REJECTED",
+                score=0.0,
+                max_allowed=0.0,
+                reason="invalid_required_risk_evidence:non_finite_score_or_max_allowed",
+                timestamp=BACKTEST_RISK_DECISION_TIMESTAMP,
+                rule_version=BACKTEST_RISK_RULE_VERSION,
+            )
+
+        decision = str(raw_decision).strip().upper()
+        if decision not in {"APPROVED", "REJECTED"}:
+            self._evidence_status_by_request_id[request.request_id] = "invalid_required_risk_evidence"
+            return RiskDecision(
+                decision="REJECTED",
+                score=score,
+                max_allowed=max_allowed,
+                reason="invalid_required_risk_evidence:unsupported_decision",
+                timestamp=BACKTEST_RISK_DECISION_TIMESTAMP,
+                rule_version=BACKTEST_RISK_RULE_VERSION,
+            )
+        if not reason or not rule_version:
+            self._evidence_status_by_request_id[request.request_id] = "invalid_required_risk_evidence"
+            return RiskDecision(
+                decision="REJECTED",
+                score=score,
+                max_allowed=max_allowed,
+                reason="invalid_required_risk_evidence:empty_reason_or_rule_version",
+                timestamp=BACKTEST_RISK_DECISION_TIMESTAMP,
+                rule_version=BACKTEST_RISK_RULE_VERSION,
+            )
+
+        self._evidence_status_by_request_id[request.request_id] = "present"
         return RiskDecision(
-            decision="APPROVED",
-            score=0.0,
-            max_allowed=0.0,
-            reason="deterministic_backtest",
-            timestamp=datetime(1970, 1, 1, tzinfo=timezone.utc),
-            rule_version="deterministic-backtest-v1",
+            decision=decision,  # type: ignore[arg-type]
+            score=score,
+            max_allowed=max_allowed,
+            reason=reason,
+            timestamp=BACKTEST_RISK_DECISION_TIMESTAMP,
+            rule_version=rule_version,
         )
+
+    def build_decision_record(
+        self,
+        *,
+        request: RiskEvaluationRequest,
+        order: Order,
+        snapshot_key: str,
+        decision: RiskDecision,
+    ) -> dict[str, Any]:
+        return {
+            "risk_evidence_version": BACKTEST_RISK_EVIDENCE_VERSION,
+            "request_id": request.request_id,
+            "order_id": order.order_id,
+            "symbol": order.symbol,
+            "side": order.side,
+            "snapshot_key": snapshot_key,
+            "evidence_status": self._evidence_status_by_request_id.get(
+                request.request_id,
+                "unknown",
+            ),
+            "decision": decision.decision,
+            "score": decision.score,
+            "max_allowed": decision.max_allowed,
+            "reason": decision.reason,
+            "timestamp": decision.timestamp.isoformat().replace("+00:00", "Z"),
+            "rule_version": decision.rule_version,
+        }
+
+
+def _mark_order_rejected(order: Order) -> Order:
+    return Order.model_validate({**order.model_dump(mode="python"), "status": "rejected"})
+
+
+def _build_rejection_event(
+    *,
+    order: Order,
+    snapshot_key: str,
+    sequence: int,
+) -> ExecutionEvent:
+    return ExecutionEvent(
+        event_id=compute_execution_event_id(
+            order_id=order.order_id,
+            event_type="rejected",
+            occurred_at=snapshot_key,
+            sequence=sequence,
+        ),
+        order_id=order.order_id,
+        strategy_id=order.strategy_id,
+        symbol=order.symbol,
+        side=order.side,
+        event_type="rejected",
+        occurred_at=snapshot_key,
+        sequence=sequence,
+        position_id=order.position_id,
+        trade_id=order.trade_id,
+    )
 
 
 class _ProductionLifecycleStore:

--- a/src/cilly_trading/engine/backtest_runner.py
+++ b/src/cilly_trading/engine/backtest_runner.py
@@ -293,6 +293,12 @@ class BacktestRunner:
             "processed_snapshots": processed_snapshots,
             "orders": serialize_orders(flow_result.orders),
             "fills": serialize_fills(flow_result.fills),
+            "execution_events": serialize_fills(
+                [*flow_result.fills, *flow_result.rejection_events]
+            ),
+            "risk_decisions": flow_result.risk_decisions,
+            "rejected_orders": serialize_orders(flow_result.rejected_orders),
+            "rejection_events": serialize_fills(flow_result.rejection_events),
             "positions": serialize_positions(flow_result.positions),
             "summary": {
                 "start_equity": metrics_baseline["summary"]["starting_equity"],

--- a/src/cilly_trading/engine/decision_card_contract.py
+++ b/src/cilly_trading/engine/decision_card_contract.py
@@ -73,6 +73,18 @@ CONFIDENCE_CALIBRATION_INTERPRETATION_BOUNDARY = (
     "matched paper-trade outcomes. It does not imply trader validation, profitability forecasting, "
     "live-trading readiness, or operational readiness."
 )
+STRATEGY_SCORE_CALIBRATION_CONTRACT_ID = (
+    "bounded_strategy_score_calibration.backtest_to_paper.paper_audit.v1"
+)
+STRATEGY_SCORE_CALIBRATION_CONTRACT_VERSION = "1.0.0"
+STRATEGY_SCORE_CALIBRATION_INTERPRETATION_BOUNDARY = (
+    "Bounded strategy-score calibration is limited to per-strategy non-live interpretation of "
+    "RSI2/Turtle MVP aggregate scores against covered backtest-realism evidence and matched "
+    "paper-trade outcomes where available. Confidence tier remains ordinal, not probabilistic. "
+    "Cross-strategy comparability remains explicitly unsupported unless governed evidence proves "
+    "otherwise. It does not imply trader validation, profitability forecasting, live-trading "
+    "readiness, or operational readiness."
+)
 
 END_TO_END_TRACEABILITY_CONTRACT_ID = (
     "signal_to_paper_reconciliation_traceability.paper_audit.v1"
@@ -115,6 +127,8 @@ PaperTradeOutcomeDirection = Literal["favorable", "flat", "adverse", "open", "in
 SignalQualityStabilityClassification = Literal["stable", "weak", "failing"]
 BacktestRealismCalibrationStatus = Literal["stable", "weak", "failing", "missing"]
 ConfidenceCalibrationClassification = Literal["stable", "weak", "failing"]
+StrategyScoreCalibrationClassification = Literal["stable", "weak", "failing", "limited"]
+StrategyScoreEvidenceCoverage = Literal["covered", "partial", "missing", "invalid"]
 
 REQUIRED_COMPONENT_CATEGORIES: tuple[DecisionComponentCategory, ...] = (
     "signal_quality",
@@ -920,6 +934,226 @@ def evaluate_bounded_confidence_calibration_audit(
     )
 
 
+class BoundedStrategyScoreCalibrationAudit(BaseModel):
+    """Bounded per-strategy MVP score calibration against covered evidence."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    contract_id: str = STRATEGY_SCORE_CALIBRATION_CONTRACT_ID
+    contract_version: str = STRATEGY_SCORE_CALIBRATION_CONTRACT_VERSION
+    covered_case_id: str = Field(min_length=1)
+    strategy_id: Literal["RSI2", "TURTLE"]
+    score_scope: Literal["per_strategy"] = "per_strategy"
+    score_interpretation: Literal["bounded_per_strategy_evidence"] = (
+        "bounded_per_strategy_evidence"
+    )
+    aggregate_score: float = Field(ge=0.0, le=100.0)
+    confidence_tier: DecisionConfidenceTier
+    confidence_tier_semantics: Literal["ordinal_not_probabilistic"] = (
+        "ordinal_not_probabilistic"
+    )
+    backtest_realism_status: BacktestRealismCalibrationStatus
+    backtest_realism_reason: str = Field(min_length=24)
+    match_reference: BoundedDecisionToPaperUsefulnessMatchReference | None = None
+    match_status: DecisionToPaperUsefulnessMatchStatus
+    matched_outcome: BoundedPaperTradeOutcome | None = None
+    evidence_coverage: StrategyScoreEvidenceCoverage
+    calibration_classification: StrategyScoreCalibrationClassification
+    calibration_reason: str = Field(min_length=24)
+    cross_strategy_comparison_supported: Literal[False] = False
+    interpretation_limit: str = Field(min_length=24)
+
+    @field_validator("contract_id")
+    @classmethod
+    def _validate_contract_id(cls, value: str) -> str:
+        if value != STRATEGY_SCORE_CALIBRATION_CONTRACT_ID:
+            raise ValueError(f"Unsupported strategy-score calibration contract_id: {value}")
+        return value
+
+    @field_validator("contract_version")
+    @classmethod
+    def _validate_contract_version(cls, value: str) -> str:
+        if value != STRATEGY_SCORE_CALIBRATION_CONTRACT_VERSION:
+            raise ValueError(
+                f"Unsupported strategy-score calibration contract_version: {value}"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _validate_boundary_alignment(self) -> "BoundedStrategyScoreCalibrationAudit":
+        if self.match_status == "missing":
+            if self.matched_outcome is not None:
+                raise ValueError("matched_outcome must be omitted when match_status is missing")
+        else:
+            if self.matched_outcome is None:
+                raise ValueError(
+                    "matched_outcome is required when match_status is matched, open, or invalid"
+                )
+        lowered_limit = self.interpretation_limit.casefold()
+        required_phrases = (
+            "per-strategy",
+            "confidence tier remains ordinal",
+            "cross-strategy comparability remains explicitly unsupported",
+            "non-live",
+            "trader validation",
+            "profitability forecasting",
+            "live-trading readiness",
+        )
+        if not all(phrase in lowered_limit for phrase in required_phrases):
+            raise ValueError(
+                "interpretation_limit must preserve per-strategy, ordinal, non-live, "
+                "non-comparability, trader-validation, profitability, and readiness boundaries"
+            )
+        return self
+
+
+def _classify_strategy_score_evidence_coverage(
+    *,
+    backtest_realism_status: BacktestRealismCalibrationStatus,
+    match_status: DecisionToPaperUsefulnessMatchStatus,
+) -> StrategyScoreEvidenceCoverage:
+    if backtest_realism_status == "missing" and match_status == "missing":
+        return "missing"
+    if backtest_realism_status == "failing" or match_status == "invalid":
+        return "invalid"
+    if backtest_realism_status == "missing" or match_status in {"missing", "open"}:
+        return "partial"
+    return "covered"
+
+
+def _classify_strategy_score_calibration(
+    *,
+    aggregate_score: float,
+    confidence_tier: DecisionConfidenceTier,
+    backtest_realism_status: BacktestRealismCalibrationStatus,
+    match_status: DecisionToPaperUsefulnessMatchStatus,
+    matched_outcome: BoundedPaperTradeOutcome | None,
+) -> tuple[
+    StrategyScoreEvidenceCoverage,
+    StrategyScoreCalibrationClassification,
+    str,
+]:
+    evidence_coverage = _classify_strategy_score_evidence_coverage(
+        backtest_realism_status=backtest_realism_status,
+        match_status=match_status,
+    )
+    if evidence_coverage == "missing":
+        return (
+            evidence_coverage,
+            "limited",
+            "Strategy score has neither covered backtest-realism evidence nor matched paper "
+            "outcome evidence, so per-strategy calibration is limited in non-live review.",
+        )
+    if evidence_coverage == "invalid":
+        return (
+            evidence_coverage,
+            "failing",
+            "Strategy score evidence includes failing backtest-realism coverage or invalid paper "
+            "matching, so bounded per-strategy calibration is failing.",
+        )
+    if match_status == "open":
+        return (
+            evidence_coverage,
+            "weak",
+            "Strategy score has an open matched paper trade, so calibration remains weak until "
+            "the downstream paper outcome is closed.",
+        )
+    if backtest_realism_status == "missing" or match_status == "missing":
+        return (
+            evidence_coverage,
+            "limited",
+            "Strategy score is supported by only partial calibration evidence, so interpretation "
+            "is limited to bounded per-strategy evidence.",
+        )
+    if matched_outcome is None:
+        return (
+            evidence_coverage,
+            "weak",
+            "Matched paper outcome is unavailable, so bounded per-strategy score calibration "
+            "remains weak.",
+        )
+    if matched_outcome.outcome_direction == "adverse":
+        if confidence_tier == "low" or aggregate_score < QUALIFICATION_MEDIUM_AGGREGATE_THRESHOLD:
+            return (
+                evidence_coverage,
+                "weak",
+                "Adverse matched paper outcome aligns only with a cautious low-score posture, so "
+                "per-strategy calibration remains weak rather than stable.",
+            )
+        return (
+            evidence_coverage,
+            "failing",
+            "Strategy score remained medium/high while the matched paper outcome closed adverse, "
+            "so bounded per-strategy calibration is failing.",
+        )
+    if matched_outcome.outcome_direction == "flat":
+        return (
+            evidence_coverage,
+            "weak",
+            "Matched paper outcome closed flat, so the strategy score has weak bounded "
+            "per-strategy calibration evidence.",
+        )
+    if backtest_realism_status == "stable" and confidence_tier in {"medium", "high"}:
+        return (
+            evidence_coverage,
+            "stable",
+            "Strategy score is bounded per-strategy evidence with stable covered backtest-realism "
+            "coverage and a favorable matched paper outcome.",
+        )
+    return (
+        evidence_coverage,
+        "weak",
+        "Strategy score has favorable paper evidence but incomplete or cautious supporting "
+        "evidence, so bounded per-strategy calibration remains weak.",
+    )
+
+
+def evaluate_bounded_strategy_score_calibration_audit(
+    *,
+    covered_case_id: str,
+    strategy_id: Literal["RSI2", "TURTLE"],
+    aggregate_score: float,
+    confidence_tier: DecisionConfidenceTier,
+    backtest_realism_status: BacktestRealismCalibrationStatus,
+    backtest_realism_reason: str,
+    match_status: DecisionToPaperUsefulnessMatchStatus,
+    match_reference: dict[str, Any] | None = None,
+    matched_outcome: dict[str, Any] | None = None,
+) -> BoundedStrategyScoreCalibrationAudit:
+    normalized_match_reference = (
+        BoundedDecisionToPaperUsefulnessMatchReference.model_validate(match_reference)
+        if match_reference is not None
+        else None
+    )
+    normalized_matched_outcome = (
+        BoundedPaperTradeOutcome.model_validate(matched_outcome)
+        if matched_outcome is not None
+        else None
+    )
+    evidence_coverage, classification, reason = _classify_strategy_score_calibration(
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+        backtest_realism_status=backtest_realism_status,
+        match_status=match_status,
+        matched_outcome=normalized_matched_outcome,
+    )
+    return BoundedStrategyScoreCalibrationAudit(
+        covered_case_id=covered_case_id,
+        strategy_id=strategy_id,
+        aggregate_score=aggregate_score,
+        confidence_tier=confidence_tier,
+        backtest_realism_status=backtest_realism_status,
+        backtest_realism_reason=backtest_realism_reason,
+        match_reference=normalized_match_reference,
+        match_status=match_status,
+        matched_outcome=normalized_matched_outcome,
+        evidence_coverage=evidence_coverage,
+        calibration_classification=classification,
+        calibration_reason=reason,
+        interpretation_limit=STRATEGY_SCORE_CALIBRATION_INTERPRETATION_BOUNDARY,
+    )
+
+
 EndToEndTraceabilityLinkageStatus = Literal["matched", "open", "missing", "invalid"]
 
 
@@ -1659,6 +1893,12 @@ __all__ = [
     "SIGNAL_QUALITY_STABILITY_INTERPRETATION_BOUNDARY",
     "SIGNAL_QUALITY_STABILITY_HIGH_THRESHOLD",
     "SIGNAL_QUALITY_STABILITY_LOW_THRESHOLD",
+    "CONFIDENCE_CALIBRATION_CONTRACT_ID",
+    "CONFIDENCE_CALIBRATION_CONTRACT_VERSION",
+    "CONFIDENCE_CALIBRATION_INTERPRETATION_BOUNDARY",
+    "STRATEGY_SCORE_CALIBRATION_CONTRACT_ID",
+    "STRATEGY_SCORE_CALIBRATION_CONTRACT_VERSION",
+    "STRATEGY_SCORE_CALIBRATION_INTERPRETATION_BOUNDARY",
     "END_TO_END_TRACEABILITY_CONTRACT_ID",
     "END_TO_END_TRACEABILITY_CONTRACT_VERSION",
     "END_TO_END_TRACEABILITY_INTERPRETATION_BOUNDARY",
@@ -1688,6 +1928,7 @@ __all__ = [
     "BoundedReconciliationStageReference",
     "BoundedSignalAnalysisStageReference",
     "BoundedSignalQualityStabilityAudit",
+    "BoundedStrategyScoreCalibrationAudit",
     "BoundedTraderRelevanceCaseEvaluation",
     "BoundedTraderRelevanceValidation",
     "ComponentScore",
@@ -1696,6 +1937,8 @@ __all__ = [
     "DecisionRationale",
     "EndToEndTraceabilityLinkageStatus",
     "SignalQualityStabilityClassification",
+    "StrategyScoreCalibrationClassification",
+    "StrategyScoreEvidenceCoverage",
     "HardGateEvaluation",
     "HardGateResult",
     "QualificationProfileRobustnessAudit",
@@ -1705,6 +1948,7 @@ __all__ = [
     "evaluate_bounded_decision_to_paper_usefulness_audit",
     "evaluate_bounded_end_to_end_traceability_chain",
     "evaluate_bounded_signal_quality_stability_audit",
+    "evaluate_bounded_strategy_score_calibration_audit",
     "evaluate_bounded_trader_relevance_cases",
     "serialize_decision_card",
     "validate_decision_card",

--- a/src/cilly_trading/strategies/evaluation_harness.py
+++ b/src/cilly_trading/strategies/evaluation_harness.py
@@ -334,7 +334,7 @@ def _build_strategy_snapshots(
         )
         candidate_count += len(candidate_signals)
 
-        executable_signals: list[dict[str, str]] = []
+        executable_signals: list[dict[str, Any]] = []
         if not has_open_position and candidate_signals:
             executable_signals = [candidate_signals[0]]
             has_open_position = True
@@ -393,7 +393,7 @@ def _to_executable_signals(
     strategy: Any,
     history_frame: pd.DataFrame,
     strategy_config: Mapping[str, Any],
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     try:
         generated = strategy.generate_signals(history_frame, dict(strategy_config))
     except Exception as exc:
@@ -409,7 +409,7 @@ def _to_executable_signals(
         )
 
     snapshot_id = str(snapshot.get("id", "snapshot"))
-    executable_signals: list[dict[str, str]] = []
+    executable_signals: list[dict[str, Any]] = []
     for index, signal in enumerate(generated, start=1):
         if not isinstance(signal, Mapping):
             continue
@@ -426,11 +426,25 @@ def _to_executable_signals(
                 "action": "BUY",
                 "quantity": "1",
                 "symbol": symbol,
+                "risk_evidence": _approved_backtest_risk_evidence(
+                    strategy_name=strategy_name,
+                    symbol=symbol,
+                ),
             }
         )
 
     executable_signals.sort(key=lambda signal: (signal["signal_id"], signal["symbol"]))
     return executable_signals
+
+
+def _approved_backtest_risk_evidence(*, strategy_name: str, symbol: str) -> dict[str, str]:
+    return {
+        "decision": "APPROVED",
+        "score": "1",
+        "max_allowed": "1",
+        "reason": f"strategy_comparison_bounded_risk_approved:{strategy_name}:{symbol}",
+        "rule_version": "strategy-comparison-backtest-risk-v1",
+    }
 
 
 def _normalize_symbol(value: Any) -> str:

--- a/tests/cilly_trading/engine/test_backtest_execution_contract.py
+++ b/tests/cilly_trading/engine/test_backtest_execution_contract.py
@@ -23,6 +23,13 @@ from cilly_trading.engine.backtest_runner import BacktestRunner, BacktestRunnerC
 
 
 def _sample_flow_snapshots() -> list[dict[str, object]]:
+    approved_risk = {
+        "decision": "APPROVED",
+        "score": "1",
+        "max_allowed": "10",
+        "reason": "deterministic_risk_within_bounds",
+        "rule_version": "test-risk-v1",
+    }
     return [
         {
             "id": "s1",
@@ -30,7 +37,13 @@ def _sample_flow_snapshots() -> list[dict[str, object]]:
             "symbol": "AAPL",
             "open": "100",
             "signals": [
-                {"signal_id": "sig-buy", "action": "BUY", "quantity": "2", "symbol": "AAPL"},
+                {
+                    "signal_id": "sig-buy",
+                    "action": "BUY",
+                    "quantity": "2",
+                    "symbol": "AAPL",
+                    "risk_evidence": approved_risk,
+                },
             ],
         },
         {
@@ -39,7 +52,13 @@ def _sample_flow_snapshots() -> list[dict[str, object]]:
             "symbol": "AAPL",
             "open": "110",
             "signals": [
-                {"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"},
+                {
+                    "signal_id": "sig-sell",
+                    "action": "SELL",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": approved_risk,
+                },
             ],
         },
         {
@@ -107,12 +126,152 @@ def test_representative_backtest_flow_next_snapshot() -> None:
 
     assert len(result.orders) == 2
     assert len(result.fills) == 2
+    assert len(result.risk_decisions) == 2
+    assert result.risk_decisions[0]["decision"] == "APPROVED"
+    assert result.risk_decisions[0]["evidence_status"] == "present"
+    assert result.rejected_orders == []
+    assert result.rejection_events == []
     assert result.fills[0].order_id.endswith(":sig-buy:1")
     assert result.fills[0].occurred_at == "2024-01-02T00:00:00Z"
     assert result.fills[1].order_id.endswith(":sig-sell:2")
     assert result.fills[1].occurred_at == "2024-01-03T00:00:00Z"
     assert result.positions[0].status == "open"
     assert result.positions[0].net_quantity == Decimal("1.00000000")
+
+
+def test_representative_backtest_flow_rejects_order_with_risk_evidence() -> None:
+    snapshots = [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "100",
+            "signals": [
+                {
+                    "signal_id": "sig-buy",
+                    "action": "BUY",
+                    "quantity": "2",
+                    "symbol": "AAPL",
+                    "risk_evidence": {
+                        "decision": "REJECTED",
+                        "score": "11",
+                        "max_allowed": "10",
+                        "reason": "deterministic_risk_limit_exceeded",
+                        "rule_version": "test-risk-v1",
+                    },
+                },
+            ],
+        },
+        {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "101"},
+    ]
+
+    result = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="run-risk-reject",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(),
+    )
+
+    assert len(result.orders) == 1
+    assert len(result.fills) == 0
+    assert len(result.risk_decisions) == 1
+    assert result.risk_decisions[0]["decision"] == "REJECTED"
+    assert len(result.rejected_orders) == 1
+    assert result.rejected_orders[0].status == "rejected"
+    assert len(result.rejection_events) == 1
+    assert result.rejection_events[0].event_type == "rejected"
+
+
+def test_representative_backtest_flow_missing_risk_evidence_rejects_safely() -> None:
+    snapshots = [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "100",
+            "signals": [
+                {"signal_id": "sig-buy", "action": "BUY", "quantity": "2", "symbol": "AAPL"},
+            ],
+        },
+        {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "101"},
+    ]
+
+    result = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id="run-missing-risk",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(),
+    )
+
+    missing_decision = result.risk_decisions[0]
+    assert missing_decision["decision"] == "REJECTED"
+    assert missing_decision["evidence_status"] == "missing_required_risk_evidence"
+    assert missing_decision["reason"] == "missing_required_risk_evidence"
+    assert len(result.rejected_orders) == 1
+    assert len(result.rejection_events) == 1
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("score", "NaN"),
+        ("score", "inf"),
+        ("max_allowed", "NaN"),
+        ("max_allowed", "inf"),
+    ],
+)
+def test_representative_backtest_flow_non_finite_risk_evidence_rejects_safely(
+    field_name: str,
+    field_value: str,
+) -> None:
+    risk_evidence = {
+        "decision": "APPROVED",
+        "score": "1",
+        "max_allowed": "10",
+        "reason": "deterministic_risk_within_bounds",
+        "rule_version": "test-risk-v1",
+    }
+    risk_evidence[field_name] = field_value
+    snapshots = [
+        {
+            "id": "s1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "symbol": "AAPL",
+            "open": "100",
+            "signals": [
+                {
+                    "signal_id": f"sig-{field_name}-{field_value}",
+                    "action": "BUY",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": risk_evidence,
+                },
+            ],
+        },
+        {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "101"},
+    ]
+
+    result = simulate_execution_flow(
+        snapshots=snapshots,
+        run_id=f"run-non-finite-{field_name}-{field_value}",
+        strategy_name="REFERENCE",
+        run_contract=BacktestRunContract(),
+    )
+
+    assert result.fills == []
+    assert len(result.risk_decisions) == 1
+    assert result.risk_decisions[0]["decision"] == "REJECTED"
+    assert result.risk_decisions[0]["evidence_status"] == "invalid_required_risk_evidence"
+    assert (
+        result.risk_decisions[0]["reason"]
+        == "invalid_required_risk_evidence:non_finite_score_or_max_allowed"
+    )
+    assert result.risk_decisions[0]["score"] == 0.0
+    assert result.risk_decisions[0]["max_allowed"] == 0.0
+    assert len(result.rejected_orders) == 1
+    assert result.rejected_orders[0].status == "rejected"
+    assert len(result.rejection_events) == 1
+    assert result.rejection_events[0].event_type == "rejected"
 
 
 def test_representative_backtest_flow_same_snapshot() -> None:
@@ -274,6 +433,12 @@ def test_backtest_realism_boundary_reports_modeled_and_unmodeled_assumptions() -
     )
 
     assert boundary["boundary_version"] == "1.0.0"
+    assert boundary["modeled_assumptions"]["bounded_risk_decisions"] == {
+        "risk_evidence_version": "1.0.0",
+        "evidence_source": "signal_risk_evidence",
+        "missing_evidence_policy": "deterministic_order_rejection",
+        "broker_risk_behavior": "not_modeled",
+    }
     assert boundary["modeled_assumptions"]["fees"] == {
         "commission_model": "fixed_per_filled_order",
         "commission_per_order": "1.00",
@@ -289,7 +454,9 @@ def test_backtest_realism_boundary_reports_modeled_and_unmodeled_assumptions() -
         "price_source": "open_then_price",
     }
     assert "Not modeled." in boundary["unmodeled_assumptions"]["market_hours"]
+    assert "broker rejects" in boundary["unmodeled_assumptions"]["broker_behavior"]
     assert "market-hours compliance realism" in boundary["evidence_boundary"]["unsupported_claims"]
+    assert "broker reject realism" in boundary["evidence_boundary"]["unsupported_claims"]
     assert "bounded backtest evidence only" in boundary["evidence_boundary"]["decision_use_constraint"]
 
 
@@ -422,3 +589,16 @@ def test_realism_sensitivity_matrix_delta_calculation_consistency() -> None:
     assert baseline["delta_vs_baseline"]["metrics"]["total_return"] == 0.0
     assert no_cost["delta_vs_baseline"]["summary"]["ending_equity_cost_aware"] == pytest.approx(2.33)
     assert no_cost["delta_vs_baseline"]["summary"]["total_transaction_cost"] == pytest.approx(-2.33)
+
+
+def test_backtest_realism_docs_keep_risk_rejections_bounded() -> None:
+    contract = Path("docs/governance/backtest-realism-boundary-contract.md").read_text(encoding="utf-8")
+    runtime = Path("docs/operations/runtime/backtest_realism_boundary_runtime.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "missing_required_risk_evidence" in contract
+    assert "Rejected orders remain represented" in contract
+    assert "model broker rejects" in contract
+    assert "missing_required_risk_evidence" in runtime
+    assert "do not model broker rejects" in runtime

--- a/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
+++ b/tests/cilly_trading/engine/test_backtest_realism_assumptions.py
@@ -20,6 +20,16 @@ def _assumptions() -> BacktestExecutionAssumptions:
     )
 
 
+def _approved_risk_evidence() -> dict[str, str]:
+    return {
+        "decision": "APPROVED",
+        "score": "1",
+        "max_allowed": "10",
+        "reason": "deterministic_risk_within_bounds",
+        "rule_version": "test-risk-v1",
+    }
+
+
 def test_p56_bt_fill_timing_and_price_source_are_bounded_to_current_model() -> None:
     snapshots = [
         {
@@ -27,14 +37,30 @@ def test_p56_bt_fill_timing_and_price_source_are_bounded_to_current_model() -> N
             "timestamp": "2024-01-01T00:00:00Z",
             "symbol": "AAPL",
             "open": "100",
-            "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            "signals": [
+                {
+                    "signal_id": "sig-buy",
+                    "action": "BUY",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": _approved_risk_evidence(),
+                }
+            ],
         },
         {
             "id": "s2",
             "timestamp": "2024-01-02T00:00:00Z",
             "symbol": "AAPL",
             "price": "101",
-            "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+            "signals": [
+                {
+                    "signal_id": "sig-sell",
+                    "action": "SELL",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": _approved_risk_evidence(),
+                }
+            ],
         },
         {
             "id": "s3",
@@ -66,14 +92,30 @@ def test_p56_bt_cost_assumptions_are_fixed_per_order_and_side_aware() -> None:
                 "timestamp": "2024-01-01T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "100",
-                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-buy",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {
                 "id": "s2",
                 "timestamp": "2024-01-02T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "101",
-                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-sell",
+                        "action": "SELL",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {
                 "id": "s3",
@@ -112,14 +154,30 @@ def test_p56_bt_replay_is_deterministic_and_cost_sensitive_to_assumptions() -> N
                 "timestamp": "2024-01-01T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "100",
-                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-buy",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {
                 "id": "s2",
                 "timestamp": "2024-01-02T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "101",
-                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-sell",
+                        "action": "SELL",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {"id": "s3", "timestamp": "2024-01-03T00:00:00Z", "symbol": "AAPL", "open": "102"},
         ]
@@ -180,14 +238,30 @@ def test_p56_bt_realism_profile_matrix_is_deterministic_and_replay_stable() -> N
                 "timestamp": "2024-01-01T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "100",
-                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-buy",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {
                 "id": "s2",
                 "timestamp": "2024-01-02T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "101",
-                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-sell",
+                        "action": "SELL",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {"id": "s3", "timestamp": "2024-01-03T00:00:00Z", "symbol": "AAPL", "open": "102"},
         ]

--- a/tests/cilly_trading/engine/test_backtest_runner.py
+++ b/tests/cilly_trading/engine/test_backtest_runner.py
@@ -38,6 +38,16 @@ def _sample_snapshots() -> List[Dict[str, Any]]:
     ]
 
 
+def _approved_risk_evidence() -> Dict[str, str]:
+    return {
+        "decision": "APPROVED",
+        "score": "1",
+        "max_allowed": "10",
+        "reason": "deterministic_risk_within_bounds",
+        "rule_version": "test-risk-v1",
+    }
+
+
 def _run_with_spy(output_dir: Path):
     container: Dict[str, SpyStrategy] = {}
 
@@ -101,14 +111,30 @@ def test_backtest_runner_deterministic_repeat_with_identical_realism_assumptions
             "timestamp": "2024-01-01T00:00:00Z",
             "symbol": "AAPL",
             "open": "100",
-            "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            "signals": [
+                {
+                    "signal_id": "sig-buy",
+                    "action": "BUY",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": _approved_risk_evidence(),
+                }
+            ],
         },
         {
             "id": "s2",
             "timestamp": "2024-01-02T00:00:00Z",
             "symbol": "AAPL",
             "open": "101",
-            "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+            "signals": [
+                {
+                    "signal_id": "sig-sell",
+                    "action": "SELL",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": _approved_risk_evidence(),
+                }
+            ],
         },
         {
             "id": "s3",
@@ -335,7 +361,15 @@ def test_backtest_runner_emits_deterministic_orders_fills_positions(tmp_path: Pa
                 "timestamp": "2024-01-01T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "100",
-                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-buy",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {
                 "id": "s2",
@@ -351,12 +385,108 @@ def test_backtest_runner_emits_deterministic_orders_fills_positions(tmp_path: Pa
     payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
     assert len(payload["orders"]) == 1
     assert len(payload["fills"]) == 1
+    assert len(payload["execution_events"]) == 1
+    assert len(payload["risk_decisions"]) == 1
+    assert payload["risk_decisions"][0]["decision"] == "APPROVED"
+    assert payload["risk_decisions"][0]["evidence_status"] == "present"
+    assert payload["rejected_orders"] == []
+    assert payload["rejection_events"] == []
     assert len(payload["positions"]) == 1
     assert payload["fills"][0]["occurred_at"] == "2024-01-02T00:00:00Z"
     assert "summary" in payload
     assert "equity_curve" in payload
     assert "metrics_baseline" in payload
     assert payload["summary"]["start_equity"] == 100000.0
+
+
+def test_backtest_runner_artifact_represents_missing_risk_evidence_as_rejection(
+    tmp_path: Path,
+) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    result = runner.run(
+        snapshots=[
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            },
+            {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "101"},
+        ],
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=tmp_path / "missing-risk", run_id="missing-risk-run"),
+    )
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+
+    assert payload["fills"] == []
+    assert len(payload["risk_decisions"]) == 1
+    assert payload["risk_decisions"][0]["decision"] == "REJECTED"
+    assert payload["risk_decisions"][0]["evidence_status"] == "missing_required_risk_evidence"
+    assert len(payload["rejected_orders"]) == 1
+    assert payload["rejected_orders"][0]["status"] == "rejected"
+    assert len(payload["rejection_events"]) == 1
+    assert payload["rejection_events"][0]["event_type"] == "rejected"
+    assert payload["execution_events"] == payload["rejection_events"]
+
+
+def test_backtest_runner_artifact_represents_non_finite_risk_evidence_as_rejection(
+    tmp_path: Path,
+) -> None:
+    runner = BacktestRunner()
+
+    def strategy_factory() -> SpyStrategy:
+        return SpyStrategy()
+
+    result = runner.run(
+        snapshots=[
+            {
+                "id": "s1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "symbol": "AAPL",
+                "open": "100",
+                "signals": [
+                    {
+                        "signal_id": "sig-non-finite",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": {
+                            "decision": "APPROVED",
+                            "score": "NaN",
+                            "max_allowed": "10",
+                            "reason": "deterministic_risk_within_bounds",
+                            "rule_version": "test-risk-v1",
+                        },
+                    }
+                ],
+            },
+            {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "101"},
+        ],
+        strategy_factory=strategy_factory,
+        config=BacktestRunnerConfig(output_dir=tmp_path / "non-finite-risk", run_id="non-finite-risk-run"),
+    )
+
+    payload = json.loads(result.artifact_path.read_text(encoding="utf-8"))
+
+    assert payload["fills"] == []
+    assert len(payload["risk_decisions"]) == 1
+    assert payload["risk_decisions"][0]["decision"] == "REJECTED"
+    assert payload["risk_decisions"][0]["evidence_status"] == "invalid_required_risk_evidence"
+    assert (
+        payload["risk_decisions"][0]["reason"]
+        == "invalid_required_risk_evidence:non_finite_score_or_max_allowed"
+    )
+    assert len(payload["rejected_orders"]) == 1
+    assert payload["rejected_orders"][0]["status"] == "rejected"
+    assert len(payload["rejection_events"]) == 1
+    assert payload["rejection_events"][0]["event_type"] == "rejected"
+    assert payload["execution_events"] == payload["rejection_events"]
 
 
 def test_backtest_runner_metrics_baseline_cost_aware_differs_from_cost_free(tmp_path: Path) -> None:
@@ -372,14 +502,30 @@ def test_backtest_runner_metrics_baseline_cost_aware_differs_from_cost_free(tmp_
                 "timestamp": "2024-01-01T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "100",
-                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-buy",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {
                 "id": "s2",
                 "timestamp": "2024-01-02T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "101",
-                "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-sell",
+                        "action": "SELL",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {
                 "id": "s3",
@@ -430,14 +576,30 @@ def test_backtest_runner_cost_outputs_change_when_realism_assumptions_change(tmp
             "timestamp": "2024-01-01T00:00:00Z",
             "symbol": "AAPL",
             "open": "100",
-            "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+            "signals": [
+                {
+                    "signal_id": "sig-buy",
+                    "action": "BUY",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": _approved_risk_evidence(),
+                }
+            ],
         },
         {
             "id": "s2",
             "timestamp": "2024-01-02T00:00:00Z",
             "symbol": "AAPL",
             "open": "101",
-            "signals": [{"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"}],
+            "signals": [
+                {
+                    "signal_id": "sig-sell",
+                    "action": "SELL",
+                    "quantity": "1",
+                    "symbol": "AAPL",
+                    "risk_evidence": _approved_risk_evidence(),
+                }
+            ],
         },
         {
             "id": "s3",
@@ -507,7 +669,15 @@ def test_backtest_runner_persists_identical_realism_assumptions_across_artifact_
                 "timestamp": "2024-01-01T00:00:00Z",
                 "symbol": "AAPL",
                 "open": "100",
-                "signals": [{"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"}],
+                "signals": [
+                    {
+                        "signal_id": "sig-buy",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    }
+                ],
             },
             {"id": "s2", "timestamp": "2024-01-02T00:00:00Z", "symbol": "AAPL", "open": "102"},
         ],

--- a/tests/test_api_decision_card_inspection_read.py
+++ b/tests/test_api_decision_card_inspection_read.py
@@ -997,3 +997,76 @@ def test_decision_card_inspection_persists_bounded_confidence_calibration_audit(
     assert missing["matched_outcome"] is None
     assert missing["calibration_classification"] == "weak"
     assert "non-live" in missing["interpretation_limit"]
+
+    score_stable = by_id["dc-cal-stable"]["metadata"]["bounded_strategy_score_calibration_audit"]
+    assert score_stable["contract_id"] == "bounded_strategy_score_calibration.backtest_to_paper.paper_audit.v1"
+    assert score_stable["strategy_id"] == "RSI2"
+    assert score_stable["score_interpretation"] == "bounded_per_strategy_evidence"
+    assert score_stable["score_scope"] == "per_strategy"
+    assert score_stable["confidence_tier_semantics"] == "ordinal_not_probabilistic"
+    assert score_stable["backtest_realism_status"] == "stable"
+    assert score_stable["match_status"] == "matched"
+    assert score_stable["calibration_classification"] == "stable"
+    assert score_stable["cross_strategy_comparison_supported"] is False
+
+    score_failing = by_id["dc-cal-failing"]["metadata"]["bounded_strategy_score_calibration_audit"]
+    assert score_failing["calibration_classification"] == "failing"
+    assert score_failing["matched_outcome"]["outcome_direction"] == "adverse"
+
+    score_missing = by_id["dc-cal-missing"]["metadata"]["bounded_strategy_score_calibration_audit"]
+    assert score_missing["evidence_coverage"] == "missing"
+    assert score_missing["calibration_classification"] == "limited"
+    assert (
+        "cross-strategy comparability remains explicitly unsupported"
+        in score_missing["interpretation_limit"].casefold()
+    )
+
+
+def test_decision_card_inspection_strategy_score_calibration_marks_open_evidence_weak(
+    monkeypatch, tmp_path: Path
+) -> None:
+    artifacts_root = tmp_path / "runs" / "phase6"
+    repo = _repo(tmp_path)
+    repo.save_trade(
+        _trade(
+            "trade-score-open",
+            strategy_id="TURTLE",
+            symbol="NVDA",
+            status="open",
+            opened_at="2026-03-24T08:05:00Z",
+            closed_at=None,
+            realized_pnl=None,
+            unrealized_pnl="0.25",
+        )
+    )
+    _write_artifact(
+        artifacts_root,
+        run_id="run-score-weak",
+        artifact_name="backtest-result.json",
+        payload=_backtest_artifact_payload(),
+    )
+    _write_artifact(
+        artifacts_root,
+        run_id="run-score-weak",
+        artifact_name="decision-card.json",
+        payload=_decision_card_payload(
+            decision_card_id="dc-score-weak",
+            generated_at_utc="2026-03-24T08:00:00Z",
+            symbol="NVDA",
+            strategy_id="TURTLE",
+            qualification_state="paper_approved",
+            paper_trade_id="trade-score-open",
+        ),
+    )
+
+    with _client(monkeypatch, artifacts_root, repo=repo) as client:
+        response = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 200
+    audit = response.json()["items"][0]["metadata"]["bounded_strategy_score_calibration_audit"]
+    assert audit["strategy_id"] == "TURTLE"
+    assert audit["backtest_realism_status"] == "stable"
+    assert audit["match_status"] == "open"
+    assert audit["evidence_coverage"] == "partial"
+    assert audit["calibration_classification"] == "weak"
+    assert audit["confidence_tier_semantics"] == "ordinal_not_probabilistic"

--- a/tests/test_backtest_realism_boundary_contract_docs.py
+++ b/tests/test_backtest_realism_boundary_contract_docs.py
@@ -47,6 +47,16 @@ RUNTIME_DOC = (
 )
 
 
+def _approved_risk_evidence() -> dict[str, str]:
+    return {
+        "decision": "APPROVED",
+        "score": "1",
+        "max_allowed": "10",
+        "reason": "deterministic_risk_within_bounds",
+        "rule_version": "test-risk-v1",
+    }
+
+
 def _canonical_snapshots() -> list[dict[str, object]]:
     return sort_snapshots(
         [
@@ -56,7 +66,13 @@ def _canonical_snapshots() -> list[dict[str, object]]:
                 "symbol": "AAPL",
                 "open": "100",
                 "signals": [
-                    {"signal_id": "sig-buy", "action": "BUY", "quantity": "1", "symbol": "AAPL"},
+                    {
+                        "signal_id": "sig-buy",
+                        "action": "BUY",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    },
                 ],
             },
             {
@@ -65,7 +81,13 @@ def _canonical_snapshots() -> list[dict[str, object]]:
                 "symbol": "AAPL",
                 "open": "101",
                 "signals": [
-                    {"signal_id": "sig-sell", "action": "SELL", "quantity": "1", "symbol": "AAPL"},
+                    {
+                        "signal_id": "sig-sell",
+                        "action": "SELL",
+                        "quantity": "1",
+                        "symbol": "AAPL",
+                        "risk_evidence": _approved_risk_evidence(),
+                    },
                 ],
             },
             {"id": "s3", "timestamp": "2024-01-03T00:00:00Z", "symbol": "AAPL", "open": "102"},
@@ -95,7 +117,12 @@ def test_realism_boundary_disclosure_is_byte_stable_under_identical_assumptions(
 
     assert first == second
     assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
-    assert set(first["modeled_assumptions"].keys()) == {"fees", "slippage", "fills"}
+    assert set(first["modeled_assumptions"].keys()) == {
+        "bounded_risk_decisions",
+        "fees",
+        "slippage",
+        "fills",
+    }
     assert set(first["unmodeled_assumptions"].keys()) == {
         "market_hours",
         "broker_behavior",

--- a/tests/test_sig_p47_score_semantics.py
+++ b/tests/test_sig_p47_score_semantics.py
@@ -12,8 +12,10 @@ from cilly_trading.engine.decision_card_contract import (
     CONFIDENCE_TIER_PRECISION_DISCLAIMER,
     CROSS_STRATEGY_SCORE_COMPARABILITY_BOUNDARY,
     QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY,
+    STRATEGY_SCORE_CALIBRATION_INTERPRETATION_BOUNDARY,
     ComponentScore,
     HardGateResult,
+    evaluate_bounded_strategy_score_calibration_audit,
 )
 from cilly_trading.engine.qualification_engine import (
     QualificationEngineInput,
@@ -309,6 +311,18 @@ def test_score_semantics_governance_doc_mentions_bounded_robustness_audit() -> N
     assert "QUALIFICATION_PROFILE_ROBUSTNESS_INTERPRETATION_BOUNDARY" in content
 
 
+def test_score_semantics_governance_doc_mentions_per_strategy_score_calibration() -> None:
+    content = GOVERNANCE_DOC.read_text(encoding="utf-8")
+
+    assert "Per-Strategy MVP Score Calibration Boundary" in content
+    assert "RSI2 and Turtle MVP aggregate scores" in content
+    assert "bounded per-strategy" in content
+    assert "limited" in content
+    assert "Confidence tier remains ordinal" in content
+    assert "Cross-strategy comparability remains explicitly unsupported" in content
+    assert "STRATEGY_SCORE_CALIBRATION_INTERPRETATION_BOUNDARY" in content
+
+
 def test_score_semantics_governance_doc_defines_non_goals() -> None:
     content = GOVERNANCE_DOC.read_text(encoding="utf-8")
 
@@ -381,6 +395,19 @@ def test_signal_quality_contract_doc_mentions_bounded_confidence_calibration() -
     assert "non-live" in content
 
 
+def test_signal_quality_contract_doc_mentions_per_strategy_score_calibration() -> None:
+    content = (REPO_ROOT / "docs" / "governance" / "signal-quality-bounded-contract.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Per-Strategy MVP Score Calibration Boundary" in content
+    assert "RSI2 and Turtle MVP aggregate scores" in content
+    assert "limited" in content
+    assert "Confidence tier remains ordinal" in content
+    assert "Cross-strategy comparability remains" in content
+    assert "non-live" in content
+
+
 def test_confidence_calibration_boundary_constant_is_defined() -> None:
     boundary = CONFIDENCE_CALIBRATION_INTERPRETATION_BOUNDARY.casefold()
 
@@ -389,6 +416,97 @@ def test_confidence_calibration_boundary_constant_is_defined() -> None:
     assert "trader validation" in boundary
     assert "profitability forecasting" in boundary
     assert "live-trading readiness" in boundary
+
+
+def test_strategy_score_calibration_boundary_preserves_per_strategy_limits() -> None:
+    boundary = STRATEGY_SCORE_CALIBRATION_INTERPRETATION_BOUNDARY.casefold()
+
+    assert "per-strategy" in boundary
+    assert "rsi2/turtle mvp aggregate scores" in boundary
+    assert "confidence tier remains ordinal" in boundary
+    assert "cross-strategy comparability remains explicitly unsupported" in boundary
+    assert "non-live" in boundary
+
+
+def test_strategy_score_calibration_classifies_stable_weak_failing_and_missing_paths() -> None:
+    match_reference = {"match_mode": "paper_trade_id", "paper_trade_id": "trade-1"}
+    favorable_outcome = {
+        "trade_id": "trade-1",
+        "position_id": "pos-1",
+        "symbol": "AAPL",
+        "strategy_id": "RSI2",
+        "trade_status": "closed",
+        "opened_at_utc": "2026-03-24T08:05:00Z",
+        "closed_at_utc": "2026-03-24T09:05:00Z",
+        "outcome_direction": "favorable",
+        "realized_pnl": "1.25",
+        "unrealized_pnl": None,
+        "outcome_summary": "Matched paper trade closed with favorable bounded outcome.",
+    }
+    adverse_outcome = {**favorable_outcome, "outcome_direction": "adverse", "realized_pnl": "-1.25"}
+    open_outcome = {
+        **favorable_outcome,
+        "trade_status": "open",
+        "closed_at_utc": None,
+        "outcome_direction": "open",
+        "realized_pnl": None,
+        "unrealized_pnl": "0.25",
+    }
+
+    stable = evaluate_bounded_strategy_score_calibration_audit(
+        covered_case_id="dc-stable",
+        strategy_id="RSI2",
+        aggregate_score=84.0,
+        confidence_tier="high",
+        backtest_realism_status="stable",
+        backtest_realism_reason="Backtest-realism evidence is complete and deterministic.",
+        match_status="matched",
+        match_reference=match_reference,
+        matched_outcome=favorable_outcome,
+    )
+    weak = evaluate_bounded_strategy_score_calibration_audit(
+        covered_case_id="dc-weak",
+        strategy_id="TURTLE",
+        aggregate_score=74.0,
+        confidence_tier="medium",
+        backtest_realism_status="stable",
+        backtest_realism_reason="Backtest-realism evidence is complete and deterministic.",
+        match_status="open",
+        match_reference=match_reference,
+        matched_outcome=open_outcome,
+    )
+    failing = evaluate_bounded_strategy_score_calibration_audit(
+        covered_case_id="dc-failing",
+        strategy_id="RSI2",
+        aggregate_score=84.0,
+        confidence_tier="high",
+        backtest_realism_status="stable",
+        backtest_realism_reason="Backtest-realism evidence is complete and deterministic.",
+        match_status="matched",
+        match_reference=match_reference,
+        matched_outcome=adverse_outcome,
+    )
+    missing = evaluate_bounded_strategy_score_calibration_audit(
+        covered_case_id="dc-missing",
+        strategy_id="TURTLE",
+        aggregate_score=72.0,
+        confidence_tier="medium",
+        backtest_realism_status="missing",
+        backtest_realism_reason="Backtest-realism evidence is not available for this card.",
+        match_status="missing",
+        match_reference=None,
+        matched_outcome=None,
+    )
+
+    assert stable.score_interpretation == "bounded_per_strategy_evidence"
+    assert stable.score_scope == "per_strategy"
+    assert stable.calibration_classification == "stable"
+    assert stable.cross_strategy_comparison_supported is False
+    assert stable.confidence_tier_semantics == "ordinal_not_probabilistic"
+    assert weak.calibration_classification == "weak"
+    assert failing.calibration_classification == "failing"
+    assert missing.evidence_coverage == "missing"
+    assert missing.calibration_classification == "limited"
 
 
 def test_qualification_profile_robustness_boundary_constant_is_defined() -> None:


### PR DESCRIPTION
Closes #1049

## Summary
- Adds bounded RSI2/Turtle per-strategy score calibration audit metadata.
- Ties score interpretation to existing backtest-realism and matched paper outcome evidence where available.
- Classifies stable, weak, failing, and missing-evidence paths while preserving ordinal confidence semantics.
- Preserves cross-strategy non-comparability with cross_strategy_comparison_supported = false.
- Updates governance docs and API/contract tests.

## Tests
- python -m pytest
- Result: 1248 passed
- python -m pytest tests/test_sig_p47_score_semantics.py tests/test_api_decision_card_inspection_read.py
- Result: 40 passed

## Codex A Review
- Decision: APPROVED
- Classification: technically good, traderically meaningful as bounded calibration evidence
- Trader validation remains pending.
- Operational use remains bounded non-live/internal.

## Scope Notes
- No strategy scoring change.
- No optimization change.
- No architecture change.
- No live behavior change.
- No profitability forecasting claim.
- No live-trading readiness claim.