### PR TITLE
Fix operator review artifact schema contract

### DIFF
--- a/scripts/run_daily_bounded_paper_runtime.py
+++ b/scripts/run_daily_bounded_paper_runtime.py
@@ -67,6 +67,12 @@ OPERATOR_REVIEW_OUTCOME_NON_INFERENCE_STATEMENT = (
     "This artifact records bounded paper-runtime observations only. It is not trader validation, "
     "not profitability evidence, and not broker/live readiness evidence."
 )
+OPERATOR_REVIEW_OUTCOME_REQUIRED_CLASSIFICATIONS: frozenset[str] = frozenset(
+    {
+        "stale_open_trade_review_required",
+        "unknown_freshness_review_required",
+    }
+)
 STALE_OPEN_PAPER_TRADE_REVIEW_WORKFLOW_VERSION = 1
 STALE_OPEN_PAPER_TRADE_REVIEW_WORKFLOW_ID = (
     "ops_bounded_stale_open_paper_trade_review"
@@ -464,7 +470,7 @@ def _write_json_file_with_sha256(path: Path, payload: dict[str, Any]) -> str:
     json_bytes = _json_file_bytes(payload)
     path.write_bytes(json_bytes)
     digest = hashlib.sha256(json_bytes).hexdigest()
-    path.with_suffix(f"{path.suffix}.sha256").write_text(f"{digest}  {path.name}\n", encoding="ascii")
+    path.with_suffix(".sha256").write_text(f"{digest}  {path.name}\n", encoding="ascii")
     return digest
 
 
@@ -1125,7 +1131,7 @@ def build_operator_review_outcome_artifact(
     review_outcomes: list[dict[str, Any]] = []
     for trade in _items_from_payload(paper_state_freshness, key="open_trades"):
         if (
-            trade.get("classification") != "stale_open_trade_review_required"
+            trade.get("classification") not in OPERATOR_REVIEW_OUTCOME_REQUIRED_CLASSIFICATIONS
             or trade.get("duplicate_entry_blocker") is not True
         ):
             continue
@@ -1137,13 +1143,16 @@ def build_operator_review_outcome_artifact(
                 "decision_validity": "valid_review_required_evidence",
                 "direction": trade.get("direction"),
                 "duplicate_entry_blocker": True,
-                "duplicate_entry_blocker_reason": "stale_open_trade_duplicate_entry_blocker",
+                "duplicate_entry_blocker_reason": (
+                    trade.get("duplicate_entry_blocker_reason")
+                    or "review_required_duplicate_entry_blocker"
+                ),
                 "mutates_paper_state": False,
                 "opened_at": trade.get("opened_at"),
                 "operator_decision": "pending_operator_review",
                 "operator_review_guidance": trade.get("operator_review_guidance"),
                 "operator_rationale": (
-                    "Stale open paper trade blocked duplicate entry; operator must review lifecycle evidence "
+                    "Review-required open paper trade blocked duplicate entry; operator must review lifecycle evidence "
                     "before interpreting the blocker."
                 ),
                 "position_id": trade.get("position_id"),

--- a/tests/test_run_daily_bounded_paper_runtime_script.py
+++ b/tests/test_run_daily_bounded_paper_runtime_script.py
@@ -286,10 +286,11 @@ def test_daily_runner_executes_ops_p63_order_and_writes_run_record(
         "workflow_id": "bounded_daily_paper_runtime",
         "workflow_version": "OPS-P64",
     }
-    operator_review_sha_file = operator_review_file.with_suffix(".json.sha256")
+    operator_review_sha_file = operator_review_file.with_suffix(".sha256")
     assert operator_review_sha_file.read_text(encoding="ascii") == (
         f"{hashlib.sha256(operator_review_bytes).hexdigest()}  operator-review.json\n"
     )
+    assert not operator_review_file.with_suffix(".json.sha256").exists()
     assert payload["stale_open_paper_trade_review_workflow"]["workflow_id"] == (
         "ops_bounded_stale_open_paper_trade_review"
     )
@@ -376,6 +377,10 @@ def test_daily_runner_emits_non_empty_operator_review_artifact_for_stale_duplica
                         "results": [
                             {
                                 "outcome": "skip:duplicate_entry",
+                                "reason": "open trade exists for (COST, TURTLE, long)",
+                            },
+                            {
+                                "outcome": "skip:duplicate_entry",
                                 "reason": "open trade exists for (WMT, TURTLE, long)",
                             },
                             {
@@ -415,6 +420,28 @@ def test_daily_runner_emits_non_empty_operator_review_artifact_for_stale_duplica
                 "items": [
                     {
                         "direction": "long",
+                        "opened_at": "2026-05-06T11:00:00+00:00",
+                        "position_id": "pos-aapl",
+                        "quantity_closed": "0",
+                        "quantity_opened": "1",
+                        "status": "open",
+                        "strategy_id": "TURTLE",
+                        "symbol": "AAPL",
+                        "trade_id": "trade-aapl",
+                    },
+                    {
+                        "direction": "long",
+                        "opened_at": None,
+                        "position_id": "pos-cost",
+                        "quantity_closed": "0",
+                        "quantity_opened": "1",
+                        "status": "open",
+                        "strategy_id": "TURTLE",
+                        "symbol": "COST",
+                        "trade_id": "trade-cost",
+                    },
+                    {
+                        "direction": "long",
                         "opened_at": "2026-04-02T00:00:00+00:00",
                         "position_id": "pos-wmt",
                         "quantity_closed": "0",
@@ -436,15 +463,17 @@ def test_daily_runner_emits_non_empty_operator_review_artifact_for_stale_duplica
                         "trade_id": "trade-gs",
                     },
                 ],
-                "total": 2,
+                "total": 4,
             }
         if url.endswith("/paper/positions"):
             return {
                 "items": [
+                    {"position_id": "pos-aapl", "status": "open"},
+                    {"position_id": "pos-cost", "status": "open"},
                     {"position_id": "pos-wmt", "status": "open"},
                     {"position_id": "pos-gs", "status": "open"},
                 ],
-                "total": 2,
+                "total": 4,
             }
         if url.endswith("/paper/account"):
             return {"account": {"as_of": "2026-05-06T12:00:00+00:00"}}
@@ -484,20 +513,31 @@ def test_daily_runner_emits_non_empty_operator_review_artifact_for_stale_duplica
     assert artifact["read_only"] is True
     assert artifact["mutates_paper_state"] is False
     assert artifact["source_daily_runtime_summary"] == payload["summary_file"]
-    assert artifact["review_required_count"] == 2
-    assert artifact["recorded_count"] == 2
+    assert artifact["review_required_count"] == 3
+    assert artifact["recorded_count"] == 3
     assert artifact["invalid_count"] == 0
-    assert [item["trade_id"] for item in artifact["review_outcomes"]] == ["trade-gs", "trade-wmt"]
+    assert len(artifact["review_outcomes"]) == artifact["recorded_count"]
+    assert [item["trade_id"] for item in artifact["review_outcomes"]] == [
+        "trade-cost",
+        "trade-gs",
+        "trade-wmt",
+    ]
     assert {item["classification"] for item in artifact["review_outcomes"]} == {
-        "stale_open_trade_review_required"
+        "stale_open_trade_review_required",
+        "unknown_freshness_review_required",
     }
+    assert "trade-aapl" not in {item["trade_id"] for item in artifact["review_outcomes"]}
     assert all(item["mutates_paper_state"] is False for item in artifact["review_outcomes"])
     assert all(item["operator_decision"] == "pending_operator_review" for item in artifact["review_outcomes"])
     assert all(item["decision_validity"] == "valid_review_required_evidence" for item in artifact["review_outcomes"])
-    assert all(item["duplicate_entry_blocker_reason"] == "stale_open_trade_duplicate_entry_blocker" for item in artifact["review_outcomes"])
-    assert operator_review_file.with_suffix(".json.sha256").read_text(encoding="ascii") == (
+    assert all(
+        item["duplicate_entry_blocker_reason"].startswith("open trade exists for")
+        for item in artifact["review_outcomes"]
+    )
+    assert operator_review_file.with_suffix(".sha256").read_text(encoding="ascii") == (
         f"{hashlib.sha256(operator_review_bytes).hexdigest()}  operator-review.json\n"
     )
+    assert not operator_review_file.with_suffix(".json.sha256").exists()
     assert [item for item in request_sequence if "/paper/" in item[1]] == [
         ("GET", "http://127.0.0.1:18000/paper/trades"),
         ("GET", "http://127.0.0.1:18000/paper/positions"),
@@ -971,6 +1011,18 @@ def test_operator_review_artifact_records_each_stale_duplicate_entry_blocker() -
         trades_payload={
             "items": [
                 {
+                    "average_entry_price": "190",
+                    "direction": "long",
+                    "opened_at": "2026-05-06T11:00:00+00:00",
+                    "position_id": "pos-aapl",
+                    "quantity_closed": "0",
+                    "quantity_opened": "1",
+                    "status": "open",
+                    "strategy_id": "TURTLE",
+                    "symbol": "AAPL",
+                    "trade_id": "trade-aapl",
+                },
+                {
                     "average_entry_price": "100",
                     "direction": "long",
                     "opened_at": "2026-04-02T00:00:00+00:00",
@@ -997,7 +1049,7 @@ def test_operator_review_artifact_records_each_stale_duplicate_entry_blocker() -
                 {
                     "average_entry_price": "900",
                     "direction": "long",
-                    "opened_at": "2026-05-06T11:00:00+00:00",
+                    "opened_at": None,
                     "position_id": "pos-cost",
                     "quantity_closed": "0",
                     "quantity_opened": "1",
@@ -1010,6 +1062,7 @@ def test_operator_review_artifact_records_each_stale_duplicate_entry_blocker() -
         },
         positions_payload={
             "items": [
+                {"position_id": "pos-aapl", "status": "open"},
                 {"position_id": "pos-wmt", "status": "open"},
                 {"position_id": "pos-gs", "status": "open"},
                 {"position_id": "pos-cost", "status": "open"},
@@ -1057,16 +1110,23 @@ def test_operator_review_artifact_records_each_stale_duplicate_entry_blocker() -
     assert artifact["mutates_paper_state"] is False
     assert artifact["source_daily_runtime_summary"] == "runs/daily-runtime/2026-05-06/daily-runtime-summary.json"
     assert artifact["observed_at"] == "2026-05-06T12:00:00+00:00"
-    assert artifact["review_required_count"] == 2
-    assert artifact["recorded_count"] == 2
+    assert artifact["review_required_count"] == 3
+    assert artifact["recorded_count"] == 3
     assert artifact["invalid_count"] == 0
     assert "not trader validation" in artifact["non_inference_statement"]
     assert "not profitability evidence" in artifact["non_inference_statement"]
     assert "not broker/live readiness" in artifact["non_inference_statement"]
-    assert [item["trade_id"] for item in artifact["review_outcomes"]] == ["trade-gs", "trade-wmt"]
+    assert len(artifact["review_outcomes"]) == artifact["recorded_count"]
+    assert [item["trade_id"] for item in artifact["review_outcomes"]] == [
+        "trade-cost",
+        "trade-gs",
+        "trade-wmt",
+    ]
     assert {item["classification"] for item in artifact["review_outcomes"]} == {
-        "stale_open_trade_review_required"
+        "stale_open_trade_review_required",
+        "unknown_freshness_review_required",
     }
+    assert "trade-aapl" not in {item["trade_id"] for item in artifact["review_outcomes"]}
     required_outcome_fields = {
         "account_as_of",
         "account_freshness",


### PR DESCRIPTION
Closes #1182

Summary:
- Recreated the branch on current main so the PR diff is limited to #1182 artifact/evidence contract work.
- Writes the operator-review SHA sidecar as operator-review.sha256 from the actual daily runtime writer path.
- Verifies the SHA against the exact operator-review.json bytes and asserts operator-review.json.sha256 is absent.
- Emits deterministic operator-review outcomes for review-required duplicate-entry blockers with stale and unknown freshness classifications.
- Keeps fresh non-review trades out of operator-review.json outcomes.

Tests:
- python -m py_compile scripts/run_daily_bounded_paper_runtime.py tests/test_run_daily_bounded_paper_runtime_script.py
- python -m pytest tests/test_run_daily_bounded_paper_runtime_script.py -q
- python -m pytest tests -q -k "paper and runtime" (1 existing OpenAPI/Pydantic ForwardRef failure outside allowed #1182 files: tests/test_api_paper_runtime_evidence_series_read.py::test_paper_runtime_evidence_series_summarizes_fixture_inputs_deterministically)

Notes:
- .codex/issue-1182-review-package.md is not committed; it remains local review evidence only.
- No strategy logic, thresholds, broker/live behavior, paper-state mutation/reset behavior, or runtime semantics outside artifact evidence changed.