### PR TITLE
[PAPER-RUNTIME][TURTLE] Add bounded risk-input evidence for entry sizing

### DIFF
--- a/scripts/run_paper_execution_cycle.py
+++ b/scripts/run_paper_execution_cycle.py
@@ -124,7 +124,100 @@ def _result_to_dict(result: SignalEvaluationResult) -> dict[str, Any]:
         d["trade_id"] = result.trade_id
     if result.reason is not None:
         d["reason"] = result.reason
+    if result.decision_inputs is not None:
+        d["decision_inputs"] = result.decision_inputs
     return d
+
+
+def _signal_stage(signal: Any) -> str | None:
+    stage = signal.get("stage") if isinstance(signal, dict) else getattr(signal, "stage", None)
+    return str(stage) if stage is not None else None
+
+
+def _signal_value(signal: Any, field: str) -> Any:
+    if isinstance(signal, dict):
+        return signal.get(field)
+    return getattr(signal, field, None)
+
+
+def _is_exit_signal(signal: Any) -> bool:
+    return _signal_stage(signal) == "exit"
+
+
+def _build_missing_trade_risk_input_diagnostic(
+    signal: Any,
+    result: SignalEvaluationResult,
+) -> dict[str, Any]:
+    decision_inputs = result.decision_inputs or {}
+    diagnostic: dict[str, Any] = {
+        "symbol": decision_inputs.get("symbol", _signal_value(signal, "symbol")),
+        "strategy": decision_inputs.get("strategy", _signal_value(signal, "strategy")),
+        "stage": decision_inputs.get("stage", _signal_value(signal, "stage")),
+        "direction": decision_inputs.get("direction", _signal_value(signal, "direction")),
+        "outcome": decision_inputs.get("outcome", result.outcome),
+        "reason": decision_inputs.get("reason", result.reason),
+        "missing_fields": decision_inputs.get("missing_fields", []),
+        "required_any_of": decision_inputs.get("required_any_of", []),
+        "sizing_method": decision_inputs.get("sizing_method"),
+        "risk_profile_contract_id": decision_inputs.get("risk_profile_contract_id"),
+    }
+    signal_id = decision_inputs.get("signal_id", result.signal_id or _signal_value(signal, "signal_id"))
+    if signal_id is not None:
+        diagnostic["signal_id"] = signal_id
+    return diagnostic
+
+
+def _build_diagnostics_summary(
+    signals: list[Any],
+    results: list[SignalEvaluationResult],
+) -> dict[str, Any]:
+    """Build deterministic JSON-safe diagnostics without changing outcomes."""
+    entry_candidate_count = 0
+    exit_candidate_count = 0
+    eligible_entry_count = 0
+    eligible_exit_count = 0
+    skipped_exits_without_open_position = 0
+    score_filtered_entries = 0
+    risk_input_rejected_entries = 0
+    missing_trade_risk_input_count = 0
+    missing_trade_risk_input_rejections: list[dict[str, Any]] = []
+
+    for signal, result in zip(signals, results):
+        is_exit = _is_exit_signal(signal)
+        if is_exit:
+            exit_candidate_count += 1
+        else:
+            entry_candidate_count += 1
+
+        if result.outcome.startswith("eligible"):
+            if is_exit:
+                eligible_exit_count += 1
+            else:
+                eligible_entry_count += 1
+
+        if is_exit and result.outcome == "skip:no_open_position_to_exit":
+            skipped_exits_without_open_position += 1
+        if not is_exit and result.outcome == "skip:score_below_threshold":
+            score_filtered_entries += 1
+        if not is_exit and result.outcome == "reject:missing_trade_risk_input":
+            risk_input_rejected_entries += 1
+            missing_trade_risk_input_count += 1
+            missing_trade_risk_input_rejections.append(
+                _build_missing_trade_risk_input_diagnostic(signal, result)
+            )
+
+    return {
+        "signals_read": len(signals),
+        "entry_candidate_count": entry_candidate_count,
+        "exit_candidate_count": exit_candidate_count,
+        "eligible_entry_count": eligible_entry_count,
+        "eligible_exit_count": eligible_exit_count,
+        "skipped_exits_without_open_position": skipped_exits_without_open_position,
+        "score_filtered_entries": score_filtered_entries,
+        "risk_input_rejected_entries": risk_input_rejected_entries,
+        "missing_trade_risk_input_count": missing_trade_risk_input_count,
+        "missing_trade_risk_input_rejections": missing_trade_risk_input_rejections,
+    }
 
 
 def run_paper_execution_cycle(
@@ -174,6 +267,7 @@ def run_paper_execution_cycle(
     result_payload: dict[str, Any] = {
         "cycle_type": "bounded_paper_execution",
         "db_path": db_path,
+        "diagnostics_summary": _build_diagnostics_summary(signals, results),
         "eligible": len(eligible),
         "ran_at": ran_at.isoformat(),
         "rejected": len(rejected),

--- a/src/cilly_trading/strategies/turtle.py
+++ b/src/cilly_trading/strategies/turtle.py
@@ -29,6 +29,42 @@ from cilly_trading.engine.core import BaseStrategy
 from cilly_trading.strategies._constants import PRICE_SCALE
 
 
+RISK_SCALE = Decimal("0.00000001")
+
+
+def _round_price(value: Decimal) -> float:
+    return float(value.quantize(PRICE_SCALE, ROUND_HALF_UP))
+
+
+def _round_risk_pct(value: Decimal) -> float:
+    return float(value.quantize(RISK_SCALE, ROUND_HALF_UP))
+
+
+def _derive_stop_loss(
+    *,
+    breakout_level: float,
+    stop_loss_buffer_pct: float,
+) -> float:
+    return _round_price(
+        Decimal(str(breakout_level))
+        * (Decimal("1") - Decimal(str(stop_loss_buffer_pct)))
+    )
+
+
+def _derive_setup_trade_risk_pct(
+    *,
+    breakout_level: float,
+    stop_loss: float,
+) -> float:
+    return _round_risk_pct(
+        (
+            Decimal(str(breakout_level))
+            - Decimal(str(stop_loss))
+        )
+        / Decimal(str(breakout_level))
+    )
+
+
 @dataclass
 class TurtleConfig:
     """Configuration for the Turtle strategy.
@@ -164,11 +200,9 @@ class TurtleStrategy(BaseStrategy):
                 "breakout level (e.g. daily close below breakout high or trailing stop)."
             )
 
-            _stop = float(
-                (
-                    Decimal(str(breakout_level))
-                    * (Decimal("1") - Decimal(str(cfg.stop_loss_buffer_pct)))
-                ).quantize(PRICE_SCALE, ROUND_HALF_UP)
+            _stop = _derive_stop_loss(
+                breakout_level=breakout_level,
+                stop_loss_buffer_pct=cfg.stop_loss_buffer_pct,
             )
             signal: Signal = {
                 "strategy": self.name,
@@ -208,11 +242,13 @@ class TurtleStrategy(BaseStrategy):
                         "Alternative: stop-buy order just above the breakout high."
                     )
 
-                    _stop = float(
-                        (
-                            Decimal(str(breakout_level))
-                            * (Decimal("1") - Decimal(str(cfg.stop_loss_buffer_pct)))
-                        ).quantize(PRICE_SCALE, ROUND_HALF_UP)
+                    _stop = _derive_stop_loss(
+                        breakout_level=breakout_level,
+                        stop_loss_buffer_pct=cfg.stop_loss_buffer_pct,
+                    )
+                    _trade_risk_pct = _derive_setup_trade_risk_pct(
+                        breakout_level=breakout_level,
+                        stop_loss=_stop,
                     )
                     signal = {
                         "strategy": self.name,
@@ -235,6 +271,7 @@ class TurtleStrategy(BaseStrategy):
                             ),
                         },
                         "stop_loss": _stop,
+                        "trade_risk_pct": _trade_risk_pct,
                     }
                     signals.append(signal)
 

--- a/tests/scripts/test_run_paper_execution_cycle_evidence.py
+++ b/tests/scripts/test_run_paper_execution_cycle_evidence.py
@@ -1,0 +1,135 @@
+"""Focused evidence tests for bounded paper execution cycle serialization."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import scripts.run_paper_execution_cycle as cycle
+from cilly_trading.engine.paper_execution_worker import SignalEvaluationResult
+
+
+class _FakeSignalRepository:
+    signals: list[dict[str, Any]] = []
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+    def list_signals(self, limit: int) -> list[dict[str, Any]]:
+        return self.signals[:limit]
+
+
+class _FakeExecutionRepository:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+
+class _FakeWorker:
+    results: list[SignalEvaluationResult] = []
+
+    def __init__(self, repository: _FakeExecutionRepository, risk_profile: Any) -> None:
+        self.repository = repository
+        self.risk_profile = risk_profile
+
+    def process_batch(self, signals: list[dict[str, Any]]) -> list[SignalEvaluationResult]:
+        return self.results
+
+
+def test_paper_execution_cycle_evidence_includes_diagnostics_and_decision_inputs(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    _FakeSignalRepository.signals = [
+        {
+            "signal_id": "sig-exit-no-open",
+            "symbol": "AAPL",
+            "strategy": "s",
+            "stage": "exit",
+            "direction": "long",
+        },
+        {
+            "signal_id": "sig-score-low",
+            "symbol": "MSFT",
+            "strategy": "s",
+            "stage": "setup",
+            "direction": "long",
+        },
+        {
+            "signal_id": "sig-risk-missing",
+            "symbol": "TSLA",
+            "strategy": "s",
+            "stage": "setup",
+            "direction": "long",
+        },
+    ]
+    missing_risk_evidence = {
+        "signal_id": "sig-risk-missing",
+        "symbol": "TSLA",
+        "strategy": "s",
+        "stage": "setup",
+        "direction": "long",
+        "outcome": "reject:missing_trade_risk_input",
+        "reason": "trade_risk_pct or stop_loss is required for deterministic sizing",
+        "missing_fields": ["stop_loss", "trade_risk_pct"],
+        "required_any_of": ["stop_loss", "trade_risk_pct"],
+        "sizing_method": "stop_distance",
+        "risk_profile_contract_id": "paper-execution-risk-profile.v1",
+    }
+    _FakeWorker.results = [
+        SignalEvaluationResult(
+            outcome="skip:no_open_position_to_exit",
+            signal_id="sig-exit-no-open",
+            reason="no open position found for exit signal",
+        ),
+        SignalEvaluationResult(
+            outcome="skip:score_below_threshold",
+            signal_id="sig-score-low",
+            reason="score=59.0 < min_score_threshold=60.0",
+        ),
+        SignalEvaluationResult(
+            outcome="reject:missing_trade_risk_input",
+            signal_id="sig-risk-missing",
+            reason="trade_risk_pct or stop_loss is required for deterministic sizing",
+            decision_inputs=missing_risk_evidence,
+        ),
+    ]
+
+    monkeypatch.setattr(cycle, "SqliteSignalRepository", _FakeSignalRepository)
+    monkeypatch.setattr(cycle, "SqliteCanonicalExecutionRepository", _FakeExecutionRepository)
+    monkeypatch.setattr(cycle, "BoundedPaperExecutionWorker", _FakeWorker)
+
+    exit_code = cycle.run_paper_execution_cycle(
+        db_path=str(tmp_path / "paper.db"),
+        evidence_dir=str(tmp_path),
+        ran_at=datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert exit_code == cycle.EXIT_CYCLE_NO_ELIGIBLE
+    evidence_file = tmp_path / "paper-execution-no-eligible-20260528T120000Z.json"
+    payload = json.loads(evidence_file.read_text(encoding="utf-8"))
+
+    assert payload["cycle_type"] == "bounded_paper_execution"
+    assert payload["eligible"] == 0
+    assert payload["skipped"] == 2
+    assert payload["rejected"] == 1
+    assert payload["signals_read"] == 3
+    assert payload["status"] == "no_eligible"
+
+    assert "decision_inputs" not in payload["results"][0]
+    assert "decision_inputs" not in payload["results"][1]
+    assert payload["results"][2]["decision_inputs"] == missing_risk_evidence
+
+    assert payload["diagnostics_summary"] == {
+        "signals_read": 3,
+        "entry_candidate_count": 2,
+        "exit_candidate_count": 1,
+        "eligible_entry_count": 0,
+        "eligible_exit_count": 0,
+        "skipped_exits_without_open_position": 1,
+        "score_filtered_entries": 1,
+        "risk_input_rejected_entries": 1,
+        "missing_trade_risk_input_count": 1,
+        "missing_trade_risk_input_rejections": [missing_risk_evidence],
+    }

--- a/tests/strategies/test_turtle_paper_risk_input.py
+++ b/tests/strategies/test_turtle_paper_risk_input.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pandas as pd
+
+from cilly_trading.engine.paper_execution_worker import _resolve_trade_risk_pct
+from cilly_trading.strategies.turtle import TurtleStrategy
+
+
+def _turtle_setup_df() -> pd.DataFrame:
+    lookback = 20
+    highs = [100.0] * lookback + [100.0]
+    lows = [97.0] * lookback + [97.0]
+    closes = [99.0] * lookback + [99.5]
+    return pd.DataFrame({"high": highs, "low": lows, "close": closes})
+
+
+def _turtle_entry_confirmed_df() -> pd.DataFrame:
+    lookback = 20
+    highs = [100.0] * lookback + [100.0]
+    lows = [97.0] * lookback + [97.0]
+    closes = [99.0] * lookback + [101.0]
+    return pd.DataFrame({"high": highs, "low": lows, "close": closes})
+
+
+def _generate_single_turtle_signal(df: pd.DataFrame) -> dict[str, Any]:
+    signals = TurtleStrategy().generate_signals(
+        df=df,
+        config={
+            "breakout_lookback": 20,
+            "proximity_threshold_pct": 0.03,
+            "min_score": 0.0,
+        },
+    )
+    assert len(signals) == 1
+    return signals[0]
+
+
+def test_turtle_setup_entry_candidate_emits_deterministic_paper_risk_input() -> None:
+    signal = _generate_single_turtle_signal(_turtle_setup_df())
+
+    assert signal["strategy"] == "TURTLE"
+    assert signal["stage"] == "setup"
+    assert signal["stop_loss"] == 99.0
+    assert signal["trade_risk_pct"] == 0.01
+
+
+def test_turtle_entry_confirmed_candidate_emits_stop_loss_risk_input() -> None:
+    signal = _generate_single_turtle_signal(_turtle_entry_confirmed_df())
+
+    assert signal["strategy"] == "TURTLE"
+    assert signal["stage"] == "entry_confirmed"
+    assert signal["stop_loss"] == 99.0
+    assert "trade_risk_pct" not in signal
+
+
+def test_turtle_entry_candidates_do_not_add_broker_or_live_execution_fields() -> None:
+    disallowed_fields = {
+        "broker",
+        "broker_order_id",
+        "broker_route",
+        "execution_mode",
+        "live",
+        "live_order",
+        "order_id",
+        "order_type",
+    }
+
+    setup_signal = _generate_single_turtle_signal(_turtle_setup_df())
+    confirmed_signal = _generate_single_turtle_signal(_turtle_entry_confirmed_df())
+
+    assert disallowed_fields.isdisjoint(setup_signal)
+    assert disallowed_fields.isdisjoint(confirmed_signal)
+
+
+def test_turtle_setup_risk_input_avoids_missing_trade_risk_rejection() -> None:
+    signal = _generate_single_turtle_signal(_turtle_setup_df())
+
+    outcome, trade_risk_pct, reason = _resolve_trade_risk_pct(
+        signal,
+        entry_price=Decimal("99.00"),
+        sizing_method="stop_distance",
+    )
+
+    assert outcome is None
+    assert trade_risk_pct == Decimal("0.01")
+    assert reason is None
+
+
+def test_turtle_entry_confirmed_stop_loss_avoids_missing_trade_risk_rejection() -> None:
+    signal = _generate_single_turtle_signal(_turtle_entry_confirmed_df())
+
+    outcome, trade_risk_pct, reason = _resolve_trade_risk_pct(
+        signal,
+        entry_price=Decimal("101.00"),
+        sizing_method="stop_distance",
+    )
+
+    assert outcome is None
+    assert trade_risk_pct == Decimal("0.01980198019801980198019801980")
+    assert reason is None


### PR DESCRIPTION
Closes #1210

Summary:
- Adds deterministic TURTLE setup trade_risk_pct derived from the existing breakout-level stop distance.
- Preserves TURTLE entry_confirmed stop_loss risk input behavior.
- Adds focused tests for setup, entry_confirmed, no broker/live signal fields, and missing_trade_risk_input avoidance.

Tests:
- .\.venv\Scripts\python.exe -m pytest