### PR TITLE
Fix staging runtime prometheus-client dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "yfinance",
   "ccxt",
   "httpx",
+  "prometheus-client>=0.25.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_runtime_dependency_imports.py
+++ b/tests/test_runtime_dependency_imports.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_prometheus_client_runtime_dependency_imports() -> None:
+    assert importlib.import_module("prometheus_client") is not None
+
+
+def test_api_main_runtime_imports() -> None:
+    assert importlib.import_module("api.main") is not None

--- a/uv.lock
+++ b/uv.lock
@@ -344,6 +344,7 @@ dependencies = [
     { name = "httpx" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "prometheus-client" },
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
@@ -368,6 +369,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "requests" },
     { name = "sqlalchemy" },
@@ -966,6 +968,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1166

## Summary
- Add `prometheus-client>=0.25.0` as a production runtime dependency.
- Update `uv.lock` so `uv sync --frozen --no-dev` installs `prometheus-client==0.25.0`.
- Add targeted runtime import coverage for `prometheus_client` and `api.main`.

## Validation
- `docker build -f docker/staging/Dockerfile -t cilly-trading-staging-issue-1166 .`
  - Succeeded.
  - Build output confirms `prometheus-client==0.25.0` installed during `uv sync --frozen --no-dev`.
- `docker exec staging-api-1 python -c "import prometheus_client; import api.main; print('imports ok')"`
  - Succeeded.
- `python -m uv sync --frozen --no-dev`
  - Succeeded.
- `python -m uv run pytest`
  - `1326 passed`.

## Scope
- Dependency-startup-only fix for #1166.
- No API, Docker, auth, runtime, strategy, signal, risk, threshold, ingestion, broker, paper-runtime, or live-trading files modified.

## Follow-up
Staging health endpoint/auth alignment is intentionally out of scope for #1166 and should be handled in a separate issue:
- Docker healthcheck receives HTTP 401 on `/health/engine`.
- `/health/live` returns HTTP 404.
- `/health/ready` returns HTTP 404.