### PR TITLE
Improve paper runtime diagnostics evidence

### DIFF
--- a/scripts/run_paper_execution_cycle.py
+++ b/scripts/run_paper_execution_cycle.py
@@ -124,7 +124,100 @@ def _result_to_dict(result: SignalEvaluationResult) -> dict[str, Any]:
         d["trade_id"] = result.trade_id
     if result.reason is not None:
         d["reason"] = result.reason
+    if result.decision_inputs is not None:
+        d["decision_inputs"] = result.decision_inputs
     return d
+
+
+def _signal_stage(signal: Any) -> str | None:
+    stage = signal.get("stage") if isinstance(signal, dict) else getattr(signal, "stage", None)
+    return str(stage) if stage is not None else None
+
+
+def _signal_value(signal: Any, field: str) -> Any:
+    if isinstance(signal, dict):
+        return signal.get(field)
+    return getattr(signal, field, None)
+
+
+def _is_exit_signal(signal: Any) -> bool:
+    return _signal_stage(signal) == "exit"
+
+
+def _build_missing_trade_risk_input_diagnostic(
+    signal: Any,
+    result: SignalEvaluationResult,
+) -> dict[str, Any]:
+    decision_inputs = result.decision_inputs or {}
+    diagnostic: dict[str, Any] = {
+        "symbol": decision_inputs.get("symbol", _signal_value(signal, "symbol")),
+        "strategy": decision_inputs.get("strategy", _signal_value(signal, "strategy")),
+        "stage": decision_inputs.get("stage", _signal_value(signal, "stage")),
+        "direction": decision_inputs.get("direction", _signal_value(signal, "direction")),
+        "outcome": decision_inputs.get("outcome", result.outcome),
+        "reason": decision_inputs.get("reason", result.reason),
+        "missing_fields": decision_inputs.get("missing_fields", []),
+        "required_any_of": decision_inputs.get("required_any_of", []),
+        "sizing_method": decision_inputs.get("sizing_method"),
+        "risk_profile_contract_id": decision_inputs.get("risk_profile_contract_id"),
+    }
+    signal_id = decision_inputs.get("signal_id", result.signal_id or _signal_value(signal, "signal_id"))
+    if signal_id is not None:
+        diagnostic["signal_id"] = signal_id
+    return diagnostic
+
+
+def _build_diagnostics_summary(
+    signals: list[Any],
+    results: list[SignalEvaluationResult],
+) -> dict[str, Any]:
+    """Build deterministic JSON-safe diagnostics without changing outcomes."""
+    entry_candidate_count = 0
+    exit_candidate_count = 0
+    eligible_entry_count = 0
+    eligible_exit_count = 0
+    skipped_exits_without_open_position = 0
+    score_filtered_entries = 0
+    risk_input_rejected_entries = 0
+    missing_trade_risk_input_count = 0
+    missing_trade_risk_input_rejections: list[dict[str, Any]] = []
+
+    for signal, result in zip(signals, results):
+        is_exit = _is_exit_signal(signal)
+        if is_exit:
+            exit_candidate_count += 1
+        else:
+            entry_candidate_count += 1
+
+        if result.outcome.startswith("eligible"):
+            if is_exit:
+                eligible_exit_count += 1
+            else:
+                eligible_entry_count += 1
+
+        if is_exit and result.outcome == "skip:no_open_position_to_exit":
+            skipped_exits_without_open_position += 1
+        if not is_exit and result.outcome == "skip:score_below_threshold":
+            score_filtered_entries += 1
+        if not is_exit and result.outcome == "reject:missing_trade_risk_input":
+            risk_input_rejected_entries += 1
+            missing_trade_risk_input_count += 1
+            missing_trade_risk_input_rejections.append(
+                _build_missing_trade_risk_input_diagnostic(signal, result)
+            )
+
+    return {
+        "signals_read": len(signals),
+        "entry_candidate_count": entry_candidate_count,
+        "exit_candidate_count": exit_candidate_count,
+        "eligible_entry_count": eligible_entry_count,
+        "eligible_exit_count": eligible_exit_count,
+        "skipped_exits_without_open_position": skipped_exits_without_open_position,
+        "score_filtered_entries": score_filtered_entries,
+        "risk_input_rejected_entries": risk_input_rejected_entries,
+        "missing_trade_risk_input_count": missing_trade_risk_input_count,
+        "missing_trade_risk_input_rejections": missing_trade_risk_input_rejections,
+    }
 
 
 def run_paper_execution_cycle(
@@ -174,6 +267,7 @@ def run_paper_execution_cycle(
     result_payload: dict[str, Any] = {
         "cycle_type": "bounded_paper_execution",
         "db_path": db_path,
+        "diagnostics_summary": _build_diagnostics_summary(signals, results),
         "eligible": len(eligible),
         "ran_at": ran_at.isoformat(),
         "rejected": len(rejected),

--- a/tests/scripts/test_run_paper_execution_cycle_evidence.py
+++ b/tests/scripts/test_run_paper_execution_cycle_evidence.py
@@ -1,0 +1,135 @@
+"""Focused evidence tests for bounded paper execution cycle serialization."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import scripts.run_paper_execution_cycle as cycle
+from cilly_trading.engine.paper_execution_worker import SignalEvaluationResult
+
+
+class _FakeSignalRepository:
+    signals: list[dict[str, Any]] = []
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+    def list_signals(self, limit: int) -> list[dict[str, Any]]:
+        return self.signals[:limit]
+
+
+class _FakeExecutionRepository:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+
+class _FakeWorker:
+    results: list[SignalEvaluationResult] = []
+
+    def __init__(self, repository: _FakeExecutionRepository, risk_profile: Any) -> None:
+        self.repository = repository
+        self.risk_profile = risk_profile
+
+    def process_batch(self, signals: list[dict[str, Any]]) -> list[SignalEvaluationResult]:
+        return self.results
+
+
+def test_paper_execution_cycle_evidence_includes_diagnostics_and_decision_inputs(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    _FakeSignalRepository.signals = [
+        {
+            "signal_id": "sig-exit-no-open",
+            "symbol": "AAPL",
+            "strategy": "s",
+            "stage": "exit",
+            "direction": "long",
+        },
+        {
+            "signal_id": "sig-score-low",
+            "symbol": "MSFT",
+            "strategy": "s",
+            "stage": "setup",
+            "direction": "long",
+        },
+        {
+            "signal_id": "sig-risk-missing",
+            "symbol": "TSLA",
+            "strategy": "s",
+            "stage": "setup",
+            "direction": "long",
+        },
+    ]
+    missing_risk_evidence = {
+        "signal_id": "sig-risk-missing",
+        "symbol": "TSLA",
+        "strategy": "s",
+        "stage": "setup",
+        "direction": "long",
+        "outcome": "reject:missing_trade_risk_input",
+        "reason": "trade_risk_pct or stop_loss is required for deterministic sizing",
+        "missing_fields": ["stop_loss", "trade_risk_pct"],
+        "required_any_of": ["stop_loss", "trade_risk_pct"],
+        "sizing_method": "stop_distance",
+        "risk_profile_contract_id": "paper-execution-risk-profile.v1",
+    }
+    _FakeWorker.results = [
+        SignalEvaluationResult(
+            outcome="skip:no_open_position_to_exit",
+            signal_id="sig-exit-no-open",
+            reason="no open position found for exit signal",
+        ),
+        SignalEvaluationResult(
+            outcome="skip:score_below_threshold",
+            signal_id="sig-score-low",
+            reason="score=59.0 < min_score_threshold=60.0",
+        ),
+        SignalEvaluationResult(
+            outcome="reject:missing_trade_risk_input",
+            signal_id="sig-risk-missing",
+            reason="trade_risk_pct or stop_loss is required for deterministic sizing",
+            decision_inputs=missing_risk_evidence,
+        ),
+    ]
+
+    monkeypatch.setattr(cycle, "SqliteSignalRepository", _FakeSignalRepository)
+    monkeypatch.setattr(cycle, "SqliteCanonicalExecutionRepository", _FakeExecutionRepository)
+    monkeypatch.setattr(cycle, "BoundedPaperExecutionWorker", _FakeWorker)
+
+    exit_code = cycle.run_paper_execution_cycle(
+        db_path=str(tmp_path / "paper.db"),
+        evidence_dir=str(tmp_path),
+        ran_at=datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert exit_code == cycle.EXIT_CYCLE_NO_ELIGIBLE
+    evidence_file = tmp_path / "paper-execution-no-eligible-20260528T120000Z.json"
+    payload = json.loads(evidence_file.read_text(encoding="utf-8"))
+
+    assert payload["cycle_type"] == "bounded_paper_execution"
+    assert payload["eligible"] == 0
+    assert payload["skipped"] == 2
+    assert payload["rejected"] == 1
+    assert payload["signals_read"] == 3
+    assert payload["status"] == "no_eligible"
+
+    assert "decision_inputs" not in payload["results"][0]
+    assert "decision_inputs" not in payload["results"][1]
+    assert payload["results"][2]["decision_inputs"] == missing_risk_evidence
+
+    assert payload["diagnostics_summary"] == {
+        "signals_read": 3,
+        "entry_candidate_count": 2,
+        "exit_candidate_count": 1,
+        "eligible_entry_count": 0,
+        "eligible_exit_count": 0,
+        "skipped_exits_without_open_position": 1,
+        "score_filtered_entries": 1,
+        "risk_input_rejected_entries": 1,
+        "missing_trade_risk_input_count": 1,
+        "missing_trade_risk_input_rejections": [missing_risk_evidence],
+    }


### PR DESCRIPTION
## Summary
- Preserve SignalEvaluationResult decision_inputs in paper execution evidence results when present.
- Add deterministic diagnostics_summary counts for entry/exit candidates and key skip/reject categories.
- Include actionable missing trade-risk input diagnostics in the evidence payload.

## Tests
- python -m pytest tests/scripts/test_run_paper_execution_cycle_evidence.py tests/engine/test_paper_execution_worker.py

Closes #1208