### PR TITLE
P1-trading: ATR sizing, correlation gate, drawdown guard, partial exits

### DIFF
--- a/src/cilly_trading/engine/paper_execution_risk_profile.py
+++ b/src/cilly_trading/engine/paper_execution_risk_profile.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal
 from math import isfinite
-from typing import Any
+from typing import Any, Literal
 
 
 PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID = "paper-execution-risk-profile-v1"
@@ -48,6 +48,9 @@ def _require_finite_score(*, name: str, value: float) -> None:
         raise ValueError(f"{name} must be in range [0.0, 100.0]")
 
 
+SizingMethod = Literal["stop_distance", "atr", "fixed"]
+
+
 @dataclass(frozen=True)
 class PaperExecutionRiskProfile:
     """Validated bounded risk profile for paper execution."""
@@ -69,6 +72,18 @@ class PaperExecutionRiskProfile:
     default_paper_entry_price: Decimal = Decimal("100")
     commission_rate: Decimal = Decimal("0.001")
     slippage_rate: Decimal = Decimal("0.0005")
+    # #1147 — ATR-based position sizing
+    sizing_method: SizingMethod = "stop_distance"
+    atr_multiple: Decimal = Decimal("2.0")
+    # #1145 — correlation risk gate (requires price_history passed to process_signal)
+    correlation_check_enabled: bool = False
+    correlation_threshold: float = 0.7
+    max_correlated_pairs: int = 2
+    correlation_window: int = 60
+    # #1146 — drawdown guard (circuit-breaker for losing streaks)
+    drawdown_guard_enabled: bool = False
+    max_consecutive_losses: int = 3
+    max_drawdown_pct: Decimal = Decimal("0.10")
 
     def __post_init__(self) -> None:
         if self.contract_id != PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID:
@@ -135,6 +150,22 @@ class PaperExecutionRiskProfile:
             name="slippage_rate",
             value=self.slippage_rate,
         )
+        if self.sizing_method not in ("stop_distance", "atr", "fixed"):
+            raise ValueError(
+                f"sizing_method must be 'stop_distance', 'atr', or 'fixed', got {self.sizing_method!r}"
+            )
+        _require_finite_positive_decimal(name="atr_multiple", value=self.atr_multiple)
+        if not isfinite(self.correlation_threshold):
+            raise ValueError("correlation_threshold must be finite")
+        if not (0.0 <= self.correlation_threshold <= 1.0):
+            raise ValueError("correlation_threshold must be in range [0.0, 1.0]")
+        if self.max_correlated_pairs < 0:
+            raise ValueError("max_correlated_pairs must be >= 0")
+        if self.correlation_window <= 0:
+            raise ValueError("correlation_window must be > 0")
+        if self.max_consecutive_losses <= 0:
+            raise ValueError("max_consecutive_losses must be > 0")
+        _require_finite_pct(name="max_drawdown_pct", value=self.max_drawdown_pct)
 
     def to_payload(self) -> dict[str, Any]:
         """Return a deterministic JSON-safe payload for evidence/logging."""
@@ -156,6 +187,15 @@ class PaperExecutionRiskProfile:
             "default_paper_entry_price": str(self.default_paper_entry_price),
             "commission_rate": str(self.commission_rate),
             "slippage_rate": str(self.slippage_rate),
+            "sizing_method": self.sizing_method,
+            "atr_multiple": str(self.atr_multiple),
+            "correlation_check_enabled": self.correlation_check_enabled,
+            "correlation_threshold": self.correlation_threshold,
+            "max_correlated_pairs": self.max_correlated_pairs,
+            "correlation_window": self.correlation_window,
+            "drawdown_guard_enabled": self.drawdown_guard_enabled,
+            "max_consecutive_losses": self.max_consecutive_losses,
+            "max_drawdown_pct": str(self.max_drawdown_pct),
         }
 
 
@@ -166,4 +206,5 @@ __all__ = [
     "DEFAULT_PAPER_EXECUTION_RISK_PROFILE",
     "PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID",
     "PaperExecutionRiskProfile",
+    "SizingMethod",
 ]

--- a/src/cilly_trading/engine/paper_execution_worker.py
+++ b/src/cilly_trading/engine/paper_execution_worker.py
@@ -57,6 +57,10 @@ from cilly_trading.portfolio_framework.capital_allocation_policy import (
 )
 from cilly_trading.repositories import CanonicalExecutionRepository
 from cilly_trading.risk_framework.allocation_rules import RiskLimits
+from cilly_trading.risk_framework.correlation_risk import (
+    PriceHistory,
+    evaluate_correlation_risk,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -128,13 +132,20 @@ _PRICE_SCALE: Decimal = Decimal("0.0001")
 
 OutcomeCode = Literal[
     "eligible",
+    "eligible:partial_exit",
+    "eligible:full_exit",
     "skip:score_below_threshold",
     "skip:duplicate_entry",
     "skip:cooldown_active",
     "skip:entry_zone_not_reached",
+    "skip:correlation_risk_blocked",
+    "skip:drawdown_guard_active",
+    "skip:no_open_position_to_exit",
+    "skip:exit_quantity_zero",
     "reject:invalid_signal_fields",
     "reject:missing_trade_risk_input",
     "reject:invalid_trade_risk_input",
+    "reject:atr_not_provided",
     "reject:max_risk_per_trade_exceeded",
     "reject:position_size_exceeds_limit",
     "reject:total_exposure_exceeds_limit",
@@ -217,6 +228,11 @@ def _compute_paper_trade_id(signal_id: str) -> str:
 def _compute_paper_position_id(signal_id: str) -> str:
     """Compute a deterministic paper position ID from a signal ID."""
     return f"pos_{sha256_hex(canonical_json({'scope': 'paper_entry', 'signal_id': signal_id}))}"
+
+
+def _compute_paper_exit_order_id(signal_id: str) -> str:
+    """Compute a deterministic paper exit order ID from a signal ID."""
+    return f"ord_{sha256_hex(canonical_json({'scope': 'paper_exit', 'signal_id': signal_id}))}"
 
 
 # ---------------------------------------------------------------------------
@@ -425,16 +441,101 @@ def _derive_trade_risk_pct_from_stop_loss(
     return None, derived, None
 
 
+def _derive_trade_risk_pct_from_atr(
+    signal: Signal,
+    *,
+    entry_price: Decimal,
+    atr_multiple: Decimal,
+) -> tuple[OutcomeCode | None, Decimal | None, str | None]:
+    """Derive trade_risk_pct from the signal's ATR field.
+
+    Converts ATR * multiple to a fractional risk-per-unit relative to entry:
+    ``trade_risk_pct = (atr * atr_multiple) / entry_price``
+
+    This is equivalent to using ATR-scaled stop distance as the risk denominator,
+    which normalises position sizes across symbols with different volatility.
+    """
+    raw_atr = signal.get("atr")
+    if raw_atr is None:
+        return (
+            "reject:atr_not_provided",
+            None,
+            "sizing_method='atr' requires signal.atr to be set",
+        )
+    try:
+        atr = Decimal(str(raw_atr))
+    except Exception:
+        return (
+            "reject:invalid_trade_risk_input",
+            None,
+            f"atr is not numeric: {raw_atr!r}",
+        )
+    if not atr.is_finite() or atr <= Decimal("0"):
+        return (
+            "reject:invalid_trade_risk_input",
+            None,
+            f"atr must be finite and > 0, got {atr}",
+        )
+    if entry_price <= Decimal("0"):
+        return (
+            "reject:invalid_trade_risk_input",
+            None,
+            f"entry_price must be > 0, got {entry_price}",
+        )
+    with localcontext() as ctx:
+        ctx.prec = 28
+        ctx.rounding = ROUND_HALF_UP
+        risk_per_unit = atr * atr_multiple
+        derived = risk_per_unit / entry_price
+    if derived <= Decimal("0"):
+        return (
+            "reject:invalid_trade_risk_input",
+            None,
+            f"atr-derived trade_risk_pct must be > 0, got {derived}",
+        )
+    return None, derived, None
+
+
 def _resolve_trade_risk_pct(
     signal: Signal,
     *,
     entry_price: Decimal,
+    sizing_method: str = "stop_distance",
+    atr_multiple: Decimal = Decimal("2.0"),
 ) -> tuple[OutcomeCode | None, Decimal | None, str | None]:
+    if sizing_method == "atr":
+        return _derive_trade_risk_pct_from_atr(
+            signal, entry_price=entry_price, atr_multiple=atr_multiple
+        )
+
+    if sizing_method == "fixed":
+        # Use trade_risk_pct directly from the signal — no derivation.
+        raw_trade_risk_pct = signal.get("trade_risk_pct")
+        if raw_trade_risk_pct is None:
+            return (
+                "reject:missing_trade_risk_input",
+                None,
+                "sizing_method='fixed' requires signal.trade_risk_pct to be set",
+            )
+        try:
+            trade_risk_pct = Decimal(str(raw_trade_risk_pct))
+        except Exception:
+            return (
+                "reject:invalid_trade_risk_input",
+                None,
+                f"trade_risk_pct is not numeric: {raw_trade_risk_pct!r}",
+            )
+        if not trade_risk_pct.is_finite() or trade_risk_pct <= Decimal("0"):
+            return (
+                "reject:invalid_trade_risk_input",
+                None,
+                f"trade_risk_pct must be finite and > 0, got {trade_risk_pct}",
+            )
+        return None, trade_risk_pct, None
+
+    # Default: "stop_distance" — prefer explicit trade_risk_pct, fall back to stop_loss.
     raw_trade_risk_pct = signal.get("trade_risk_pct")
     if raw_trade_risk_pct is None:
-        # Fall back to deriving from stop_loss distance — this is the
-        # canonical "1% rule" sizing input that strategies populate via
-        # the Signal.stop_loss field.
         derived_outcome, derived_pct, derived_reason = (
             _derive_trade_risk_pct_from_stop_loss(signal, entry_price=entry_price)
         )
@@ -495,6 +596,50 @@ def _build_decision_inputs_payload(
     }
 
 
+def _compute_drawdown_state(
+    closed_trades: list[Trade],
+    *,
+    initial_equity: Decimal,
+) -> tuple[int, Decimal]:
+    """Return (consecutive_losses, current_drawdown_pct) from closed trade history.
+
+    consecutive_losses: how many of the most recent closed trades are losses
+    current_drawdown_pct: (equity_peak - current_equity) / equity_peak
+    """
+    if not closed_trades:
+        return 0, Decimal("0")
+
+    sorted_trades = sorted(closed_trades, key=lambda t: t.closed_at or "")
+
+    running_pnl = Decimal("0")
+    peak_equity = initial_equity
+    for t in sorted_trades:
+        pnl = t.realized_pnl or Decimal("0")
+        running_pnl += pnl
+        current = initial_equity + running_pnl
+        if current > peak_equity:
+            peak_equity = current
+
+    current_equity = initial_equity + running_pnl
+    if peak_equity <= Decimal("0"):
+        drawdown_pct = Decimal("0")
+    else:
+        with localcontext() as ctx:
+            ctx.prec = 28
+            ctx.rounding = ROUND_HALF_UP
+            drawdown_pct = (peak_equity - current_equity) / peak_equity
+
+    consecutive_losses = 0
+    for t in reversed(sorted_trades):
+        pnl = t.realized_pnl or Decimal("0")
+        if pnl < Decimal("0"):
+            consecutive_losses += 1
+        else:
+            break
+
+    return consecutive_losses, drawdown_pct
+
+
 # ---------------------------------------------------------------------------
 # Worker
 # ---------------------------------------------------------------------------
@@ -503,9 +648,9 @@ def _build_decision_inputs_payload(
 class BoundedPaperExecutionWorker:
     """Deterministic worker: converts eligible signals into bounded paper execution state.
 
-    Each call to ``process_signal`` applies the ordered 5-step evaluation
-    policy defined in ``signal_to_paper_execution_policy.md`` and returns an
-    explicit ``SignalEvaluationResult``.
+    Each call to ``process_signal`` applies the ordered evaluation policy
+    defined in ``signal_to_paper_execution_policy.md`` and returns an explicit
+    ``SignalEvaluationResult``.
 
     When a signal is eligible all canonical paper entities (Order,
     ExecutionEvents, Trade) are created deterministically and persisted to the
@@ -535,6 +680,7 @@ class BoundedPaperExecutionWorker:
         signal: Signal,
         *,
         entry_bar: EntryBar | None = None,
+        price_history: PriceHistory | None = None,
     ) -> SignalEvaluationResult:
         """Evaluate and process a single signal against the bounded policy.
 
@@ -546,14 +692,184 @@ class BoundedPaperExecutionWorker:
         on the signal, the worker rejects fills whose next bar gapped past
         the zone (``skip:entry_zone_not_reached``). Callers without bar
         context behave as before.
+
+        ``price_history`` is optional. When provided and
+        ``risk_profile.correlation_check_enabled`` is True, the worker
+        evaluates pairwise correlation against open positions and blocks
+        entries that would exceed ``max_correlated_pairs``.
         """
-        result = self._evaluate(signal, entry_bar=entry_bar)
+        result = self._evaluate(signal, entry_bar=entry_bar, price_history=price_history)
         if result.outcome == "eligible":
             result = self._persist_paper_entry(
                 signal,
                 decision_inputs=result.decision_inputs,
             )
         return result
+
+    def process_exit_signal(
+        self,
+        signal: Signal,
+    ) -> SignalEvaluationResult:
+        """Execute a full or partial position exit for a matching open trade.
+
+        Uses ``signal.exit_pct`` (fraction of remaining quantity to close,
+        default 1.0 = full exit). The exit fill price has slippage applied
+        inverse to the entry direction (long exits receive slightly below
+        reference; short exits pay slightly above).
+
+        Returns ``"eligible:partial_exit"`` when the position remains open
+        after the exit, or ``"eligible:full_exit"`` when fully closed.
+        """
+        field_error = _validate_signal_fields(signal)
+        if field_error is not None:
+            return SignalEvaluationResult(
+                outcome="reject:invalid_signal_fields",
+                reason=field_error,
+            )
+
+        symbol: str = signal["symbol"]  # type: ignore[assignment]
+        strategy: str = signal["strategy"]  # type: ignore[assignment]
+        direction: str = signal["direction"]  # type: ignore[assignment]
+        occurred_at: str = signal["timestamp"]  # type: ignore[assignment]
+
+        trades = self._repo.list_trades(strategy_id=strategy, symbol=symbol, limit=100)
+        open_trades = [t for t in trades if t.status == "open" and t.direction == direction]
+
+        if not open_trades:
+            return SignalEvaluationResult(
+                outcome="skip:no_open_position_to_exit",
+                reason=f"no open position for ({symbol}, {strategy}, {direction})",
+            )
+
+        trade = open_trades[0]
+        remaining_qty = trade.quantity_opened - trade.quantity_closed
+
+        raw_exit_pct = signal.get("exit_pct")
+        if raw_exit_pct is not None:
+            with localcontext() as ctx:
+                ctx.prec = 28
+                ctx.rounding = ROUND_HALF_UP
+                exit_pct = Decimal(str(raw_exit_pct))
+                exit_qty = (remaining_qty * exit_pct).quantize(Decimal("0.00000001"))
+        else:
+            exit_qty = remaining_qty
+
+        exit_qty = min(exit_qty, remaining_qty)
+        if exit_qty <= Decimal("0"):
+            return SignalEvaluationResult(
+                outcome="skip:exit_quantity_zero",
+                reason=f"exit_qty={exit_qty} after applying exit_pct={raw_exit_pct}",
+            )
+
+        # Exit fill: inverse slippage direction (long exit = short side slippage)
+        ref_price = _extract_entry_price(
+            signal,
+            fallback_entry_price=trade.average_entry_price or self._risk_profile.default_paper_entry_price,
+        )
+        exit_slippage_direction = "short" if direction == "long" else "long"
+        fill_price = _apply_slippage(
+            reference_price=ref_price,
+            direction=exit_slippage_direction,
+            slippage_rate=self._risk_profile.slippage_rate,
+        )
+        commission = _compute_commission(
+            quantity=exit_qty,
+            fill_price=fill_price,
+            commission_rate=self._risk_profile.commission_rate,
+        )
+
+        entry_price = trade.average_entry_price or Decimal("0")
+        with localcontext() as ctx:
+            ctx.prec = 28
+            ctx.rounding = ROUND_HALF_UP
+            if direction == "long":
+                partial_pnl = exit_qty * (fill_price - entry_price) - commission
+            else:
+                partial_pnl = exit_qty * (entry_price - fill_price) - commission
+
+            new_qty_closed = trade.quantity_closed + exit_qty
+
+            prior_exit_notional = (trade.average_exit_price or Decimal("0")) * trade.quantity_closed
+            new_exit_notional = prior_exit_notional + fill_price * exit_qty
+            new_avg_exit_price = new_exit_notional / new_qty_closed
+
+        new_realized_pnl = (trade.realized_pnl or Decimal("0")) + partial_pnl
+        is_full_exit = new_qty_closed >= trade.quantity_opened
+
+        remaining_qty = trade.quantity_opened - new_qty_closed
+        entry_px = trade.average_entry_price or Decimal("0")
+        new_exposure = remaining_qty * entry_px
+
+        trade_data: dict = {
+            **trade.model_dump(mode="python"),
+            "quantity_closed": new_qty_closed,
+            "average_exit_price": new_avg_exit_price,
+            "realized_pnl": new_realized_pnl,
+            "exposure_notional": new_exposure,
+        }
+        if is_full_exit:
+            trade_data["status"] = "closed"
+            trade_data["closed_at"] = occurred_at
+
+        updated_trade = Trade.model_validate(trade_data)
+
+        # Exit order and execution event
+        signal_id = _resolve_signal_id(signal)
+        exit_order_id = _compute_paper_exit_order_id(signal_id)
+        exit_event_id = compute_execution_event_id(
+            order_id=exit_order_id,
+            event_type="filled",
+            occurred_at=occurred_at,
+            sequence=1,
+        )
+        exit_side = "SELL" if direction == "long" else "BUY"
+        exit_order = Order.model_validate(
+            {
+                "order_id": exit_order_id,
+                "strategy_id": strategy,
+                "symbol": symbol,
+                "sequence": 1,
+                "side": exit_side,
+                "order_type": "market",
+                "time_in_force": "day",
+                "status": "filled",
+                "quantity": exit_qty,
+                "filled_quantity": exit_qty,
+                "created_at": occurred_at,
+                "submitted_at": occurred_at,
+                "average_fill_price": fill_price,
+                "last_execution_event_id": exit_event_id,
+                "position_id": trade.position_id,
+                "trade_id": trade.trade_id,
+            }
+        )
+        exit_event = ExecutionEvent.model_validate(
+            {
+                "event_id": exit_event_id,
+                "order_id": exit_order_id,
+                "strategy_id": strategy,
+                "symbol": symbol,
+                "side": exit_side,
+                "event_type": "filled",
+                "occurred_at": occurred_at,
+                "sequence": 1,
+                "execution_quantity": exit_qty,
+                "execution_price": fill_price,
+                "commission": commission,
+                "position_id": trade.position_id,
+                "trade_id": trade.trade_id,
+            }
+        )
+
+        self._repo.save_order(exit_order)
+        self._repo.save_execution_events([exit_event])
+        self._repo.save_trade(updated_trade)
+
+        return SignalEvaluationResult(
+            outcome="eligible:full_exit" if is_full_exit else "eligible:partial_exit",
+            signal_id=signal_id,
+            trade_id=trade.trade_id,
+        )
 
     def process_batch(
         self,
@@ -587,6 +903,10 @@ class BoundedPaperExecutionWorker:
                 self._risk_profile.max_strategy_exposure_pct
             ),
             max_symbol_exposure_pct=float(self._risk_profile.max_symbol_exposure_pct),
+            correlation_threshold=self._risk_profile.correlation_threshold,
+            max_correlated_pairs=self._risk_profile.max_correlated_pairs,
+            correlation_check_enabled=self._risk_profile.correlation_check_enabled,
+            correlation_window=self._risk_profile.correlation_window,
         )
 
     def _compute_trade_sizing_for_signal(
@@ -598,6 +918,8 @@ class BoundedPaperExecutionWorker:
         rejection_outcome, trade_risk_pct, rejection_reason = _resolve_trade_risk_pct(
             signal,
             entry_price=entry_price,
+            sizing_method=self._risk_profile.sizing_method,
+            atr_multiple=self._risk_profile.atr_multiple,
         )
         if rejection_outcome is not None or trade_risk_pct is None:
             return (
@@ -652,8 +974,9 @@ class BoundedPaperExecutionWorker:
         signal: Signal,
         *,
         entry_bar: EntryBar | None = None,
+        price_history: PriceHistory | None = None,
     ) -> SignalEvaluationResult:
-        """Apply the 5-step ordered policy evaluation.
+        """Apply the ordered policy evaluation.
 
         Steps:
             1. Eligibility check (required fields)
@@ -661,7 +984,10 @@ class BoundedPaperExecutionWorker:
             3. Duplicate-entry check
             4. Cooldown check
             5. Entry-bar fill check (if entry_bar provided)
-            6. Exposure and position-limit checks
+            6. Drawdown guard (if drawdown_guard_enabled)
+            7. Trade sizing
+            8. Exposure and position-limit checks
+            9. Correlation risk check (if price_history provided and correlation_check_enabled)
         """
         # Step 1: eligibility — required signal fields
         field_error = _validate_signal_fields(signal)
@@ -686,9 +1012,6 @@ class BoundedPaperExecutionWorker:
             )
 
         # Load canonical state for this (symbol, strategy) pair.
-        # The limit of 1000 is sufficient for bounded paper simulation;
-        # a paper session with more than 1000 trades per pair is outside
-        # the supported bounded scope.
         symbol_strategy_trades = self._repo.list_trades(
             strategy_id=strategy,
             symbol=symbol,
@@ -706,7 +1029,7 @@ class BoundedPaperExecutionWorker:
                     ),
                 )
 
-        # Step 4: cooldown — min 24h since last accepted entry for (symbol, strategy)
+        # Step 4: cooldown — min N hours since last accepted entry for (symbol, strategy)
         if symbol_strategy_trades:
             most_recent_opened_at = max(t.opened_at for t in symbol_strategy_trades)
             signal_ts = _parse_timestamp(signal["timestamp"])  # type: ignore[arg-type]
@@ -743,7 +1066,30 @@ class BoundedPaperExecutionWorker:
                     ),
                 )
 
-        # Step 6: exposure and position-limit checks
+        # Step 6: drawdown guard — block new entries during losing streaks / drawdown periods.
+        if self._risk_profile.drawdown_guard_enabled:
+            all_closed = [t for t in self._repo.list_trades(limit=5000) if t.status == "closed"]
+            consecutive_losses, drawdown_pct = _compute_drawdown_state(
+                all_closed, initial_equity=self._risk_profile.account_equity
+            )
+            if consecutive_losses >= self._risk_profile.max_consecutive_losses:
+                return SignalEvaluationResult(
+                    outcome="skip:drawdown_guard_active",
+                    reason=(
+                        f"drawdown_guard: consecutive_losses={consecutive_losses} >= "
+                        f"max_consecutive_losses={self._risk_profile.max_consecutive_losses}"
+                    ),
+                )
+            if drawdown_pct >= self._risk_profile.max_drawdown_pct:
+                return SignalEvaluationResult(
+                    outcome="skip:drawdown_guard_active",
+                    reason=(
+                        f"drawdown_guard: drawdown_pct={drawdown_pct:.4f} >= "
+                        f"max_drawdown_pct={self._risk_profile.max_drawdown_pct}"
+                    ),
+                )
+
+        # Step 7: trade sizing
         entry_price = _extract_entry_price(
             signal,
             fallback_entry_price=self._risk_profile.default_paper_entry_price,
@@ -758,14 +1104,10 @@ class BoundedPaperExecutionWorker:
                 reason="trade sizing failed",
             )
 
-        # Load all open trades for canonical exposure/concurrent-position checks.
-        # The limit of 1000 reflects the bounded paper simulation scope
-        # (max_concurrent_positions=10 by default; even large sessions remain
-        # well within this bound).
+        # Step 8: exposure and position-limit checks.
         all_trades = self._repo.list_trades(limit=1000)
         all_open_trades = [t for t in all_trades if t.status == "open"]
 
-        # Concurrent position limit
         if len(all_open_trades) >= self._risk_profile.max_concurrent_positions:
             return SignalEvaluationResult(
                 outcome="reject:concurrent_position_limit_exceeded",
@@ -810,6 +1152,22 @@ class BoundedPaperExecutionWorker:
                 reason=normalized_reason,
                 decision_inputs=decision_inputs,
             )
+
+        # Step 9: correlation risk — only when price history is supplied and the gate is enabled.
+        if price_history is not None and self._risk_profile.correlation_check_enabled:
+            open_symbols = [t.symbol for t in all_open_trades]
+            corr_check = evaluate_correlation_risk(
+                proposed_symbol=symbol,
+                open_position_symbols=open_symbols,
+                price_history=price_history,
+                limits=self._risk_limits,
+            )
+            if corr_check.rejection_reason is not None:
+                return SignalEvaluationResult(
+                    outcome="skip:correlation_risk_blocked",
+                    reason=corr_check.rejection_reason,
+                    decision_inputs=decision_inputs,
+                )
 
         return SignalEvaluationResult(outcome="eligible", decision_inputs=decision_inputs)
 
@@ -1006,7 +1364,9 @@ __all__ = [
     "DEFAULT_PAPER_ENTRY_PRICE",
     "EntryBar",
     "PaperExecutionRiskProfile",
+    "PriceHistory",
     "bar_intersects_entry_zone",
     "stop_loss_breached",
     "_direction_to_order_side",
+    "_compute_drawdown_state",
 ]

--- a/src/cilly_trading/models.py
+++ b/src/cilly_trading/models.py
@@ -181,6 +181,9 @@ class Signal(TypedDict, total=False):
     score: NotRequired[float]
     entry_zone: NotRequired[Optional[EntryZone]]
     stop_loss: NotRequired[Optional[float]]
+    trade_risk_pct: NotRequired[Optional[float]]
+    atr: NotRequired[Optional[float]]
+    exit_pct: NotRequired[Optional[float]]
     confirmation_rule: NotRequired[str]
     reasons: NotRequired[Optional[List[SignalReason]]]
 

--- a/tests/engine/test_paper_execution_worker.py
+++ b/tests/engine/test_paper_execution_worker.py
@@ -1143,3 +1143,671 @@ def test_stop_loss_helper_rejects_unknown_direction() -> None:
             bar_low=Decimal("99"),
             bar_high=Decimal("101"),
         )
+
+
+# ---------------------------------------------------------------------------
+# #1147: ATR-based position sizing
+# ---------------------------------------------------------------------------
+
+
+def _atr_profile(**kwargs) -> PaperExecutionRiskProfile:
+    return PaperExecutionRiskProfile(
+        account_equity=Decimal("100000"),
+        max_risk_per_trade_pct=Decimal("0.01"),
+        min_trade_risk_pct=Decimal("0.005"),
+        max_trade_risk_pct=Decimal("0.50"),
+        max_total_exposure_pct=Decimal("1.00"),
+        max_strategy_exposure_pct=Decimal("1.00"),
+        max_symbol_exposure_pct=Decimal("1.00"),
+        max_concurrent_positions=20,
+        commission_rate=Decimal("0"),
+        slippage_rate=Decimal("0"),
+        cooldown_hours=0,
+        **kwargs,
+    )
+
+
+def test_atr_sizing_produces_notional_proportional_to_risk_budget(
+    tmp_path: Path,
+) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "atr1.db")
+    profile = _atr_profile(sizing_method="atr", atr_multiple=Decimal("2.0"))
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "atr": 2.0,
+        "entry_zone": {"from_": 100.0, "to": 100.0},
+    }
+    result = worker.process_signal(signal)
+    assert result.outcome == "eligible"
+    # ATR-derived risk_pct = (2.0 * 2.0) / 100.0 = 0.04
+    # proposed_notional = equity * max_risk_pct / trade_risk_pct = 100000 * 0.01 / 0.04 = 25000
+    assert result.decision_inputs is not None
+    assert Decimal(result.decision_inputs["trade_risk_pct"]) == Decimal("0.04")
+
+
+def test_atr_sizing_rejected_when_atr_not_provided(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "atr2.db")
+    profile = _atr_profile(sizing_method="atr")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        # no atr field
+    }
+    result = worker.process_signal(signal)
+    assert result.outcome == "reject:atr_not_provided"
+
+
+def test_fixed_sizing_uses_explicit_trade_risk_pct(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "fixed1.db")
+    profile = _atr_profile(sizing_method="fixed")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+    }
+    result = worker.process_signal(signal)
+    assert result.outcome == "eligible"
+    assert result.decision_inputs is not None
+    assert Decimal(result.decision_inputs["trade_risk_pct"]) == Decimal("0.05")
+
+
+def test_fixed_sizing_rejected_when_trade_risk_pct_missing(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "fixed2.db")
+    profile = _atr_profile(sizing_method="fixed")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        # no trade_risk_pct
+    }
+    result = worker.process_signal(signal)
+    assert result.outcome == "reject:missing_trade_risk_input"
+
+
+def test_atr_multiple_scales_position_size(tmp_path: Path) -> None:
+    """Higher atr_multiple → larger stop distance → smaller position size."""
+    def _notional(atr_multiple: str) -> Decimal:
+        repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / f"atrm_{atr_multiple}.db")
+        profile = _atr_profile(sizing_method="atr", atr_multiple=Decimal(atr_multiple))
+        worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+        sig: Signal = {
+            "symbol": "AAPL",
+            "strategy": "s",
+            "direction": "long",  # type: ignore[typeddict-item]
+            "score": 80.0,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "stage": "setup",  # type: ignore[typeddict-item]
+            "atr": 1.0,
+            "entry_zone": {"from_": 100.0, "to": 100.0},
+        }
+        result = worker.process_signal(sig)
+        assert result.decision_inputs is not None
+        return Decimal(result.decision_inputs["proposed_position_notional"])
+
+    notional_2x = _notional("2.0")
+    notional_4x = _notional("4.0")
+    assert notional_4x < notional_2x
+
+
+# ---------------------------------------------------------------------------
+# #1145: Correlation risk gate
+# ---------------------------------------------------------------------------
+
+
+def _corr_profile(**kwargs) -> PaperExecutionRiskProfile:
+    return PaperExecutionRiskProfile(
+        account_equity=Decimal("100000"),
+        max_risk_per_trade_pct=Decimal("0.01"),
+        min_trade_risk_pct=Decimal("0.005"),
+        max_trade_risk_pct=Decimal("0.50"),
+        max_total_exposure_pct=Decimal("1.00"),
+        max_strategy_exposure_pct=Decimal("1.00"),
+        max_symbol_exposure_pct=Decimal("1.00"),
+        max_concurrent_positions=20,
+        commission_rate=Decimal("0"),
+        slippage_rate=Decimal("0"),
+        cooldown_hours=0,
+        **kwargs,
+    )
+
+
+def _price_history_perfectly_correlated() -> dict[str, list[float]]:
+    base = [float(i) for i in range(1, 61)]
+    return {"AAPL": base, "MSFT": base}
+
+
+def test_correlation_gate_blocks_entry_when_highly_correlated(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "corr1.db")
+    profile = _corr_profile(
+        correlation_check_enabled=True,
+        correlation_threshold=0.7,
+        max_correlated_pairs=0,  # block any correlated pair
+        sizing_method="fixed",
+    )
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    # Open an AAPL position first
+    aapl: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-corr-aapl",
+    }
+    first = worker.process_signal(aapl)
+    assert first.outcome == "eligible"
+
+    # Now try MSFT — perfectly correlated with AAPL
+    msft: Signal = {
+        "symbol": "MSFT",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-corr-msft",
+    }
+    blocked = worker.process_signal(msft, price_history=_price_history_perfectly_correlated())
+    assert blocked.outcome == "skip:correlation_risk_blocked"
+    assert blocked.reason is not None
+
+
+def test_correlation_gate_skipped_when_disabled(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "corr2.db")
+    profile = _corr_profile(
+        correlation_check_enabled=False,
+        sizing_method="fixed",
+    )
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    aapl: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-nc-aapl",
+    }
+    worker.process_signal(aapl)
+
+    msft: Signal = {
+        "symbol": "MSFT",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-nc-msft",
+    }
+    result = worker.process_signal(msft, price_history=_price_history_perfectly_correlated())
+    assert result.outcome == "eligible"
+
+
+def test_correlation_gate_passes_without_price_history(tmp_path: Path) -> None:
+    """When price_history is None, correlation check is silently skipped."""
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "corr3.db")
+    profile = _corr_profile(
+        correlation_check_enabled=True,
+        max_correlated_pairs=0,
+        sizing_method="fixed",
+    )
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    aapl: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-noph-aapl",
+    }
+    worker.process_signal(aapl)
+
+    msft: Signal = {
+        "symbol": "MSFT",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-noph-msft",
+    }
+    result = worker.process_signal(msft, price_history=None)
+    assert result.outcome == "eligible"
+
+
+# ---------------------------------------------------------------------------
+# #1146: Drawdown guard
+# ---------------------------------------------------------------------------
+
+
+def _drawdown_profile(**kwargs) -> PaperExecutionRiskProfile:
+    return PaperExecutionRiskProfile(
+        account_equity=Decimal("100000"),
+        max_risk_per_trade_pct=Decimal("0.01"),
+        min_trade_risk_pct=Decimal("0.005"),
+        max_trade_risk_pct=Decimal("0.50"),
+        max_total_exposure_pct=Decimal("1.00"),
+        max_strategy_exposure_pct=Decimal("1.00"),
+        max_symbol_exposure_pct=Decimal("1.00"),
+        max_concurrent_positions=20,
+        commission_rate=Decimal("0"),
+        slippage_rate=Decimal("0"),
+        cooldown_hours=0,
+        **kwargs,
+    )
+
+
+def test_compute_drawdown_state_no_trades() -> None:
+    from cilly_trading.engine.paper_execution_worker import _compute_drawdown_state
+
+    losses, dd = _compute_drawdown_state([], initial_equity=Decimal("100000"))
+    assert losses == 0
+    assert dd == Decimal("0")
+
+
+def test_compute_drawdown_state_consecutive_losses_counted_from_most_recent() -> None:
+    from cilly_trading.engine.paper_execution_worker import _compute_drawdown_state
+    from cilly_trading.models import Trade
+
+    # qty=100 units @ entry 100; exit prices chosen so realized_pnl matches
+    def _closed_trade(trade_id: str, exit_price: str, pnl: Decimal, closed_at: str) -> Trade:
+        return Trade.model_validate(
+            {
+                "trade_id": trade_id,
+                "position_id": f"pos-{trade_id}",
+                "strategy_id": "s",
+                "symbol": "AAPL",
+                "direction": "long",
+                "status": "closed",
+                "opened_at": "2026-01-01T00:00:00Z",
+                "closed_at": closed_at,
+                "quantity_opened": Decimal("100"),
+                "quantity_closed": Decimal("100"),
+                "average_entry_price": Decimal("100"),
+                "average_exit_price": Decimal(exit_price),
+                "exposure_notional": Decimal("0"),  # fully closed — no remaining exposure
+                "realized_pnl": pnl,
+                "opening_order_ids": [],
+                "execution_event_ids": [],
+            }
+        )
+
+    trades = [
+        _closed_trade("t1", "105", Decimal("500"), "2026-01-01T00:00:00Z"),   # win  (100 * 5 = 500)
+        _closed_trade("t2", "98", Decimal("-200"), "2026-01-02T00:00:00Z"),   # loss (100 * -2 = -200)
+        _closed_trade("t3", "97", Decimal("-300"), "2026-01-03T00:00:00Z"),   # loss (100 * -3 = -300)
+    ]
+    losses, dd = _compute_drawdown_state(trades, initial_equity=Decimal("100000"))
+    assert losses == 2
+    # peak was after t1: 100500; current is 100000; drawdown = 500/100500
+    assert dd > Decimal("0")
+
+
+def test_drawdown_guard_blocks_entry_after_consecutive_losses(tmp_path: Path) -> None:
+    from cilly_trading.models import Trade
+
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "dg1.db")
+    profile = _drawdown_profile(
+        drawdown_guard_enabled=True,
+        max_consecutive_losses=2,
+        max_drawdown_pct=Decimal("0.50"),
+        sizing_method="fixed",
+    )
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    # Inject 2 closed losing trades directly into the repo
+    for i in range(2):
+        repo.save_trade(Trade.model_validate(
+            {
+                "trade_id": f"loss-{i}",
+                "position_id": f"pos-loss-{i}",
+                "strategy_id": "s",
+                "symbol": "AAPL",
+                "direction": "long",
+                "status": "closed",
+                "opened_at": f"2026-01-0{i+1}T00:00:00Z",
+                "closed_at": f"2026-01-0{i+1}T12:00:00Z",
+                "quantity_opened": Decimal("1"),
+                "quantity_closed": Decimal("1"),
+                "average_entry_price": Decimal("100"),
+                "average_exit_price": Decimal("90"),
+                "exposure_notional": Decimal("0"),
+                "realized_pnl": Decimal("-10"),
+                "opening_order_ids": [],
+                "execution_event_ids": [],
+            }
+        ))
+
+    result = worker.process_signal({
+        "symbol": "MSFT",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-10T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-dg-block",
+    })
+    assert result.outcome == "skip:drawdown_guard_active"
+    assert "consecutive_losses" in (result.reason or "")
+
+
+def test_drawdown_guard_disabled_does_not_block(tmp_path: Path) -> None:
+    from cilly_trading.models import Trade
+
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "dg2.db")
+    profile = _drawdown_profile(
+        drawdown_guard_enabled=False,
+        max_consecutive_losses=1,
+        sizing_method="fixed",
+    )
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    repo.save_trade(Trade.model_validate(
+        {
+            "trade_id": "loss-x",
+            "position_id": "pos-loss-x",
+            "strategy_id": "s",
+            "symbol": "AAPL",
+            "direction": "long",
+            "status": "closed",
+            "opened_at": "2026-01-01T00:00:00Z",
+            "closed_at": "2026-01-01T12:00:00Z",
+            "quantity_opened": Decimal("1"),
+            "quantity_closed": Decimal("1"),
+            "average_entry_price": Decimal("100"),
+            "average_exit_price": Decimal("90"),
+            "exposure_notional": Decimal("0"),
+            "realized_pnl": Decimal("-10"),
+            "opening_order_ids": [],
+            "execution_event_ids": [],
+        }
+    ))
+
+    result = worker.process_signal({
+        "symbol": "MSFT",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-10T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-dg-nodisable",
+    })
+    assert result.outcome == "eligible"
+
+
+def test_drawdown_guard_blocks_on_equity_drawdown(tmp_path: Path) -> None:
+    from cilly_trading.models import Trade
+
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "dg3.db")
+    profile = _drawdown_profile(
+        drawdown_guard_enabled=True,
+        max_consecutive_losses=100,     # not triggered by streak
+        max_drawdown_pct=Decimal("0.05"),  # 5% drawdown limit
+        sizing_method="fixed",
+    )
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    # A single large win then a large loss to create >5% drawdown from peak
+    repo.save_trade(Trade.model_validate(
+        {
+            "trade_id": "win-dd",
+            "position_id": "pos-win-dd",
+            "strategy_id": "s",
+            "symbol": "AAPL",
+            "direction": "long",
+            "status": "closed",
+            "opened_at": "2026-01-01T00:00:00Z",
+            "closed_at": "2026-01-02T00:00:00Z",
+            "quantity_opened": Decimal("1"),
+            "quantity_closed": Decimal("1"),
+            "average_entry_price": Decimal("100"),
+            "average_exit_price": Decimal("200"),
+            "exposure_notional": Decimal("0"),
+            "realized_pnl": Decimal("10000"),  # equity peak = 110000
+            "opening_order_ids": [],
+            "execution_event_ids": [],
+        }
+    ))
+    repo.save_trade(Trade.model_validate(
+        {
+            "trade_id": "loss-dd",
+            "position_id": "pos-loss-dd",
+            "strategy_id": "s",
+            "symbol": "AAPL",
+            "direction": "long",
+            "status": "closed",
+            "opened_at": "2026-01-03T00:00:00Z",
+            "closed_at": "2026-01-04T00:00:00Z",
+            "quantity_opened": Decimal("1"),
+            "quantity_closed": Decimal("1"),
+            "average_entry_price": Decimal("100"),
+            "average_exit_price": Decimal("50"),
+            "exposure_notional": Decimal("0"),
+            "realized_pnl": Decimal("-7000"),  # current equity = 103000; dd = 7000/110000 ≈ 6.4%
+            "opening_order_ids": [],
+            "execution_event_ids": [],
+        }
+    ))
+
+    result = worker.process_signal({
+        "symbol": "MSFT",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-10T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "sig-dg-equity",
+    })
+    assert result.outcome == "skip:drawdown_guard_active"
+    assert "drawdown_pct" in (result.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# #1148: Partial take-profit (process_exit_signal)
+# ---------------------------------------------------------------------------
+
+
+def _exit_profile(**kwargs) -> PaperExecutionRiskProfile:
+    return PaperExecutionRiskProfile(
+        account_equity=Decimal("100000"),
+        max_risk_per_trade_pct=Decimal("0.01"),
+        min_trade_risk_pct=Decimal("0.005"),
+        max_trade_risk_pct=Decimal("0.50"),
+        max_total_exposure_pct=Decimal("1.00"),
+        max_strategy_exposure_pct=Decimal("1.00"),
+        max_symbol_exposure_pct=Decimal("1.00"),
+        max_concurrent_positions=20,
+        commission_rate=Decimal("0"),
+        slippage_rate=Decimal("0"),
+        cooldown_hours=0,
+        sizing_method="fixed",
+        **kwargs,
+    )
+
+
+def _entry_signal(signal_id: str, symbol: str = "AAPL") -> Signal:
+    return {
+        "symbol": symbol,
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "entry_zone": {"from_": 100.0, "to": 100.0},
+        "signal_id": signal_id,
+    }
+
+
+def test_process_exit_signal_full_exit_closes_trade(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "exit1.db")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=_exit_profile())
+
+    entry_result = worker.process_signal(_entry_signal("sig-exit-full"))
+    assert entry_result.outcome == "eligible"
+    assert entry_result.trade_id is not None
+
+    exit_sig: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T12:00:00Z",
+        "stage": "exit",  # type: ignore[typeddict-item]
+        "entry_zone": {"from_": 110.0, "to": 110.0},
+        "signal_id": "sig-exit-full-out",
+    }
+    result = worker.process_exit_signal(exit_sig)
+    assert result.outcome == "eligible:full_exit"
+    assert result.trade_id == entry_result.trade_id
+
+    trades = repo.list_trades(strategy_id="s", symbol="AAPL", limit=10)
+    closed = [t for t in trades if t.status == "closed"]
+    assert len(closed) == 1
+    assert closed[0].closed_at == "2026-01-02T12:00:00Z"
+    assert closed[0].realized_pnl is not None
+
+
+def test_process_exit_signal_partial_exit_leaves_trade_open(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "exit2.db")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=_exit_profile())
+
+    worker.process_signal(_entry_signal("sig-exit-partial"))
+
+    exit_sig: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T12:00:00Z",
+        "stage": "exit",  # type: ignore[typeddict-item]
+        "entry_zone": {"from_": 110.0, "to": 110.0},
+        "exit_pct": 0.5,
+        "signal_id": "sig-exit-partial-out",
+    }
+    result = worker.process_exit_signal(exit_sig)
+    assert result.outcome == "eligible:partial_exit"
+
+    trades = repo.list_trades(strategy_id="s", symbol="AAPL", limit=10)
+    open_trades = [t for t in trades if t.status == "open"]
+    assert len(open_trades) == 1
+    assert open_trades[0].quantity_closed > Decimal("0")
+    assert open_trades[0].quantity_closed < open_trades[0].quantity_opened
+
+
+def test_process_exit_signal_skipped_when_no_open_position(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "exit3.db")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=_exit_profile())
+
+    result = worker.process_exit_signal({
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T00:00:00Z",
+        "stage": "exit",  # type: ignore[typeddict-item]
+        "signal_id": "sig-exit-nopos",
+    })
+    assert result.outcome == "skip:no_open_position_to_exit"
+
+
+def test_process_exit_signal_partial_then_full_exit(tmp_path: Path) -> None:
+    """Two sequential exits: 50% then the remaining 100% close the trade."""
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "exit4.db")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=_exit_profile())
+
+    worker.process_signal(_entry_signal("sig-2step-entry"))
+
+    partial: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T00:00:00Z",
+        "stage": "exit",  # type: ignore[typeddict-item]
+        "entry_zone": {"from_": 110.0, "to": 110.0},
+        "exit_pct": 0.5,
+        "signal_id": "sig-2step-partial",
+    }
+    r1 = worker.process_exit_signal(partial)
+    assert r1.outcome == "eligible:partial_exit"
+
+    full: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-03T00:00:00Z",
+        "stage": "exit",  # type: ignore[typeddict-item]
+        "entry_zone": {"from_": 115.0, "to": 115.0},
+        "signal_id": "sig-2step-full",
+    }
+    r2 = worker.process_exit_signal(full)
+    assert r2.outcome == "eligible:full_exit"
+
+    trades = repo.list_trades(strategy_id="s", symbol="AAPL", limit=10)
+    closed = [t for t in trades if t.status == "closed"]
+    assert len(closed) == 1
+
+
+def test_process_exit_signal_realized_pnl_positive_on_profitable_exit(tmp_path: Path) -> None:
+    """Exit at a higher price than entry must produce positive realized_pnl."""
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "exit5.db")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=_exit_profile())
+
+    worker.process_signal(_entry_signal("sig-pnl-entry"))
+
+    result = worker.process_exit_signal({
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-02T00:00:00Z",
+        "stage": "exit",  # type: ignore[typeddict-item]
+        "entry_zone": {"from_": 120.0, "to": 120.0},  # exit at 120, entry was 100
+        "signal_id": "sig-pnl-exit",
+    })
+    assert result.outcome == "eligible:full_exit"
+
+    trades = repo.list_trades(strategy_id="s", symbol="AAPL", limit=10)
+    closed = [t for t in trades if t.status == "closed"]
+    assert len(closed) == 1
+    assert (closed[0].realized_pnl or Decimal("0")) > Decimal("0")


### PR DESCRIPTION
## Summary

Second batch of trader-perspective improvements (four P1-trading issues). These complete the volatility-awareness, portfolio-level risk, drawdown protection, and exit-management gaps in paper execution.

### #1147 — ATR-based position sizing
- New `sizing_method` field on `PaperExecutionRiskProfile`: `"stop_distance"` (default, preserves existing behaviour), `"atr"`, or `"fixed"`
- `Signal.atr` optional field; `sizing_method="atr"` converts `atr × atr_multiple` to a fractional `trade_risk_pct`, normalising position sizes across symbols with different volatility
- `sizing_method="fixed"` reads `signal.trade_risk_pct` directly, bypassing derivation
- `reject:atr_not_provided` outcome when `sizing_method="atr"` and `signal.atr` is absent

### #1145 — Correlation risk gate
- `price_history` optional parameter on `process_signal` (same opt-in pattern as `entry_bar`)
- `PaperExecutionRiskProfile` adds `correlation_check_enabled` (default `False`), `correlation_threshold`, `max_correlated_pairs`, `correlation_window`
- Wires the existing `evaluate_correlation_risk()` into `_evaluate()` as Step 9 — only executes when both `price_history` is provided and `correlation_check_enabled=True`
- `_build_risk_limits` propagates correlation params to `RiskLimits`
- `skip:correlation_risk_blocked` outcome when correlated pairs exceed the limit

### #1146 — Drawdown guard
- `PaperExecutionRiskProfile` adds `drawdown_guard_enabled` (default `False`), `max_consecutive_losses`, `max_drawdown_pct`
- `_compute_drawdown_state(closed_trades, initial_equity)` computes consecutive losing trades from most recent and current drawdown-from-equity-peak
- Blocks new entries as `skip:drawdown_guard_active` when either consecutive-loss streak or drawdown-pct limit is breached
- Disabled by default — opt-in via profile to avoid breaking existing callers

### #1148 — Partial take-profit
- `Signal.exit_pct` optional field (fraction of remaining position to close, `1.0` = full exit)
- `process_exit_signal(signal)` method: locates the open trade, applies inverse-direction slippage, updates `quantity_closed` / `average_exit_price` / `realized_pnl` / `exposure_notional`
- Returns `eligible:partial_exit` (trade remains open) or `eligible:full_exit` (trade closed with `closed_at` set)
- Sequential partial→full exit pattern supported; each step persists exit order + execution event
- `skip:no_open_position_to_exit` when no matching open trade exists

## Test plan

- [x] 327 tests pass across all engine test suites
- [x] ATR sizing: 5 tests covering proportional notional, missing-ATR rejection, fixed sizing, multiple scaling
- [x] Correlation gate: 3 tests — block on perfectly-correlated portfolio, pass when disabled, pass without price history
- [x] Drawdown guard: 4 tests — consecutive-loss count helper, consecutive-loss block, disabled guard, equity-drawdown block
- [x] Partial exits: 5 tests — full exit, 50 % partial, no-position skip, partial-then-full chain, profitable P&L

Closes #1145
Closes #1146
Closes #1147
Closes #1148

https://claude.ai/code/session_01JpFr8BS58w3bmDa2MswX6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpFr8BS58w3bmDa2MswX6f)_