### PR TITLE
feat(journal): Performance-Report Phase 2

### DIFF
--- a/src/api/models/journal_models.py
+++ b/src/api/models/journal_models.py
@@ -86,3 +86,71 @@ class JournalTradesListResponse(BaseModel):
     total: int
 
     model_config = ConfigDict(extra="forbid")
+
+
+# ── Phase 2: Performance ──────────────────────────────────────────────────────
+
+class PerformanceMetrics(BaseModel):
+    """Aggregierte Performance-Kennzahlen für eine Gruppe von Trades."""
+
+    total_trades: int
+    open_trades: int
+    closed_trades: int
+    winning_trades: Optional[int] = None
+    win_rate_pct: Optional[float] = None
+    avg_pnl_pct: Optional[float] = None
+    total_pnl_pct: Optional[float] = None
+    best_trade_pnl_pct: Optional[float] = None
+    worst_trade_pnl_pct: Optional[float] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @classmethod
+    def from_trades(cls, trades: list[JournalTradeResponse]) -> "PerformanceMetrics":
+        closed = [t for t in trades if t.status == "closed" and t.pnl_pct is not None]
+        winning = [t for t in closed if t.pnl_pct > 0]  # type: ignore[operator]
+
+        win_rate = round(len(winning) / len(closed) * 100, 2) if closed else None
+        pnl_values = [t.pnl_pct for t in closed]  # type: ignore[misc]
+        avg_pnl = round(sum(pnl_values) / len(pnl_values), 4) if pnl_values else None
+        total_pnl = round(sum(pnl_values), 4) if pnl_values else None
+        best = round(max(pnl_values), 4) if pnl_values else None
+        worst = round(min(pnl_values), 4) if pnl_values else None
+
+        return cls(
+            total_trades=len(trades),
+            open_trades=sum(1 for t in trades if t.status == "open"),
+            closed_trades=len(closed),
+            winning_trades=len(winning) if closed else None,
+            win_rate_pct=win_rate,
+            avg_pnl_pct=avg_pnl,
+            total_pnl_pct=total_pnl,
+            best_trade_pnl_pct=best,
+            worst_trade_pnl_pct=worst,
+        )
+
+
+class SignalPerformanceResponse(BaseModel):
+    signal_id: str
+    metrics: PerformanceMetrics
+    trades: list[JournalTradeResponse]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class PerformanceGroupItem(BaseModel):
+    """Performance-Kennzahlen für eine Strategie oder ein Symbol."""
+
+    key: str
+    metrics: PerformanceMetrics
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class PerformanceSummaryResponse(BaseModel):
+    metrics: PerformanceMetrics
+    by_strategy: list[PerformanceGroupItem]
+    by_symbol: list[PerformanceGroupItem]
+
+    model_config = ConfigDict(extra="forbid")
+

--- a/src/api/routers/journal_router.py
+++ b/src/api/routers/journal_router.py
@@ -12,6 +12,10 @@ from api.models.journal_models import (
     JournalTradeExitRequest,
     JournalTradeResponse,
     JournalTradesListResponse,
+    PerformanceGroupItem,
+    PerformanceMetrics,
+    PerformanceSummaryResponse,
+    SignalPerformanceResponse,
 )
 from cilly_trading.models import PersistedTradePayload
 
@@ -119,4 +123,77 @@ def build_journal_router(*, deps: JournalRouterDependencies) -> APIRouter:
         items = [JournalTradeResponse.from_payload(dict(t)) for t in trades]
         return JournalTradesListResponse(items=items, total=len(items))
 
+    @router.get(
+        "/performance",
+        response_model=PerformanceSummaryResponse,
+        summary="Gesamt-Performance",
+        description=(
+            "Aggregierte Performance über alle manuell eingetragenen Trades. "
+            "Zeigt Kennzahlen gesamt sowie aufgeschlüsselt nach Strategie und Symbol."
+        ),
+    )
+    def performance_summary_handler(
+        symbol: Optional[str] = Query(default=None),
+        strategy: Optional[str] = Query(default=None),
+        limit: int = Query(default=500, ge=1, le=1000),
+        _: str = Depends(deps.require_role("read_only")),
+    ) -> PerformanceSummaryResponse:
+        repo = deps.get_trade_repo()
+        raw = repo.list_trades(limit=limit, symbol=symbol, strategy=strategy)
+        trades = [JournalTradeResponse.from_payload(dict(t)) for t in raw]
+
+        overall = PerformanceMetrics.from_trades(trades)
+
+        by_strategy = _group_performance(trades, key_fn=lambda t: t.strategy)
+        by_symbol = _group_performance(trades, key_fn=lambda t: t.symbol)
+
+        return PerformanceSummaryResponse(
+            metrics=overall,
+            by_strategy=by_strategy,
+            by_symbol=by_symbol,
+        )
+
+    @router.get(
+        "/signals/{signal_id}/performance",
+        response_model=SignalPerformanceResponse,
+        summary="Performance für ein Signal",
+        description="Zeigt alle Trades die aus einem bestimmten Signal entstanden sind, mit aggregierten Kennzahlen.",
+    )
+    def signal_performance_handler(
+        signal_id: str,
+        _: str = Depends(deps.require_role("read_only")),
+    ) -> SignalPerformanceResponse:
+        repo = deps.get_trade_repo()
+        raw = repo.list_trades(limit=1000, signal_id=signal_id)
+        if not raw:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No trades found for signal_id={signal_id!r}",
+            )
+        trades = [JournalTradeResponse.from_payload(dict(t)) for t in raw]
+        return SignalPerformanceResponse(
+            signal_id=signal_id,
+            metrics=PerformanceMetrics.from_trades(trades),
+            trades=trades,
+        )
+
     return router
+
+
+def _group_performance(
+    trades: list[JournalTradeResponse],
+    *,
+    key_fn,
+) -> list[PerformanceGroupItem]:
+    groups: dict[str, list[JournalTradeResponse]] = {}
+    for t in trades:
+        k = key_fn(t)
+        groups.setdefault(k, []).append(t)
+    return sorted(
+        [
+            PerformanceGroupItem(key=k, metrics=PerformanceMetrics.from_trades(v))
+            for k, v in groups.items()
+        ],
+        key=lambda item: (item.metrics.closed_trades or 0),
+        reverse=True,
+    )


### PR DESCRIPTION
## Summary

Erweitert das Trade-Journal um zwei Performance-Endpoints.

## Neue Endpoints

### `GET /journal/performance`
Gesamt-Performance über alle manuell eingetragenen Trades — optional gefiltert nach `symbol` oder `strategy`.

```json
{
  "metrics": {
    "total_trades": 12,
    "open_trades": 3,
    "closed_trades": 9,
    "winning_trades": 6,
    "win_rate_pct": 66.67,
    "avg_pnl_pct": 2.14,
    "total_pnl_pct": 19.26,
    "best_trade_pnl_pct": 8.42,
    "worst_trade_pnl_pct": -3.11
  },
  "by_strategy": [
    { "key": "RSI2", "metrics": { ... } },
    { "key": "TURTLE", "metrics": { ... } }
  ],
  "by_symbol": [
    { "key": "AAPL", "metrics": { ... } }
  ]
}
```

### `GET /journal/signals/{signal_id}/performance`
Alle Trades die aus einem bestimmten Signal entstanden sind, mit denselben Kennzahlen.

```json
{
  "signal_id": "abc123",
  "metrics": { "total_trades": 1, "closed_trades": 1, "win_rate_pct": 100.0, "avg_pnl_pct": 3.18 },
  "trades": [ { "id": 1, "symbol": "AAPL", "pnl_pct": 3.18, "status": "closed", ... } ]
}
```

## Kennzahlen im Detail

| Feld | Beschreibung |
|---|---|
| `win_rate_pct` | Anteil profitable Trades an geschlossenen Trades |
| `avg_pnl_pct` | Ø P&L pro Trade in % |
| `total_pnl_pct` | Summe aller P&L % (kein Compounding) |
| `best_trade_pnl_pct` | Bester einzelner Trade |
| `worst_trade_pnl_pct` | Schlechtester einzelner Trade |

## Test plan

- [x] `uv run -- python -m pytest tests/ -x -q --import-mode=importlib` → 1246/1246 passed

## Nächster Schritt (Phase 3)
- CSV-Export für Website-Veröffentlichung
- RSI Wilder's Smoothing (separates Ticket)

https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P)_