### PR TITLE
P2-trading: performance metrics, attribution, and regime filter

### DIFF
--- a/src/cilly_trading/engine/paper_execution_risk_profile.py
+++ b/src/cilly_trading/engine/paper_execution_risk_profile.py
@@ -7,7 +7,7 @@ parameters from this profile.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from math import isfinite
 from typing import Any, Literal
@@ -84,6 +84,8 @@ class PaperExecutionRiskProfile:
     drawdown_guard_enabled: bool = False
     max_consecutive_losses: int = 3
     max_drawdown_pct: Decimal = Decimal("0.10")
+    # #1151 — regime filter (empty frozenset = allow all regimes)
+    allowed_regimes: frozenset[str] = field(default_factory=frozenset)
 
     def __post_init__(self) -> None:
         if self.contract_id != PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID:
@@ -166,6 +168,10 @@ class PaperExecutionRiskProfile:
         if self.max_consecutive_losses <= 0:
             raise ValueError("max_consecutive_losses must be > 0")
         _require_finite_pct(name="max_drawdown_pct", value=self.max_drawdown_pct)
+        from cilly_trading.engine.regime_classifier import _ALL_REGIME_LABELS
+        unknown = self.allowed_regimes - _ALL_REGIME_LABELS
+        if unknown:
+            raise ValueError(f"unknown regime labels in allowed_regimes: {sorted(unknown)}")
 
     def to_payload(self) -> dict[str, Any]:
         """Return a deterministic JSON-safe payload for evidence/logging."""
@@ -196,6 +202,7 @@ class PaperExecutionRiskProfile:
             "drawdown_guard_enabled": self.drawdown_guard_enabled,
             "max_consecutive_losses": self.max_consecutive_losses,
             "max_drawdown_pct": str(self.max_drawdown_pct),
+            "allowed_regimes": sorted(self.allowed_regimes),
         }
 
 
@@ -207,4 +214,5 @@ __all__ = [
     "PAPER_EXECUTION_RISK_PROFILE_CONTRACT_ID",
     "PaperExecutionRiskProfile",
     "SizingMethod",
+    "RegimeLabel",
 ]

--- a/src/cilly_trading/engine/paper_execution_worker.py
+++ b/src/cilly_trading/engine/paper_execution_worker.py
@@ -57,6 +57,13 @@ from cilly_trading.portfolio_framework.capital_allocation_policy import (
 )
 from cilly_trading.repositories import CanonicalExecutionRepository
 from cilly_trading.risk_framework.allocation_rules import RiskLimits
+from cilly_trading.engine.paper_performance import (
+    PaperPerformanceAttribution,
+    PaperPerformanceSummary,
+    compute_paper_performance_attribution,
+    compute_paper_performance_summary,
+)
+from cilly_trading.engine.regime_classifier import RegimeState
 from cilly_trading.risk_framework.correlation_risk import (
     PriceHistory,
     evaluate_correlation_risk,
@@ -140,6 +147,7 @@ OutcomeCode = Literal[
     "skip:entry_zone_not_reached",
     "skip:correlation_risk_blocked",
     "skip:drawdown_guard_active",
+    "skip:regime_filtered",
     "skip:no_open_position_to_exit",
     "skip:exit_quantity_zero",
     "reject:invalid_signal_fields",
@@ -681,6 +689,7 @@ class BoundedPaperExecutionWorker:
         *,
         entry_bar: EntryBar | None = None,
         price_history: PriceHistory | None = None,
+        regime_state: RegimeState | None = None,
     ) -> SignalEvaluationResult:
         """Evaluate and process a single signal against the bounded policy.
 
@@ -697,8 +706,12 @@ class BoundedPaperExecutionWorker:
         ``risk_profile.correlation_check_enabled`` is True, the worker
         evaluates pairwise correlation against open positions and blocks
         entries that would exceed ``max_correlated_pairs``.
+
+        ``regime_state`` is optional. When provided and
+        ``risk_profile.allowed_regimes`` is non-empty, the worker skips
+        entries whose regime label is not in the allowed set.
         """
-        result = self._evaluate(signal, entry_bar=entry_bar, price_history=price_history)
+        result = self._evaluate(signal, entry_bar=entry_bar, price_history=price_history, regime_state=regime_state)
         if result.outcome == "eligible":
             result = self._persist_paper_entry(
                 signal,
@@ -886,6 +899,18 @@ class BoundedPaperExecutionWorker:
         """Return the canonical validated risk profile used by this worker."""
         return self._risk_profile
 
+    def get_performance_summary(self) -> PaperPerformanceSummary:
+        """Compute performance metrics from all closed trades in the repository."""
+        trades = self._repo.list_trades(limit=10000)
+        return compute_paper_performance_summary(
+            trades, initial_equity=self._risk_profile.account_equity
+        )
+
+    def get_performance_attribution(self) -> PaperPerformanceAttribution:
+        """Compute per-strategy and per-symbol attribution from all closed trades."""
+        trades = self._repo.list_trades(limit=10000)
+        return compute_paper_performance_attribution(trades)
+
     def _build_risk_limits(self) -> RiskLimits:
         """Build deterministic risk-framework limits for paper execution."""
         with localcontext() as ctx:
@@ -975,6 +1000,7 @@ class BoundedPaperExecutionWorker:
         *,
         entry_bar: EntryBar | None = None,
         price_history: PriceHistory | None = None,
+        regime_state: RegimeState | None = None,
     ) -> SignalEvaluationResult:
         """Apply the ordered policy evaluation.
 
@@ -984,10 +1010,11 @@ class BoundedPaperExecutionWorker:
             3. Duplicate-entry check
             4. Cooldown check
             5. Entry-bar fill check (if entry_bar provided)
-            6. Drawdown guard (if drawdown_guard_enabled)
-            7. Trade sizing
-            8. Exposure and position-limit checks
-            9. Correlation risk check (if price_history provided and correlation_check_enabled)
+            6. Regime filter (if regime_state provided and allowed_regimes non-empty)
+            7. Drawdown guard (if drawdown_guard_enabled)
+            8. Trade sizing
+            9. Exposure and position-limit checks
+            10. Correlation risk check (if price_history provided and correlation_check_enabled)
         """
         # Step 1: eligibility — required signal fields
         field_error = _validate_signal_fields(signal)
@@ -1066,7 +1093,18 @@ class BoundedPaperExecutionWorker:
                     ),
                 )
 
-        # Step 6: drawdown guard — block new entries during losing streaks / drawdown periods.
+        # Step 6: regime filter — skip entries in disallowed market regimes.
+        if regime_state is not None and self._risk_profile.allowed_regimes:
+            if regime_state.label not in self._risk_profile.allowed_regimes:
+                return SignalEvaluationResult(
+                    outcome="skip:regime_filtered",
+                    reason=(
+                        f"regime={regime_state.label!r} not in "
+                        f"allowed_regimes={sorted(self._risk_profile.allowed_regimes)}"
+                    ),
+                )
+
+        # Step 7: drawdown guard — block new entries during losing streaks / drawdown periods.
         if self._risk_profile.drawdown_guard_enabled:
             all_closed = [t for t in self._repo.list_trades(limit=5000) if t.status == "closed"]
             consecutive_losses, drawdown_pct = _compute_drawdown_state(
@@ -1365,6 +1403,9 @@ __all__ = [
     "EntryBar",
     "PaperExecutionRiskProfile",
     "PriceHistory",
+    "RegimeState",
+    "PaperPerformanceSummary",
+    "PaperPerformanceAttribution",
     "bar_intersects_entry_zone",
     "stop_loss_breached",
     "_direction_to_order_side",

--- a/src/cilly_trading/engine/paper_performance.py
+++ b/src/cilly_trading/engine/paper_performance.py
@@ -1,0 +1,277 @@
+"""Paper-execution performance analytics (P2-trading #1149, #1150).
+
+All functions are pure: they operate on closed Trade records and return
+deterministic, frozen dataclasses.  No I/O, no side effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal, localcontext
+from typing import Sequence
+
+from cilly_trading.models import Trade
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sorted_closed(trades: Sequence[Trade]) -> list[Trade]:
+    return sorted(
+        (t for t in trades if t.status == "closed"),
+        key=lambda t: t.closed_at or "",
+    )
+
+
+def _is_win(trade: Trade) -> bool:
+    return (trade.realized_pnl or Decimal("0")) > Decimal("0")
+
+
+def _max_drawdown_pct(
+    closed: list[Trade],
+    *,
+    initial_equity: Decimal,
+) -> Decimal:
+    if not closed:
+        return Decimal("0")
+    running = Decimal("0")
+    peak = initial_equity
+    max_dd = Decimal("0")
+    with localcontext() as ctx:
+        ctx.prec = 28
+        ctx.rounding = ROUND_HALF_UP
+        for t in closed:
+            running += t.realized_pnl or Decimal("0")
+            current = initial_equity + running
+            if current > peak:
+                peak = current
+            if peak > Decimal("0"):
+                dd = (peak - current) / peak
+                if dd > max_dd:
+                    max_dd = dd
+    return max_dd
+
+
+def _bucket_metrics(
+    group: list[Trade],
+) -> tuple[int, Decimal, Decimal, Decimal]:
+    """Return (trade_count, win_rate, expectancy, net_pnl) for a group."""
+    if not group:
+        return 0, Decimal("0"), Decimal("0"), Decimal("0")
+    wins = [t for t in group if _is_win(t)]
+    losses = [t for t in group if not _is_win(t)]
+    win_rate = Decimal(len(wins)) / Decimal(len(group))
+    avg_win = (
+        sum((t.realized_pnl or Decimal("0")) for t in wins) / Decimal(len(wins))
+        if wins
+        else Decimal("0")
+    )
+    avg_loss = (
+        abs(sum((t.realized_pnl or Decimal("0")) for t in losses)) / Decimal(len(losses))
+        if losses
+        else Decimal("0")
+    )
+    with localcontext() as ctx:
+        ctx.prec = 28
+        ctx.rounding = ROUND_HALF_UP
+        loss_rate = Decimal("1") - win_rate
+        expectancy = (win_rate * avg_win) - (loss_rate * avg_loss)
+        net_pnl = sum((t.realized_pnl or Decimal("0")) for t in group)
+    return len(group), win_rate, expectancy, net_pnl
+
+
+# ---------------------------------------------------------------------------
+# #1149 — PaperPerformanceSummary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PaperPerformanceSummary:
+    """Trader-relevant performance metrics computed from closed trades.
+
+    All monetary values are in the account's quote currency.
+    ``max_drawdown_pct`` is peak-to-trough drawdown from the equity curve.
+    ``recovery_factor`` is ``net_pnl / (initial_equity * max_drawdown_pct)``;
+    values above 1.0 indicate the strategy earns back more than its worst
+    drawdown implies.
+    """
+
+    trade_count: int
+    win_count: int
+    loss_count: int
+    win_rate: Decimal
+    avg_win: Decimal
+    avg_loss: Decimal
+    expectancy: Decimal
+    profit_factor: Decimal
+    max_consecutive_wins: int
+    max_consecutive_losses: int
+    net_pnl: Decimal
+    gross_profit: Decimal
+    gross_loss: Decimal
+    max_drawdown_pct: Decimal
+    recovery_factor: Decimal
+
+
+def compute_paper_performance_summary(
+    trades: Sequence[Trade],
+    *,
+    initial_equity: Decimal = Decimal("100000"),
+) -> PaperPerformanceSummary:
+    """Compute performance metrics from a sequence of Trade records.
+
+    Only ``status="closed"`` trades with a non-None ``realized_pnl`` are
+    included.  Returns a zero-value summary when no closed trades exist.
+    """
+    closed = _sorted_closed(trades)
+    if not closed:
+        return PaperPerformanceSummary(
+            trade_count=0,
+            win_count=0,
+            loss_count=0,
+            win_rate=Decimal("0"),
+            avg_win=Decimal("0"),
+            avg_loss=Decimal("0"),
+            expectancy=Decimal("0"),
+            profit_factor=Decimal("0"),
+            max_consecutive_wins=0,
+            max_consecutive_losses=0,
+            net_pnl=Decimal("0"),
+            gross_profit=Decimal("0"),
+            gross_loss=Decimal("0"),
+            max_drawdown_pct=Decimal("0"),
+            recovery_factor=Decimal("0"),
+        )
+
+    wins = [t for t in closed if _is_win(t)]
+    losses = [t for t in closed if not _is_win(t)]
+
+    gross_profit = sum((t.realized_pnl or Decimal("0")) for t in wins)
+    gross_loss = abs(sum((t.realized_pnl or Decimal("0")) for t in losses))
+    net_pnl = gross_profit - gross_loss
+
+    with localcontext() as ctx:
+        ctx.prec = 28
+        ctx.rounding = ROUND_HALF_UP
+
+        win_rate = Decimal(len(wins)) / Decimal(len(closed))
+        avg_win = gross_profit / Decimal(len(wins)) if wins else Decimal("0")
+        avg_loss = gross_loss / Decimal(len(losses)) if losses else Decimal("0")
+        loss_rate = Decimal("1") - win_rate
+        expectancy = (win_rate * avg_win) - (loss_rate * avg_loss)
+        profit_factor = gross_profit / gross_loss if gross_loss > Decimal("0") else Decimal("0")
+
+    # Consecutive streaks
+    max_cons_wins = cur_wins = 0
+    max_cons_losses = cur_losses = 0
+    for t in closed:
+        if _is_win(t):
+            cur_wins += 1
+            cur_losses = 0
+        else:
+            cur_losses += 1
+            cur_wins = 0
+        max_cons_wins = max(max_cons_wins, cur_wins)
+        max_cons_losses = max(max_cons_losses, cur_losses)
+
+    max_dd = _max_drawdown_pct(closed, initial_equity=initial_equity)
+    with localcontext() as ctx:
+        ctx.prec = 28
+        ctx.rounding = ROUND_HALF_UP
+        drawdown_amount = initial_equity * max_dd
+        recovery_factor = (
+            net_pnl / drawdown_amount if drawdown_amount > Decimal("0") else Decimal("0")
+        )
+
+    return PaperPerformanceSummary(
+        trade_count=len(closed),
+        win_count=len(wins),
+        loss_count=len(losses),
+        win_rate=win_rate,
+        avg_win=avg_win,
+        avg_loss=avg_loss,
+        expectancy=expectancy,
+        profit_factor=profit_factor,
+        max_consecutive_wins=max_cons_wins,
+        max_consecutive_losses=max_cons_losses,
+        net_pnl=net_pnl,
+        gross_profit=gross_profit,
+        gross_loss=gross_loss,
+        max_drawdown_pct=max_dd,
+        recovery_factor=recovery_factor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1150 — PaperPerformanceAttribution
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AttributionBucket:
+    """Performance slice for a single grouping dimension."""
+
+    trade_count: int
+    win_rate: Decimal
+    expectancy: Decimal
+    net_pnl: Decimal
+
+
+@dataclass(frozen=True)
+class PaperPerformanceAttribution:
+    """Per-strategy and per-symbol breakdown of closed-trade performance.
+
+    ``by_strategy_symbol`` is keyed by ``(strategy_id, symbol)`` tuples.
+    All buckets with zero trades are omitted.
+    """
+
+    by_strategy: dict[str, AttributionBucket]
+    by_symbol: dict[str, AttributionBucket]
+    by_strategy_symbol: dict[tuple[str, str], AttributionBucket]
+
+
+def compute_paper_performance_attribution(
+    trades: Sequence[Trade],
+) -> PaperPerformanceAttribution:
+    """Compute attribution buckets from a sequence of Trade records.
+
+    Only ``status="closed"`` trades are included.
+    """
+    closed = _sorted_closed(trades)
+
+    strategy_groups: dict[str, list[Trade]] = {}
+    symbol_groups: dict[str, list[Trade]] = {}
+    pair_groups: dict[tuple[str, str], list[Trade]] = {}
+
+    for t in closed:
+        strat = t.strategy_id
+        sym = t.symbol
+        strategy_groups.setdefault(strat, []).append(t)
+        symbol_groups.setdefault(sym, []).append(t)
+        pair_groups.setdefault((strat, sym), []).append(t)
+
+    def _to_bucket(group: list[Trade]) -> AttributionBucket:
+        count, wr, exp, net = _bucket_metrics(group)
+        return AttributionBucket(
+            trade_count=count,
+            win_rate=wr,
+            expectancy=exp,
+            net_pnl=net,
+        )
+
+    return PaperPerformanceAttribution(
+        by_strategy={k: _to_bucket(v) for k, v in strategy_groups.items()},
+        by_symbol={k: _to_bucket(v) for k, v in symbol_groups.items()},
+        by_strategy_symbol={k: _to_bucket(v) for k, v in pair_groups.items()},
+    )
+
+
+__all__ = [
+    "AttributionBucket",
+    "PaperPerformanceAttribution",
+    "PaperPerformanceSummary",
+    "compute_paper_performance_attribution",
+    "compute_paper_performance_summary",
+]

--- a/src/cilly_trading/engine/regime_classifier.py
+++ b/src/cilly_trading/engine/regime_classifier.py
@@ -1,0 +1,177 @@
+"""Lightweight market regime classifier (P2-trading #1151).
+
+Classifies bar sequences into four regimes using Average Directional Index
+(ADX) for trend strength and realized volatility for vol state.  All
+functions are pure and side-effect-free.
+
+Regime labels:
+    trending_up    — ADX > threshold AND recent close above lookback close
+    trending_down  — ADX > threshold AND recent close below lookback close
+    volatile       — realized vol > high_vol_threshold (regardless of ADX)
+    ranging        — everything else
+
+Usage in paper execution:
+    PaperExecutionRiskProfile.allowed_regimes = frozenset({"trending_up"})
+    process_signal(signal, regime_state=classify_regime(bars))
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite, log, sqrt
+from typing import Literal, Sequence
+
+from cilly_trading.engine.marketdata.models.market_data_models import Bar
+
+
+RegimeLabel = Literal["trending_up", "trending_down", "ranging", "volatile"]
+
+_ALL_REGIME_LABELS: frozenset[str] = frozenset(
+    {"trending_up", "trending_down", "ranging", "volatile"}
+)
+
+
+@dataclass(frozen=True)
+class RegimeState:
+    """Snapshot of market regime at a point in time."""
+
+    label: RegimeLabel
+    adx: float
+    realized_vol: float
+
+
+def compute_adx(bars: Sequence[Bar], *, period: int = 14) -> float:
+    """Compute Wilder's Average Directional Index for a bar sequence.
+
+    Returns 0.0 when fewer than ``2 * period`` bars are available.
+    """
+    bars_list = list(bars)
+    if len(bars_list) < period + 1:
+        return 0.0
+
+    tr_list: list[float] = []
+    plus_dm_list: list[float] = []
+    minus_dm_list: list[float] = []
+
+    for i in range(1, len(bars_list)):
+        curr = bars_list[i]
+        prev = bars_list[i - 1]
+
+        high = float(curr.high)
+        low = float(curr.low)
+        prev_close = float(prev.close)
+        prev_high = float(prev.high)
+        prev_low = float(prev.low)
+
+        tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+
+        up_move = high - prev_high
+        down_move = prev_low - low
+        plus_dm = max(up_move, 0.0) if up_move > down_move else 0.0
+        minus_dm = max(down_move, 0.0) if down_move > up_move else 0.0
+
+        tr_list.append(tr)
+        plus_dm_list.append(plus_dm)
+        minus_dm_list.append(minus_dm)
+
+    if len(tr_list) < period:
+        return 0.0
+
+    # Wilder's initial smoothing (simple sum for first period)
+    smooth_tr = sum(tr_list[:period])
+    smooth_plus = sum(plus_dm_list[:period])
+    smooth_minus = sum(minus_dm_list[:period])
+
+    dx_list: list[float] = []
+    for i in range(period, len(tr_list)):
+        smooth_tr = smooth_tr - smooth_tr / period + tr_list[i]
+        smooth_plus = smooth_plus - smooth_plus / period + plus_dm_list[i]
+        smooth_minus = smooth_minus - smooth_minus / period + minus_dm_list[i]
+
+        if smooth_tr == 0.0:
+            continue
+
+        plus_di = 100.0 * smooth_plus / smooth_tr
+        minus_di = 100.0 * smooth_minus / smooth_tr
+        di_sum = plus_di + minus_di
+        dx = 100.0 * abs(plus_di - minus_di) / di_sum if di_sum != 0.0 else 0.0
+        dx_list.append(dx)
+
+    if not dx_list:
+        return 0.0
+
+    # Wilder-smooth DX into ADX
+    adx = sum(dx_list[:period]) / period if len(dx_list) >= period else sum(dx_list) / len(dx_list)
+    for i in range(period, len(dx_list)):
+        adx = (adx * (period - 1) + dx_list[i]) / period
+
+    return adx if isfinite(adx) else 0.0
+
+
+def compute_realized_vol(bars: Sequence[Bar], *, period: int = 20) -> float:
+    """Compute annualized realized volatility from log-close returns.
+
+    Uses the most recent ``period + 1`` bars.  Returns 0.0 when fewer
+    bars are available or when closes contain non-positive values.
+    """
+    bars_list = list(bars)
+    window = bars_list[-(period + 1):]
+    closes = [float(b.close) for b in window if float(b.close) > 0]
+    if len(closes) < 2:
+        return 0.0
+
+    log_returns = [log(closes[i] / closes[i - 1]) for i in range(1, len(closes))]
+    n = len(log_returns)
+    mean = sum(log_returns) / n
+    variance = sum((r - mean) ** 2 for r in log_returns) / n
+    rv = sqrt(variance) * sqrt(252)
+    return rv if isfinite(rv) else 0.0
+
+
+def classify_regime(
+    bars: Sequence[Bar],
+    *,
+    adx_period: int = 14,
+    vol_period: int = 20,
+    trend_lookback: int = 20,
+    adx_trend_threshold: float = 25.0,
+    high_vol_threshold: float = 0.30,
+) -> RegimeState:
+    """Classify the current market regime from a bar sequence.
+
+    Precedence:
+        1. ``volatile``     — realized vol > high_vol_threshold
+        2. ``trending_up``  — ADX > threshold AND latest close > lookback close
+        3. ``trending_down`` — ADX > threshold AND latest close < lookback close
+        4. ``ranging``      — fallback
+
+    Requires at least ``max(adx_period * 2, trend_lookback) + 1`` bars for
+    reliable results; returns ``ranging`` with zero indicators otherwise.
+    """
+    bars_list = list(bars)
+    adx = compute_adx(bars_list, period=adx_period)
+    rv = compute_realized_vol(bars_list, period=vol_period)
+
+    if rv > high_vol_threshold:
+        return RegimeState("volatile", adx, rv)
+
+    if adx > adx_trend_threshold and len(bars_list) >= trend_lookback + 1:
+        latest_close = float(bars_list[-1].close)
+        lookback_close = float(bars_list[-trend_lookback - 1].close)
+        if lookback_close > 0:
+            if latest_close > lookback_close:
+                return RegimeState("trending_up", adx, rv)
+            if latest_close < lookback_close:
+                return RegimeState("trending_down", adx, rv)
+
+    return RegimeState("ranging", adx, rv)
+
+
+__all__ = [
+    "RegimeLabel",
+    "RegimeState",
+    "_ALL_REGIME_LABELS",
+    "classify_regime",
+    "compute_adx",
+    "compute_realized_vol",
+]

--- a/tests/engine/test_paper_p2_trading.py
+++ b/tests/engine/test_paper_p2_trading.py
@@ -1,0 +1,410 @@
+"""Tests for P2-trading issues: performance metrics, attribution, regime filter.
+
+Covers:
+    #1149 — PaperPerformanceSummary computed from closed trades
+    #1150 — PaperPerformanceAttribution per strategy/symbol
+    #1151 — Regime classifier (ADX, realized-vol, classify_regime) + worker gate
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from cilly_trading.engine.paper_execution_risk_profile import PaperExecutionRiskProfile
+from cilly_trading.engine.paper_execution_worker import BoundedPaperExecutionWorker
+from cilly_trading.engine.paper_performance import (
+    compute_paper_performance_attribution,
+    compute_paper_performance_summary,
+)
+from cilly_trading.engine.regime_classifier import (
+    RegimeState,
+    classify_regime,
+    compute_adx,
+    compute_realized_vol,
+)
+from cilly_trading.models import Signal, Trade
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _closed_trade(
+    trade_id: str,
+    *,
+    strategy: str = "s",
+    symbol: str = "AAPL",
+    pnl: Decimal,
+    exit_price: Decimal,
+    closed_at: str = "2026-01-01T12:00:00Z",
+) -> Trade:
+    return Trade.model_validate(
+        {
+            "trade_id": trade_id,
+            "position_id": f"pos-{trade_id}",
+            "strategy_id": strategy,
+            "symbol": symbol,
+            "direction": "long",
+            "status": "closed",
+            "opened_at": "2026-01-01T00:00:00Z",
+            "closed_at": closed_at,
+            "quantity_opened": Decimal("10"),
+            "quantity_closed": Decimal("10"),
+            "average_entry_price": Decimal("100"),
+            "average_exit_price": exit_price,
+            "exposure_notional": Decimal("0"),
+            "realized_pnl": pnl,
+            "opening_order_ids": [],
+            "execution_event_ids": [],
+        }
+    )
+
+
+def _base_profile(**kwargs) -> PaperExecutionRiskProfile:
+    return PaperExecutionRiskProfile(
+        account_equity=Decimal("100000"),
+        max_risk_per_trade_pct=Decimal("0.01"),
+        min_trade_risk_pct=Decimal("0.005"),
+        max_trade_risk_pct=Decimal("0.50"),
+        max_total_exposure_pct=Decimal("1.00"),
+        max_strategy_exposure_pct=Decimal("1.00"),
+        max_symbol_exposure_pct=Decimal("1.00"),
+        max_concurrent_positions=20,
+        commission_rate=Decimal("0"),
+        slippage_rate=Decimal("0"),
+        cooldown_hours=0,
+        sizing_method="fixed",
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1149: PaperPerformanceSummary
+# ---------------------------------------------------------------------------
+
+
+def test_performance_summary_empty_returns_zeros() -> None:
+    summary = compute_paper_performance_summary([], initial_equity=Decimal("100000"))
+    assert summary.trade_count == 0
+    assert summary.win_rate == Decimal("0")
+    assert summary.expectancy == Decimal("0")
+
+
+def test_performance_summary_win_rate_correct() -> None:
+    trades = [
+        _closed_trade("t1", pnl=Decimal("100"), exit_price=Decimal("110")),
+        _closed_trade("t2", pnl=Decimal("50"), exit_price=Decimal("105")),
+        _closed_trade("t3", pnl=Decimal("-80"), exit_price=Decimal("92")),
+        _closed_trade("t4", pnl=Decimal("-20"), exit_price=Decimal("98")),
+    ]
+    summary = compute_paper_performance_summary(trades, initial_equity=Decimal("100000"))
+    assert summary.trade_count == 4
+    assert summary.win_count == 2
+    assert summary.loss_count == 2
+    assert summary.win_rate == Decimal("0.5")
+
+
+def test_performance_summary_expectancy_positive_for_winning_strategy() -> None:
+    trades = [
+        _closed_trade("w1", pnl=Decimal("200"), exit_price=Decimal("120")),
+        _closed_trade("w2", pnl=Decimal("200"), exit_price=Decimal("120")),
+        _closed_trade("w3", pnl=Decimal("200"), exit_price=Decimal("120")),
+        _closed_trade("l1", pnl=Decimal("-50"), exit_price=Decimal("95")),
+    ]
+    summary = compute_paper_performance_summary(trades, initial_equity=Decimal("100000"))
+    assert summary.expectancy > Decimal("0")
+    assert summary.profit_factor > Decimal("1")
+
+
+def test_performance_summary_consecutive_streaks() -> None:
+    trades = [
+        _closed_trade("a1", pnl=Decimal("10"), exit_price=Decimal("101"), closed_at="2026-01-01T00:00:00Z"),
+        _closed_trade("a2", pnl=Decimal("10"), exit_price=Decimal("101"), closed_at="2026-01-02T00:00:00Z"),
+        _closed_trade("a3", pnl=Decimal("10"), exit_price=Decimal("101"), closed_at="2026-01-03T00:00:00Z"),
+        _closed_trade("b1", pnl=Decimal("-5"), exit_price=Decimal("99.5"), closed_at="2026-01-04T00:00:00Z"),
+        _closed_trade("b2", pnl=Decimal("-5"), exit_price=Decimal("99.5"), closed_at="2026-01-05T00:00:00Z"),
+    ]
+    summary = compute_paper_performance_summary(trades, initial_equity=Decimal("100000"))
+    assert summary.max_consecutive_wins == 3
+    assert summary.max_consecutive_losses == 2
+
+
+def test_performance_summary_max_drawdown_computed_from_equity_curve() -> None:
+    # Equity: 100000 → 100100 (win) → 100200 (win) → 100050 (loss) → 100100 (win)
+    # Peak after trade 2 = 100200; trough = 100050; dd = 150/100200 ≈ 0.15%
+    trades = [
+        _closed_trade("d1", pnl=Decimal("100"), exit_price=Decimal("110"), closed_at="2026-01-01T00:00:00Z"),
+        _closed_trade("d2", pnl=Decimal("100"), exit_price=Decimal("110"), closed_at="2026-01-02T00:00:00Z"),
+        _closed_trade("d3", pnl=Decimal("-150"), exit_price=Decimal("85"), closed_at="2026-01-03T00:00:00Z"),
+        _closed_trade("d4", pnl=Decimal("50"), exit_price=Decimal("105"), closed_at="2026-01-04T00:00:00Z"),
+    ]
+    summary = compute_paper_performance_summary(trades, initial_equity=Decimal("100000"))
+    assert summary.max_drawdown_pct > Decimal("0")
+    # dd = 150 / 100200 ≈ 0.001497
+    assert summary.max_drawdown_pct < Decimal("0.01")
+
+
+def test_performance_summary_recovery_factor_positive_when_net_profitable() -> None:
+    trades = [
+        _closed_trade("rf1", pnl=Decimal("500"), exit_price=Decimal("150"), closed_at="2026-01-01T00:00:00Z"),
+        _closed_trade("rf2", pnl=Decimal("-100"), exit_price=Decimal("90"), closed_at="2026-01-02T00:00:00Z"),
+        _closed_trade("rf3", pnl=Decimal("300"), exit_price=Decimal("130"), closed_at="2026-01-03T00:00:00Z"),
+    ]
+    summary = compute_paper_performance_summary(trades, initial_equity=Decimal("100000"))
+    assert summary.net_pnl > Decimal("0")
+    assert summary.recovery_factor > Decimal("0")
+
+
+def test_worker_get_performance_summary_integrates_with_repo(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "perf.db")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=_base_profile())
+
+    repo.save_trade(_closed_trade("pt1", pnl=Decimal("200"), exit_price=Decimal("120")))
+    repo.save_trade(_closed_trade("pt2", pnl=Decimal("-50"), exit_price=Decimal("95")))
+
+    summary = worker.get_performance_summary()
+    assert summary.trade_count == 2
+    assert summary.win_count == 1
+
+
+# ---------------------------------------------------------------------------
+# #1150: PaperPerformanceAttribution
+# ---------------------------------------------------------------------------
+
+
+def test_attribution_groups_by_strategy() -> None:
+    trades = [
+        _closed_trade("s1", strategy="alpha", symbol="AAPL", pnl=Decimal("100"), exit_price=Decimal("110")),
+        _closed_trade("s2", strategy="alpha", symbol="MSFT", pnl=Decimal("-50"), exit_price=Decimal("95")),
+        _closed_trade("s3", strategy="beta", symbol="AAPL", pnl=Decimal("200"), exit_price=Decimal("120")),
+    ]
+    attr = compute_paper_performance_attribution(trades)
+    assert "alpha" in attr.by_strategy
+    assert "beta" in attr.by_strategy
+    assert attr.by_strategy["alpha"].trade_count == 2
+    assert attr.by_strategy["beta"].trade_count == 1
+
+
+def test_attribution_groups_by_symbol() -> None:
+    trades = [
+        _closed_trade("y1", strategy="s", symbol="AAPL", pnl=Decimal("100"), exit_price=Decimal("110")),
+        _closed_trade("y2", strategy="s", symbol="AAPL", pnl=Decimal("50"), exit_price=Decimal("105")),
+        _closed_trade("y3", strategy="s", symbol="MSFT", pnl=Decimal("-30"), exit_price=Decimal("97")),
+    ]
+    attr = compute_paper_performance_attribution(trades)
+    assert attr.by_symbol["AAPL"].trade_count == 2
+    assert attr.by_symbol["MSFT"].trade_count == 1
+    assert attr.by_symbol["AAPL"].win_rate == Decimal("1")
+
+
+def test_attribution_groups_by_strategy_symbol_pair() -> None:
+    trades = [
+        _closed_trade("p1", strategy="alpha", symbol="AAPL", pnl=Decimal("100"), exit_price=Decimal("110")),
+        _closed_trade("p2", strategy="beta", symbol="AAPL", pnl=Decimal("50"), exit_price=Decimal("105")),
+        _closed_trade("p3", strategy="alpha", symbol="MSFT", pnl=Decimal("-10"), exit_price=Decimal("99")),
+    ]
+    attr = compute_paper_performance_attribution(trades)
+    assert ("alpha", "AAPL") in attr.by_strategy_symbol
+    assert ("beta", "AAPL") in attr.by_strategy_symbol
+    assert ("alpha", "MSFT") in attr.by_strategy_symbol
+    assert attr.by_strategy_symbol[("alpha", "AAPL")].win_rate == Decimal("1")
+
+
+def test_attribution_empty_returns_empty_dicts() -> None:
+    attr = compute_paper_performance_attribution([])
+    assert attr.by_strategy == {}
+    assert attr.by_symbol == {}
+    assert attr.by_strategy_symbol == {}
+
+
+def test_worker_get_performance_attribution_integrates_with_repo(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "attr.db")
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=_base_profile())
+    repo.save_trade(_closed_trade("at1", strategy="alpha", symbol="AAPL", pnl=Decimal("100"), exit_price=Decimal("110")))
+    repo.save_trade(_closed_trade("at2", strategy="beta", symbol="MSFT", pnl=Decimal("-20"), exit_price=Decimal("98")))
+    attr = worker.get_performance_attribution()
+    assert "alpha" in attr.by_strategy
+    assert "beta" in attr.by_strategy
+
+
+# ---------------------------------------------------------------------------
+# #1151: Regime classifier — unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_bars(closes: list[float]) -> list:
+    """Build minimal Bar objects for testing."""
+    from cilly_trading.engine.marketdata.models.market_data_models import Bar
+
+    bars = []
+    for i, c in enumerate(closes):
+        bars.append(
+            Bar(
+                timestamp=f"2026-01-{i+1:02d}T00:00:00Z",
+                open=Decimal(str(c * 0.99)),
+                high=Decimal(str(c * 1.01)),
+                low=Decimal(str(c * 0.98)),
+                close=Decimal(str(c)),
+                volume=Decimal("1000"),
+                symbol="TEST",
+                timeframe="1d",
+            )
+        )
+    return bars
+
+
+def test_compute_realized_vol_returns_zero_for_insufficient_bars() -> None:
+    bars = _make_bars([100.0])
+    rv = compute_realized_vol(bars, period=20)
+    assert rv == 0.0
+
+
+def test_compute_realized_vol_positive_for_moving_prices() -> None:
+    closes = [100.0 + i * 0.5 for i in range(25)]
+    bars = _make_bars(closes)
+    rv = compute_realized_vol(bars, period=20)
+    assert rv > 0.0
+
+
+def test_compute_adx_returns_zero_for_insufficient_bars() -> None:
+    bars = _make_bars([100.0] * 5)
+    adx = compute_adx(bars, period=14)
+    assert adx == 0.0
+
+
+def test_compute_adx_nonzero_for_trending_series() -> None:
+    # Strong uptrend
+    closes = [100.0 + i * 2.0 for i in range(60)]
+    bars = _make_bars(closes)
+    adx = compute_adx(bars, period=14)
+    assert adx > 0.0
+
+
+def test_classify_regime_returns_ranging_for_flat_low_vol_data() -> None:
+    # Flat prices → low ADX, low vol → ranging
+    closes = [100.0] * 50
+    bars = _make_bars(closes)
+    state = classify_regime(bars)
+    assert state.label == "ranging"
+    assert state.adx == 0.0
+
+
+def test_classify_regime_returns_volatile_for_high_vol_data() -> None:
+    import random
+    random.seed(42)
+    # Large random daily moves → high realized vol
+    closes = [100.0]
+    for _ in range(50):
+        closes.append(closes[-1] * (1 + random.uniform(-0.08, 0.08)))
+    bars = _make_bars(closes)
+    state = classify_regime(bars, high_vol_threshold=0.10)
+    assert state.label == "volatile"
+
+
+def test_classify_regime_returns_trending_up_for_steady_uptrend() -> None:
+    # Steady uptrend: ADX high, close[-1] > close[-21]
+    closes = [100.0 + i * 3.0 for i in range(60)]
+    bars = _make_bars(closes)
+    state = classify_regime(bars, adx_trend_threshold=10.0, high_vol_threshold=5.0)
+    assert state.label == "trending_up"
+
+
+def test_classify_regime_returns_trending_down_for_steady_downtrend() -> None:
+    closes = [200.0 - i * 3.0 for i in range(60)]
+    bars = _make_bars(closes)
+    state = classify_regime(bars, adx_trend_threshold=10.0, high_vol_threshold=5.0)
+    assert state.label == "trending_down"
+
+
+# ---------------------------------------------------------------------------
+# #1151: Regime filter wired into process_signal
+# ---------------------------------------------------------------------------
+
+
+def test_regime_filter_blocks_entry_in_disallowed_regime(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "reg1.db")
+    profile = _base_profile(allowed_regimes=frozenset({"trending_up"}))
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "reg-block",
+    }
+    result = worker.process_signal(signal, regime_state=RegimeState("ranging", 10.0, 0.05))
+    assert result.outcome == "skip:regime_filtered"
+    assert "ranging" in (result.reason or "")
+
+
+def test_regime_filter_allows_entry_in_allowed_regime(tmp_path: Path) -> None:
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "reg2.db")
+    profile = _base_profile(allowed_regimes=frozenset({"trending_up", "ranging"}))
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "reg-allow",
+    }
+    result = worker.process_signal(signal, regime_state=RegimeState("trending_up", 30.0, 0.05))
+    assert result.outcome == "eligible"
+
+
+def test_regime_filter_skipped_when_allowed_regimes_empty(tmp_path: Path) -> None:
+    """Empty allowed_regimes means all regimes are permitted."""
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "reg3.db")
+    profile = _base_profile(allowed_regimes=frozenset())
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "reg-empty",
+    }
+    result = worker.process_signal(signal, regime_state=RegimeState("volatile", 5.0, 0.80))
+    assert result.outcome == "eligible"
+
+
+def test_regime_filter_skipped_when_no_regime_state(tmp_path: Path) -> None:
+    """No regime_state → filter never fires, even with restricted allowed_regimes."""
+    repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "reg4.db")
+    profile = _base_profile(allowed_regimes=frozenset({"trending_up"}))
+    worker = BoundedPaperExecutionWorker(repository=repo, risk_profile=profile)
+
+    signal: Signal = {
+        "symbol": "AAPL",
+        "strategy": "s",
+        "direction": "long",  # type: ignore[typeddict-item]
+        "score": 80.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "stage": "setup",  # type: ignore[typeddict-item]
+        "trade_risk_pct": 0.05,
+        "signal_id": "reg-none",
+    }
+    result = worker.process_signal(signal)  # no regime_state
+    assert result.outcome == "eligible"
+
+
+def test_profile_rejects_unknown_regime_label() -> None:
+    with pytest.raises(ValueError, match="unknown regime labels"):
+        _base_profile(allowed_regimes=frozenset({"moon_phase"}))


### PR DESCRIPTION
## Summary

Third batch of trader-perspective improvements (three P2-trading issues). These add a complete performance analytics layer and market-regime awareness to the paper execution worker.

### #1149 — Performance metrics
- New `paper_performance.py` module with `compute_paper_performance_summary(trades, initial_equity)`
- Computes: `win_rate`, `avg_win/loss`, `expectancy`, `profit_factor`, `max_consecutive_wins/losses`, `net_pnl`, `gross_profit/loss`, `max_drawdown_pct` (from equity curve peak-to-trough), `recovery_factor`
- `BoundedPaperExecutionWorker.get_performance_summary()` wires directly to the canonical repository

### #1150 — Attribution analysis
- `compute_paper_performance_attribution(trades)` groups closed trades by `strategy_id`, `symbol`, and `(strategy_id, symbol)` pairs
- Each `AttributionBucket` contains: `trade_count`, `win_rate`, `expectancy`, `net_pnl`
- `BoundedPaperExecutionWorker.get_performance_attribution()` for direct use

### #1151 — Market regime detection
- New `regime_classifier.py`: `compute_adx()` (Wilder's ADX), `compute_realized_vol()` (annualized log-return vol), `classify_regime()` → `RegimeState(label, adx, realized_vol)`
- Four labels: `trending_up`, `trending_down`, `ranging`, `volatile`
- `PaperExecutionRiskProfile.allowed_regimes: frozenset[str]` — empty = allow all (default, backwards compatible)
- `process_signal(signal, *, regime_state=...)` opt-in parameter — same pattern as `entry_bar` and `price_history`
- `skip:regime_filtered` outcome when regime label not in allowed set
- Profile validation rejects unknown regime label strings

## Test plan

- [x] 352 tests pass across all engine test suites (+25 new P2 tests)
- [x] Performance summary: zero-value baseline, win rate, expectancy sign, streak counts, drawdown from equity curve, recovery factor
- [x] Attribution: strategy grouping, symbol grouping, (strategy, symbol) pair grouping, empty input
- [x] Regime classifier: ADX zero for flat data, nonzero for trending, realized vol positive for moving prices, all four regime labels reachable
- [x] Regime filter: blocks disallowed regime, allows allowed regime, skips when allowed_regimes empty, skips when no regime_state passed

Closes #1149
Closes #1150
Closes #1151

https://claude.ai/code/session_01JpFr8BS58w3bmDa2MswX6f

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpFr8BS58w3bmDa2MswX6f)_