### PR TITLE
Close bounded signal-to-portfolio-to-paper reconciliation workflow

### DIFF
--- a/docs/api/paper_inspection.md
+++ b/docs/api/paper_inspection.md
@@ -104,6 +104,7 @@ This is the minimum operator inspection path for paper trading from order intent
 
 The workflow response exposes:
 
+- `surfaces.signal_inspection` for `/signals` and `/signals/decision-surface`.
 - `surfaces.canonical_inspection` for `/decision-cards` and `/trading-core/*`.
 - `surfaces.portfolio_inspection` for `/portfolio/positions`.
 - `surfaces.paper_inspection` for `/paper/trades`, `/paper/positions`, and `/paper/account`.
@@ -112,6 +113,27 @@ The workflow response exposes:
 - `inspection_summary` for canonical, portfolio, paper, and reconciliation counts derived from the same canonical execution repository.
 
 The workflow is bounded operator inspection only. It does not imply trader validation, live-trading readiness, broker readiness, or operational readiness.
+
+## Signal-to-Portfolio-to-Paper Audit
+
+Each `GET /decision-cards` item includes
+`metadata.bounded_signal_portfolio_paper_reconciliation_audit` when rendered by
+the inspection API. The audit is read-only and deterministic. It links:
+
+- signal evidence (`signal.signal_id` or deterministic fallback ID)
+- decision-card evidence (`decision_card.decision_card_id`)
+- portfolio impact (`portfolio_impact.portfolio_impact_id`)
+- paper order lifecycle (`paper_order.paper_order_id`, order IDs, execution event IDs)
+- paper outcome (`paper_outcome.paper_trade_id`, `paper_outcome.outcome_state`)
+- reconciliation (`reconciliation.status`, related mismatch codes)
+
+The explicit paper outcome states are `missing`, `invalid`, `open`, and
+`closed`. Portfolio impact is exposed before paper execution through the
+portfolio impact reference and `/portfolio/positions`; it is not an execution
+approval or mutation endpoint.
+
+This audit does not imply auto-trading, broker execution, live-trading
+readiness, paper profitability, trader validation, or operational readiness.
 
 ## Deterministic Ordering
 

--- a/docs/operations/runtime/phase-44-paper-operator-workflow.md
+++ b/docs/operations/runtime/phase-44-paper-operator-workflow.md
@@ -26,6 +26,8 @@ In scope:
 - portfolio inspection derived from canonical trade evidence
 - paper inspection and reconciliation surfaces derived from canonical entities
 - explicit reference-chain continuity from decision evidence to reconciliation
+- deterministic signal-to-decision-card, decision-card-to-portfolio-impact, portfolio-impact-to-paper-order, paper-order-lifecycle, reconciliation, and paper-outcome references
+- explicit missing, invalid, open, and closed paper outcome states
 - mismatch-based validation for workflow coherence
 
 Out of scope:
@@ -43,6 +45,8 @@ Out of scope:
 - `tests/cilly_trading/engine/test_paper_order_lifecycle.py`
 
 ### Canonical inspection surfaces
+- `GET /signals`
+- `GET /signals/decision-surface`
 - `GET /decision-cards`
 - `GET /trading-core/orders`
 - `GET /trading-core/execution-events`
@@ -67,8 +71,9 @@ Out of scope:
 5. Inspect portfolio-aware and paper-facing projections via `GET /portfolio/positions`, `GET /paper/trades`, `GET /paper/positions`, and `GET /paper/account`.
 6. Reconcile the workflow state via `GET /paper/reconciliation` and require `ok: true` and `summary.mismatches: 0`.
 7. Inspect `/decision-cards` and review `metadata.bounded_decision_to_paper_usefulness_audit` for any covered cases.
-8. Inspect the top-level `traceability_chain` on each `/decision-cards` item to confirm the explicit signal/analysis -> decision -> paper -> reconciliation reference chain (see [End-to-End Traceability Chain](#end-to-end-traceability-chain)).
-9. Inspect `GET /paper/workflow` `reference_chain` and `inspection_summary` to confirm portfolio inspection is linked into the bounded workflow without introducing a competing state authority.
+8. Inspect `/decision-cards` and review `metadata.bounded_signal_portfolio_paper_reconciliation_audit` for the deterministic signal -> decision-card -> portfolio-impact -> paper-order -> paper-outcome -> reconciliation chain.
+9. Inspect the top-level `traceability_chain` on each `/decision-cards` item to confirm the explicit signal/analysis -> decision -> paper -> reconciliation reference chain (see [End-to-End Traceability Chain](#end-to-end-traceability-chain)).
+10. Inspect `GET /paper/workflow` `reference_chain` and `inspection_summary` to confirm portfolio inspection is linked into the bounded workflow without introducing a competing state authority.
 
 ## End-to-End Traceability Chain
 
@@ -95,17 +100,50 @@ The chain is bounded to non-live deterministic auditability and does not
 imply trader validation, profitability forecasting, live-trading readiness,
 or operational readiness.
 
+Each decision-card item also exposes
+`metadata.bounded_signal_portfolio_paper_reconciliation_audit`. That audit
+closes the bounded operator loop with deterministic IDs for:
+
+1. signal evidence (`signal.signal_id` or a deterministic fallback from
+   analysis run, symbol, strategy, and decision timestamp),
+2. decision card evidence (`decision_card.decision_card_id`),
+3. portfolio impact (`portfolio_impact.portfolio_impact_id`),
+4. paper order and lifecycle evidence (`paper_order.paper_order_id`,
+   `opening_order_ids`, `closing_order_ids`, and `execution_event_ids`),
+5. paper outcome evidence (`paper_outcome.paper_trade_id` and
+   `paper_outcome.outcome_state`), and
+6. reconciliation evidence (`reconciliation.status` and related mismatch
+   codes).
+
+The explicit paper outcome state vocabulary is `missing`, `invalid`, `open`,
+and `closed`. `closed` means a valid referenced paper trade exists and has
+closed. `open` means the referenced trade exists but is still open. `missing`
+means the required reference is absent or unresolved. `invalid` means the
+reference violates the bounded symbol, strategy, timing, or reconciliation
+contract. These states are inspection evidence only and do not imply paper
+profitability, trader validation, live-trading readiness, or operational
+readiness.
+
 `GET /paper/workflow` also exposes a workflow-level `reference_chain` that
 binds the covered operator inspection sequence:
 
-1. `decision_evidence` through `/decision-cards` using `decision_card_id` and
+1. `signal_evidence` through `/signals` and `/signals/decision-surface` using
+   `analysis_run_id`, `symbol`, `strategy_id`, and decision timestamp.
+2. `decision_evidence` through `/decision-cards` using `decision_card_id` and
    `metadata.bounded_decision_to_paper_match.paper_trade_id`.
-2. `portfolio_inspection` through `/portfolio/positions` using `strategy_id`
+3. `portfolio_impact` through `/portfolio/positions` using deterministic
+   `portfolio_impact_id = decision_card_id + strategy_id + symbol`.
+4. `paper_order_lifecycle` through `/trading-core/orders` and
+   `/trading-core/execution-events` using `paper_order_id` and
+   `execution_event_ids`.
+5. `portfolio_inspection` through `/portfolio/positions` using `strategy_id`
    and `symbol` aggregation derived from canonical trades.
-3. `paper_execution` through `/paper/trades` using `paper_trade_id ->
+6. `paper_execution` through `/paper/trades` using `paper_trade_id ->
    Trade.trade_id`.
-4. `reconciliation` through `/paper/reconciliation` using canonical
+7. `reconciliation` through `/paper/reconciliation` using canonical
    `order_id`, `event_id`, `trade_id`, `position_id`, and account equations.
+8. `paper_outcome` through `/paper/trades` and decision-card metadata using
+   `paper_trade_id` plus explicit `paper_outcome.outcome_state`.
 
 The workflow-level `inspection_summary` reports counts for canonical orders,
 execution events, trades, positions, portfolio positions, paper trades, paper
@@ -119,6 +157,7 @@ The bounded Phase 44 workflow claim requires all of the following evidence:
 - Paper inspection and reconciliation contract coverage is passing (`tests/test_api_paper_inspection_read.py`).
 - Reconciliation returns `ok: true` and `summary.mismatches: 0` for valid lifecycle data.
 - `GET /paper/workflow` exposes `surfaces.portfolio_inspection`, `reference_chain`, and `inspection_summary`.
+- `/decision-cards` exposes `metadata.bounded_signal_portfolio_paper_reconciliation_audit` with portfolio impact before paper execution and explicit missing/invalid/open/closed outcome states.
 - Paper inspection views are derived from canonical trading-core entities, not legacy trade payload authority.
 - Covered decision-card usefulness audit remains bounded to non-live explanatory review and exact paper-trade matches only.
 - Full repository regression gate remains green (`python -m pytest`).

--- a/src/api/models/inspection_models.py
+++ b/src/api/models/inspection_models.py
@@ -253,6 +253,7 @@ class PaperOperatorWorkflowStepResponse(BaseModel):
 class PaperOperatorWorkflowSurfaceResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    signal_inspection: List[str]
     canonical_inspection: List[str]
     portfolio_inspection: List[str]
     paper_inspection: List[str]
@@ -263,10 +264,14 @@ class PaperOperatorWorkflowReferenceResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     stage: Literal[
+        "signal_evidence",
         "decision_evidence",
+        "portfolio_impact",
+        "paper_order_lifecycle",
         "portfolio_inspection",
         "paper_execution",
         "reconciliation",
+        "paper_outcome",
     ]
     surface: str
     reference: str

--- a/src/api/services/inspection_service.py
+++ b/src/api/services/inspection_service.py
@@ -436,6 +436,10 @@ def read_paper_operator_workflow(
             ),
         ],
         surfaces=PaperOperatorWorkflowSurfaceResponse(
+            signal_inspection=[
+                "/signals",
+                "/signals/decision-surface",
+            ],
             canonical_inspection=[
                 "/decision-cards",
                 "/trading-core/orders",
@@ -455,12 +459,39 @@ def read_paper_operator_workflow(
         ),
         reference_chain=[
             PaperOperatorWorkflowReferenceResponse(
+                stage="signal_evidence",
+                surface="/signals + /signals/decision-surface",
+                reference="analysis_run_id + symbol + strategy_id + generated_at_utc",
+                continuity=(
+                    "Covered signal evidence carries deterministic analysis and signal references "
+                    "before decision-card inspection."
+                ),
+            ),
+            PaperOperatorWorkflowReferenceResponse(
                 stage="decision_evidence",
                 surface="/decision-cards",
                 reference="decision_card_id + metadata.bounded_decision_to_paper_match.paper_trade_id",
                 continuity=(
                     "Covered decision evidence carries the explicit paper_trade_id reference used by "
                     "bounded usefulness and traceability audits."
+                ),
+            ),
+            PaperOperatorWorkflowReferenceResponse(
+                stage="portfolio_impact",
+                surface="/portfolio/positions",
+                reference="portfolio_impact_id = decision_card_id + strategy_id + symbol",
+                continuity=(
+                    "Portfolio impact is inspectable before paper execution through deterministic "
+                    "strategy_id and symbol aggregation from canonical trades."
+                ),
+            ),
+            PaperOperatorWorkflowReferenceResponse(
+                stage="paper_order_lifecycle",
+                surface="/trading-core/orders + /trading-core/execution-events",
+                reference="paper_order_id + execution_event_ids",
+                continuity=(
+                    "Paper order lifecycle references connect portfolio handoff intent to canonical "
+                    "created, submitted, fill, cancel, or terminal execution events."
                 ),
             ),
             PaperOperatorWorkflowReferenceResponse(
@@ -486,6 +517,15 @@ def read_paper_operator_workflow(
                 reference="order_id + event_id + trade_id + position_id + account equations",
                 continuity=(
                     "Reconciliation deterministically reports any broken reference or account equation mismatch."
+                ),
+            ),
+            PaperOperatorWorkflowReferenceResponse(
+                stage="paper_outcome",
+                surface="/paper/trades + /decision-cards metadata",
+                reference="paper_trade_id + paper_outcome.outcome_state",
+                continuity=(
+                    "Decision-card metadata explicitly classifies paper outcomes as missing, invalid, "
+                    "open, or closed without inferring live or operational readiness."
                 ),
             ),
         ],
@@ -1384,6 +1424,26 @@ def build_decision_card_inspection_items(
                 analysis_run_id_meta
                 if isinstance(analysis_run_id_meta, str) and len(analysis_run_id_meta) > 0
                 else None
+            )
+            signal_id_meta = card.metadata.get("signal_id")
+            signal_id = (
+                signal_id_meta
+                if isinstance(signal_id_meta, str) and len(signal_id_meta) > 0
+                else None
+            )
+            metadata["bounded_signal_portfolio_paper_reconciliation_audit"] = (
+                paper_inspection_service.build_bounded_signal_portfolio_paper_reconciliation_audit(
+                    canonical_execution_repo=canonical_repo,
+                    decision_card_id=card.decision_card_id,
+                    generated_at_utc=card.generated_at_utc,
+                    symbol=card.symbol,
+                    strategy_id=card.strategy_id,
+                    action=card.action,
+                    qualification_state=card.qualification.state,
+                    analysis_run_id=analysis_run_id,
+                    signal_id=signal_id,
+                    match_reference=match_reference,
+                )
             )
             traceability_chain = evaluate_bounded_end_to_end_traceability_chain(
                 decision_card_id=card.decision_card_id,

--- a/src/api/services/paper_inspection_service.py
+++ b/src/api/services/paper_inspection_service.py
@@ -26,6 +26,17 @@ from cilly_trading.engine.decision_card_contract import (
 from cilly_trading.models import ExecutionEvent, Order, Position, Trade
 
 
+BOUNDED_SIGNAL_PORTFOLIO_PAPER_RECONCILIATION_CONTRACT_ID = (
+    "signal_portfolio_paper_reconciliation_trace.paper_audit.v1"
+)
+BOUNDED_SIGNAL_PORTFOLIO_PAPER_RECONCILIATION_CONTRACT_VERSION = "1.0.0"
+BOUNDED_SIGNAL_PORTFOLIO_PAPER_RECONCILIATION_INTERPRETATION_LIMIT = (
+    "Signal-to-portfolio-to-paper reconciliation audit is bounded to non-live deterministic "
+    "operator inspection. It does not imply auto-trading, broker execution, live-trading "
+    "readiness, profitability forecasting, trader validation, or operational readiness."
+)
+
+
 def paginate_items(items: list[object], *, limit: int, offset: int) -> tuple[list[object], int]:
     total = len(items)
     return items[offset : offset + limit], total
@@ -910,6 +921,187 @@ def build_bounded_decision_to_paper_usefulness_audit(
         matched_outcome=matched_outcome,
     )
     return audit.model_dump(mode="python")
+
+
+def _deterministic_reference_id(*parts: str | None) -> str:
+    normalized_parts = [part.strip() for part in parts if isinstance(part, str) and part.strip()]
+    return ":".join(normalized_parts) if normalized_parts else "missing"
+
+
+def _paper_outcome_state_from_match_status(
+    match_status: Literal["matched", "open", "missing", "invalid"],
+) -> Literal["closed", "open", "missing", "invalid"]:
+    if match_status == "matched":
+        return "closed"
+    if match_status == "open":
+        return "open"
+    return match_status
+
+
+def _related_reconciliation_mismatches(
+    *,
+    mismatches: Sequence[dict[str, Optional[str]]],
+    order_ids: Sequence[str],
+    execution_event_ids: Sequence[str],
+    trade_id: str | None,
+    position_id: str | None,
+) -> list[dict[str, Optional[str]]]:
+    related_ids = {item for item in [*order_ids, *execution_event_ids, trade_id, position_id] if item}
+    if not related_ids:
+        return []
+    return [
+        mismatch
+        for mismatch in mismatches
+        if mismatch.get("entity_id") in related_ids
+        or any((identifier in (mismatch.get("message") or "")) for identifier in related_ids)
+    ]
+
+
+def build_bounded_signal_portfolio_paper_reconciliation_audit(
+    *,
+    canonical_execution_repo: Any | None,
+    decision_card_id: str,
+    generated_at_utc: str,
+    symbol: str,
+    strategy_id: str,
+    action: str,
+    qualification_state: str,
+    analysis_run_id: str | None,
+    signal_id: str | None,
+    match_reference: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build an explicit bounded signal -> portfolio -> paper -> reconciliation audit.
+
+    This is an inspection payload only. It derives every resolved paper/order/
+    reconciliation field from the canonical execution repository and uses
+    deterministic fallback IDs when upstream artifacts do not carry explicit IDs.
+    """
+
+    paper_linkage_status, paper_trade_id = resolve_bounded_paper_linkage_status(
+        canonical_execution_repo=canonical_execution_repo,
+        generated_at_utc=generated_at_utc,
+        symbol=symbol,
+        strategy_id=strategy_id,
+        match_reference=match_reference,
+    )
+    outcome_state = _paper_outcome_state_from_match_status(paper_linkage_status)
+
+    resolved_signal_id = (
+        signal_id
+        if isinstance(signal_id, str) and signal_id.strip()
+        else _deterministic_reference_id("signal", analysis_run_id, symbol, strategy_id, generated_at_utc)
+    )
+    portfolio_impact_id = _deterministic_reference_id(
+        "portfolio-impact",
+        decision_card_id,
+        strategy_id,
+        symbol,
+    )
+
+    trade: Trade | None = None
+    if canonical_execution_repo is not None and paper_trade_id is not None:
+        try:
+            trade = canonical_execution_repo.get_trade(paper_trade_id)
+        except Exception:
+            trade = None
+
+    opening_order_ids: list[str] = list(trade.opening_order_ids) if trade is not None else []
+    closing_order_ids: list[str] = list(trade.closing_order_ids) if trade is not None else []
+    execution_event_ids: list[str] = list(trade.execution_event_ids) if trade is not None else []
+    paper_order_id = opening_order_ids[0] if opening_order_ids else None
+    position_id = trade.position_id if trade is not None else None
+
+    lifecycle_status: Literal["closed", "open", "missing", "invalid"] = outcome_state
+    reconciliation_status: Literal["matched", "open", "missing", "invalid"] = paper_linkage_status
+    related_mismatches: list[dict[str, Optional[str]]] = []
+    if canonical_execution_repo is not None and trade is not None:
+        try:
+            state = build_bounded_paper_simulation_state(
+                canonical_execution_repo=canonical_execution_repo,
+            )
+            related_mismatches = _related_reconciliation_mismatches(
+                mismatches=state.reconciliation_mismatches,
+                order_ids=[*opening_order_ids, *closing_order_ids],
+                execution_event_ids=execution_event_ids,
+                trade_id=trade.trade_id,
+                position_id=trade.position_id,
+            )
+        except Exception:
+            related_mismatches = [
+                {
+                    "code": "paper_reconciliation_state_unavailable",
+                    "message": "canonical paper reconciliation state could not be derived",
+                    "entity_type": "trade",
+                    "entity_id": trade.trade_id,
+                }
+            ]
+        if related_mismatches:
+            reconciliation_status = "invalid"
+            lifecycle_status = "invalid"
+
+    portfolio_impact_status: Literal["available", "missing"] = (
+        "available" if action in {"entry", "exit"} and qualification_state != "reject" else "missing"
+    )
+
+    return {
+        "contract_id": BOUNDED_SIGNAL_PORTFOLIO_PAPER_RECONCILIATION_CONTRACT_ID,
+        "contract_version": BOUNDED_SIGNAL_PORTFOLIO_PAPER_RECONCILIATION_CONTRACT_VERSION,
+        "signal": {
+            "signal_id": resolved_signal_id,
+            "analysis_run_id": analysis_run_id,
+            "symbol": symbol,
+            "strategy_id": strategy_id,
+            "linkage_status": "matched" if analysis_run_id is not None else "missing",
+        },
+        "decision_card": {
+            "decision_card_id": decision_card_id,
+            "generated_at_utc": generated_at_utc,
+            "qualification_state": qualification_state,
+            "action": action,
+            "linkage_status": "matched",
+        },
+        "portfolio_impact": {
+            "portfolio_impact_id": portfolio_impact_id,
+            "status": portfolio_impact_status,
+            "surface": "GET /portfolio/positions",
+            "pre_paper_execution_visible": True,
+            "reference": "decision_card_id + strategy_id + symbol",
+        },
+        "paper_order": {
+            "paper_order_id": paper_order_id,
+            "opening_order_ids": opening_order_ids,
+            "closing_order_ids": closing_order_ids,
+            "execution_event_ids": execution_event_ids,
+            "lifecycle_status": lifecycle_status,
+            "surface": "GET /trading-core/orders + GET /trading-core/execution-events",
+        },
+        "paper_outcome": {
+            "paper_trade_id": paper_trade_id,
+            "position_id": position_id,
+            "outcome_state": outcome_state,
+            "linkage_status": paper_linkage_status,
+            "surface": "GET /paper/trades",
+        },
+        "reconciliation": {
+            "status": reconciliation_status,
+            "surface": "GET /paper/reconciliation",
+            "related_mismatch_count": len(related_mismatches),
+            "related_mismatch_codes": [item["code"] for item in related_mismatches],
+        },
+        "deterministic_reference_chain": [
+            resolved_signal_id,
+            decision_card_id,
+            portfolio_impact_id,
+            paper_order_id or "paper_order:missing",
+            paper_trade_id or "paper_trade:missing",
+            "GET /paper/reconciliation",
+        ],
+        "classification_vocabulary": {
+            "paper_outcome_states": ["missing", "invalid", "open", "closed"],
+            "linkage_statuses": ["missing", "invalid", "open", "matched"],
+        },
+        "interpretation_limit": BOUNDED_SIGNAL_PORTFOLIO_PAPER_RECONCILIATION_INTERPRETATION_LIMIT,
+    }
 
 
 def resolve_bounded_paper_linkage_status(

--- a/tests/test_api_decision_card_inspection_read.py
+++ b/tests/test_api_decision_card_inspection_read.py
@@ -1070,3 +1070,99 @@ def test_decision_card_inspection_strategy_score_calibration_marks_open_evidence
     assert audit["evidence_coverage"] == "partial"
     assert audit["calibration_classification"] == "weak"
     assert audit["confidence_tier_semantics"] == "ordinal_not_probabilistic"
+
+
+def test_decision_card_metadata_exposes_signal_portfolio_paper_reconciliation_states(
+    monkeypatch, tmp_path: Path
+) -> None:
+    artifacts_root = tmp_path / "runs" / "phase6"
+    repo = _repo(tmp_path)
+    repo.save_trade(
+        _trade(
+            "trade-closed",
+            strategy_id="RSI2",
+            symbol="AAPL",
+            status="closed",
+            opened_at="2026-03-24T08:05:00Z",
+            closed_at="2026-03-24T08:45:00Z",
+            realized_pnl="1.50",
+            unrealized_pnl=None,
+        )
+    )
+    repo.save_trade(
+        _trade(
+            "trade-open",
+            strategy_id="RSI2",
+            symbol="MSFT",
+            status="open",
+            opened_at="2026-03-24T09:05:00Z",
+            closed_at=None,
+            realized_pnl=None,
+            unrealized_pnl="0.25",
+        )
+    )
+    repo.save_trade(
+        _trade(
+            "trade-invalid",
+            strategy_id="RSI2",
+            symbol="TSLA",
+            status="closed",
+            opened_at="2026-03-24T10:05:00Z",
+            closed_at="2026-03-24T10:45:00Z",
+            realized_pnl="1.00",
+            unrealized_pnl=None,
+        )
+    )
+
+    for decision_card_id, symbol, paper_trade_id in (
+        ("dc-closed", "AAPL", "trade-closed"),
+        ("dc-open", "MSFT", "trade-open"),
+        ("dc-invalid", "NVDA", "trade-invalid"),
+        ("dc-missing", "GOOG", None),
+    ):
+        _write_artifact(
+            artifacts_root,
+            run_id=f"run-{decision_card_id}",
+            artifact_name="decision-card.json",
+            payload=_decision_card_payload(
+                decision_card_id=decision_card_id,
+                generated_at_utc="2026-03-24T08:00:00Z",
+                symbol=symbol,
+                strategy_id="RSI2",
+                qualification_state="paper_approved",
+                paper_trade_id=paper_trade_id,
+            ),
+        )
+
+    with _client(monkeypatch, artifacts_root, repo=repo) as client:
+        response = client.get("/decision-cards", headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 200
+    by_id = {item["decision_card_id"]: item for item in response.json()["items"]}
+    states = {
+        decision_card_id: item["metadata"][
+            "bounded_signal_portfolio_paper_reconciliation_audit"
+        ]["paper_outcome"]["outcome_state"]
+        for decision_card_id, item in by_id.items()
+    }
+    assert states == {
+        "dc-closed": "closed",
+        "dc-open": "open",
+        "dc-invalid": "invalid",
+        "dc-missing": "missing",
+    }
+
+    closed = by_id["dc-closed"]["metadata"][
+        "bounded_signal_portfolio_paper_reconciliation_audit"
+    ]
+    assert closed["portfolio_impact"]["pre_paper_execution_visible"] is True
+    assert closed["portfolio_impact"]["portfolio_impact_id"] == (
+        "portfolio-impact:dc-closed:RSI2:AAPL"
+    )
+    assert closed["paper_order"]["opening_order_ids"] == ["ord-trade-closed"]
+    assert closed["classification_vocabulary"]["paper_outcome_states"] == [
+        "missing",
+        "invalid",
+        "open",
+        "closed",
+    ]

--- a/tests/test_api_paper_inspection_read.py
+++ b/tests/test_api_paper_inspection_read.py
@@ -484,6 +484,10 @@ def test_paper_workflow_contract_is_explicit_and_aligned_to_surfaces(
         },
     ]
     assert payload["surfaces"] == {
+        "signal_inspection": [
+            "/signals",
+            "/signals/decision-surface",
+        ],
         "canonical_inspection": [
             "/decision-cards",
             "/trading-core/orders",
@@ -503,10 +507,28 @@ def test_paper_workflow_contract_is_explicit_and_aligned_to_surfaces(
     }
     assert payload["reference_chain"] == [
         {
+            "stage": "signal_evidence",
+            "surface": "/signals + /signals/decision-surface",
+            "reference": "analysis_run_id + symbol + strategy_id + generated_at_utc",
+            "continuity": "Covered signal evidence carries deterministic analysis and signal references before decision-card inspection.",
+        },
+        {
             "stage": "decision_evidence",
             "surface": "/decision-cards",
             "reference": "decision_card_id + metadata.bounded_decision_to_paper_match.paper_trade_id",
             "continuity": "Covered decision evidence carries the explicit paper_trade_id reference used by bounded usefulness and traceability audits.",
+        },
+        {
+            "stage": "portfolio_impact",
+            "surface": "/portfolio/positions",
+            "reference": "portfolio_impact_id = decision_card_id + strategy_id + symbol",
+            "continuity": "Portfolio impact is inspectable before paper execution through deterministic strategy_id and symbol aggregation from canonical trades.",
+        },
+        {
+            "stage": "paper_order_lifecycle",
+            "surface": "/trading-core/orders + /trading-core/execution-events",
+            "reference": "paper_order_id + execution_event_ids",
+            "continuity": "Paper order lifecycle references connect portfolio handoff intent to canonical created, submitted, fill, cancel, or terminal execution events.",
         },
         {
             "stage": "portfolio_inspection",
@@ -525,6 +547,12 @@ def test_paper_workflow_contract_is_explicit_and_aligned_to_surfaces(
             "surface": "/paper/reconciliation",
             "reference": "order_id + event_id + trade_id + position_id + account equations",
             "continuity": "Reconciliation deterministically reports any broken reference or account equation mismatch.",
+        },
+        {
+            "stage": "paper_outcome",
+            "surface": "/paper/trades + /decision-cards metadata",
+            "reference": "paper_trade_id + paper_outcome.outcome_state",
+            "continuity": "Decision-card metadata explicitly classifies paper outcomes as missing, invalid, open, or closed without inferring live or operational readiness.",
         },
     ]
     assert payload["inspection_summary"] == {
@@ -741,6 +769,7 @@ def test_paper_workflow_surfaces_align_with_traceability_chain_contract(
     # The bounded end-to-end traceability chain references these canonical
     # surfaces; assert the workflow contract still exposes them so the chain
     # remains traversable from /decision-cards through /paper/reconciliation.
+    assert "/signals/decision-surface" in surfaces["signal_inspection"]
     assert "/decision-cards" in surfaces["canonical_inspection"]
     assert "/portfolio/positions" in surfaces["portfolio_inspection"]
     assert "/paper/trades" in surfaces["paper_inspection"]
@@ -761,12 +790,16 @@ def test_paper_workflow_inspection_summary_and_reference_chain_are_deterministic
     assert first == second
     assert first["inspection_summary"]["portfolio_positions"] == portfolio_positions["total"]
     assert [item["stage"] for item in first["reference_chain"]] == [
+        "signal_evidence",
         "decision_evidence",
+        "portfolio_impact",
+        "paper_order_lifecycle",
         "portfolio_inspection",
         "paper_execution",
         "reconciliation",
+        "paper_outcome",
     ]
-    assert first["reference_chain"][1]["surface"] == "/portfolio/positions"
+    assert first["reference_chain"][2]["surface"] == "/portfolio/positions"
     assert "operational readiness" in first["steps"][-1]["expected_result"]
     assert first["boundary"]["in_scope"][-1] == (
         "bounded paper operator inspection with no readiness or operational-readiness claim"

--- a/tests/test_phase44_paper_operator_workflow_docs.py
+++ b/tests/test_phase44_paper_operator_workflow_docs.py
@@ -35,6 +35,8 @@ def test_phase44_workflow_doc_defines_bounded_operator_flow_and_surfaces() -> No
         "GET /paper/reconciliation",
         "GET /paper/workflow",
         "## Explicit Operator Steps",
+        "bounded_signal_portfolio_paper_reconciliation_audit",
+        "missing, invalid, open, and closed",
         "## Workflow Boundary",
         "## Minimum Operator Evidence",
         "reference_chain",
@@ -138,6 +140,7 @@ def test_paper_inspection_api_doc_cross_references_long_run_workflow() -> None:
     assert_contains_all(
         content,
         "## Long-Run Evaluation and Review Workflow",
+        "## Signal-to-Portfolio-to-Paper Audit",
         "phase-44-paper-operator-workflow.md",
         "R1-R8",
     )


### PR DESCRIPTION
Closes #1050

## Summary
- Add deterministic signal-to-portfolio-to-paper reconciliation audit metadata on decision-card inspection.
- Link signal evidence, decision card, portfolio impact, paper order lifecycle, paper outcome, and reconciliation evidence.
- Classify paper outcome states as missing, invalid, open, or closed.
- Extend paper workflow reference surfaces with signal, portfolio impact, order lifecycle, and outcome stages.
- Document bounded non-live inspection limits and explicit no-readiness boundaries.

## Tests
- .\.venv\Scripts\python -m pytest
- Result: 1249 passed

## Codex A Review
- Decision: APPROVED
- Classification: technically good and operationally meaningful
- Trader validation remains pending.
- Operational use remains bounded read-only/internal inspection evidence.

## Scope Notes
- Read-only inspection workflow only.
- No mutation endpoint introduced.
- No live-trading readiness claimed.
- No broker-execution readiness claimed.
- No trader-validation claim introduced.
- No operational-readiness claim introduced.