### PR TITLE
Add read-only paper runtime evidence series inspection API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,6 @@ scripts/*
 !scripts/capture_restart_evidence.py
 !scripts/run_paper_execution_cycle.py
 !scripts/run_daily_bounded_paper_runtime.py
+!scripts/validation/
+!scripts/validation/summarize_bounded_paper_runtime_evidence.py
 *.code-workspace

--- a/docs/api/paper_runtime_evidence_series.md
+++ b/docs/api/paper_runtime_evidence_series.md
@@ -1,0 +1,44 @@
+# Paper Runtime Evidence Series API
+
+`GET /paper/runtime/evidence-series` is a read-only inspection endpoint for
+offline bounded paper-runtime evidence series summaries.
+
+The endpoint only reads saved local JSON run-output artifacts from
+`CILLY_PAPER_RUNTIME_EVIDENCE_SERIES_DIR`. It does not trigger paper-runtime runs,
+import or execute `scripts/run_daily_bounded_paper_runtime.py`, modify
+paper execution behavior, modify signal generation, modify risk logic, modify
+score thresholds, modify data ingestion, deploy to a VPS, or write runtime
+artifacts.
+
+## States
+
+- `not_configured` - `CILLY_PAPER_RUNTIME_EVIDENCE_SERIES_DIR` is unset.
+- `missing` - the configured path is absent or is not a directory.
+- `empty` - the configured directory exists but has no matching `run-*.json`
+  files.
+- `available` - matching saved run-output files were read and summarized.
+
+All states return HTTP 200 with an explicit bounded payload.
+
+## Response Summary
+
+The response includes deterministic aggregate fields:
+
+- run count
+- run-quality distribution
+- eligible, skipped, and rejected totals
+- skip-reason counts
+- reconciliation status counts
+- total reconciliation mismatches
+- per-run mismatch counts
+- summary-file references
+- run-file references
+
+Ordering is deterministic: files and count maps are sorted by stable string
+keys.
+
+## Boundary
+
+This endpoint is inspection-only and non-live. It does not imply trader validation,
+production readiness, live-trading readiness, broker readiness, operational
+readiness, or profitability.

--- a/docs/operations/runtime/bounded-paper-runtime-evidence-series-summarizer.md
+++ b/docs/operations/runtime/bounded-paper-runtime-evidence-series-summarizer.md
@@ -1,0 +1,101 @@
+# Bounded Paper Runtime Evidence Series Summarizer
+
+## Purpose
+
+`scripts/validation/summarize_bounded_paper_runtime_evidence.py` summarizes a
+directory of saved bounded paper-runtime JSON outputs for later review.
+
+This tool is analysis-only. It reads existing JSON files from disk and writes an
+aggregate JSON or Markdown report. It is not part of runtime execution and must
+not be deployed into the VPS runtime path.
+
+## Scope Boundary
+
+In scope:
+
+- offline parsing of saved bounded paper-runtime JSON outputs
+- deterministic aggregation across matching run files
+- run-quality distribution
+- eligible, skipped, and rejected totals
+- skip-reason counts
+- reconciliation status counts and mismatch totals
+- summary-file references where present
+
+Out of scope:
+
+- modifying `scripts/run_daily_bounded_paper_runtime.py`
+- paper execution behavior
+- signal generation
+- risk logic
+- score thresholds
+- data ingestion behavior
+- Docker or VPS deployment behavior
+- live trading
+- broker integration
+- readiness or profitability claims
+
+## Usage
+
+### Default JSON Summary
+
+Summarize files named like `run-*.json` under an operator-provided directory and
+write deterministic JSON to stdout:
+
+```bash
+python scripts/validation/summarize_bounded_paper_runtime_evidence.py \
+  --input-dir runs/daily-runtime \
+  --pattern "run-*.json"
+```
+
+### Daily Runtime Summary Artifact Pattern
+
+Summarize existing daily runtime summary artifacts:
+
+```bash
+python scripts/validation/summarize_bounded_paper_runtime_evidence.py \
+  --input-dir runs/daily-runtime \
+  --pattern "daily-runtime-summary-*.json"
+```
+
+### Markdown Output
+
+Write deterministic Markdown output to a file:
+
+```bash
+python scripts/validation/summarize_bounded_paper_runtime_evidence.py \
+  --input-dir runs/daily-runtime \
+  --pattern "run-*.json" \
+  --format markdown \
+  --output runs/daily-runtime/evidence-series-summary.md
+```
+
+## Determinism
+
+The summarizer sorts matched file paths, counter keys, run-file references, and
+summary-file references before rendering output. Repeated runs over the same
+input files produce the same aggregate content.
+
+## Test Execution Evidence
+
+Canonical command attempted:
+
+```bash
+uv run -- python -m pytest --import-mode=importlib
+```
+
+Fallback repository test command:
+
+```bash
+python -m pytest -q
+```
+
+## Claim Boundary
+
+The summary is evidence review material only:
+
+- it does not place live orders
+- it does not call broker APIs
+- it does not execute the daily paper runtime runner
+- it does not change paper execution, signal generation, risk logic, or thresholds
+- it does not establish live-trading, broker-readiness, production-readiness,
+  trader-validation, or profitability claims

--- a/scripts/validation/summarize_bounded_paper_runtime_evidence.py
+++ b/scripts/validation/summarize_bounded_paper_runtime_evidence.py
@@ -1,0 +1,287 @@
+"""Offline bounded paper-runtime evidence series summarizer.
+
+Analysis-only boundary:
+    This script reads saved JSON run-output files from disk and produces an
+    aggregate summary. It does not import or execute the daily runtime runner,
+    paper execution worker, signal generation, risk logic, or deployment flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_PATTERN = "run-*.json"
+RUN_QUALITY_VALUES = ("healthy", "no_eligible", "degraded")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize saved bounded paper-runtime JSON outputs. "
+            "This is offline analysis tooling only."
+        ),
+    )
+    parser.add_argument(
+        "--input-dir",
+        required=True,
+        help="Directory containing saved run-output JSON files.",
+    )
+    parser.add_argument(
+        "--pattern",
+        default=DEFAULT_PATTERN,
+        help=f"Glob pattern for run files. Default: {DEFAULT_PATTERN}.",
+    )
+    parser.add_argument(
+        "--no-recursive",
+        action="store_true",
+        help="Only scan the input directory itself instead of scanning recursively.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Summary output format. Default: json.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional output file path. When omitted, writes to stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _load_run_files(input_dir: Path, pattern: str, *, recursive: bool) -> list[tuple[Path, dict[str, Any]]]:
+    if not input_dir.exists():
+        raise FileNotFoundError(f"input directory does not exist: {input_dir}")
+    if not input_dir.is_dir():
+        raise NotADirectoryError(f"input path is not a directory: {input_dir}")
+
+    paths = input_dir.rglob(pattern) if recursive else input_dir.glob(pattern)
+    loaded: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted((p for p in paths if p.is_file()), key=lambda p: p.as_posix()):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"run file must contain a JSON object: {path}")
+        loaded.append((path, payload))
+    return loaded
+
+
+def _relative_path(path: Path, base: Path) -> str:
+    try:
+        relative = path.relative_to(base)
+    except ValueError:
+        relative = path
+    return relative.as_posix()
+
+
+def _execution_payload(run: dict[str, Any]) -> dict[str, Any]:
+    steps = run.get("steps")
+    if not isinstance(steps, dict):
+        return {}
+    execution_step = steps.get("bounded_paper_execution_cycle")
+    if not isinstance(execution_step, dict):
+        return {}
+    payload = execution_step.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _reconciliation_payload(run: dict[str, Any]) -> dict[str, Any]:
+    steps = run.get("steps")
+    if isinstance(steps, dict):
+        reconciliation_step = steps.get("reconciliation")
+        if isinstance(reconciliation_step, dict):
+            payload = reconciliation_step.get("payload")
+            if isinstance(payload, dict):
+                return payload
+
+    verification_surfaces = run.get("verification_surfaces")
+    if isinstance(verification_surfaces, dict):
+        payload = verification_surfaces.get("paper-reconciliation")
+        if isinstance(payload, dict):
+            return payload
+
+    return {}
+
+
+def _run_quality(run: dict[str, Any]) -> str:
+    value = run.get("run_quality_status")
+    if isinstance(value, str) and value:
+        return value
+    if run.get("status") == "failed":
+        return "degraded"
+    return "unknown"
+
+
+def _skip_reason_from_result(result: dict[str, Any]) -> str | None:
+    outcome = result.get("outcome")
+    if isinstance(outcome, str) and outcome.startswith("skip:"):
+        return outcome.removeprefix("skip:")
+    reason = result.get("reason")
+    if isinstance(reason, str) and reason:
+        return reason.removeprefix("skip:")
+    return None
+
+
+def _sorted_counter(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def summarize_evidence(input_dir: Path, pattern: str = DEFAULT_PATTERN, *, recursive: bool = True) -> dict[str, Any]:
+    base = input_dir.resolve()
+    loaded = _load_run_files(base, pattern, recursive=recursive)
+
+    run_quality_counts: Counter[str] = Counter()
+    skip_reason_counts: Counter[str] = Counter()
+    reconciliation_status_counts: Counter[str] = Counter()
+    eligible_total = 0
+    skipped_total = 0
+    rejected_total = 0
+    mismatch_total = 0
+    summary_files: list[str] = []
+    run_files: list[str] = []
+
+    for path, run in loaded:
+        run_files.append(_relative_path(path, base))
+        run_quality_counts[_run_quality(run)] += 1
+
+        execution = _execution_payload(run)
+        eligible_total += _to_int(execution.get("eligible"))
+        skipped_total += _to_int(execution.get("skipped"))
+        rejected_total += _to_int(execution.get("rejected"))
+
+        results = execution.get("results")
+        if isinstance(results, list):
+            for result in results:
+                if not isinstance(result, dict):
+                    continue
+                reason = _skip_reason_from_result(result)
+                if reason:
+                    skip_reason_counts[reason] += 1
+
+        reconciliation = _reconciliation_payload(run)
+        reconciliation_status = reconciliation.get("status")
+        if isinstance(reconciliation_status, str) and reconciliation_status:
+            reconciliation_status_counts[reconciliation_status] += 1
+        elif reconciliation.get("ok") is True:
+            reconciliation_status_counts["ok"] += 1
+        elif reconciliation.get("ok") is False:
+            reconciliation_status_counts["fail"] += 1
+        else:
+            reconciliation_status_counts["unknown"] += 1
+        mismatch_total += _to_int(reconciliation.get("mismatches"))
+
+        summary_file = run.get("summary_file")
+        if isinstance(summary_file, str) and summary_file:
+            summary_files.append(summary_file)
+
+    run_quality_distribution = _sorted_counter(run_quality_counts)
+    for value in RUN_QUALITY_VALUES:
+        run_quality_distribution.setdefault(value, 0)
+
+    return {
+        "analysis_boundary": "offline_analysis_only",
+        "eligible_skipped_rejected_totals": {
+            "eligible": eligible_total,
+            "rejected": rejected_total,
+            "skipped": skipped_total,
+        },
+        "input": {
+            "directory": str(base),
+            "pattern": pattern,
+            "recursive": recursive,
+        },
+        "reconciliation": {
+            "mismatch_total": mismatch_total,
+            "status_counts": _sorted_counter(reconciliation_status_counts),
+        },
+        "run_count": len(loaded),
+        "run_files": sorted(run_files),
+        "run_quality_distribution": dict(sorted(run_quality_distribution.items())),
+        "skip_reason_counts": _sorted_counter(skip_reason_counts),
+        "summary_files": sorted(summary_files),
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    quality = summary["run_quality_distribution"]
+    totals = summary["eligible_skipped_rejected_totals"]
+    reconciliation = summary["reconciliation"]
+    lines = [
+        "# Bounded Paper Runtime Evidence Series Summary",
+        "",
+        "Analysis boundary: offline analysis only. This output does not alter runtime execution.",
+        "",
+        f"- Run count: {summary['run_count']}",
+        f"- Eligible total: {totals['eligible']}",
+        f"- Skipped total: {totals['skipped']}",
+        f"- Rejected total: {totals['rejected']}",
+        f"- Reconciliation mismatches: {reconciliation['mismatch_total']}",
+        "",
+        "## Run Quality Distribution",
+        "",
+    ]
+    for key in sorted(quality):
+        lines.append(f"- {key}: {quality[key]}")
+
+    lines.extend(["", "## Skip Reasons", ""])
+    skip_reasons = summary["skip_reason_counts"]
+    if skip_reasons:
+        for key in sorted(skip_reasons):
+            lines.append(f"- {key}: {skip_reasons[key]}")
+    else:
+        lines.append("- none: 0")
+
+    lines.extend(["", "## Reconciliation Status", ""])
+    for key, value in reconciliation["status_counts"].items():
+        lines.append(f"- {key}: {value}")
+
+    lines.extend(["", "## Summary Files", ""])
+    summary_files = summary["summary_files"]
+    if summary_files:
+        for path in summary_files:
+            lines.append(f"- {path}")
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    summary = summarize_evidence(
+        Path(args.input_dir),
+        pattern=args.pattern,
+        recursive=not args.no_recursive,
+    )
+    if args.format == "markdown":
+        rendered = render_markdown(summary)
+    else:
+        rendered = json.dumps(summary, sort_keys=True, ensure_ascii=True, indent=2) + "\n"
+
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/composition/main_compat.py
+++ b/src/api/composition/main_compat.py
@@ -45,6 +45,7 @@ def bind_main_runtime_exports(
         {
             "UI_DIRECTORY": settings.ui_directory,
             "JOURNAL_ARTIFACTS_ROOT": settings.journal_artifacts_root,
+            "PAPER_RUNTIME_EVIDENCE_SERIES_DIR": settings.paper_runtime_evidence_series_dir,
             "ENGINE_RUNTIME_NOT_RUNNING_STATUS": settings.engine_runtime_not_running_status,
             "ENGINE_RUNTIME_NOT_RUNNING_CODE": settings.engine_runtime_not_running_code,
             "ENGINE_RUNTIME_GUARD_ACTIVE": False,

--- a/src/api/composition/router_wiring.py
+++ b/src/api/composition/router_wiring.py
@@ -10,10 +10,12 @@ from ..routers import (
     AnalysisRouterDependencies,
     ControlPlaneRouterDependencies,
     InspectionRouterDependencies,
+    PaperRuntimeEvidenceSeriesRouterDependencies,
     WatchlistsRouterDependencies,
     build_analysis_router,
     build_control_plane_router,
     build_inspection_router,
+    build_paper_runtime_evidence_series_router,
     build_watchlists_router,
 )
 
@@ -37,6 +39,7 @@ class ApiRouterWiring:
     get_order_event_repo: Callable[[], Any]
     get_canonical_execution_repo: Callable[[], Any]
     get_journal_artifacts_root: Callable[[], Any]
+    get_paper_runtime_evidence_series_dir: Callable[[], Any]
     get_default_strategy_configs: Callable[[], Dict[str, Dict[str, Any]]]
     get_watchlist_repo: Callable[[], Any]
     get_require_ingestion_run: Callable[..., None]
@@ -77,6 +80,14 @@ def include_api_routers(*, app: FastAPI, wiring: ApiRouterWiring) -> None:
                 get_canonical_execution_repo=wiring.get_canonical_execution_repo,
                 get_journal_artifacts_root=wiring.get_journal_artifacts_root,
                 get_default_strategy_configs=wiring.get_default_strategy_configs,
+            ),
+        )
+    )
+    app.include_router(
+        build_paper_runtime_evidence_series_router(
+            deps=PaperRuntimeEvidenceSeriesRouterDependencies(
+                require_role=wiring.require_role,
+                get_evidence_series_dir=wiring.get_paper_runtime_evidence_series_dir,
             ),
         )
     )

--- a/src/api/composition/runtime_assembly.py
+++ b/src/api/composition/runtime_assembly.py
@@ -106,6 +106,9 @@ def build_api_router_wiring(*, compat: MainModuleCompatibilitySurface) -> ApiRou
         get_order_event_repo=lambda: compat.get("order_event_repo"),
         get_canonical_execution_repo=lambda: compat.get("canonical_execution_repo"),
         get_journal_artifacts_root=lambda: compat.get("JOURNAL_ARTIFACTS_ROOT"),
+        get_paper_runtime_evidence_series_dir=lambda: compat.get(
+            "PAPER_RUNTIME_EVIDENCE_SERIES_DIR"
+        ),
         get_default_strategy_configs=lambda: compat.get("default_strategy_configs"),
         get_watchlist_repo=lambda: compat.get("watchlist_repo"),
         get_require_ingestion_run=lambda *args, **kwargs: compat.get("_require_ingestion_run")(

--- a/src/api/composition/runtime_settings.py
+++ b/src/api/composition/runtime_settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from cilly_trading.strategies.registry import initialize_default_registry
 
@@ -12,6 +12,7 @@ from cilly_trading.strategies.registry import initialize_default_registry
 class ApiRuntimeSettings:
     ui_directory: Path
     journal_artifacts_root: Path
+    paper_runtime_evidence_series_dir: Optional[Path]
     engine_runtime_not_running_status: int
     engine_runtime_not_running_code: str
     phase_13_read_only_endpoints: frozenset[str]
@@ -66,9 +67,18 @@ def build_default_strategy_configs() -> dict[str, dict[str, Any]]:
 
 
 def build_api_runtime_settings() -> ApiRuntimeSettings:
+    paper_runtime_evidence_series_dir_raw = os.getenv(
+        "CILLY_PAPER_RUNTIME_EVIDENCE_SERIES_DIR",
+        "",
+    ).strip()
     return ApiRuntimeSettings(
         ui_directory=Path(__file__).resolve().parents[2] / "ui",
         journal_artifacts_root=Path(__file__).resolve().parents[3] / "runs" / "phase6",
+        paper_runtime_evidence_series_dir=(
+            Path(paper_runtime_evidence_series_dir_raw)
+            if paper_runtime_evidence_series_dir_raw
+            else None
+        ),
         engine_runtime_not_running_status=503,
         engine_runtime_not_running_code="engine_runtime_not_running",
         phase_13_read_only_endpoints=frozenset({"/health", "/runtime/introspection"}),

--- a/src/api/models/paper_runtime_evidence_series_models.py
+++ b/src/api/models/paper_runtime_evidence_series_models.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PaperRuntimeEvidenceSeriesBoundaryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["paper_runtime_evidence_series_inspection_only"]
+    analysis_boundary: Literal["offline_analysis_only"]
+    inspection_statement: str
+    non_live_statement: str
+    out_of_scope: List[str]
+
+
+class PaperRuntimeEvidenceSeriesTotalsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    eligible: int
+    skipped: int
+    rejected: int
+
+
+class PaperRuntimeEvidenceSeriesReconciliationResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mismatch_total: int
+    status_counts: Dict[str, int]
+
+
+class PaperRuntimeEvidenceSeriesSourceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    directory: Optional[str]
+    pattern: str
+    recursive: bool
+
+
+class PaperRuntimeEvidenceSeriesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: Literal["not_configured", "missing", "empty", "available"]
+    boundary: PaperRuntimeEvidenceSeriesBoundaryResponse
+    source: PaperRuntimeEvidenceSeriesSourceResponse
+    run_count: int
+    run_quality_distribution: Dict[str, int]
+    eligible_skipped_rejected_totals: PaperRuntimeEvidenceSeriesTotalsResponse
+    skip_reason_counts: Dict[str, int]
+    reconciliation: PaperRuntimeEvidenceSeriesReconciliationResponse
+    mismatch_counts: Dict[str, int]
+    summary_files: List[str]
+    run_files: List[str]
+    message: str

--- a/src/api/routers/__init__.py
+++ b/src/api/routers/__init__.py
@@ -3,15 +3,21 @@
 from .analysis_router import AnalysisRouterDependencies, build_analysis_router
 from .control_plane_router import ControlPlaneRouterDependencies, build_control_plane_router
 from .inspection_router import InspectionRouterDependencies, build_inspection_router
+from .paper_runtime_evidence_series_router import (
+    PaperRuntimeEvidenceSeriesRouterDependencies,
+    build_paper_runtime_evidence_series_router,
+)
 from .watchlists_router import WatchlistsRouterDependencies, build_watchlists_router
 
 __all__ = [
     "AnalysisRouterDependencies",
     "ControlPlaneRouterDependencies",
     "InspectionRouterDependencies",
+    "PaperRuntimeEvidenceSeriesRouterDependencies",
     "WatchlistsRouterDependencies",
     "build_analysis_router",
     "build_control_plane_router",
     "build_inspection_router",
+    "build_paper_runtime_evidence_series_router",
     "build_watchlists_router",
 ]

--- a/src/api/routers/paper_runtime_evidence_series_router.py
+++ b/src/api/routers/paper_runtime_evidence_series_router.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from fastapi import APIRouter, Depends
+
+from ..models.paper_runtime_evidence_series_models import PaperRuntimeEvidenceSeriesResponse
+from ..services.paper_runtime_evidence_series_service import read_paper_runtime_evidence_series
+
+
+@dataclass
+class PaperRuntimeEvidenceSeriesRouterDependencies:
+    require_role: Callable[[str], Callable[..., str]]
+    get_evidence_series_dir: Callable[[], Optional[Path]]
+
+
+def build_paper_runtime_evidence_series_router(
+    *,
+    deps: PaperRuntimeEvidenceSeriesRouterDependencies,
+) -> APIRouter:
+    router = APIRouter()
+
+    @router.get(
+        "/paper/runtime/evidence-series",
+        response_model=PaperRuntimeEvidenceSeriesResponse,
+        summary="Paper Runtime Evidence Series",
+        description=(
+            "Read-only inspection endpoint for offline bounded paper-runtime evidence series "
+            "summaries. The endpoint only reads configured local JSON evidence artifacts and "
+            "cannot trigger runtime execution, signal generation, risk logic, data ingestion, "
+            "deployment, live trading, broker integration, or readiness/profitability claims."
+        ),
+    )
+    def read_paper_runtime_evidence_series_handler(
+        _: str = Depends(deps.require_role("read_only")),
+    ) -> PaperRuntimeEvidenceSeriesResponse:
+        return read_paper_runtime_evidence_series(
+            evidence_series_dir=deps.get_evidence_series_dir(),
+        )
+
+    return router

--- a/src/api/services/paper_runtime_evidence_series_service.py
+++ b/src/api/services/paper_runtime_evidence_series_service.py
@@ -1,0 +1,299 @@
+"""Read-only paper-runtime evidence series inspection.
+
+This module reads saved offline bounded paper-runtime JSON outputs from disk.
+It does not import or execute runtime runners, paper execution, signal
+generation, risk logic, data ingestion, or deployment code.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+from ..models.paper_runtime_evidence_series_models import (
+    PaperRuntimeEvidenceSeriesBoundaryResponse,
+    PaperRuntimeEvidenceSeriesReconciliationResponse,
+    PaperRuntimeEvidenceSeriesResponse,
+    PaperRuntimeEvidenceSeriesSourceResponse,
+    PaperRuntimeEvidenceSeriesTotalsResponse,
+)
+
+DEFAULT_PATTERN = "run-*.json"
+RUN_QUALITY_VALUES = ("healthy", "no_eligible", "degraded")
+
+
+def _boundary() -> PaperRuntimeEvidenceSeriesBoundaryResponse:
+    return PaperRuntimeEvidenceSeriesBoundaryResponse(
+        mode="paper_runtime_evidence_series_inspection_only",
+        analysis_boundary="offline_analysis_only",
+        inspection_statement=(
+            "This endpoint only reads saved bounded paper-runtime evidence files and returns "
+            "deterministic aggregate inspection data."
+        ),
+        non_live_statement=(
+            "This endpoint does not trigger paper-runtime execution and does not imply live "
+            "trading, broker readiness, trader validation, production readiness, or profitability."
+        ),
+        out_of_scope=[
+            "triggering paper-runtime runs",
+            "modifying paper execution behavior",
+            "modifying signal generation",
+            "modifying risk logic",
+            "modifying data ingestion behavior",
+            "deploying runtime changes",
+            "live trading",
+            "broker integration",
+            "readiness or profitability claims",
+        ],
+    )
+
+
+def _empty_response(
+    *,
+    state: Literal["not_configured", "missing", "empty", "available"],
+    source_dir: Optional[Path],
+    pattern: str,
+    recursive: bool,
+    message: str,
+) -> PaperRuntimeEvidenceSeriesResponse:
+    quality = {key: 0 for key in sorted(RUN_QUALITY_VALUES)}
+    return PaperRuntimeEvidenceSeriesResponse(
+        state=state,
+        boundary=_boundary(),
+        source=PaperRuntimeEvidenceSeriesSourceResponse(
+            directory=str(source_dir.resolve()) if source_dir is not None else None,
+            pattern=pattern,
+            recursive=recursive,
+        ),
+        run_count=0,
+        run_quality_distribution=quality,
+        eligible_skipped_rejected_totals=PaperRuntimeEvidenceSeriesTotalsResponse(
+            eligible=0,
+            skipped=0,
+            rejected=0,
+        ),
+        skip_reason_counts={},
+        reconciliation=PaperRuntimeEvidenceSeriesReconciliationResponse(
+            mismatch_total=0,
+            status_counts={},
+        ),
+        mismatch_counts={},
+        summary_files=[],
+        run_files=[],
+        message=message,
+    )
+
+
+def _to_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _relative_path(path: Path, base: Path) -> str:
+    try:
+        return path.relative_to(base).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _load_run_files(
+    *,
+    input_dir: Path,
+    pattern: str,
+    recursive: bool,
+) -> list[tuple[Path, dict[str, Any]]]:
+    paths = input_dir.rglob(pattern) if recursive else input_dir.glob(pattern)
+    loaded: list[tuple[Path, dict[str, Any]]] = []
+    for path in sorted(
+        (candidate for candidate in paths if candidate.is_file()),
+        key=lambda item: item.as_posix(),
+    ):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            loaded.append((path, payload))
+    return loaded
+
+
+def _execution_payload(run: dict[str, Any]) -> dict[str, Any]:
+    steps = run.get("steps")
+    if not isinstance(steps, dict):
+        return {}
+    execution_step = steps.get("bounded_paper_execution_cycle")
+    if not isinstance(execution_step, dict):
+        return {}
+    payload = execution_step.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _reconciliation_payload(run: dict[str, Any]) -> dict[str, Any]:
+    steps = run.get("steps")
+    if isinstance(steps, dict):
+        reconciliation_step = steps.get("reconciliation")
+        if isinstance(reconciliation_step, dict):
+            payload = reconciliation_step.get("payload")
+            if isinstance(payload, dict):
+                return payload
+
+    verification_surfaces = run.get("verification_surfaces")
+    if isinstance(verification_surfaces, dict):
+        payload = verification_surfaces.get("paper-reconciliation")
+        if isinstance(payload, dict):
+            return payload
+
+    return {}
+
+
+def _run_quality(run: dict[str, Any]) -> str:
+    value = run.get("run_quality_status")
+    if isinstance(value, str) and value:
+        return value
+    if run.get("status") == "failed":
+        return "degraded"
+    return "unknown"
+
+
+def _skip_reason_from_result(result: dict[str, Any]) -> str | None:
+    outcome = result.get("outcome")
+    if isinstance(outcome, str) and outcome.startswith("skip:"):
+        return outcome.removeprefix("skip:")
+    reason = result.get("reason")
+    if isinstance(reason, str) and reason:
+        return reason.removeprefix("skip:")
+    return None
+
+
+def _sorted_counter(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def read_paper_runtime_evidence_series(
+    *,
+    evidence_series_dir: Optional[Path],
+    pattern: str = DEFAULT_PATTERN,
+    recursive: bool = True,
+) -> PaperRuntimeEvidenceSeriesResponse:
+    if evidence_series_dir is None:
+        return _empty_response(
+            state="not_configured",
+            source_dir=None,
+            pattern=pattern,
+            recursive=recursive,
+            message="CILLY_PAPER_RUNTIME_EVIDENCE_SERIES_DIR is not configured.",
+        )
+
+    base = evidence_series_dir.resolve()
+    if not base.exists():
+        return _empty_response(
+            state="missing",
+            source_dir=base,
+            pattern=pattern,
+            recursive=recursive,
+            message="Configured paper-runtime evidence series directory does not exist.",
+        )
+    if not base.is_dir():
+        return _empty_response(
+            state="missing",
+            source_dir=base,
+            pattern=pattern,
+            recursive=recursive,
+            message="Configured paper-runtime evidence series path is not a directory.",
+        )
+
+    loaded = _load_run_files(input_dir=base, pattern=pattern, recursive=recursive)
+    if not loaded:
+        return _empty_response(
+            state="empty",
+            source_dir=base,
+            pattern=pattern,
+            recursive=recursive,
+            message="Configured paper-runtime evidence series directory contains no matching run files.",
+        )
+
+    run_quality_counts: Counter[str] = Counter()
+    skip_reason_counts: Counter[str] = Counter()
+    reconciliation_status_counts: Counter[str] = Counter()
+    mismatch_counts: Counter[str] = Counter()
+    eligible_total = 0
+    skipped_total = 0
+    rejected_total = 0
+    mismatch_total = 0
+    summary_files: list[str] = []
+    run_files: list[str] = []
+
+    for path, run in loaded:
+        run_files.append(_relative_path(path, base))
+        run_quality_counts[_run_quality(run)] += 1
+
+        execution = _execution_payload(run)
+        eligible_total += _to_int(execution.get("eligible"))
+        skipped_total += _to_int(execution.get("skipped"))
+        rejected_total += _to_int(execution.get("rejected"))
+
+        results = execution.get("results")
+        if isinstance(results, list):
+            for result in results:
+                if not isinstance(result, dict):
+                    continue
+                reason = _skip_reason_from_result(result)
+                if reason:
+                    skip_reason_counts[reason] += 1
+
+        reconciliation = _reconciliation_payload(run)
+        status = reconciliation.get("status")
+        if isinstance(status, str) and status:
+            reconciliation_status_counts[status] += 1
+        elif reconciliation.get("ok") is True:
+            reconciliation_status_counts["ok"] += 1
+        elif reconciliation.get("ok") is False:
+            reconciliation_status_counts["fail"] += 1
+        else:
+            reconciliation_status_counts["unknown"] += 1
+
+        mismatches = _to_int(reconciliation.get("mismatches"))
+        mismatch_total += mismatches
+        if mismatches > 0:
+            mismatch_counts[_relative_path(path, base)] = mismatches
+
+        summary_file = run.get("summary_file")
+        if isinstance(summary_file, str) and summary_file:
+            summary_files.append(summary_file)
+
+    quality = _sorted_counter(run_quality_counts)
+    for value in RUN_QUALITY_VALUES:
+        quality.setdefault(value, 0)
+
+    return PaperRuntimeEvidenceSeriesResponse(
+        state="available",
+        boundary=_boundary(),
+        source=PaperRuntimeEvidenceSeriesSourceResponse(
+            directory=str(base),
+            pattern=pattern,
+            recursive=recursive,
+        ),
+        run_count=len(loaded),
+        run_quality_distribution=dict(sorted(quality.items())),
+        eligible_skipped_rejected_totals=PaperRuntimeEvidenceSeriesTotalsResponse(
+            eligible=eligible_total,
+            skipped=skipped_total,
+            rejected=rejected_total,
+        ),
+        skip_reason_counts=_sorted_counter(skip_reason_counts),
+        reconciliation=PaperRuntimeEvidenceSeriesReconciliationResponse(
+            mismatch_total=mismatch_total,
+            status_counts=_sorted_counter(reconciliation_status_counts),
+        ),
+        mismatch_counts=_sorted_counter(mismatch_counts),
+        summary_files=sorted(summary_files),
+        run_files=sorted(run_files),
+        message="Paper-runtime evidence series summary is available for read-only inspection.",
+    )

--- a/tests/test_api_paper_runtime_evidence_series_docs.py
+++ b/tests/test_api_paper_runtime_evidence_series_docs.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+
+def test_paper_runtime_evidence_series_docs_state_inspection_only_boundary(
+    read_repo_doc,
+    doc_assert_contains_all,
+) -> None:
+    content = read_repo_doc("docs/api/paper_runtime_evidence_series.md")
+
+    doc_assert_contains_all(
+        content,
+        "GET /paper/runtime/evidence-series",
+        "read-only inspection endpoint",
+        "does not trigger paper-runtime runs",
+        "scripts/run_daily_bounded_paper_runtime.py",
+        "not_configured",
+        "missing",
+        "empty",
+        "available",
+        "does not imply trader validation",
+        "live-trading readiness",
+        "broker readiness",
+        "profitability",
+    )

--- a/tests/test_api_paper_runtime_evidence_series_read.py
+++ b/tests/test_api_paper_runtime_evidence_series_read.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+
+READ_ONLY_HEADERS = {api_main.ROLE_HEADER_NAME: "read_only"}
+
+
+def _patch_runtime_lifecycle(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "start_engine_runtime", lambda: "running")
+    monkeypatch.setattr(api_main, "shutdown_engine_runtime", lambda: "stopped")
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_paper_runtime_evidence_series_returns_not_configured_state(monkeypatch) -> None:
+    _patch_runtime_lifecycle(monkeypatch)
+    monkeypatch.setattr(api_main, "PAPER_RUNTIME_EVIDENCE_SERIES_DIR", None)
+
+    with TestClient(api_main.app) as client:
+        response = client.get("/paper/runtime/evidence-series", headers=READ_ONLY_HEADERS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "not_configured"
+    assert payload["run_count"] == 0
+    assert payload["source"]["directory"] is None
+    assert payload["boundary"]["mode"] == "paper_runtime_evidence_series_inspection_only"
+    assert "does not trigger paper-runtime execution" in payload["boundary"]["non_live_statement"]
+
+
+def test_paper_runtime_evidence_series_returns_missing_and_empty_states(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _patch_runtime_lifecycle(monkeypatch)
+    missing_dir = tmp_path / "missing"
+    monkeypatch.setattr(api_main, "PAPER_RUNTIME_EVIDENCE_SERIES_DIR", missing_dir)
+
+    with TestClient(api_main.app) as client:
+        missing = client.get("/paper/runtime/evidence-series", headers=READ_ONLY_HEADERS)
+
+    assert missing.status_code == 200
+    assert missing.json()["state"] == "missing"
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    monkeypatch.setattr(api_main, "PAPER_RUNTIME_EVIDENCE_SERIES_DIR", empty_dir)
+
+    with TestClient(api_main.app) as client:
+        empty = client.get("/paper/runtime/evidence-series", headers=READ_ONLY_HEADERS)
+
+    assert empty.status_code == 200
+    assert empty.json()["state"] == "empty"
+    assert empty.json()["run_files"] == []
+
+
+def test_paper_runtime_evidence_series_summarizes_fixture_inputs_deterministically(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _patch_runtime_lifecycle(monkeypatch)
+    _write_json(
+        tmp_path / "2026-04-07" / "run-002.json",
+        {
+            "run_quality_status": "no_eligible",
+            "status": "ok",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {
+                        "eligible": 0,
+                        "rejected": 1,
+                        "results": [
+                            {"outcome": "skip:score_below_threshold", "signal_id": "sig-3"},
+                            {"outcome": "reject:invalid_quantity", "signal_id": "sig-4"},
+                        ],
+                        "skipped": 1,
+                    }
+                },
+                "reconciliation": {
+                    "payload": {"mismatches": 0, "ok": True, "status": "pass"}
+                },
+            },
+            "summary_file": "/data/artifacts/daily-runtime/2026-04-07/daily-runtime-summary.json",
+        },
+    )
+    _write_json(
+        tmp_path / "2026-04-06" / "run-001.json",
+        {
+            "run_quality_status": "healthy",
+            "status": "ok",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {
+                        "eligible": 2,
+                        "rejected": 0,
+                        "results": [{"outcome": "skip:duplicate_entry", "signal_id": "sig-2"}],
+                        "skipped": 1,
+                    }
+                },
+                "reconciliation": {
+                    "payload": {"mismatches": 0, "ok": True, "status": "pass"}
+                },
+            },
+            "summary_file": "/data/artifacts/daily-runtime/2026-04-06/daily-runtime-summary.json",
+        },
+    )
+    _write_json(
+        tmp_path / "2026-04-08" / "run-003.json",
+        {
+            "run_quality_status": "degraded",
+            "status": "ok",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {
+                        "eligible": 1,
+                        "rejected": 0,
+                        "results": [{"outcome": "skip:duplicate_entry", "signal_id": "sig-5"}],
+                        "skipped": 1,
+                    }
+                },
+                "reconciliation": {
+                    "payload": {"mismatches": 2, "ok": False, "status": "fail"}
+                },
+            },
+            "summary_file": "/data/artifacts/daily-runtime/2026-04-08/daily-runtime-summary.json",
+        },
+    )
+    monkeypatch.setattr(api_main, "PAPER_RUNTIME_EVIDENCE_SERIES_DIR", tmp_path)
+
+    with TestClient(api_main.app) as client:
+        first = client.get("/paper/runtime/evidence-series", headers=READ_ONLY_HEADERS)
+        second = client.get("/paper/runtime/evidence-series", headers=READ_ONLY_HEADERS)
+        openapi = client.get("/openapi.json").json()
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    payload = first.json()
+    assert payload["state"] == "available"
+    assert payload["run_count"] == 3
+    assert payload["run_files"] == [
+        "2026-04-06/run-001.json",
+        "2026-04-07/run-002.json",
+        "2026-04-08/run-003.json",
+    ]
+    assert payload["run_quality_distribution"] == {
+        "degraded": 1,
+        "healthy": 1,
+        "no_eligible": 1,
+    }
+    assert payload["eligible_skipped_rejected_totals"] == {
+        "eligible": 3,
+        "skipped": 3,
+        "rejected": 1,
+    }
+    assert payload["skip_reason_counts"] == {
+        "duplicate_entry": 2,
+        "score_below_threshold": 1,
+    }
+    assert payload["reconciliation"] == {
+        "mismatch_total": 2,
+        "status_counts": {"fail": 1, "pass": 2},
+    }
+    assert payload["mismatch_counts"] == {"2026-04-08/run-003.json": 2}
+    assert payload["summary_files"] == [
+        "/data/artifacts/daily-runtime/2026-04-06/daily-runtime-summary.json",
+        "/data/artifacts/daily-runtime/2026-04-07/daily-runtime-summary.json",
+        "/data/artifacts/daily-runtime/2026-04-08/daily-runtime-summary.json",
+    ]
+    assert "/paper/runtime/evidence-series" in openapi["paths"]
+    assert set(openapi["paths"]["/paper/runtime/evidence-series"].keys()) == {"get"}
+
+
+def test_paper_runtime_evidence_series_endpoint_does_not_import_runner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _patch_runtime_lifecycle(monkeypatch)
+    _write_json(
+        tmp_path / "run-001.json",
+        {
+            "run_quality_status": "healthy",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {"eligible": 1, "rejected": 0, "results": [], "skipped": 0}
+                },
+                "reconciliation": {"payload": {"mismatches": 0, "ok": True}},
+            },
+        },
+    )
+    monkeypatch.setattr(api_main, "PAPER_RUNTIME_EVIDENCE_SERIES_DIR", tmp_path)
+    runner_module = "scripts.run_daily_bounded_paper_runtime"
+    previous_module = sys.modules.pop(runner_module, None)
+    try:
+        with TestClient(api_main.app) as client:
+            response = client.get("/paper/runtime/evidence-series", headers=READ_ONLY_HEADERS)
+
+        assert response.status_code == 200
+        assert runner_module not in sys.modules
+    finally:
+        if previous_module is not None:
+            sys.modules[runner_module] = previous_module

--- a/tests/test_bounded_paper_runtime_evidence_summarizer.py
+++ b/tests/test_bounded_paper_runtime_evidence_summarizer.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script_module():
+    module_path = REPO_ROOT / "scripts" / "validation" / "summarize_bounded_paper_runtime_evidence.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_bounded_paper_runtime_evidence_summarizer_module",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load summarize_bounded_paper_runtime_evidence.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_summarizer_aggregates_saved_run_outputs_deterministically(tmp_path: Path) -> None:
+    module = _load_script_module()
+
+    _write_json(
+        tmp_path / "2026-04-07" / "run-002.json",
+        {
+            "run_quality_status": "no_eligible",
+            "status": "ok",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {
+                        "eligible": 0,
+                        "rejected": 1,
+                        "results": [
+                            {"outcome": "skip:score_below_threshold", "signal_id": "sig-3"},
+                            {"outcome": "reject:invalid_quantity", "signal_id": "sig-4"},
+                        ],
+                        "skipped": 1,
+                        "status": "no_eligible",
+                    },
+                    "returncode": 1,
+                },
+                "reconciliation": {
+                    "payload": {"mismatches": 0, "ok": True, "status": "pass"},
+                    "returncode": 0,
+                },
+            },
+            "summary_file": "/data/artifacts/daily-runtime/2026-04-07/daily-runtime-summary.json",
+        },
+    )
+    _write_json(
+        tmp_path / "2026-04-06" / "run-001.json",
+        {
+            "run_quality_status": "healthy",
+            "status": "ok",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {
+                        "eligible": 2,
+                        "rejected": 0,
+                        "results": [
+                            {"outcome": "eligible", "signal_id": "sig-1"},
+                            {"outcome": "skip:duplicate_entry", "signal_id": "sig-2"},
+                        ],
+                        "skipped": 1,
+                        "status": "pass",
+                    },
+                    "returncode": 0,
+                },
+                "reconciliation": {
+                    "payload": {"mismatches": 0, "ok": True, "status": "pass"},
+                    "returncode": 0,
+                },
+            },
+            "summary_file": "/data/artifacts/daily-runtime/2026-04-06/daily-runtime-summary.json",
+        },
+    )
+    _write_json(
+        tmp_path / "2026-04-08" / "run-003.json",
+        {
+            "run_quality_status": "degraded",
+            "status": "ok",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {
+                        "eligible": 1,
+                        "rejected": 0,
+                        "results": [{"outcome": "skip:duplicate_entry", "signal_id": "sig-5"}],
+                        "skipped": 1,
+                        "status": "pass",
+                    },
+                    "returncode": 0,
+                },
+                "reconciliation": {
+                    "payload": {"mismatches": 2, "ok": False, "status": "fail"},
+                    "returncode": 1,
+                },
+            },
+            "summary_file": "/data/artifacts/daily-runtime/2026-04-08/daily-runtime-summary.json",
+        },
+    )
+
+    first = module.summarize_evidence(tmp_path, pattern="run-*.json")
+    second = module.summarize_evidence(tmp_path, pattern="run-*.json")
+
+    assert first == second
+    assert first["analysis_boundary"] == "offline_analysis_only"
+    assert first["run_count"] == 3
+    assert first["run_files"] == [
+        "2026-04-06/run-001.json",
+        "2026-04-07/run-002.json",
+        "2026-04-08/run-003.json",
+    ]
+    assert first["run_quality_distribution"] == {
+        "degraded": 1,
+        "healthy": 1,
+        "no_eligible": 1,
+    }
+    assert first["eligible_skipped_rejected_totals"] == {
+        "eligible": 3,
+        "rejected": 1,
+        "skipped": 3,
+    }
+    assert first["skip_reason_counts"] == {
+        "duplicate_entry": 2,
+        "score_below_threshold": 1,
+    }
+    assert first["reconciliation"] == {
+        "mismatch_total": 2,
+        "status_counts": {"fail": 1, "pass": 2},
+    }
+    assert first["summary_files"] == [
+        "/data/artifacts/daily-runtime/2026-04-06/daily-runtime-summary.json",
+        "/data/artifacts/daily-runtime/2026-04-07/daily-runtime-summary.json",
+        "/data/artifacts/daily-runtime/2026-04-08/daily-runtime-summary.json",
+    ]
+
+
+def test_summarizer_cli_writes_json_and_markdown_outputs(tmp_path: Path) -> None:
+    module = _load_script_module()
+    _write_json(
+        tmp_path / "run-001.json",
+        {
+            "run_quality_status": "healthy",
+            "steps": {
+                "bounded_paper_execution_cycle": {
+                    "payload": {"eligible": 1, "rejected": 0, "results": [], "skipped": 0}
+                },
+                "reconciliation": {"payload": {"mismatches": 0, "ok": True}},
+            },
+            "summary_file": "summary-001.json",
+        },
+    )
+    json_output = tmp_path / "summary.json"
+    markdown_output = tmp_path / "summary.md"
+
+    assert module.main(
+        [
+            "--input-dir",
+            str(tmp_path),
+            "--pattern",
+            "run-*.json",
+            "--output",
+            str(json_output),
+        ]
+    ) == 0
+    assert module.main(
+        [
+            "--input-dir",
+            str(tmp_path),
+            "--pattern",
+            "run-*.json",
+            "--format",
+            "markdown",
+            "--output",
+            str(markdown_output),
+        ]
+    ) == 0
+
+    parsed = json.loads(json_output.read_text(encoding="utf-8"))
+    assert parsed["run_count"] == 1
+    markdown = markdown_output.read_text(encoding="utf-8")
+    assert "# Bounded Paper Runtime Evidence Series Summary" in markdown
+    assert "Analysis boundary: offline analysis only." in markdown
+    assert "- healthy: 1" in markdown


### PR DESCRIPTION
Closes #1062

Adds a read-only API endpoint for inspecting offline bounded paper-runtime evidence series summaries from a configured local artifact directory.

The endpoint returns explicit not-configured, missing, empty, and available states; summarizes run quality, eligible/skipped/rejected totals, skip reasons, reconciliation status, mismatch counts, and summary-file references; and is documented as inspection-only and non-live.

Tests cover deterministic fixture-backed responses, missing/empty/not-configured states, OpenAPI exposure, docs boundary language, and proof that the production daily runtime runner is not imported by the endpoint.

## Test Evidence

- uv run -- python -m pytest --import-mode=importlib could not run because uv is not available on PATH in this environment.
- .\.venv\Scripts\python -m pytest --import-mode=importlib passed: 1274 passed in 91.77s (0:01:31).
- .\.venv\Scripts\python -m pytest tests\test_api_paper_runtime_evidence_series_read.py tests\test_api_paper_runtime_evidence_series_docs.py -q passed: 5 passed in 4.56s.

## Scope Boundary

- Read-only inspection endpoint only.
- Reads local JSON evidence files from CILLY_PAPER_RUNTIME_EVIDENCE_SERIES_DIR.
- Does not write DB state, paper state, signal state, or runtime artifacts.
- Does not import, execute, or modify scripts/run_daily_bounded_paper_runtime.py.
- Does not introduce VPS, broker, live-trading, production-readiness, trader-validation, or profitability claims.