### PR TITLE
Fix staging API jwt runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "yfinance",
   "ccxt",
   "httpx",
+  "PyJWT",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -344,6 +344,7 @@ dependencies = [
     { name = "httpx" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pyjwt" },
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
@@ -368,6 +369,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pyjwt" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "requests" },
     { name = "sqlalchemy" },
@@ -1228,6 +1230,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add PyJWT as a runtime dependency so `import jwt` succeeds in no-dev installs.
- Update uv.lock with pyjwt 2.12.1.
- No API behavior, endpoint behavior, runtime logic, or tests were changed.

## Verification
- `python -m uv sync --frozen --no-dev`
- `.\.venv\Scripts\python.exe -c "import jwt"`
- `.\.venv\Scripts\python.exe -c "import api.main"`
- `python -m uv run pytest` -> 1324 passed

## Risk / Limitations
- Docker rebuild and container health evidence were not available because the local Docker daemon was unavailable.
- `/health/live` and `/health/ready` are absent in this checkout; local probing succeeded on `/health` and `/health/engine`.

Closes #1159