### PR TITLE
fix: close RSI and zero-equity risk-gate regressions from #1069

### DIFF
--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -126,6 +126,13 @@ def _safe_pct(numerator: float, denominator: float) -> float | None:
     return numerator / denominator
 
 
+def _nonzero_rejection_score(max_allowed: float) -> float:
+    """Return a finite score that preserves rejection semantics for undefined ratios."""
+    if isfinite(max_allowed):
+        return max_allowed + 1.0
+    return 1.0
+
+
 def _risk_limit_notional(account_equity: float, limit_pct: float | None) -> float:
     if limit_pct is None:
         return float("inf")
@@ -351,13 +358,13 @@ def adapt_risk_framework_response_to_risk_decision(
             score = float(framework_response.risk_score)
             max_allowed = float(limits.max_account_exposure_pct)
         elif reason == "rejected: max_strategy_exposure_pct_exceeded":
-            _pct = _safe_pct(normalized_strategy + normalized_proposed, normalized_equity)
-            score = _pct if _pct is not None else 0.0
             max_allowed = float(limits.max_strategy_exposure_pct)
+            _pct = _safe_pct(normalized_strategy + normalized_proposed, normalized_equity)
+            score = _pct if _pct is not None else _nonzero_rejection_score(max_allowed)
         elif reason == "rejected: max_symbol_exposure_pct_exceeded":
-            _pct = _safe_pct(normalized_symbol + normalized_proposed, normalized_equity)
-            score = _pct if _pct is not None else 0.0
             max_allowed = float(limits.max_symbol_exposure_pct)
+            _pct = _safe_pct(normalized_symbol + normalized_proposed, normalized_equity)
+            score = _pct if _pct is not None else _nonzero_rejection_score(max_allowed)
         else:  # pragma: no cover - guarded by reason map above
             raise ValueError(f"unsupported risk-framework reason: {reason}")
         if not _collect_covered_rejection_reason_codes(policy_evidence):

--- a/src/cilly_trading/indicators/rsi.py
+++ b/src/cilly_trading/indicators/rsi.py
@@ -37,8 +37,16 @@ def rsi(
     avg_gain = gain.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
     avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
 
-    rs = avg_gain / avg_loss.replace(0, float("nan"))
+    zero_loss = avg_loss == 0
+    zero_gain = avg_gain == 0
+
+    rs = avg_gain / avg_loss.mask(zero_loss)
     rsi_series = 100 - (100 / (1 + rs))
+
+    # Sustained upward moves have no average loss and should saturate at 100,
+    # not become NaN. Fully flat windows are neutral after the warm-up period.
+    rsi_series = rsi_series.mask(zero_loss & (avg_gain > 0), 100.0)
+    rsi_series = rsi_series.mask(zero_loss & zero_gain, 50.0)
     rsi_series = rsi_series.clip(0, 100)
 
     return rsi_series

--- a/tests/cilly_trading/engine/test_risk_gate.py
+++ b/tests/cilly_trading/engine/test_risk_gate.py
@@ -219,6 +219,66 @@ def test_adapter_maps_risk_framework_reason_codes_deterministically(
         assert _policy_evidence_or_empty(decision)
 
 
+def test_adapter_uses_finite_rejection_score_for_zero_equity_strategy_exposure_cap() -> None:
+    decision = adapt_risk_framework_response_to_risk_decision(
+        framework_request=FrameworkRiskEvaluationRequest(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            proposed_position_size=400.0,
+            account_equity=0.0,
+            current_exposure=0.0,
+        ),
+        framework_response=FrameworkRiskEvaluationResponse(
+            approved=False,
+            reason="rejected: max_strategy_exposure_pct_exceeded",
+            adjusted_position_size=0.0,
+            risk_score=float("inf"),
+        ),
+        limits=_framework_limits(),
+        strategy_exposure=200.0,
+        symbol_exposure=100.0,
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert decision.decision == "REJECTED"
+    assert decision.score > decision.max_allowed
+    assert math.isfinite(decision.score)
+    policy_evidence = _policy_evidence_or_empty(decision)
+    assert policy_evidence[0].observed_value > policy_evidence[0].limit_value
+    assert math.isfinite(policy_evidence[0].observed_value)
+
+
+def test_adapter_uses_finite_rejection_score_for_zero_equity_symbol_exposure_cap() -> None:
+    decision = adapt_risk_framework_response_to_risk_decision(
+        framework_request=FrameworkRiskEvaluationRequest(
+            strategy_id="strategy-a",
+            symbol="AAPL",
+            proposed_position_size=400.0,
+            account_equity=0.0,
+            current_exposure=0.0,
+        ),
+        framework_response=FrameworkRiskEvaluationResponse(
+            approved=False,
+            reason="rejected: max_symbol_exposure_pct_exceeded",
+            adjusted_position_size=0.0,
+            risk_score=float("inf"),
+        ),
+        limits=_framework_limits(),
+        strategy_exposure=200.0,
+        symbol_exposure=100.0,
+        rule_version="adapter-v1",
+        evaluated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    assert decision.decision == "REJECTED"
+    assert decision.score > decision.max_allowed
+    assert math.isfinite(decision.score)
+    policy_evidence = _policy_evidence_or_empty(decision)
+    assert policy_evidence[0].observed_value > policy_evidence[0].limit_value
+    assert math.isfinite(policy_evidence[0].observed_value)
+
+
 def test_adapter_rejects_unknown_reason_code() -> None:
     with pytest.raises(ValueError, match="unsupported risk-framework reason"):
         adapt_risk_framework_response_to_risk_decision(

--- a/tests/test_rsi_regression.py
+++ b/tests/test_rsi_regression.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from cilly_trading.indicators.rsi import rsi
+
+
+def test_rsi_saturates_at_100_when_average_loss_is_zero_and_gain_positive() -> None:
+    df = pd.DataFrame({"close": [float(value) for value in range(1, 21)]})
+
+    result = rsi(df, period=14)
+
+    assert result.iloc[-1] == 100.0
+    assert not pd.isna(result.iloc[-1])
+
+
+def test_rsi_returns_neutral_value_for_flat_warm_window() -> None:
+    df = pd.DataFrame({"close": [100.0] * 20})
+
+    result = rsi(df, period=14)
+
+    assert result.iloc[-1] == 50.0
+    assert not pd.isna(result.iloc[-1])


### PR DESCRIPTION
## Summary

- Fix RSI zero-loss behavior so sustained upward moves saturate at `100.0` instead of becoming `NaN`.
- Preserve neutral `50.0` RSI behavior for fully flat warm windows.
- Fix zero-equity strategy/symbol exposure-cap mapping so rejected decisions keep finite nonzero rejection evidence instead of reporting `score = 0.0`.
- Add targeted regression tests for both issues raised during the #1069 automated review.

## Scope Boundary

- Hotfix only for #1069 regressions.
- No strategy logic redesign.
- No broker, live-trading, runtime-runner, deployment, or production-readiness behavior changed.
- No readiness, profitability, or trader-validation claim introduced.

## Test Evidence

Not run in this environment. Suggested targeted checks:

```bash
python -m pytest tests/test_rsi_regression.py tests/cilly_trading/engine/test_risk_gate.py -q
```

Suggested full check before merge:

```bash
python -m pytest -q
```

Addresses Codex review findings on PR #1069:

- P1: RSI should return 100 when average loss is zero and average gain is positive.
- P2: zero-equity exposure-cap rejections should not emit contradictory `score = 0.0` evidence.