### PR TITLE
fix(p0): SQLite retry backoff, runtime controller injectable, log-level fixes

### DIFF
--- a/src/cilly_trading/engine/core.py
+++ b/src/cilly_trading/engine/core.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Protocol
 
+
 import pandas as pd
 
 from cilly_trading.engine.data import (
@@ -415,8 +416,8 @@ def run_watchlist_analysis(
                         market_type=engine_config.market_type,
                     )
                 except Exception:
-                    logger.error(
-                        "Error loading data: component=engine symbol=%s timeframe=%s ingestion_run_id=%s",
+                    logger.warning(
+                        "Skipping symbol due to data load failure: component=engine symbol=%s timeframe=%s ingestion_run_id=%s",
                         symbol,
                         engine_config.timeframe,
                         ingestion_run_id or "n/a",
@@ -612,8 +613,8 @@ def run_watchlist_analysis(
                     engine_config.timeframe,
                 )
                 continue
-            logger.error(
-                "Snapshot data error while processing symbol: component=engine symbol=%s timeframe=%s",
+            logger.warning(
+                "Snapshot data error propagating for symbol: component=engine symbol=%s timeframe=%s",
                 symbol,
                 engine_config.timeframe,
                 exc_info=True,
@@ -667,10 +668,12 @@ def run_watchlist_analysis(
         completion_status = "signals_persisted"
         try:
             signal_repo.save_signals(all_signals)
-        except Exception:
+        except Exception as exc:
+            # Intentional broad catch: repository boundary — any implementation can fail.
             logger.error(
-                "Error persisting signals: component=engine signals_total=%d",
+                "Signal persistence failed: component=engine signals_total=%d error=%s",
                 len(all_signals),
+                exc,
                 exc_info=True,
             )
             completion_status = "signal_persistence_failed"

--- a/src/cilly_trading/engine/runtime_controller.py
+++ b/src/cilly_trading/engine/runtime_controller.py
@@ -133,75 +133,99 @@ class EngineRuntimeController:
         self._state = "running"
         return self._state
 
-_RUNTIME_LOCK: Final[Lock] = Lock()
-_RUNTIME_CONTROLLER: EngineRuntimeController | None = None
+
+class RuntimeControllerRegistry:
+    """Thread-safe registry for an EngineRuntimeController instance.
+
+    Use this class directly when you need an isolated controller (e.g. in
+    tests or multi-tenant scenarios) without relying on the process-wide
+    singleton functions below.
+
+    Example::
+
+        registry = RuntimeControllerRegistry()
+        registry.start()
+        state = registry.get_controller().state
+        registry.shutdown()
+    """
+
+    def __init__(self) -> None:
+        self._lock: Lock = Lock()
+        self._controller: EngineRuntimeController | None = None
+
+    def _get_or_create(self) -> EngineRuntimeController:
+        if self._controller is None:
+            self._controller = EngineRuntimeController()
+        return self._controller
+
+    def get_controller(self) -> EngineRuntimeController:
+        with self._lock:
+            return self._get_or_create()
+
+    def start(self) -> str:
+        with self._lock:
+            runtime = self._get_or_create()
+            if runtime.state == "init":
+                runtime.init()
+            if runtime.state == "ready":
+                runtime.start()
+            assert_postcondition_running(runtime.state)
+            return runtime.state
+
+    def shutdown(self) -> str:
+        with self._lock:
+            runtime = self._get_or_create()
+            if runtime.state in {"init", "ready"}:
+                return runtime.state
+            return runtime.shutdown()
+
+    def pause(self) -> str:
+        with self._lock:
+            return self._get_or_create().pause_execution()
+
+    def resume(self) -> str:
+        with self._lock:
+            return self._get_or_create().resume_execution()
+
+    def reset(self) -> None:
+        """Reset the controller to a fresh ``init`` state."""
+        with self._lock:
+            self._controller = None
 
 
-def _get_or_create_runtime_controller() -> EngineRuntimeController:
-    global _RUNTIME_CONTROLLER
+# ---------------------------------------------------------------------------
+# Process-wide singleton — kept for backward compatibility.
+# Prefer injecting a RuntimeControllerRegistry instance instead.
+# ---------------------------------------------------------------------------
 
-    if _RUNTIME_CONTROLLER is None:
-        _RUNTIME_CONTROLLER = EngineRuntimeController()
-
-    return _RUNTIME_CONTROLLER
+_REGISTRY: Final[RuntimeControllerRegistry] = RuntimeControllerRegistry()
 
 
 def get_runtime_controller() -> EngineRuntimeController:
     """Return the single process-wide runtime controller owned by the engine."""
-
-    with _RUNTIME_LOCK:
-        return _get_or_create_runtime_controller()
+    return _REGISTRY.get_controller()
 
 
 def start_engine_runtime() -> str:
     """Initialize and start the process-wide engine runtime."""
-
-    with _RUNTIME_LOCK:
-        runtime = _get_or_create_runtime_controller()
-
-        if runtime.state == "init":
-            runtime.init()
-
-        if runtime.state == "ready":
-            runtime.start()
-
-        assert_postcondition_running(runtime.state)
-
-        return runtime.state
+    return _REGISTRY.start()
 
 
 def shutdown_engine_runtime() -> str:
     """Best-effort shutdown for the process-wide engine runtime."""
-
-    with _RUNTIME_LOCK:
-        runtime = _get_or_create_runtime_controller()
-
-        if runtime.state in {"init", "ready"}:
-            return runtime.state
-
-        return runtime.shutdown()
+    return _REGISTRY.shutdown()
 
 
 def pause_engine_runtime() -> str:
     """Pause execution for the process-wide runtime."""
-
-    with _RUNTIME_LOCK:
-        runtime = _get_or_create_runtime_controller()
-        return runtime.pause_execution()
+    return _REGISTRY.pause()
 
 
 def resume_engine_runtime() -> str:
     """Resume execution for the process-wide runtime."""
-
-    with _RUNTIME_LOCK:
-        runtime = _get_or_create_runtime_controller()
-        return runtime.resume_execution()
+    return _REGISTRY.resume()
 
 
 def _reset_runtime_controller_for_tests() -> None:
     """Reset process-wide runtime controller singleton for test isolation."""
-
-    global _RUNTIME_CONTROLLER
-
-    with _RUNTIME_LOCK:
-        _RUNTIME_CONTROLLER = None
+    _REGISTRY.reset()

--- a/src/cilly_trading/repositories/_base_sqlite.py
+++ b/src/cilly_trading/repositories/_base_sqlite.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import logging
+import random
 import sqlite3
+import time
 from contextlib import closing
 from pathlib import Path
 from typing import Optional
 
 from cilly_trading.db import DEFAULT_DB_PATH, init_db
+
+logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 4
+_BASE_DELAY_S = 0.1
 
 
 class BaseSqliteRepository:
@@ -14,12 +22,28 @@ class BaseSqliteRepository:
         init_db(self._db_path)
 
     def _get_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=5.0)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL;")
-        conn.execute("PRAGMA foreign_keys = ON;")
-        conn.execute("PRAGMA busy_timeout = 5000;")
-        return conn
+        last_exc: sqlite3.OperationalError | None = None
+        for attempt in range(_MAX_RETRIES):
+            try:
+                conn = sqlite3.connect(self._db_path, timeout=30.0)
+                conn.row_factory = sqlite3.Row
+                conn.execute("PRAGMA journal_mode=WAL;")
+                conn.execute("PRAGMA foreign_keys = ON;")
+                conn.execute("PRAGMA busy_timeout = 30000;")
+                return conn
+            except sqlite3.OperationalError as exc:
+                last_exc = exc
+                if attempt < _MAX_RETRIES - 1:
+                    delay = _BASE_DELAY_S * (2**attempt) + random.uniform(0, 0.05)
+                    logger.warning(
+                        "SQLite connection failed (attempt %d/%d), retrying in %.2fs: %s",
+                        attempt + 1,
+                        _MAX_RETRIES,
+                        delay,
+                        exc,
+                    )
+                    time.sleep(delay)
+        raise last_exc  # type: ignore[misc]
 
     def _connection(self):
         return closing(self._get_connection())


### PR DESCRIPTION
- _base_sqlite.py: Exponential backoff retry (4 attempts, 100ms base) for
  sqlite3.OperationalError on connection; timeout raised from 5s to 30s,
  busy_timeout from 5000ms to 30000ms to handle concurrent WAL access.

- runtime_controller.py: Extracted RuntimeControllerRegistry class —
  thread-safe, testable, injectable alternative to the process-wide singleton.
  Module-level functions now delegate to a single _REGISTRY instance.
  All existing callers and _reset_runtime_controller_for_tests() remain
  backward-compatible.

- core.py: Changed logger.error → logger.warning for OHLCV load failures
  that are handled by continuing (log level must reflect the action taken).
  Signal persistence exception documented as intentional broad catch at
  repository boundary. Snapshot propagation log level corrected.

1300 tests passing.

https://claude.ai/code/session_01JpFr8BS58w3bmDa2MswX6f