### PR TITLE
feat(indicators): RSI auf Wilder's Smoothing umstellen

### DIFF
--- a/src/cilly_trading/indicators/rsi.py
+++ b/src/cilly_trading/indicators/rsi.py
@@ -2,6 +2,8 @@
 RSI-Indikator für die Cilly Trading Engine.
 
 Berechnet den Relative Strength Index (RSI) auf Basis der Schlusskurse.
+Verwendet Wilder's Smoothing (SMA-Seed + rekursive Glättung) — den von Wilder
+ursprünglich definierten Algorithmus, nicht EWMA.
 """
 
 from __future__ import annotations
@@ -15,38 +17,47 @@ def rsi(
     price_column: str = "close",
 ) -> pd.Series:
     """
-    Berechnet den RSI auf Basis eines DataFrames mit einer Kurs-Spalte.
+    Berechnet den RSI nach Wilder's Smoothing-Methode.
 
     :param df: DataFrame mit mindestens einer Spalte für Schlusskurse
     :param period: Länge des RSI-Fensters (Standard: 14)
     :param price_column: Name der Spalte mit Schlusskursen (Standard: "close")
-    :return: Pandas Series mit RSI-Werten (0–100), index-align mit df
+    :return: Pandas Series mit RSI-Werten (0–100), index-aligned mit df;
+             die ersten `period` Werte sind NaN (Warm-up-Phase)
     """
     if price_column not in df.columns:
         raise ValueError(f"Column '{price_column}' not found in DataFrame")
 
     close = df[price_column].astype(float)
+    n = len(close)
+
+    if n <= period:
+        return pd.Series([float("nan")] * n, index=df.index, dtype=float)
 
     delta = close.diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
 
-    # Gewinne/Verluste trennen
-    gain = delta.where(delta > 0, 0.0)
-    loss = -delta.where(delta < 0, 0.0)
+    # Wilder's SMA seed: average of first `period` up/down moves (indices 1..period)
+    avg_gain = gain.iloc[1 : period + 1].mean()
+    avg_loss = loss.iloc[1 : period + 1].mean()
 
-    # Glättung via EWMA (klassischer RSI-Ansatz)
-    avg_gain = gain.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
-    avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    rsi_values = [float("nan")] * n
+    rsi_values[period] = _rs_to_rsi(avg_gain, avg_loss)
 
-    zero_loss = avg_loss == 0
-    zero_gain = avg_gain == 0
+    for i in range(period + 1, n):
+        avg_gain = (avg_gain * (period - 1) + gain.iloc[i]) / period
+        avg_loss = (avg_loss * (period - 1) + loss.iloc[i]) / period
+        rsi_values[i] = _rs_to_rsi(avg_gain, avg_loss)
 
-    rs = avg_gain / avg_loss.mask(zero_loss)
-    rsi_series = 100 - (100 / (1 + rs))
+    return pd.Series(rsi_values, index=df.index, dtype=float).clip(0, 100)
 
-    # Sustained upward moves have no average loss and should saturate at 100,
-    # not become NaN. Fully flat windows are neutral after the warm-up period.
-    rsi_series = rsi_series.mask(zero_loss & (avg_gain > 0), 100.0)
-    rsi_series = rsi_series.mask(zero_loss & zero_gain, 50.0)
-    rsi_series = rsi_series.clip(0, 100)
 
-    return rsi_series
+def _rs_to_rsi(avg_gain: float, avg_loss: float) -> float:
+    """Convert average gain/loss to RSI value, handling zero-division edge cases."""
+    if avg_loss == 0.0 and avg_gain == 0.0:
+        return 50.0  # flat market: neutral
+    if avg_loss == 0.0:
+        return 100.0  # pure uptrend: saturate at 100
+    rs = avg_gain / avg_loss
+    return 100.0 - (100.0 / (1.0 + rs))

--- a/tests/test_rsi_regression.py
+++ b/tests/test_rsi_regression.py
@@ -1,8 +1,42 @@
 from __future__ import annotations
 
+import pytest
 import pandas as pd
 
 from cilly_trading.indicators.rsi import rsi
+
+
+def test_rsi_wilders_sma_seed_differs_from_ewma_for_period_gt_2() -> None:
+    """Wilder's uses SMA seed; EWMA would produce a different value for period=3+."""
+    # 3 up moves, then 3 down moves — EWMA and Wilder's diverge here
+    closes = [10.0, 11.0, 12.0, 13.0, 12.0, 11.0, 10.0]
+    df = pd.DataFrame({"close": closes})
+    result = rsi(df, period=3)
+
+    # SMA seed: avg_gain=1.0 (mean of first 3 diffs: +1,+1,+1), avg_loss=0.0
+    # → RSI at index 3 = 100.0
+    assert result.iloc[3] == 100.0
+
+    # After index 4 (loss=1): avg_gain=(1*2+0)/3=2/3, avg_loss=(0*2+1)/3=1/3
+    # RS = 2, RSI = 100 - 100/3 ≈ 66.67
+    assert result.iloc[4] == pytest.approx(66.6667, abs=1e-3)
+
+    # Warm-up indices must be NaN
+    assert all(pd.isna(result.iloc[i]) for i in range(3))
+
+
+def test_rsi_warm_up_indices_are_nan() -> None:
+    df = pd.DataFrame({"close": [float(i) for i in range(1, 21)]})
+    result = rsi(df, period=14)
+    assert all(pd.isna(result.iloc[i]) for i in range(14))
+    assert not pd.isna(result.iloc[14])
+
+
+def test_rsi_too_short_returns_all_nan() -> None:
+    df = pd.DataFrame({"close": [1.0, 2.0, 3.0]})
+    result = rsi(df, period=14)
+    assert all(pd.isna(v) for v in result)
+    assert len(result) == 3
 
 
 def test_rsi_saturates_at_100_when_average_loss_is_zero_and_gain_positive() -> None:


### PR DESCRIPTION
## Summary

- Ersetzt EWMA (`ewm(alpha=1/period)`) durch Wilder's ursprünglichen Algorithmus: SMA-Seed über die ersten `period` Differenzen, danach rekursive Glättung `avg_new = (avg_old * (n-1) + x) / n`
- Für `period=2` (RSI2-Strategie) sind beide Methoden mathematisch identisch — keine Verhaltensänderung für bestehende Strategien
- Für `period>2` (z.B. Standard-RSI14) liefert Wilder's korrektere Initialisierung, da EWMA den ersten Beobachtungswert als Seed nutzt statt des SMA

## Änderungen

**`src/cilly_trading/indicators/rsi.py`**
- Algorithmus von EWMA auf Wilder's Smoothing umgestellt
- Neue Hilfsfunktion `_rs_to_rsi()` für klare Zero-Division-Behandlung
- Edge Cases: `avg_loss=0, avg_gain=0` → 50 (flat); `avg_loss=0, avg_gain>0` → 100 (pure uptrend)
- Zu kurze Serien (`n <= period`) geben sofort `[NaN] * n` zurück

**`tests/test_rsi_regression.py`**
- 3 neue Tests: SMA-Seed-Verhalten für `period=3` mit bekannten Werten, Warm-up-NaN-Prüfung, zu-kurze-Serie-Guard

## Test plan

- [ ] Alle 1246 Tests grün (`uv run -- python -m pytest tests/ -x -q`)
- [ ] RSI-spezifische Tests: `uv run -- python -m pytest tests/test_rsi_regression.py tests/test_indicators.py -v`
- [ ] RSI2-Strategie unverändert (period=2 → mathematisch äquivalent)

https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P)_