### PR TITLE
refactor: P1+P2 Codebase-Sanierung (5 Waves)

### DIFF
--- a/src/api/services/analysis_service.py
+++ b/src/api/services/analysis_service.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from fastapi import HTTPException
 
 from cilly_trading.engine.core import EngineConfig, compute_analysis_run_id
+from cilly_trading.repositories import AnalysisRunRepository, SignalRepository, WatchlistRepository
 from cilly_trading.strategies.registry import StrategyNotRegisteredError, run_registry_smoke
 
 from ..models import (
@@ -33,9 +34,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class AnalysisServiceDependencies:
-    analysis_run_repo: Any
-    signal_repo: Any
-    watchlist_repo: Any
+    analysis_run_repo: AnalysisRunRepository
+    signal_repo: SignalRepository
+    watchlist_repo: WatchlistRepository
     default_strategy_configs: Dict[str, Dict[str, Any]]
     require_ingestion_run: Callable[[str], None]
     require_snapshot_ready: Callable[..., None]

--- a/src/api/services/paper_inspection_service.py
+++ b/src/api/services/paper_inspection_service.py
@@ -7,9 +7,10 @@ See ``cilly_trading.portfolio.paper_state_authority`` for the full contract.
 from __future__ import annotations
 
 import os
+import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal, Optional, Sequence
 
 from fastapi import HTTPException
@@ -46,7 +47,7 @@ def resolve_paper_starting_cash() -> Decimal:
     raw_value = os.getenv("CILLY_PAPER_ACCOUNT_STARTING_CASH", "100000")
     try:
         value = Decimal(raw_value)
-    except Exception as exc:
+    except (InvalidOperation, ValueError) as exc:
         raise HTTPException(status_code=500, detail="paper_account_starting_cash_invalid") from exc
     if value < Decimal("0"):
         raise HTTPException(status_code=500, detail="paper_account_starting_cash_invalid")
@@ -758,9 +759,16 @@ def build_bounded_paper_simulation_state(
 def resolve_runtime_canonical_execution_repo() -> Any | None:
     try:
         import api.main as api_main
-    except Exception:
+    except ImportError:
         return None
     return getattr(api_main, "canonical_execution_repo", None)
+
+
+def _safe_get_trade(repo: Any, trade_id: str) -> Any | None:
+    try:
+        return repo.get_trade(trade_id)
+    except (sqlite3.Error, ValidationError, KeyError, ValueError):
+        return None
 
 
 def _parse_iso_datetime(value: str) -> datetime:
@@ -895,12 +903,11 @@ def build_bounded_decision_to_paper_usefulness_audit(
     except ValidationError:
         return None
 
-    trade: Trade | None = None
-    if canonical_execution_repo is not None:
-        try:
-            trade = canonical_execution_repo.get_trade(normalized_match_reference.paper_trade_id)
-        except Exception:
-            trade = None
+    trade: Trade | None = (
+        _safe_get_trade(canonical_execution_repo, normalized_match_reference.paper_trade_id)
+        if canonical_execution_repo is not None
+        else None
+    )
 
     match_status: Literal["matched", "open", "missing", "invalid"] = "missing"
     matched_outcome: dict[str, Any] | None = None
@@ -998,12 +1005,11 @@ def build_bounded_signal_portfolio_paper_reconciliation_audit(
         symbol,
     )
 
-    trade: Trade | None = None
-    if canonical_execution_repo is not None and paper_trade_id is not None:
-        try:
-            trade = canonical_execution_repo.get_trade(paper_trade_id)
-        except Exception:
-            trade = None
+    trade: Trade | None = (
+        _safe_get_trade(canonical_execution_repo, paper_trade_id)
+        if canonical_execution_repo is not None and paper_trade_id is not None
+        else None
+    )
 
     opening_order_ids: list[str] = list(trade.opening_order_ids) if trade is not None else []
     closing_order_ids: list[str] = list(trade.closing_order_ids) if trade is not None else []
@@ -1133,10 +1139,7 @@ def resolve_bounded_paper_linkage_status(
     if canonical_execution_repo is None:
         return "missing", paper_trade_id
 
-    try:
-        trade = canonical_execution_repo.get_trade(paper_trade_id)
-    except Exception:
-        trade = None
+    trade = _safe_get_trade(canonical_execution_repo, paper_trade_id)
 
     if trade is None:
         return "missing", paper_trade_id
@@ -1184,14 +1187,11 @@ def build_bounded_signal_quality_stability_audit(
     match_status: Literal["matched", "open", "missing", "invalid"] = "missing"
     matched_outcome: dict[str, Any] | None = None
     if normalized_match_reference is not None:
-        trade: Trade | None = None
-        if canonical_execution_repo is not None:
-            try:
-                trade = canonical_execution_repo.get_trade(
-                    normalized_match_reference.paper_trade_id
-                )
-            except Exception:
-                trade = None
+        trade: Trade | None = (
+            _safe_get_trade(canonical_execution_repo, normalized_match_reference.paper_trade_id)
+            if canonical_execution_repo is not None
+            else None
+        )
         if trade is not None:
             match_status, matched_outcome = _build_paper_trade_outcome_payload(
                 trade=trade,
@@ -1328,14 +1328,11 @@ def build_bounded_confidence_calibration_audit(
     match_status: Literal["matched", "open", "missing", "invalid"] = "missing"
     matched_outcome: dict[str, Any] | None = None
     if normalized_match_reference is not None:
-        trade: Trade | None = None
-        if canonical_execution_repo is not None:
-            try:
-                trade = canonical_execution_repo.get_trade(
-                    normalized_match_reference.paper_trade_id
-                )
-            except Exception:
-                trade = None
+        trade: Trade | None = (
+            _safe_get_trade(canonical_execution_repo, normalized_match_reference.paper_trade_id)
+            if canonical_execution_repo is not None
+            else None
+        )
         if trade is not None:
             match_status, matched_outcome = _build_paper_trade_outcome_payload(
                 trade=trade,
@@ -1394,14 +1391,11 @@ def build_bounded_strategy_score_calibration_audit(
     match_status: Literal["matched", "open", "missing", "invalid"] = "missing"
     matched_outcome: dict[str, Any] | None = None
     if normalized_match_reference is not None:
-        trade: Trade | None = None
-        if canonical_execution_repo is not None:
-            try:
-                trade = canonical_execution_repo.get_trade(
-                    normalized_match_reference.paper_trade_id
-                )
-            except Exception:
-                trade = None
+        trade: Trade | None = (
+            _safe_get_trade(canonical_execution_repo, normalized_match_reference.paper_trade_id)
+            if canonical_execution_repo is not None
+            else None
+        )
         if trade is not None:
             match_status, matched_outcome = _build_paper_trade_outcome_payload(
                 trade=trade,

--- a/src/cilly_trading/engine/core.py
+++ b/src/cilly_trading/engine/core.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -158,7 +159,7 @@ def _derive_timestamp_from_df(df: Any) -> Optional[str]:
     if getattr(df, "columns", None) is not None and "timestamp" in df.columns:
         try:
             return _normalize_timestamp_to_utc(df["timestamp"].iloc[-1])
-        except Exception:
+        except (IndexError, KeyError, AttributeError, TypeError, ValueError):
             logger.warning(
                 "Failed to derive timestamp from OHLCV column: component=engine",
                 exc_info=True,
@@ -440,7 +441,7 @@ def run_watchlist_analysis(
                 raw_config = strategy_configs_map.get(strat_name)
                 try:
                     strat_config = _normalize_strategy_config(strat_name, raw_config)
-                except Exception as exc:
+                except (ValueError, KeyError, TypeError) as exc:
                     logger.error(
                         "Invalid strategy config: component=engine strategy=%s error=%s",
                         strat_name,
@@ -542,7 +543,7 @@ def run_watchlist_analysis(
                             exc,
                         )
                         continue
-                    except Exception:
+                    except (AttributeError, TypeError, KeyError, ValueError):
                         logger.error(
                             "Invalid signal object from strategy: component=engine strategy=%s symbol=%s timeframe=%s (skipping signal)",
                             strat_name,
@@ -562,7 +563,7 @@ def run_watchlist_analysis(
                         if not reasons:
                             raise ReasonGenerationError("Reason generation returned empty reasons list")
                         s["reasons"] = reasons
-                    except Exception as exc:
+                    except (ValueError, KeyError, TypeError, AttributeError) as exc:
                         logger.error(
                             "Reason generation failed: component=engine strategy=%s symbol=%s timeframe=%s",
                             strat_name,

--- a/src/cilly_trading/engine/determinism_guard.py
+++ b/src/cilly_trading/engine/determinism_guard.py
@@ -6,6 +6,7 @@ import datetime
 import random
 import secrets
 import socket
+import threading
 import time
 from typing import Any, Callable
 
@@ -23,6 +24,7 @@ class DeterminismViolationError(RuntimeError):
 
 _ORIGINALS: dict[tuple[Any, str], Any] = {}
 _INSTALLED = False
+_guard_lock: threading.Lock = threading.Lock()
 
 
 def _raise_violation(message: str) -> None:
@@ -48,51 +50,53 @@ def install_guard() -> None:
     """Install deterministic validation guard by monkeypatching forbidden APIs."""
 
     global _INSTALLED
-    if _INSTALLED:
-        return
+    with _guard_lock:
+        if _INSTALLED:
+            return
 
-    # System time access.
-    _patch(time, "time", _blocked_callable("Determinism violation: system time access (time.time)"))
-    _patch(time, "time_ns", _blocked_callable("Determinism violation: system time access (time.time_ns)"))
+        # System time access.
+        _patch(time, "time", _blocked_callable("Determinism violation: system time access (time.time)"))
+        _patch(time, "time_ns", _blocked_callable("Determinism violation: system time access (time.time_ns)"))
 
-    class _DeterministicDatetime(datetime.datetime):
-        @classmethod
-        def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
-            _raise_violation("Determinism violation: system time access (datetime.datetime.now)")
+        class _DeterministicDatetime(datetime.datetime):
+            @classmethod
+            def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+                _raise_violation("Determinism violation: system time access (datetime.datetime.now)")
 
-        @classmethod
-        def utcnow(cls) -> datetime.datetime:
-            _raise_violation("Determinism violation: system time access (datetime.datetime.utcnow)")
+            @classmethod
+            def utcnow(cls) -> datetime.datetime:
+                _raise_violation("Determinism violation: system time access (datetime.datetime.utcnow)")
 
-    _patch(datetime, "datetime", _DeterministicDatetime)
+        _patch(datetime, "datetime", _DeterministicDatetime)
 
-    # Randomness access.
-    _patch(random, "random", _blocked_callable("Determinism violation: randomness access (random.random)"))
-    _patch(random, "randint", _blocked_callable("Determinism violation: randomness access (random.randint)"))
-    _patch(random, "choice", _blocked_callable("Determinism violation: randomness access (random.choice)"))
-    _patch(random, "randrange", _blocked_callable("Determinism violation: randomness access (random.randrange)"))
-    _patch(secrets, "token_bytes", _blocked_callable("Determinism violation: randomness access (secrets.token_bytes)"))
-    _patch(secrets, "token_hex", _blocked_callable("Determinism violation: randomness access (secrets.token_hex)"))
-    _patch(secrets, "choice", _blocked_callable("Determinism violation: randomness access (secrets.choice)"))
+        # Randomness access.
+        _patch(random, "random", _blocked_callable("Determinism violation: randomness access (random.random)"))
+        _patch(random, "randint", _blocked_callable("Determinism violation: randomness access (random.randint)"))
+        _patch(random, "choice", _blocked_callable("Determinism violation: randomness access (random.choice)"))
+        _patch(random, "randrange", _blocked_callable("Determinism violation: randomness access (random.randrange)"))
+        _patch(secrets, "token_bytes", _blocked_callable("Determinism violation: randomness access (secrets.token_bytes)"))
+        _patch(secrets, "token_hex", _blocked_callable("Determinism violation: randomness access (secrets.token_hex)"))
+        _patch(secrets, "choice", _blocked_callable("Determinism violation: randomness access (secrets.choice)"))
 
-    # Network access.
-    _patch(socket.socket, "connect", _blocked_callable("Determinism violation: network access (socket.socket.connect)"))
-    _patch(socket, "create_connection", _blocked_callable("Determinism violation: network access (socket.create_connection)"))
-    _patch(socket, "getaddrinfo", _blocked_callable("Determinism violation: network access (socket.getaddrinfo)"))
+        # Network access.
+        _patch(socket.socket, "connect", _blocked_callable("Determinism violation: network access (socket.socket.connect)"))
+        _patch(socket, "create_connection", _blocked_callable("Determinism violation: network access (socket.create_connection)"))
+        _patch(socket, "getaddrinfo", _blocked_callable("Determinism violation: network access (socket.getaddrinfo)"))
 
-    _INSTALLED = True
+        _INSTALLED = True
 
 
 def uninstall_guard() -> None:
     """Restore all patched callables and remove the deterministic guard."""
 
     global _INSTALLED
-    if not _INSTALLED and not _ORIGINALS:
-        return
+    with _guard_lock:
+        if not _INSTALLED and not _ORIGINALS:
+            return
 
-    for (target, attr), original in reversed(list(_ORIGINALS.items())):
-        setattr(target, attr, original)
+        for (target, attr), original in reversed(list(_ORIGINALS.items())):
+            setattr(target, attr, original)
 
-    _ORIGINALS.clear()
-    _INSTALLED = False
+        _ORIGINALS.clear()
+        _INSTALLED = False
 

--- a/src/cilly_trading/repositories/__init__.py
+++ b/src/cilly_trading/repositories/__init__.py
@@ -8,7 +8,7 @@ Die konkrete Implementierung im MVP nutzt SQLite.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Protocol
+from typing import Any, Dict, List, Optional, Protocol
 
 from cilly_trading.models import ExecutionEvent, Order, PersistedTradePayload, Signal, Trade
 
@@ -165,7 +165,33 @@ class WatchlistRepository(Protocol):
         ...
 
 
+class AnalysisRunRepository(Protocol):
+    """Interface for analysis run and ingestion run persistence."""
+
+    def ingestion_run_exists(self, ingestion_run_id: str) -> bool: ...
+
+    def ingestion_run_is_ready(
+        self,
+        ingestion_run_id: str,
+        *,
+        symbols: list[str],
+        timeframe: str,
+    ) -> bool: ...
+
+    def get_run(self, analysis_run_id: str) -> Optional[Dict[str, Any]]: ...
+
+    def save_run(
+        self,
+        *,
+        analysis_run_id: str,
+        ingestion_run_id: str,
+        request_payload: Dict[str, Any],
+        result_payload: Dict[str, Any],
+    ) -> Dict[str, Any]: ...
+
+
 __all__ = [
+    "AnalysisRunRepository",
     "SignalRepository",
     "TradeRepository",
     "CanonicalExecutionRepository",

--- a/src/cilly_trading/repositories/_base_sqlite.py
+++ b/src/cilly_trading/repositories/_base_sqlite.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Optional
+
+from cilly_trading.db import DEFAULT_DB_PATH, init_db
+
+
+class BaseSqliteRepository:
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = Path(db_path if db_path is not None else DEFAULT_DB_PATH)
+        init_db(self._db_path)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA foreign_keys = ON;")
+        conn.execute("PRAGMA busy_timeout = 5000;")
+        return conn
+
+    def _connection(self):
+        return closing(self._get_connection())

--- a/src/cilly_trading/repositories/analysis_runs_sqlite.py
+++ b/src/cilly_trading/repositories/analysis_runs_sqlite.py
@@ -6,41 +6,22 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from cilly_trading.db import DEFAULT_DB_PATH, init_db
 from cilly_trading.engine.core import AnalysisRun
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 from cilly_trading.repositories.analysis_run_evidence import (
     build_analysis_run_evidence_metadata,
     write_analysis_run_evidence_artifacts,
 )
 
 
-class SqliteAnalysisRunRepository:
+class SqliteAnalysisRunRepository(BaseSqliteRepository):
     """
     Repository für Analyse-Run-Metadaten und Ergebnisse.
     """
-
-    def __init__(self, db_path: Optional[Path] = None) -> None:
-        if db_path is None:
-            db_path = DEFAULT_DB_PATH
-
-        self._db_path = Path(db_path)
-        init_db(self._db_path)
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     @staticmethod
     def _deserialize_run_row(row: sqlite3.Row) -> Dict[str, Any]:

--- a/src/cilly_trading/repositories/execution_core_sqlite.py
+++ b/src/cilly_trading/repositories/execution_core_sqlite.py
@@ -3,33 +3,20 @@
 from __future__ import annotations
 
 import sqlite3
-from contextlib import closing
 from pathlib import Path
 from typing import Optional
 
-from cilly_trading.db import DEFAULT_DB_PATH, init_db
 from cilly_trading.models import ExecutionEvent, Order, Trade
 from cilly_trading.repositories import CanonicalExecutionRepository
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 
 
-class SqliteCanonicalExecutionRepository(CanonicalExecutionRepository):
+class SqliteCanonicalExecutionRepository(BaseSqliteRepository, CanonicalExecutionRepository):
     """Deterministic persistence for canonical orders, execution events, and trades."""
 
     def __init__(self, db_path: Optional[Path] = None) -> None:
-        self._db_path = Path(db_path or DEFAULT_DB_PATH)
-        init_db(self._db_path)
+        super().__init__(db_path)
         self._ensure_tables()
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     def _ensure_tables(self) -> None:
         with self._connection() as conn:

--- a/src/cilly_trading/repositories/lineage_repository.py
+++ b/src/cilly_trading/repositories/lineage_repository.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import sqlite3
-from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-from cilly_trading.db import DEFAULT_DB_PATH, init_db
 from cilly_trading.engine.lineage import LineageContext
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 
 
 @dataclass(frozen=True)
@@ -23,27 +22,12 @@ class LineageRecord:
     created_at: str
 
 
-class SqliteLineageRepository:
+class SqliteLineageRepository(BaseSqliteRepository):
     """Persist and query lineage records in SQLite."""
 
     def __init__(self, db_path: Optional[Path] = None) -> None:
-        if db_path is None:
-            db_path = DEFAULT_DB_PATH
-
-        self._db_path = Path(db_path)
-        init_db(self._db_path)
+        super().__init__(db_path)
         self._ensure_table()
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     def _ensure_table(self) -> None:
         """Ensure the lineage table and indexes exist."""

--- a/src/cilly_trading/repositories/order_events_sqlite.py
+++ b/src/cilly_trading/repositories/order_events_sqlite.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from contextlib import closing
 from pathlib import Path
 from typing import Any, Optional
 
-from cilly_trading.db import DEFAULT_DB_PATH, init_db
 from cilly_trading.repositories import OrderEventRepository
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 
 ORDER_LIFECYCLE_STATES = (
     "created",
@@ -18,26 +17,12 @@ ORDER_LIFECYCLE_STATES = (
 )
 
 
-class SqliteOrderEventRepository(OrderEventRepository):
+class SqliteOrderEventRepository(BaseSqliteRepository, OrderEventRepository):
     """SQLite repository for deterministic order lifecycle event reads."""
 
     def __init__(self, db_path: Optional[Path] = None) -> None:
-        if db_path is None:
-            db_path = DEFAULT_DB_PATH
-        self._db_path = Path(db_path)
-        init_db(self._db_path)
+        super().__init__(db_path)
         self._ensure_order_events_table()
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     def _ensure_order_events_table(self) -> None:
         with self._connection() as conn:

--- a/src/cilly_trading/repositories/signals_sqlite.py
+++ b/src/cilly_trading/repositories/signals_sqlite.py
@@ -6,44 +6,27 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from contextlib import closing
 from pathlib import Path
 from datetime import datetime
 from typing import List, Optional, Tuple
 
-from cilly_trading.db import init_db, DEFAULT_DB_PATH  # type: ignore
 from cilly_trading.models import Signal, SignalReason, compute_signal_id, compute_signal_reason_id
 from cilly_trading.repositories import SignalRepository
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 
 
 class SignalReconstructionError(ValueError):
     """Raised when persisted signal data cannot be reconstructed deterministically."""
 
 
-class SqliteSignalRepository(SignalRepository):
+class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
     """
     Speichert und lädt Signals aus einer SQLite-Datenbank.
     """
 
     def __init__(self, db_path: Optional[Path] = None) -> None:
-        if db_path is None:
-            db_path = DEFAULT_DB_PATH
-
-        self._db_path = Path(db_path)
-        # sicherstellen, dass DB und Tabellen existieren
-        init_db(self._db_path)
+        super().__init__(db_path)
         self._ensure_signal_columns()
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     def _ensure_signal_columns(self) -> None:
         with self._connection() as conn:

--- a/src/cilly_trading/repositories/snapshot_ingestion_sqlite.py
+++ b/src/cilly_trading/repositories/snapshot_ingestion_sqlite.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from cilly_trading.db import DEFAULT_DB_PATH, init_db
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 
 
 @dataclass(frozen=True)
@@ -33,25 +32,8 @@ class OhlcvSnapshotRowRecord:
     volume: float
 
 
-class SqliteSnapshotIngestionRepository:
+class SqliteSnapshotIngestionRepository(BaseSqliteRepository):
     """Persist bounded snapshot ingestion runs into the canonical SQLite schema."""
-
-    def __init__(self, db_path: Optional[Path] = None) -> None:
-        if db_path is None:
-            db_path = DEFAULT_DB_PATH
-        self._db_path = Path(db_path)
-        init_db(self._db_path)
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     def save_snapshot_run(
         self,

--- a/src/cilly_trading/repositories/trades_sqlite.py
+++ b/src/cilly_trading/repositories/trades_sqlite.py
@@ -3,35 +3,16 @@
 from __future__ import annotations
 
 import sqlite3
-from contextlib import closing
 from pathlib import Path
 from typing import List, Optional
 
-from cilly_trading.db import init_db, DEFAULT_DB_PATH  # type: ignore
 from cilly_trading.models import PersistedTradePayload
 from cilly_trading.repositories import TradeRepository
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 
 
-class SqliteTradeRepository(TradeRepository):
+class SqliteTradeRepository(BaseSqliteRepository, TradeRepository):
     """Speichert und lädt Trades aus einer SQLite-Datenbank."""
-
-    def __init__(self, db_path: Optional[Path] = None) -> None:
-        if db_path is None:
-            db_path = DEFAULT_DB_PATH
-
-        self._db_path = Path(db_path)
-        init_db(self._db_path)
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     def save_trade(self, trade: PersistedTradePayload) -> int:
         with self._connection() as conn:

--- a/src/cilly_trading/repositories/watchlists_sqlite.py
+++ b/src/cilly_trading/repositories/watchlists_sqlite.py
@@ -3,34 +3,15 @@
 from __future__ import annotations
 
 import sqlite3
-from contextlib import closing
 from pathlib import Path
 from typing import List, Optional
 
-from cilly_trading.db import DEFAULT_DB_PATH, init_db
 from cilly_trading.repositories import Watchlist, WatchlistRepository
+from cilly_trading.repositories._base_sqlite import BaseSqliteRepository
 
 
-class SqliteWatchlistRepository(WatchlistRepository):
+class SqliteWatchlistRepository(BaseSqliteRepository, WatchlistRepository):
     """Persist named watchlists and ordered symbol membership in SQLite."""
-
-    def __init__(self, db_path: Optional[Path] = None) -> None:
-        if db_path is None:
-            db_path = DEFAULT_DB_PATH
-
-        self._db_path = Path(db_path)
-        init_db(self._db_path)
-
-    def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
-
-    def _connection(self):
-        return closing(self._get_connection())
 
     def _validate_payload(self, *, watchlist_id: str, name: str, symbols: List[str]) -> List[str]:
         normalized_symbols = [symbol.strip() for symbol in symbols]

--- a/src/cilly_trading/strategies/_constants.py
+++ b/src/cilly_trading/strategies/_constants.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+PRICE_SCALE: Decimal = Decimal("0.0001")

--- a/src/cilly_trading/strategies/rsi2.py
+++ b/src/cilly_trading/strategies/rsi2.py
@@ -22,6 +22,7 @@ import pandas as pd
 from cilly_trading.models import Signal
 from cilly_trading.engine.core import BaseStrategy
 from cilly_trading.indicators.rsi import rsi
+from cilly_trading.strategies._constants import PRICE_SCALE
 
 
 @dataclass
@@ -115,7 +116,6 @@ class Rsi2Strategy(BaseStrategy):
                 "über dem Oversold-Bereich liegt."
             )
 
-            _scale = Decimal("0.0001")
             signal: Signal = {
                 # symbol, timeframe, market_type, data_source, timestamp
                 # werden im Engine-Layer gesetzt (run_watchlist_analysis)
@@ -129,20 +129,20 @@ class Rsi2Strategy(BaseStrategy):
                         (
                             Decimal(str(last_close))
                             * Decimal(str(cfg.entry_zone_lower_factor))
-                        ).quantize(_scale, ROUND_HALF_UP)
+                        ).quantize(PRICE_SCALE, ROUND_HALF_UP)
                     ),
                     "to": float(
                         (
                             Decimal(str(last_close))
                             * Decimal(str(cfg.entry_zone_upper_factor))
-                        ).quantize(_scale, ROUND_HALF_UP)
+                        ).quantize(PRICE_SCALE, ROUND_HALF_UP)
                     ),
                 },
                 "stop_loss": float(
                     (
                         Decimal(str(last_close))
                         * (Decimal("1") - Decimal(str(cfg.stop_loss_pct)))
-                    ).quantize(_scale, ROUND_HALF_UP)
+                    ).quantize(PRICE_SCALE, ROUND_HALF_UP)
                 ),
             }
 

--- a/src/cilly_trading/strategies/turtle.py
+++ b/src/cilly_trading/strategies/turtle.py
@@ -138,7 +138,6 @@ class TurtleStrategy(BaseStrategy):
                 "Breakout-Hoch oder unter einem definierten Trailing-Stop)."
             )
 
-
             _stop = float(
                 (
                     Decimal(str(breakout_level))
@@ -184,7 +183,6 @@ class TurtleStrategy(BaseStrategy):
                         "Alternativ: Stop-Buy-Order knapp über dem Breakout-Hoch."
                     )
 
-        
                     _stop = float(
                         (
                             Decimal(str(breakout_level))

--- a/src/cilly_trading/strategies/turtle.py
+++ b/src/cilly_trading/strategies/turtle.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 from cilly_trading.models import Signal
 from cilly_trading.engine.core import BaseStrategy
+from cilly_trading.strategies._constants import PRICE_SCALE
 
 
 @dataclass
@@ -137,12 +138,12 @@ class TurtleStrategy(BaseStrategy):
                 "Breakout-Hoch oder unter einem definierten Trailing-Stop)."
             )
 
-            _scale = Decimal("0.0001")
+
             _stop = float(
                 (
                     Decimal(str(breakout_level))
                     * (Decimal("1") - Decimal(str(cfg.stop_loss_buffer_pct)))
-                ).quantize(_scale, ROUND_HALF_UP)
+                ).quantize(PRICE_SCALE, ROUND_HALF_UP)
             )
             signal: Signal = {
                 "strategy": self.name,
@@ -152,13 +153,13 @@ class TurtleStrategy(BaseStrategy):
                 "confirmation_rule": confirmation_rule,
                 "entry_zone": {
                     "from_": float(
-                        Decimal(str(breakout_level)).quantize(_scale, ROUND_HALF_UP)
+                        Decimal(str(breakout_level)).quantize(PRICE_SCALE, ROUND_HALF_UP)
                     ),
                     "to": float(
                         (
                             Decimal(str(last_close))
                             * Decimal(str(cfg.confirmed_entry_zone_upper_factor))
-                        ).quantize(_scale, ROUND_HALF_UP)
+                        ).quantize(PRICE_SCALE, ROUND_HALF_UP)
                     ),
                 },
                 "stop_loss": _stop,
@@ -183,12 +184,12 @@ class TurtleStrategy(BaseStrategy):
                         "Alternativ: Stop-Buy-Order knapp über dem Breakout-Hoch."
                     )
 
-                    _scale = Decimal("0.0001")
+        
                     _stop = float(
                         (
                             Decimal(str(breakout_level))
                             * (Decimal("1") - Decimal(str(cfg.stop_loss_buffer_pct)))
-                        ).quantize(_scale, ROUND_HALF_UP)
+                        ).quantize(PRICE_SCALE, ROUND_HALF_UP)
                     )
                     signal = {
                         "strategy": self.name,
@@ -201,13 +202,13 @@ class TurtleStrategy(BaseStrategy):
                                 (
                                     Decimal(str(breakout_level))
                                     * (Decimal("1") - Decimal(str(cfg.proximity_threshold_pct)))
-                                ).quantize(_scale, ROUND_HALF_UP)
+                                ).quantize(PRICE_SCALE, ROUND_HALF_UP)
                             ),
                             "to": float(
                                 (
                                     Decimal(str(breakout_level))
                                     * Decimal(str(cfg.setup_entry_zone_upper_factor))
-                                ).quantize(_scale, ROUND_HALF_UP)
+                                ).quantize(PRICE_SCALE, ROUND_HALF_UP)
                             ),
                         },
                         "stop_loss": _stop,


### PR DESCRIPTION
## Summary

Umsetzung der P1- und P2-Verbesserungen aus der Codebase-Analyse.
Branch wurde auf aktuellen `main` (inkl. #1086) rebasiert. 1262 Tests grün.

### Wave 1 — BaseSqliteRepository + PRICE_SCALE
- Neue `_base_sqlite.py` mit `BaseSqliteRepository`: alle 8 SQLite-Repos erben daraus, ~120 Zeilen Duplikat entfernt (`_get_connection`, `_connection`, WAL/FK/busy_timeout)
- `PRICE_SCALE = Decimal("0.0001")` in `strategies/_constants.py` zentralisiert (war dreifach definiert in rsi2.py + turtle.py)

### Wave 2 — threading.Lock in determinism_guard
- `_guard_lock: threading.Lock` sichert `install_guard()` und `uninstall_guard()` gegen Race-Conditions bei parallelen Aufrufen

### Wave 3 — Exception-Handler präzisieren
- `paper_inspection_service.py`: `except Exception` → `except ImportError` beim dynamischen Import; 6 identische `get_trade()`-try-Blöcke durch `_safe_get_trade()`-Wrapper ersetzt; `Decimal()`-Handler auf `(InvalidOperation, ValueError)` eingeengt
- `engine/core.py`: 4 Handler auf spezifische Typen eingeengt; `save_signals`-Handler bleibt `except Exception` (externe Repository-Schnittstelle)

### Wave 4 — Hardcodierte Strategy-Parameter in Config
- `Rsi2Config`: `entry_zone_lower_factor` (0.97) und `entry_zone_upper_factor` (1.01) → bereits durch #1086 in main gelandet; Wave 4 fügt nur noch den `PRICE_SCALE`-Import hinzu
- `TurtleConfig`: Score-Ranges, Entry-Zone-Faktoren → bereits durch #1086 in main; Wave 4 bereinigt lokale `_scale`-Variable

### Wave 5 — Type-Annotations im Service-Layer
- `AnalysisRunRepository` Protocol in `repositories/__init__.py` mit 4 genutzten Methoden
- `AnalysisServiceDependencies`: `analysis_run_repo`, `signal_repo`, `watchlist_repo` typisiert statt `Any`

## Test plan

- [x] `uv run -- python -m pytest tests/ -x -q --import-mode=importlib` → 1262 passed

https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWqhqAZPL3cPaLkFvN59P)_