### PR TITLE
fix(welle8): entry-zone precision, watchlists closing(), _safe_pct dedup, Signal TypedDict

### DIFF
--- a/src/cilly_trading/engine/risk/gate.py
+++ b/src/cilly_trading/engine/risk/gate.py
@@ -31,7 +31,10 @@ from cilly_trading.risk_framework.contract import (
     RiskEvaluationRequest as FrameworkRiskEvaluationRequest,
     RiskEvaluationResponse as FrameworkRiskEvaluationResponse,
 )
-from cilly_trading.risk_framework.risk_evaluator import evaluate_risk as evaluate_framework_risk
+from cilly_trading.risk_framework.risk_evaluator import (
+    _safe_pct,
+    evaluate_risk as evaluate_framework_risk,
+)
 
 GUARD_TRIGGER_EVENT = "guard.triggered"
 GUARD_TRIGGER_PAYLOAD_KEY = "guard_type"
@@ -118,12 +121,6 @@ _RISK_REASON_TO_EVIDENCE_METADATA: dict[str, tuple[str, str, str]] = {
 
 class RiskEvidenceDisciplineError(ValueError):
     """Raised when bounded risk evidence is missing or contradictory."""
-
-
-def _safe_pct(numerator: float, denominator: float) -> float | None:
-    if denominator == 0.0:
-        return None
-    return numerator / denominator
 
 
 def _nonzero_rejection_score(max_allowed: float) -> float:

--- a/src/cilly_trading/models.py
+++ b/src/cilly_trading/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import hashlib
 import json
 from decimal import Decimal
-from typing import Any, Dict, List, Literal, Mapping, Optional, TypedDict, Union
+from typing import Any, Dict, List, Literal, Mapping, NotRequired, Optional, TypedDict, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -152,23 +152,36 @@ class SignalReason(TypedDict):
 
 
 class Signal(TypedDict, total=False):
-    """Unified signal model for the existing MVP surface."""
+    """Unified signal model for the existing MVP surface.
 
-    signal_id: str
-    analysis_run_id: str
-    ingestion_run_id: str
+    Required at validation time (enforced by validate_signal_required_fields):
+    symbol, strategy, direction, stage, timestamp.
+
+    Strategies return partial Signal dicts; the engine layer fills in the
+    remaining fields before persistence.
+    """
+
+    # Identity fields — required before persistence (see validate_signal_required_fields)
     symbol: str
     strategy: str
     direction: Direction
-    score: float
-    timestamp: str
     stage: Stage
-    entry_zone: Optional[EntryZone]
-    confirmation_rule: str
-    timeframe: str
-    market_type: MarketType
-    data_source: DataSource
-    reasons: Optional[List[SignalReason]]
+    timestamp: str
+
+    # Computed by the engine layer
+    signal_id: NotRequired[str]
+    analysis_run_id: NotRequired[str]
+    ingestion_run_id: NotRequired[str]
+    snapshot_id: NotRequired[str]
+    timeframe: NotRequired[str]
+    market_type: NotRequired[MarketType]
+    data_source: NotRequired[DataSource]
+
+    # Strategy output
+    score: NotRequired[float]
+    entry_zone: NotRequired[Optional[EntryZone]]
+    confirmation_rule: NotRequired[str]
+    reasons: NotRequired[Optional[List[SignalReason]]]
 
 
 _SIGNAL_REQUIRED_FIELDS: frozenset[str] = frozenset(

--- a/src/cilly_trading/repositories/analysis_runs_sqlite.py
+++ b/src/cilly_trading/repositories/analysis_runs_sqlite.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -38,6 +39,9 @@ class SqliteAnalysisRunRepository:
         conn.execute("PRAGMA busy_timeout = 5000;")
         return conn
 
+    def _connection(self):
+        return closing(self._get_connection())
+
     @staticmethod
     def _deserialize_run_row(row: sqlite3.Row) -> Dict[str, Any]:
         return {
@@ -53,8 +57,7 @@ class SqliteAnalysisRunRepository:
         *,
         ingestion_run_id: str,
     ) -> Dict[str, Any] | None:
-        conn = self._get_connection()
-        try:
+        with self._connection() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -72,8 +75,6 @@ class SqliteAnalysisRunRepository:
                 (ingestion_run_id,),
             )
             row = cur.fetchone()
-        finally:
-            conn.close()
 
         if row is None:
             return None
@@ -130,34 +131,7 @@ class SqliteAnalysisRunRepository:
         return enriched
 
     def ingestion_run_exists(self, ingestion_run_id: str) -> bool:
-        conn = self._get_connection()
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT 1
-            FROM ingestion_runs
-            WHERE ingestion_run_id = ?
-            LIMIT 1;
-            """,
-            (ingestion_run_id,),
-        )
-        row = cur.fetchone()
-        conn.close()
-        return row is not None
-
-    def ingestion_run_is_ready(
-        self,
-        ingestion_run_id: str,
-        *,
-        symbols: list[str],
-        timeframe: str,
-    ) -> bool:
-        try:
-            conn = self._get_connection()
-        except sqlite3.Error:
-            return False
-
-        try:
+        with self._connection() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -168,28 +142,48 @@ class SqliteAnalysisRunRepository:
                 """,
                 (ingestion_run_id,),
             )
-            if cur.fetchone() is None:
-                return False
+            row = cur.fetchone()
+        return row is not None
 
-            for symbol in symbols:
+    def ingestion_run_is_ready(
+        self,
+        ingestion_run_id: str,
+        *,
+        symbols: list[str],
+        timeframe: str,
+    ) -> bool:
+        try:
+            with self._connection() as conn:
+                cur = conn.cursor()
                 cur.execute(
                     """
                     SELECT 1
-                    FROM ohlcv_snapshots
+                    FROM ingestion_runs
                     WHERE ingestion_run_id = ?
-                      AND symbol = ?
-                      AND timeframe = ?
                     LIMIT 1;
                     """,
-                    (ingestion_run_id, symbol, timeframe),
+                    (ingestion_run_id,),
                 )
                 if cur.fetchone() is None:
                     return False
-            return True
+
+                for symbol in symbols:
+                    cur.execute(
+                        """
+                        SELECT 1
+                        FROM ohlcv_snapshots
+                        WHERE ingestion_run_id = ?
+                          AND symbol = ?
+                          AND timeframe = ?
+                        LIMIT 1;
+                        """,
+                        (ingestion_run_id, symbol, timeframe),
+                    )
+                    if cur.fetchone() is None:
+                        return False
+                return True
         except sqlite3.Error:
             return False
-        finally:
-            conn.close()
 
     def get_run(self, analysis_run_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -201,23 +195,22 @@ class SqliteAnalysisRunRepository:
         Returns:
             Optionaler Dict mit gespeicherten Run-Daten.
         """
-        conn = self._get_connection()
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT
-                analysis_run_id,
-                ingestion_run_id,
-                request_payload,
-                result_payload,
-                created_at
-            FROM analysis_runs
-            WHERE analysis_run_id = ?;
-            """,
-            (analysis_run_id,),
-        )
-        row = cur.fetchone()
-        conn.close()
+        with self._connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT
+                    analysis_run_id,
+                    ingestion_run_id,
+                    request_payload,
+                    result_payload,
+                    created_at
+                FROM analysis_runs
+                WHERE analysis_run_id = ?;
+                """,
+                (analysis_run_id,),
+            )
+            row = cur.fetchone()
 
         if row is None:
             return None
@@ -243,70 +236,68 @@ class SqliteAnalysisRunRepository:
         """
         serialized_request = json.dumps(request_payload, sort_keys=True)
         serialized_result = json.dumps(result_payload, sort_keys=True)
-        conn = self._get_connection()
-        try:
-            cur = conn.cursor()
-            cur.execute(
-                """
-                INSERT INTO analysis_runs (
-                    analysis_run_id,
-                    ingestion_run_id,
-                    request_payload,
-                    result_payload,
-                    created_at
+        with self._connection() as conn:
+            try:
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    INSERT INTO analysis_runs (
+                        analysis_run_id,
+                        ingestion_run_id,
+                        request_payload,
+                        result_payload,
+                        created_at
+                    )
+                    VALUES (?, ?, ?, ?, ?);
+                    """,
+                    (
+                        analysis_run_id,
+                        ingestion_run_id,
+                        serialized_request,
+                        serialized_result,
+                        datetime.now(timezone.utc).isoformat(),
+                    ),
                 )
-                VALUES (?, ?, ?, ?, ?);
-                """,
-                (
-                    analysis_run_id,
-                    ingestion_run_id,
-                    serialized_request,
-                    serialized_result,
-                    datetime.now(timezone.utc).isoformat(),
-                ),
-            )
-            conn.commit()
-            cur.execute(
-                """
-                SELECT
-                    analysis_run_id,
-                    ingestion_run_id,
-                    request_payload,
-                    result_payload,
-                    created_at
-                FROM analysis_runs
-                WHERE analysis_run_id = ?;
-                """,
-                (analysis_run_id,),
-            )
-            row = cur.fetchone()
-            if row is None:
-                raise RuntimeError("persisted analysis run could not be reloaded")
-            return self._attach_evidence(self._deserialize_run_row(row), write_artifacts=True)
-        except sqlite3.IntegrityError:
-            conn.rollback()
-            cur = conn.cursor()
-            cur.execute(
-                """
-                SELECT
-                    analysis_run_id,
-                    ingestion_run_id,
-                    request_payload,
-                    result_payload,
-                    created_at
-                FROM analysis_runs
-                WHERE analysis_run_id = ?;
-                """,
-                (analysis_run_id,),
-            )
-            row = cur.fetchone()
-            if row is None:
-                raise
-            if row["request_payload"] == serialized_request:
-                return self._attach_evidence(self._deserialize_run_row(row), write_artifacts=False)
-            raise ValueError("analysis_run_id already exists with different persisted payload")
-        finally:
-            conn.close()
+                conn.commit()
+                cur.execute(
+                    """
+                    SELECT
+                        analysis_run_id,
+                        ingestion_run_id,
+                        request_payload,
+                        result_payload,
+                        created_at
+                    FROM analysis_runs
+                    WHERE analysis_run_id = ?;
+                    """,
+                    (analysis_run_id,),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise RuntimeError("persisted analysis run could not be reloaded")
+                return self._attach_evidence(self._deserialize_run_row(row), write_artifacts=True)
+            except sqlite3.IntegrityError:
+                conn.rollback()
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    SELECT
+                        analysis_run_id,
+                        ingestion_run_id,
+                        request_payload,
+                        result_payload,
+                        created_at
+                    FROM analysis_runs
+                    WHERE analysis_run_id = ?;
+                    """,
+                    (analysis_run_id,),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    raise
+                if row["request_payload"] == serialized_request:
+                    return self._attach_evidence(self._deserialize_run_row(row), write_artifacts=False)
+                raise ValueError("analysis_run_id already exists with different persisted payload")
 
     def save_analysis_run(
         self,
@@ -328,22 +319,21 @@ class SqliteAnalysisRunRepository:
         )
 
     def list_ingestion_runs(self, *, limit: int) -> list[Dict[str, Any]]:
-        conn = self._get_connection()
-        cur = conn.cursor()
-        cur.execute(
-            """
-            SELECT
-                ingestion_run_id,
-                created_at,
-                symbols_json
-            FROM ingestion_runs
-            ORDER BY created_at DESC, ingestion_run_id ASC
-            LIMIT ?;
-            """,
-            (limit,),
-        )
-        rows = cur.fetchall()
-        conn.close()
+        with self._connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                """
+                SELECT
+                    ingestion_run_id,
+                    created_at,
+                    symbols_json
+                FROM ingestion_runs
+                ORDER BY created_at DESC, ingestion_run_id ASC
+                LIMIT ?;
+                """,
+                (limit,),
+            )
+            rows = cur.fetchall()
 
         result: list[Dict[str, Any]] = []
         for row in rows:

--- a/src/cilly_trading/repositories/watchlists_sqlite.py
+++ b/src/cilly_trading/repositories/watchlists_sqlite.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 from typing import List, Optional
 
@@ -27,6 +28,9 @@ class SqliteWatchlistRepository(WatchlistRepository):
         conn.execute("PRAGMA foreign_keys = ON;")
         conn.execute("PRAGMA busy_timeout = 5000;")
         return conn
+
+    def _connection(self):
+        return closing(self._get_connection())
 
     def _validate_payload(self, *, watchlist_id: str, name: str, symbols: List[str]) -> List[str]:
         normalized_symbols = [symbol.strip() for symbol in symbols]
@@ -66,36 +70,33 @@ class SqliteWatchlistRepository(WatchlistRepository):
             name=name,
             symbols=symbols,
         )
-        conn = self._get_connection()
-        try:
-            cur = conn.cursor()
-            cur.execute("BEGIN;")
-            cur.execute(
-                """
-                INSERT INTO watchlists (watchlist_id, name)
-                VALUES (?, ?);
-                """,
-                (watchlist_id, name),
-            )
-            cur.executemany(
-                """
-                INSERT INTO watchlist_symbols (watchlist_id, position, symbol)
-                VALUES (?, ?, ?);
-                """,
-                [
-                    (watchlist_id, position, symbol)
-                    for position, symbol in enumerate(normalized_symbols)
-                ],
-            )
-            conn.commit()
-        except sqlite3.IntegrityError as exc:
-            conn.rollback()
-            raise ValueError("watchlist_id, name, and symbols must be unique within a watchlist") from exc
-        except Exception:
-            conn.rollback()
-            raise
-        finally:
-            conn.close()
+        with self._connection() as conn:
+            try:
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    INSERT INTO watchlists (watchlist_id, name)
+                    VALUES (?, ?);
+                    """,
+                    (watchlist_id, name),
+                )
+                cur.executemany(
+                    """
+                    INSERT INTO watchlist_symbols (watchlist_id, position, symbol)
+                    VALUES (?, ?, ?);
+                    """,
+                    [
+                        (watchlist_id, position, symbol)
+                        for position, symbol in enumerate(normalized_symbols)
+                    ],
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as exc:
+                conn.rollback()
+                raise ValueError("watchlist_id, name, and symbols must be unique within a watchlist") from exc
+            except Exception:
+                conn.rollback()
+                raise
 
         result = self.get_watchlist(watchlist_id)
         if result is None:
@@ -103,8 +104,7 @@ class SqliteWatchlistRepository(WatchlistRepository):
         return result
 
     def get_watchlist(self, watchlist_id: str) -> Optional[Watchlist]:
-        conn = self._get_connection()
-        try:
+        with self._connection() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -119,12 +119,9 @@ class SqliteWatchlistRepository(WatchlistRepository):
             if row is None:
                 return None
             return self._build_watchlist(row, symbols=self._get_symbols(conn, watchlist_id))
-        finally:
-            conn.close()
 
     def list_watchlists(self) -> List[Watchlist]:
-        conn = self._get_connection()
-        try:
+        with self._connection() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -138,8 +135,6 @@ class SqliteWatchlistRepository(WatchlistRepository):
                 self._build_watchlist(row, symbols=self._get_symbols(conn, row["watchlist_id"]))
                 for row in rows
             ]
-        finally:
-            conn.close()
 
     def update_watchlist(self, *, watchlist_id: str, name: str, symbols: List[str]) -> Watchlist:
         normalized_symbols = self._validate_payload(
@@ -147,47 +142,44 @@ class SqliteWatchlistRepository(WatchlistRepository):
             name=name,
             symbols=symbols,
         )
-        conn = self._get_connection()
-        try:
-            cur = conn.cursor()
-            cur.execute("BEGIN;")
-            cur.execute(
-                """
-                UPDATE watchlists
-                SET name = ?
-                WHERE watchlist_id = ?;
-                """,
-                (name, watchlist_id),
-            )
-            if cur.rowcount == 0:
+        with self._connection() as conn:
+            try:
+                cur = conn.cursor()
+                cur.execute(
+                    """
+                    UPDATE watchlists
+                    SET name = ?
+                    WHERE watchlist_id = ?;
+                    """,
+                    (name, watchlist_id),
+                )
+                if cur.rowcount == 0:
+                    conn.rollback()
+                    raise KeyError(f"watchlist not found: {watchlist_id}")
+                cur.execute(
+                    """
+                    DELETE FROM watchlist_symbols
+                    WHERE watchlist_id = ?;
+                    """,
+                    (watchlist_id,),
+                )
+                cur.executemany(
+                    """
+                    INSERT INTO watchlist_symbols (watchlist_id, position, symbol)
+                    VALUES (?, ?, ?);
+                    """,
+                    [
+                        (watchlist_id, position, symbol)
+                        for position, symbol in enumerate(normalized_symbols)
+                    ],
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as exc:
                 conn.rollback()
-                raise KeyError(f"watchlist not found: {watchlist_id}")
-            cur.execute(
-                """
-                DELETE FROM watchlist_symbols
-                WHERE watchlist_id = ?;
-                """,
-                (watchlist_id,),
-            )
-            cur.executemany(
-                """
-                INSERT INTO watchlist_symbols (watchlist_id, position, symbol)
-                VALUES (?, ?, ?);
-                """,
-                [
-                    (watchlist_id, position, symbol)
-                    for position, symbol in enumerate(normalized_symbols)
-                ],
-            )
-            conn.commit()
-        except sqlite3.IntegrityError as exc:
-            conn.rollback()
-            raise ValueError("watchlist name and symbols must remain unique") from exc
-        except Exception:
-            conn.rollback()
-            raise
-        finally:
-            conn.close()
+                raise ValueError("watchlist name and symbols must remain unique") from exc
+            except Exception:
+                conn.rollback()
+                raise
 
         result = self.get_watchlist(watchlist_id)
         if result is None:
@@ -195,8 +187,7 @@ class SqliteWatchlistRepository(WatchlistRepository):
         return result
 
     def delete_watchlist(self, watchlist_id: str) -> bool:
-        conn = self._get_connection()
-        try:
+        with self._connection() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
@@ -207,5 +198,3 @@ class SqliteWatchlistRepository(WatchlistRepository):
             )
             conn.commit()
             return cur.rowcount > 0
-        finally:
-            conn.close()

--- a/src/cilly_trading/strategies/rsi2.py
+++ b/src/cilly_trading/strategies/rsi2.py
@@ -113,12 +113,12 @@ class Rsi2Strategy(BaseStrategy):
                 # Entry-Zone im MVP noch simpel: Nähe der aktuellen Kerze
                 "entry_zone": {
                     "from_": float(
-                        Decimal(str(last_close * 0.97)).quantize(
+                        (Decimal(str(last_close)) * Decimal("0.97")).quantize(
                             Decimal("0.0001"), ROUND_HALF_UP
                         )
                     ),
                     "to": float(
-                        Decimal(str(last_close * 1.01)).quantize(
+                        (Decimal(str(last_close)) * Decimal("1.01")).quantize(
                             Decimal("0.0001"), ROUND_HALF_UP
                         )
                     ),

--- a/src/cilly_trading/strategies/turtle.py
+++ b/src/cilly_trading/strategies/turtle.py
@@ -128,7 +128,7 @@ class TurtleStrategy(BaseStrategy):
                         Decimal(str(breakout_level)).quantize(_scale, ROUND_HALF_UP)
                     ),
                     "to": float(
-                        Decimal(str(last_close * 1.02)).quantize(_scale, ROUND_HALF_UP)
+                        (Decimal(str(last_close)) * Decimal("1.02")).quantize(_scale, ROUND_HALF_UP)
                     ),
                 },
             }
@@ -162,12 +162,13 @@ class TurtleStrategy(BaseStrategy):
                         "entry_zone": {
                             # Einstiegszone knapp um das Breakout-Level
                             "from_": float(
-                                Decimal(
-                                    str(breakout_level * (1.0 - cfg.proximity_threshold_pct))
+                                (
+                                    Decimal(str(breakout_level))
+                                    * (Decimal("1") - Decimal(str(cfg.proximity_threshold_pct)))
                                 ).quantize(_scale, ROUND_HALF_UP)
                             ),
                             "to": float(
-                                Decimal(str(breakout_level * 1.01)).quantize(
+                                (Decimal(str(breakout_level)) * Decimal("1.01")).quantize(
                                     _scale, ROUND_HALF_UP
                                 )
                             ),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Vier Fixes aus der erneuten Codebase-Analyse (Wave 8):

- **Entry-Zone Quantisierungs-Bug** (`rsi2.py`, `turtle.py`): `Decimal`-Konvertierung passiert jetzt *vor* der Float-Multiplikation — vorher wurde der Float-Fehler durch den String-Cast konserviert statt eliminiert
- **`watchlists_sqlite.py`**: letztes Repository ohne `contextlib.closing()` — auf einheitliches Pattern umgestellt, redundantes explizites `BEGIN;` entfernt
- **`_safe_pct` Duplikat**: identische Funktion existierte in `gate.py` und `risk_evaluator.py` — lokale Kopie in `gate.py` entfernt, Import aus `risk_evaluator.py`
- **`Signal` TypedDict** (`models.py`): `total=False` bleibt (Strategien erzeugen partielle Dicts, Engine füllt auf), aber optionale Felder sind jetzt explizit mit `NotRequired[...]` annotiert und Pflichtfelder klar dokumentiert

## Test plan

- [x] `uv run -- python -m pytest tests/ -x -q --import-mode=importlib` → 1246/1246 passed

https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P)_