### PR TITLE
Risk/add correlation risk check 1102

### DIFF
--- a/docs/architecture/risk/risk_framework.md
+++ b/docs/architecture/risk/risk_framework.md
@@ -117,7 +117,7 @@ Pairs with correlation above `correlation_threshold` are reported in
 
 - `scope`: `portfolio`
 - `semantic`: `cap`
-- `rule_code`: `correlation_pair:<proposed_symbol>:<open_symbol>`
+- `rule_code`: `correlation_pair:<proposed_symbol>:<open_position_symbol>`
 - `observed_value`: computed Pearson correlation
 - `limit_value`: configured correlation threshold
 

--- a/docs/architecture/risk/risk_framework.md
+++ b/docs/architecture/risk/risk_framework.md
@@ -130,6 +130,7 @@ Limitations: this is a static rolling Pearson check over supplied price history
 only. It is not portfolio optimization, a dynamic correlation model, a
 cross-asset-class model, live-trading validation, broker integration, or a
 profitability claim.
+The documented evidence rows are deterministic review artifacts only.
 
 ## 8.2) Bounded Risk-Framework Authority Contract
 This framework is governed by one canonical bounded risk-framework authority

--- a/docs/architecture/risk/risk_framework.md
+++ b/docs/architecture/risk/risk_framework.md
@@ -94,6 +94,43 @@ Evidence discipline for this bounded contract:
   position-sizing, trade, strategy, symbol, and portfolio evidence rows
 - rejected outcomes emit canonical cap/boundary evidence rows
 
+## 8.1.1) Correlation-Based Portfolio Risk Aggregation
+The risk evaluator includes an optional correlation concentration check inside
+the existing deterministic evaluation boundary. The check compares the proposed
+symbol against symbols with open positions when both `open_position_symbols` and
+in-scope `price_history` are supplied on `RiskEvaluationRequest`.
+
+Configuration is part of `RiskLimits`:
+
+- `correlation_check_enabled`: defaults to `true`
+- `correlation_threshold`: defaults to `0.7`
+- `max_correlated_pairs`: defaults to `2`
+- `correlation_window`: defaults to `60`
+
+For each proposed/open symbol pair, the evaluator computes rolling Pearson
+correlation over the last `correlation_window` finite price values available for
+both symbols. Pairs with missing, insufficient, or zero-variance history are not
+counted because the evaluator can only use provided in-scope price history.
+
+Pairs with correlation above `correlation_threshold` are reported in
+`RiskEvaluationResponse.policy_evidence` with:
+
+- `scope`: `portfolio`
+- `semantic`: `cap`
+- `rule_code`: `correlation_pair:<proposed_symbol>:<open_symbol>`
+- `observed_value`: computed Pearson correlation
+- `limit_value`: configured correlation threshold
+
+The order is rejected with `rejected: correlated_pair_limit_exceeded` when the
+number of reported correlated proposed/open pairs exceeds
+`max_correlated_pairs`. When `correlation_check_enabled` is `false`, the check
+emits no evidence and preserves the existing portfolio-risk behavior.
+
+Limitations: this is a static rolling Pearson check over supplied price history
+only. It is not portfolio optimization, a dynamic correlation model, a
+cross-asset-class model, live-trading validation, broker integration, or a
+profitability claim.
+
 ## 8.2) Bounded Risk-Framework Authority Contract
 This framework is governed by one canonical bounded risk-framework authority
 contract that consolidates the currently implemented bounded risk primitives,

--- a/src/cilly_trading/risk_framework/allocation_rules.py
+++ b/src/cilly_trading/risk_framework/allocation_rules.py
@@ -34,7 +34,7 @@ class RiskLimits:
         correlation_check_enabled: Enable correlation-based portfolio risk
             aggregation when in-scope price history is provided.
         correlation_window: Rolling price-history window used for pairwise
-            Pearson correlation.
+            Pearson correlation over supplied in-scope prices.
     """
 
     max_account_exposure_pct: float

--- a/src/cilly_trading/risk_framework/allocation_rules.py
+++ b/src/cilly_trading/risk_framework/allocation_rules.py
@@ -27,6 +27,14 @@ class RiskLimits:
             loss percentage after applying the proposed position.
         max_portfolio_risk_pct: Optional maximum portfolio-level stop-loss
             bounded loss percentage after applying the proposed position.
+        correlation_threshold: Minimum Pearson correlation that counts a
+            proposed/open symbol pair as correlated.
+        max_correlated_pairs: Maximum number of correlated proposed/open
+            symbol pairs allowed after applying the proposed position.
+        correlation_check_enabled: Enable correlation-based portfolio risk
+            aggregation when in-scope price history is provided.
+        correlation_window: Rolling price-history window used for pairwise
+            Pearson correlation.
     """
 
     max_account_exposure_pct: float
@@ -37,3 +45,7 @@ class RiskLimits:
     max_strategy_risk_pct: Optional[float] = None
     max_symbol_risk_pct: Optional[float] = None
     max_portfolio_risk_pct: Optional[float] = None
+    correlation_threshold: float = 0.7
+    max_correlated_pairs: int = 2
+    correlation_check_enabled: bool = True
+    correlation_window: int = 60

--- a/src/cilly_trading/risk_framework/contract.py
+++ b/src/cilly_trading/risk_framework/contract.py
@@ -36,7 +36,7 @@ class RiskEvaluationRequest:
         open_position_symbols: Symbols with currently open positions available
             to this evaluation.
         price_history: In-scope price history keyed by symbol for deterministic
-            correlation checks.
+            correlation checks; normalized to immutable tuples.
     """
 
     strategy_id: str

--- a/src/cilly_trading/risk_framework/contract.py
+++ b/src/cilly_trading/risk_framework/contract.py
@@ -7,7 +7,7 @@ for risk evaluation. It contains no business logic.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Protocol
+from typing import Mapping, Optional, Protocol, Sequence
 
 from cilly_trading.non_live_evaluation_contract import NonLiveEvaluationEvidence
 
@@ -33,6 +33,10 @@ class RiskEvaluationRequest:
             proposal.
         require_bounded_risk_evidence: Require stop-loss and bounded risk-budget
             evidence to fail closed when missing or contradictory.
+        open_position_symbols: Symbols with currently open positions available
+            to this evaluation.
+        price_history: In-scope price history keyed by symbol for deterministic
+            correlation checks.
     """
 
     strategy_id: str
@@ -46,6 +50,25 @@ class RiskEvaluationRequest:
     symbol_risk_used: float = 0.0
     portfolio_risk_used: float = 0.0
     require_bounded_risk_evidence: bool = False
+    open_position_symbols: Sequence[str] = ()
+    price_history: (
+        Mapping[str, Sequence[float]] | Sequence[tuple[str, Sequence[float]]]
+    ) = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "open_position_symbols", tuple(self.open_position_symbols))
+        price_history = self.price_history
+        if isinstance(price_history, Mapping):
+            normalized_price_history = tuple(
+                (symbol, tuple(values))
+                for symbol, values in sorted(price_history.items())
+            )
+        else:
+            normalized_price_history = tuple(
+                (symbol, tuple(values))
+                for symbol, values in sorted(price_history)
+            )
+        object.__setattr__(self, "price_history", normalized_price_history)
 
 
 @dataclass(frozen=True)

--- a/src/cilly_trading/risk_framework/correlation_risk.py
+++ b/src/cilly_trading/risk_framework/correlation_risk.py
@@ -1,4 +1,4 @@
-"""Correlation-based portfolio risk aggregation checks."""
+"""Pure correlation-based portfolio risk aggregation checks."""
 
 from __future__ import annotations
 

--- a/src/cilly_trading/risk_framework/correlation_risk.py
+++ b/src/cilly_trading/risk_framework/correlation_risk.py
@@ -1,0 +1,129 @@
+"""Correlation-based portfolio risk aggregation checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite, sqrt
+from typing import Mapping, Sequence
+
+from cilly_trading.non_live_evaluation_contract import NonLiveEvaluationEvidence
+from cilly_trading.risk_framework.allocation_rules import RiskLimits
+
+
+PriceHistory = Mapping[str, Sequence[float]] | Sequence[tuple[str, Sequence[float]]]
+
+
+@dataclass(frozen=True)
+class CorrelationRiskCheck:
+    """Deterministic correlation result for proposed/open symbol pairs."""
+
+    policy_evidence: tuple[NonLiveEvaluationEvidence, ...]
+    correlated_pair_count: int
+    rejection_reason: str | None
+
+
+def _rolling_window(values: Sequence[float], window: int) -> tuple[float, ...]:
+    if window <= 0:
+        return ()
+    finite_values = tuple(float(value) for value in values if isfinite(float(value)))
+    return finite_values[-window:]
+
+
+def _pearson_correlation(left: Sequence[float], right: Sequence[float]) -> float | None:
+    if len(left) != len(right) or len(left) < 2:
+        return None
+
+    left_mean = sum(left) / len(left)
+    right_mean = sum(right) / len(right)
+    left_deltas = tuple(value - left_mean for value in left)
+    right_deltas = tuple(value - right_mean for value in right)
+    numerator = sum(
+        left_delta * right_delta
+        for left_delta, right_delta in zip(left_deltas, right_deltas, strict=True)
+    )
+    left_variance = sum(value * value for value in left_deltas)
+    right_variance = sum(value * value for value in right_deltas)
+    denominator = sqrt(left_variance * right_variance)
+    if denominator == 0.0:
+        return None
+    return numerator / denominator
+
+
+def _pair_rule_code(proposed_symbol: str, open_symbol: str) -> str:
+    return f"correlation_pair:{proposed_symbol}:{open_symbol}"
+
+
+def _history_values(price_history: PriceHistory, symbol: str) -> Sequence[float]:
+    if isinstance(price_history, Mapping):
+        return price_history.get(symbol, ())
+    for history_symbol, values in price_history:
+        if history_symbol == symbol:
+            return values
+    return ()
+
+
+def evaluate_correlation_risk(
+    *,
+    proposed_symbol: str,
+    open_position_symbols: Sequence[str],
+    price_history: PriceHistory,
+    limits: RiskLimits,
+) -> CorrelationRiskCheck:
+    """Evaluate pairwise proposed/open symbol correlations."""
+
+    if not limits.correlation_check_enabled:
+        return CorrelationRiskCheck((), 0, None)
+
+    proposed_window = _rolling_window(
+        _history_values(price_history, proposed_symbol),
+        limits.correlation_window,
+    )
+    correlated_evidence: list[NonLiveEvaluationEvidence] = []
+    seen_symbols: set[str] = set()
+
+    for open_symbol in open_position_symbols:
+        if open_symbol == proposed_symbol or open_symbol in seen_symbols:
+            continue
+        seen_symbols.add(open_symbol)
+
+        open_window = _rolling_window(
+            _history_values(price_history, open_symbol),
+            limits.correlation_window,
+        )
+        pair_size = min(len(proposed_window), len(open_window))
+        correlation = _pearson_correlation(
+            proposed_window[-pair_size:],
+            open_window[-pair_size:],
+        )
+        if correlation is None or correlation <= limits.correlation_threshold:
+            continue
+
+        correlated_pair_number = len(correlated_evidence) + 1
+        rejected = correlated_pair_number > limits.max_correlated_pairs
+        correlated_evidence.append(
+            NonLiveEvaluationEvidence(
+                decision="reject" if rejected else "approve",
+                semantic="cap",
+                scope="portfolio",
+                rule_code=_pair_rule_code(proposed_symbol, open_symbol),
+                reason_code=(
+                    "rejected: correlated_pair_limit_exceeded"
+                    if rejected
+                    else "approved: within_risk_limits"
+                ),
+                observed_value=correlation,
+                limit_value=limits.correlation_threshold,
+            )
+        )
+
+    correlated_pair_count = len(correlated_evidence)
+    rejection_reason = (
+        "rejected: correlated_pair_limit_exceeded"
+        if correlated_pair_count > limits.max_correlated_pairs
+        else None
+    )
+    return CorrelationRiskCheck(
+        policy_evidence=tuple(correlated_evidence),
+        correlated_pair_count=correlated_pair_count,
+        rejection_reason=rejection_reason,
+    )

--- a/src/cilly_trading/risk_framework/risk_evaluator.py
+++ b/src/cilly_trading/risk_framework/risk_evaluator.py
@@ -298,6 +298,7 @@ def evaluate_risk(
         limits: Immutable risk limits used for this evaluation.
         strategy_exposure: Current absolute exposure for the request strategy.
         symbol_exposure: Current absolute exposure for the request symbol.
+        config: Optional runtime kill-switch configuration.
 
     Returns:
         RiskEvaluationResponse: Deterministic evaluation result.

--- a/src/cilly_trading/risk_framework/risk_evaluator.py
+++ b/src/cilly_trading/risk_framework/risk_evaluator.py
@@ -7,6 +7,7 @@ from math import isfinite
 
 from cilly_trading.non_live_evaluation_contract import NonLiveEvaluationEvidence
 from cilly_trading.risk_framework.allocation_rules import RiskLimits
+from cilly_trading.risk_framework.correlation_risk import evaluate_correlation_risk
 from cilly_trading.risk_framework.contract import RiskEvaluationRequest, RiskEvaluationResponse
 from cilly_trading.risk_framework.exposure_model import compute_exposure_metrics
 from cilly_trading.risk_framework.kill_switch import is_kill_switch_enabled
@@ -339,6 +340,20 @@ def evaluate_risk(
         return _fail_closed_response(
             reason=bounded_rejection_reason,
             risk_score=bounded_risk_score,
+            policy_evidence=policy_evidence,
+        )
+
+    correlation_result = evaluate_correlation_risk(
+        proposed_symbol=request.symbol,
+        open_position_symbols=request.open_position_symbols,
+        price_history=request.price_history,
+        limits=limits,
+    )
+    policy_evidence = policy_evidence + correlation_result.policy_evidence
+    if correlation_result.rejection_reason is not None:
+        return _fail_closed_response(
+            reason=correlation_result.rejection_reason,
+            risk_score=risk_score,
             policy_evidence=policy_evidence,
         )
 

--- a/tests/risk/test_risk_evaluator.py
+++ b/tests/risk/test_risk_evaluator.py
@@ -43,6 +43,18 @@ def _bounded_limits() -> RiskLimits:
     )
 
 
+def _correlation_price_history() -> dict[str, tuple[float, ...]]:
+    proposed = tuple(float(value) for value in range(1, 11))
+    return {
+        "AAPL": proposed,
+        "MSFT": tuple(value * 2.0 for value in proposed),
+        "QQQ": tuple(value * 3.0 + 7.0 for value in proposed),
+        "NVDA": tuple(value * 4.0 - 3.0 for value in proposed),
+        "TLT": tuple(reversed(proposed)),
+        "GLD": (3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0, 5.0, 3.0),
+    }
+
+
 def test_approval_case() -> None:
     response = evaluate_risk(
         _request(),
@@ -371,3 +383,134 @@ def test_bounded_portfolio_risk_budget_rejection_is_deterministic() -> None:
     assert first == second
     assert first.approved is False
     assert first.reason == "rejected: portfolio_risk_budget_exceeded"
+
+
+def test_correlation_check_reports_pairs_above_threshold() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        open_position_symbols=("MSFT", "TLT", "GLD"),
+        price_history=_correlation_price_history(),
+    )
+    limits = RiskLimits(
+        max_account_exposure_pct=0.80,
+        max_position_size=10_000.0,
+        max_strategy_exposure_pct=0.80,
+        max_symbol_exposure_pct=0.80,
+        correlation_threshold=0.90,
+        max_correlated_pairs=2,
+        correlation_window=10,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is True
+    assert [row.rule_code for row in response.policy_evidence] == [
+        "correlation_pair:AAPL:MSFT",
+    ]
+    assert response.policy_evidence[0].observed_value == pytest.approx(1.0)
+    assert response.policy_evidence[0].limit_value == 0.90
+
+
+def test_correlation_check_rejects_when_pair_count_exceeds_limit() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        open_position_symbols=("MSFT", "QQQ", "NVDA"),
+        price_history=_correlation_price_history(),
+    )
+    limits = RiskLimits(
+        max_account_exposure_pct=0.80,
+        max_position_size=10_000.0,
+        max_strategy_exposure_pct=0.80,
+        max_symbol_exposure_pct=0.80,
+        correlation_threshold=0.90,
+        max_correlated_pairs=2,
+        correlation_window=10,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is False
+    assert response.reason == "rejected: correlated_pair_limit_exceeded"
+    assert response.adjusted_position_size == 0.0
+    assert [row.rule_code for row in response.policy_evidence] == [
+        "correlation_pair:AAPL:MSFT",
+        "correlation_pair:AAPL:QQQ",
+        "correlation_pair:AAPL:NVDA",
+    ]
+    assert response.policy_evidence[-1].decision == "reject"
+
+
+def test_correlation_check_allows_below_threshold() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=10_000.0,
+        open_position_symbols=("TLT", "GLD"),
+        price_history=_correlation_price_history(),
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=_limits(),
+        strategy_exposure=10_000.0,
+        symbol_exposure=5_000.0,
+    )
+
+    assert response.approved is True
+    assert response.reason == "approved: within_risk_limits"
+    assert response.policy_evidence == ()
+
+
+def test_disabled_correlation_check_preserves_existing_behavior() -> None:
+    request = RiskEvaluationRequest(
+        strategy_id="strategy-a",
+        symbol="AAPL",
+        proposed_position_size=5_000.0,
+        account_equity=100_000.0,
+        current_exposure=20_000.0,
+        open_position_symbols=("MSFT", "QQQ", "NVDA"),
+        price_history=_correlation_price_history(),
+    )
+    limits = RiskLimits(
+        max_account_exposure_pct=0.50,
+        max_position_size=10_000.0,
+        max_strategy_exposure_pct=0.30,
+        max_symbol_exposure_pct=0.20,
+        correlation_check_enabled=False,
+        correlation_threshold=0.90,
+        max_correlated_pairs=0,
+        correlation_window=10,
+    )
+
+    response = evaluate_risk(
+        request,
+        limits=limits,
+        strategy_exposure=10_000.0,
+        symbol_exposure=8_000.0,
+    )
+
+    assert response.approved is True
+    assert response.reason == "approved: within_risk_limits"
+    assert response.adjusted_position_size == 5_000.0
+    assert response.risk_score == 0.25
+    assert response.policy_evidence == ()

--- a/tests/risk/test_risk_evaluator.py
+++ b/tests/risk/test_risk_evaluator.py
@@ -44,6 +44,7 @@ def _bounded_limits() -> RiskLimits:
 
 
 def _correlation_price_history() -> dict[str, tuple[float, ...]]:
+    """Return deterministic prices with known pairwise correlations."""
     proposed = tuple(float(value) for value in range(1, 11))
     return {
         "AAPL": proposed,


### PR DESCRIPTION
## Summary
- Adds correlation-based proposed/open-position pair checks to the risk framework.
- Adds configurable correlation limits and deterministic policy evidence.
- Documents defaults, rejection behavior, disabled behavior, and limitations.

Closes #1102

## Tests
- `python -m pytest`
  - `1321 passed in 69.79s`
- `python -m pytest tests\risk\test_contract.py tests\risk\test_risk_evaluator.py -q`
  - `27 passed in 0.17s`

## Governance Notes
- Draft PR is a review container only.
- This PR must not be marked Ready for Review until Codex A returns APPROVED.
- No live-trading, broker-readiness, production-readiness, trader-validation, or profitability claim is introduced.