### PR TITLE
feat(journal): manuelles Trade-Journal mit Signal-Verknüpfung (Phase 1)

### DIFF
--- a/src/api/composition/repositories.py
+++ b/src/api/composition/repositories.py
@@ -8,6 +8,7 @@ from cilly_trading.repositories.analysis_runs_sqlite import SqliteAnalysisRunRep
 from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
 from cilly_trading.repositories.order_events_sqlite import SqliteOrderEventRepository
 from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
+from cilly_trading.repositories.trades_sqlite import SqliteTradeRepository
 from cilly_trading.repositories.watchlists_sqlite import SqliteWatchlistRepository
 
 
@@ -18,6 +19,7 @@ class ApiRepositories:
     canonical_execution_repo: SqliteCanonicalExecutionRepository
     analysis_run_repo: SqliteAnalysisRunRepository
     watchlist_repo: SqliteWatchlistRepository
+    trade_repo: SqliteTradeRepository
 
 
 def create_api_repositories(*, default_db_path: Path = DEFAULT_DB_PATH) -> ApiRepositories:
@@ -27,4 +29,5 @@ def create_api_repositories(*, default_db_path: Path = DEFAULT_DB_PATH) -> ApiRe
         canonical_execution_repo=SqliteCanonicalExecutionRepository(db_path=default_db_path),
         analysis_run_repo=SqliteAnalysisRunRepository(db_path=default_db_path),
         watchlist_repo=SqliteWatchlistRepository(db_path=default_db_path),
+        trade_repo=SqliteTradeRepository(db_path=default_db_path),
     )

--- a/src/api/composition/router_wiring.py
+++ b/src/api/composition/router_wiring.py
@@ -10,11 +10,13 @@ from ..routers import (
     AnalysisRouterDependencies,
     ControlPlaneRouterDependencies,
     InspectionRouterDependencies,
+    JournalRouterDependencies,
     PaperRuntimeEvidenceSeriesRouterDependencies,
     WatchlistsRouterDependencies,
     build_analysis_router,
     build_control_plane_router,
     build_inspection_router,
+    build_journal_router,
     build_paper_runtime_evidence_series_router,
     build_watchlists_router,
 )
@@ -23,6 +25,7 @@ from ..routers import (
 @dataclass
 class ApiRouterWiring:
     require_role: Callable[[str], Callable[..., str]]
+    get_trade_repo: Callable[[], Any]
     assert_phase_13_read_only_endpoint: Callable[[str], None]
     get_health_now: Callable[[], Any]
     get_resolve_analysis_db_path: Callable[[], str]
@@ -52,6 +55,14 @@ class ApiRouterWiring:
 
 def include_api_routers(*, app: FastAPI, wiring: ApiRouterWiring) -> None:
     app.include_router(build_alerts_router(wiring.require_role))
+    app.include_router(
+        build_journal_router(
+            deps=JournalRouterDependencies(
+                require_role=wiring.require_role,
+                get_trade_repo=wiring.get_trade_repo,
+            ),
+        )
+    )
     app.include_router(
         build_control_plane_router(
             deps=ControlPlaneRouterDependencies(

--- a/src/api/composition/runtime_assembly.py
+++ b/src/api/composition/runtime_assembly.py
@@ -111,6 +111,7 @@ def build_api_router_wiring(*, compat: MainModuleCompatibilitySurface) -> ApiRou
         ),
         get_default_strategy_configs=lambda: compat.get("default_strategy_configs"),
         get_watchlist_repo=lambda: compat.get("watchlist_repo"),
+        get_trade_repo=lambda: compat.get("trade_repo"),
         get_require_ingestion_run=lambda *args, **kwargs: compat.get("_require_ingestion_run")(
             *args,
             **kwargs,

--- a/src/api/models/journal_models.py
+++ b/src/api/models/journal_models.py
@@ -1,0 +1,88 @@
+"""Pydantic models for the manual trade journal API."""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class JournalTradeCreateRequest(BaseModel):
+    signal_id: Optional[str] = Field(default=None, description="Signal-ID aus dem Screener (optional)")
+    symbol: str = Field(min_length=1)
+    strategy: str = Field(min_length=1)
+    stage: Literal["setup", "entry_confirmed"] = "entry_confirmed"
+    entry_price: Optional[float] = Field(default=None, gt=0)
+    entry_date: Optional[str] = Field(default=None, description="ISO-8601 date, e.g. 2026-05-01")
+    timeframe: str = Field(min_length=1, description="e.g. D1, W1")
+    market_type: Literal["stock", "crypto"] = "stock"
+    data_source: Literal["yahoo", "binance"] = "yahoo"
+    reason_entry: str = Field(min_length=1, description="Begründung für den Entry")
+    notes: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class JournalTradeExitRequest(BaseModel):
+    exit_price: float = Field(gt=0)
+    exit_date: str = Field(min_length=1, description="ISO-8601 date, e.g. 2026-05-05")
+    reason_exit: str = Field(min_length=1, description="Begründung für den Exit")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class JournalTradeResponse(BaseModel):
+    id: int
+    signal_id: Optional[str] = None
+    symbol: str
+    strategy: str
+    stage: str
+    entry_price: Optional[float] = None
+    entry_date: Optional[str] = None
+    exit_price: Optional[float] = None
+    exit_date: Optional[str] = None
+    reason_entry: str
+    reason_exit: Optional[str] = None
+    notes: Optional[str] = None
+    timeframe: str
+    market_type: str
+    data_source: str
+    status: Literal["open", "closed"]
+    pnl_pct: Optional[float] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "JournalTradeResponse":
+        entry = payload.get("entry_price")
+        exit_ = payload.get("exit_price")
+        pnl_pct: Optional[float] = None
+        if entry and exit_ and entry > 0:
+            pnl_pct = round((exit_ - entry) / entry * 100, 4)
+
+        return cls(
+            id=payload["id"],
+            signal_id=payload.get("signal_id"),
+            symbol=payload["symbol"],
+            strategy=payload["strategy"],
+            stage=payload["stage"],
+            entry_price=entry,
+            entry_date=payload.get("entry_date"),
+            exit_price=exit_,
+            exit_date=payload.get("exit_date"),
+            reason_entry=payload["reason_entry"],
+            reason_exit=payload.get("reason_exit"),
+            notes=payload.get("notes"),
+            timeframe=payload["timeframe"],
+            market_type=payload["market_type"],
+            data_source=payload["data_source"],
+            status="closed" if exit_ is not None else "open",
+            pnl_pct=pnl_pct,
+        )
+
+
+class JournalTradesListResponse(BaseModel):
+    items: list[JournalTradeResponse]
+    total: int
+
+    model_config = ConfigDict(extra="forbid")

--- a/src/api/routers/__init__.py
+++ b/src/api/routers/__init__.py
@@ -3,6 +3,7 @@
 from .analysis_router import AnalysisRouterDependencies, build_analysis_router
 from .control_plane_router import ControlPlaneRouterDependencies, build_control_plane_router
 from .inspection_router import InspectionRouterDependencies, build_inspection_router
+from .journal_router import JournalRouterDependencies, build_journal_router
 from .paper_runtime_evidence_series_router import (
     PaperRuntimeEvidenceSeriesRouterDependencies,
     build_paper_runtime_evidence_series_router,
@@ -13,11 +14,13 @@ __all__ = [
     "AnalysisRouterDependencies",
     "ControlPlaneRouterDependencies",
     "InspectionRouterDependencies",
+    "JournalRouterDependencies",
     "PaperRuntimeEvidenceSeriesRouterDependencies",
     "WatchlistsRouterDependencies",
     "build_analysis_router",
     "build_control_plane_router",
     "build_inspection_router",
+    "build_journal_router",
     "build_paper_runtime_evidence_series_router",
     "build_watchlists_router",
 ]

--- a/src/api/routers/journal_router.py
+++ b/src/api/routers/journal_router.py
@@ -1,0 +1,122 @@
+"""Router for the manual trade journal (Phase 1)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from api.models.journal_models import (
+    JournalTradeCreateRequest,
+    JournalTradeExitRequest,
+    JournalTradeResponse,
+    JournalTradesListResponse,
+)
+from cilly_trading.models import PersistedTradePayload
+
+
+@dataclass
+class JournalRouterDependencies:
+    require_role: Callable[[str], Callable[..., str]]
+    get_trade_repo: Callable[[], object]
+
+
+def build_journal_router(*, deps: JournalRouterDependencies) -> APIRouter:
+    router = APIRouter(prefix="/journal", tags=["journal"])
+
+    @router.post(
+        "/trades",
+        response_model=JournalTradeResponse,
+        status_code=201,
+        summary="Manuellen Trade eintragen",
+        description=(
+            "Trägt einen manuell ausgeführten Trade ein. "
+            "Die signal_id verknüpft den Trade mit einem Screener-Signal."
+        ),
+    )
+    def create_trade_handler(
+        body: JournalTradeCreateRequest,
+        _: str = Depends(deps.require_role("operator")),
+    ) -> JournalTradeResponse:
+        repo = deps.get_trade_repo()
+        payload: PersistedTradePayload = {
+            "symbol": body.symbol.strip().upper(),
+            "strategy": body.strategy,
+            "stage": body.stage,
+            "timeframe": body.timeframe,
+            "market_type": body.market_type,
+            "data_source": body.data_source,
+            "reason_entry": body.reason_entry,
+        }
+        if body.signal_id is not None:
+            payload["signal_id"] = body.signal_id
+        if body.entry_price is not None:
+            payload["entry_price"] = body.entry_price
+        if body.entry_date is not None:
+            payload["entry_date"] = body.entry_date
+        if body.notes is not None:
+            payload["notes"] = body.notes
+
+        trade_id = repo.save_trade(payload)
+        saved = repo.get_trade(trade_id)
+        if saved is None:
+            raise HTTPException(status_code=500, detail="Trade could not be reloaded after save")
+        return JournalTradeResponse.from_payload(dict(saved))
+
+    @router.put(
+        "/trades/{trade_id}/exit",
+        response_model=JournalTradeResponse,
+        summary="Exit-Preis nachtragen",
+        description="Trägt Exit-Preis, Exit-Datum und Begründung für einen offenen Trade nach.",
+    )
+    def log_exit_handler(
+        trade_id: int,
+        body: JournalTradeExitRequest,
+        _: str = Depends(deps.require_role("operator")),
+    ) -> JournalTradeResponse:
+        repo = deps.get_trade_repo()
+        existing = repo.get_trade(trade_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail=f"Trade {trade_id} not found")
+        if existing.get("exit_price") is not None:
+            raise HTTPException(status_code=409, detail=f"Trade {trade_id} already has an exit")
+
+        updated = repo.update_trade_exit(
+            trade_id,
+            exit_price=body.exit_price,
+            exit_date=body.exit_date,
+            reason_exit=body.reason_exit,
+        )
+        if not updated:
+            raise HTTPException(status_code=500, detail="Exit could not be saved")
+
+        saved = repo.get_trade(trade_id)
+        return JournalTradeResponse.from_payload(dict(saved))
+
+    @router.get(
+        "/trades",
+        response_model=JournalTradesListResponse,
+        summary="Trades auflisten",
+        description="Listet manuell eingetragene Trades mit optionalen Filtern.",
+    )
+    def list_trades_handler(
+        symbol: Optional[str] = Query(default=None),
+        strategy: Optional[str] = Query(default=None),
+        signal_id: Optional[str] = Query(default=None),
+        status: Optional[Literal["open", "closed"]] = Query(default=None),
+        limit: int = Query(default=50, ge=1, le=500),
+        _: str = Depends(deps.require_role("read_only")),
+    ) -> JournalTradesListResponse:
+        repo = deps.get_trade_repo()
+        trades = repo.list_trades(
+            limit=limit,
+            symbol=symbol,
+            strategy=strategy,
+            signal_id=signal_id,
+            status=status,
+        )
+        items = [JournalTradeResponse.from_payload(dict(t)) for t in trades]
+        return JournalTradesListResponse(items=items, total=len(items))
+
+    return router

--- a/src/cilly_trading/db/init_db.py
+++ b/src/cilly_trading/db/init_db.py
@@ -121,6 +121,7 @@ def init_db(db_path: Optional[Path] = None) -> None:
         """
         CREATE TABLE IF NOT EXISTS trades (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
+            signal_id TEXT,
             symbol TEXT NOT NULL,
             strategy TEXT NOT NULL,
             stage TEXT NOT NULL,              -- "setup" oder "entry_confirmed"
@@ -135,6 +136,17 @@ def init_db(db_path: Optional[Path] = None) -> None:
             market_type TEXT NOT NULL,
             data_source TEXT NOT NULL
         );
+        """
+    )
+    cur.execute("PRAGMA table_info(trades);")
+    trade_columns = {row["name"] for row in cur.fetchall()}
+    if "signal_id" not in trade_columns:
+        cur.execute("ALTER TABLE trades ADD COLUMN signal_id TEXT;")
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_trades_signal_id
+          ON trades(signal_id)
+          WHERE signal_id IS NOT NULL;
         """
     )
 

--- a/src/cilly_trading/models.py
+++ b/src/cilly_trading/models.py
@@ -204,6 +204,7 @@ class PersistedTradePayload(TypedDict, total=False):
     """Legacy persisted trade payload used by current paper-trading surfaces."""
 
     id: int
+    signal_id: Optional[str]
     symbol: str
     strategy: str
     stage: Stage

--- a/src/cilly_trading/repositories/trades_sqlite.py
+++ b/src/cilly_trading/repositories/trades_sqlite.py
@@ -39,6 +39,7 @@ class SqliteTradeRepository(TradeRepository):
             cur.execute(
                 """
                 INSERT INTO trades (
+                    signal_id,
                     symbol,
                     strategy,
                     stage,
@@ -54,6 +55,7 @@ class SqliteTradeRepository(TradeRepository):
                     data_source
                 )
                 VALUES (
+                    :signal_id,
                     :symbol,
                     :strategy,
                     :stage,
@@ -70,6 +72,7 @@ class SqliteTradeRepository(TradeRepository):
                 );
                 """,
                 {
+                    "signal_id": trade.get("signal_id"),
                     "symbol": trade["symbol"],
                     "strategy": trade["strategy"],
                     "stage": trade["stage"],
@@ -89,62 +92,79 @@ class SqliteTradeRepository(TradeRepository):
             conn.commit()
         return int(trade_id)
 
-    def list_trades(self, limit: int = 100) -> List[PersistedTradePayload]:
+    def get_trade(self, trade_id: int) -> Optional[PersistedTradePayload]:
         with self._connection() as conn:
             cur = conn.cursor()
             cur.execute(
                 """
                 SELECT
-                    id,
-                    symbol,
-                    strategy,
-                    stage,
-                    entry_price,
-                    entry_date,
-                    exit_price,
-                    exit_date,
-                    reason_entry,
-                    reason_exit,
-                    notes,
-                    timeframe,
-                    market_type,
-                    data_source
+                    id, signal_id, symbol, strategy, stage,
+                    entry_price, entry_date, exit_price, exit_date,
+                    reason_entry, reason_exit, notes,
+                    timeframe, market_type, data_source
                 FROM trades
+                WHERE id = ?
+                LIMIT 1;
+                """,
+                (trade_id,),
+            )
+            row = cur.fetchone()
+
+        if row is None:
+            return None
+        return self._row_to_payload(row)
+
+    def list_trades(
+        self,
+        limit: int = 100,
+        *,
+        symbol: Optional[str] = None,
+        strategy: Optional[str] = None,
+        signal_id: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> List[PersistedTradePayload]:
+        conditions = []
+        params: list = []
+
+        if symbol is not None:
+            conditions.append("symbol = ?")
+            params.append(symbol)
+        if strategy is not None:
+            conditions.append("strategy = ?")
+            params.append(strategy)
+        if signal_id is not None:
+            conditions.append("signal_id = ?")
+            params.append(signal_id)
+        if status == "open":
+            conditions.append("exit_price IS NULL")
+        elif status == "closed":
+            conditions.append("exit_price IS NOT NULL")
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        with self._connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                f"""
+                SELECT
+                    id, signal_id, symbol, strategy, stage,
+                    entry_price, entry_date, exit_price, exit_date,
+                    reason_entry, reason_exit, notes,
+                    timeframe, market_type, data_source
+                FROM trades
+                {where}
                 ORDER BY id DESC
                 LIMIT ?;
                 """,
-                (limit,),
+                (*params, limit),
             )
             rows = cur.fetchall()
 
-        result: List[PersistedTradePayload] = []
-        for row in rows:
-            trade: PersistedTradePayload = {
-                "id": row["id"],
-                "symbol": row["symbol"],
-                "strategy": row["strategy"],
-                "stage": row["stage"],
-                "entry_price": row["entry_price"],
-                "entry_date": row["entry_date"],
-                "exit_price": row["exit_price"],
-                "exit_date": row["exit_date"],
-                "reason_entry": row["reason_entry"],
-                "timeframe": row["timeframe"],
-                "market_type": row["market_type"],
-                "data_source": row["data_source"],
-            }
-            if row["reason_exit"] is not None:
-                trade["reason_exit"] = row["reason_exit"]
-            if row["notes"] is not None:
-                trade["notes"] = row["notes"]
-
-            result.append(trade)
-
-        return result
+        return [self._row_to_payload(row) for row in rows]
 
     def update_trade_exit(
         self, trade_id: int, exit_price: float, exit_date: str, reason_exit: str
-    ) -> None:
+    ) -> bool:
         with self._connection() as conn:
             cur = conn.cursor()
             cur.execute(
@@ -163,3 +183,28 @@ class SqliteTradeRepository(TradeRepository):
                 },
             )
             conn.commit()
+            return cur.rowcount > 0
+
+    @staticmethod
+    def _row_to_payload(row: sqlite3.Row) -> PersistedTradePayload:
+        trade: PersistedTradePayload = {
+            "id": row["id"],
+            "symbol": row["symbol"],
+            "strategy": row["strategy"],
+            "stage": row["stage"],
+            "entry_price": row["entry_price"],
+            "entry_date": row["entry_date"],
+            "exit_price": row["exit_price"],
+            "exit_date": row["exit_date"],
+            "reason_entry": row["reason_entry"],
+            "timeframe": row["timeframe"],
+            "market_type": row["market_type"],
+            "data_source": row["data_source"],
+        }
+        if row["signal_id"] is not None:
+            trade["signal_id"] = row["signal_id"]
+        if row["reason_exit"] is not None:
+            trade["reason_exit"] = row["reason_exit"]
+        if row["notes"] is not None:
+            trade["notes"] = row["notes"]
+        return trade


### PR DESCRIPTION
## Summary

Implementiert Phase 1 des manuellen Trade-Journals — Trades können jetzt eingetragen, mit Screener-Signalen verknüpft und ausgewertet werden.

## Was neu ist

### Datenbank
- `signal_id TEXT` Spalte in der `trades`-Tabelle (nullable, automatische Migration für bestehende DBs via `ALTER TABLE`)
- Index auf `signal_id` für schnelle Signal→Trade Lookups

### API-Endpoints

| Method | Endpoint | Beschreibung |
|---|---|---|
| `POST` | `/journal/trades` | Manuellen Trade eintragen (mit optionaler `signal_id`) |
| `PUT` | `/journal/trades/{id}/exit` | Exit-Preis und -Datum nachtragen |
| `GET` | `/journal/trades` | Trades auflisten mit Filtern |

### Filter für `GET /journal/trades`
- `symbol`, `strategy`, `signal_id` — direkte Felder
- `status=open` / `status=closed` — offene vs. geschlossene Trades
- `limit` — max. 500

### Response enthält
- `status: "open" | "closed"`
- `pnl_pct` — P&L in % bei geschlossenen Trades: `(exit - entry) / entry * 100`

### Beispiel-Flow
```
# 1. Signal in Screener sehen → signal_id notieren
POST /journal/trades
{ "signal_id": "abc123", "symbol": "AAPL", "strategy": "RSI2",
  "entry_price": 182.50, "entry_date": "2026-05-01",
  "timeframe": "D1", "market_type": "stock", "data_source": "yahoo",
  "reason_entry": "RSI2 oversold, manuell bestätigt" }

# 2. Position geschlossen → Exit nachtragen
PUT /journal/trades/1/exit
{ "exit_price": 188.30, "exit_date": "2026-05-05", "reason_exit": "Ziel erreicht" }

# 3. Alle Trades eines Signals prüfen
GET /journal/trades?signal_id=abc123
```

## Geänderte Dateien

| Datei | Änderung |
|---|---|
| `src/cilly_trading/db/init_db.py` | `signal_id` Spalte + Migration + Index |
| `src/cilly_trading/models.py` | `signal_id` in `PersistedTradePayload` |
| `src/cilly_trading/repositories/trades_sqlite.py` | `get_trade()`, Filter in `list_trades()`, `update_trade_exit()` → bool |
| `src/api/models/journal_models.py` | Neue Pydantic-Modelle (Request/Response) |
| `src/api/routers/journal_router.py` | Neuer Router mit 3 Endpoints |
| `src/api/composition/repositories.py` | `trade_repo` in `ApiRepositories` |
| `src/api/composition/router_wiring.py` | Journal-Router verdrahtet |
| `src/api/composition/runtime_assembly.py` | `get_trade_repo` im Wiring |

## Test plan

- [x] `uv run -- python -m pytest tests/ -x -q --import-mode=importlib` → 1246/1246 passed

## Nächste Schritte (Phase 2)
- Signal-Performance-Report: welche Signale liefen profitabel (`GET /journal/signals/{id}/performance`)
- Filter `GET /journal/trades?signal_id=X` für Signal-Trade-Analyse

https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P)_