### PR TITLE
Preserve TURTLE risk fields through signal reconstruction

### DIFF
--- a/src/cilly_trading/repositories/signals_sqlite.py
+++ b/src/cilly_trading/repositories/signals_sqlite.py
@@ -25,6 +25,7 @@ _ALLOWED_SIGNAL_COLUMNS: frozenset[tuple[str, str]] = frozenset({
     ("ingestion_run_id", "TEXT"),
     ("reasons_json", "TEXT"),
     ("stop_loss", "REAL"),
+    ("trade_risk_pct", "REAL"),
 })
 
 
@@ -128,6 +129,7 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                     entry_zone_from,
                     entry_zone_to,
                     stop_loss,
+                    trade_risk_pct,
                     confirmation_rule,
                     timeframe,
                     market_type,
@@ -147,6 +149,7 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                     :entry_zone_from,
                     :entry_zone_to,
                     :stop_loss,
+                    :trade_risk_pct,
                     :confirmation_rule,
                     :timeframe,
                     :market_type,
@@ -175,6 +178,7 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                             s["entry_zone"]["to"] if "entry_zone" in s and s["entry_zone"] else None
                         ),
                         "stop_loss": s.get("stop_loss"),
+                        "trade_risk_pct": s.get("trade_risk_pct"),
                         "confirmation_rule": s.get("confirmation_rule"),
                         "timeframe": s["timeframe"],
                         "market_type": s["market_type"],
@@ -205,6 +209,7 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                     entry_zone_from,
                     entry_zone_to,
                     stop_loss,
+                    trade_risk_pct,
                     confirmation_rule,
                     timeframe,
                     market_type,
@@ -253,6 +258,8 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                 }
             if row["stop_loss"] is not None:
                 signal["stop_loss"] = row["stop_loss"]
+            if row["trade_risk_pct"] is not None:
+                signal["trade_risk_pct"] = row["trade_risk_pct"]
 
             result.append(signal)
 
@@ -383,6 +390,7 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                             entry_zone_from,
                             entry_zone_to,
                             stop_loss,
+                            trade_risk_pct,
                             confirmation_rule,
                             timeframe,
                             market_type,
@@ -421,6 +429,7 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                         entry_zone_from,
                         entry_zone_to,
                         stop_loss,
+                        trade_risk_pct,
                         confirmation_rule,
                         timeframe,
                         market_type,
@@ -454,6 +463,7 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                         entry_zone_from,
                         entry_zone_to,
                         stop_loss,
+                        trade_risk_pct,
                         confirmation_rule,
                         timeframe,
                         market_type,
@@ -503,6 +513,8 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
                 }
             if row["stop_loss"] is not None:
                 signal["stop_loss"] = row["stop_loss"]
+            if row["trade_risk_pct"] is not None:
+                signal["trade_risk_pct"] = row["trade_risk_pct"]
 
             result.append(signal)
 
@@ -666,6 +678,10 @@ def reconstruct_signal_explanation(signal: Signal) -> dict:
     }
     if "entry_zone" in signal:
         explanation["entry_zone"] = signal["entry_zone"]
+    if "stop_loss" in signal:
+        explanation["stop_loss"] = signal["stop_loss"]
+    if "trade_risk_pct" in signal:
+        explanation["trade_risk_pct"] = signal["trade_risk_pct"]
     if "confirmation_rule" in signal:
         explanation["confirmation_rule"] = signal["confirmation_rule"]
 

--- a/tests/strategies/test_turtle_paper_risk_input.py
+++ b/tests/strategies/test_turtle_paper_risk_input.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
-from cilly_trading.engine.paper_execution_worker import _resolve_trade_risk_pct
+from cilly_trading.engine.paper_execution_risk_profile import PaperExecutionRiskProfile
+from cilly_trading.engine.paper_execution_worker import (
+    BoundedPaperExecutionWorker,
+    _resolve_trade_risk_pct,
+)
+from cilly_trading.repositories.execution_core_sqlite import SqliteCanonicalExecutionRepository
+from cilly_trading.repositories.signals_sqlite import SqliteSignalRepository
 from cilly_trading.strategies.turtle import TurtleStrategy
 
 
@@ -38,6 +45,24 @@ def _generate_single_turtle_signal(df: pd.DataFrame) -> dict[str, Any]:
     return signals[0]
 
 
+def _persist_and_reconstruct_turtle_signal(
+    tmp_path: Path,
+    signal: dict[str, Any],
+) -> dict[str, Any]:
+    persisted = {
+        **signal,
+        "ingestion_run_id": "turtle-risk-ingestion",
+        "symbol": "AAPL",
+        "timestamp": "2026-01-15T00:00:00Z",
+        "timeframe": "D1",
+        "market_type": "stock",
+        "data_source": "yahoo",
+    }
+    repo = SqliteSignalRepository(db_path=tmp_path / "signals.db")
+    repo.save_signals([persisted])
+    return repo.list_signals(limit=1)[0]
+
+
 def test_turtle_setup_entry_candidate_emits_deterministic_paper_risk_input() -> None:
     signal = _generate_single_turtle_signal(_turtle_setup_df())
 
@@ -47,6 +72,18 @@ def test_turtle_setup_entry_candidate_emits_deterministic_paper_risk_input() -> 
     assert signal["trade_risk_pct"] == 0.01
 
 
+def test_persisted_reconstructed_turtle_setup_preserves_trade_risk_pct(
+    tmp_path: Path,
+) -> None:
+    signal = _generate_single_turtle_signal(_turtle_setup_df())
+
+    reconstructed = _persist_and_reconstruct_turtle_signal(tmp_path, signal)
+
+    assert reconstructed["strategy"] == "TURTLE"
+    assert reconstructed["stage"] == "setup"
+    assert reconstructed["trade_risk_pct"] == 0.01
+
+
 def test_turtle_entry_confirmed_candidate_emits_stop_loss_risk_input() -> None:
     signal = _generate_single_turtle_signal(_turtle_entry_confirmed_df())
 
@@ -54,6 +91,19 @@ def test_turtle_entry_confirmed_candidate_emits_stop_loss_risk_input() -> None:
     assert signal["stage"] == "entry_confirmed"
     assert signal["stop_loss"] == 99.0
     assert "trade_risk_pct" not in signal
+
+
+def test_persisted_reconstructed_turtle_entry_confirmed_preserves_stop_loss(
+    tmp_path: Path,
+) -> None:
+    signal = _generate_single_turtle_signal(_turtle_entry_confirmed_df())
+
+    reconstructed = _persist_and_reconstruct_turtle_signal(tmp_path, signal)
+
+    assert reconstructed["strategy"] == "TURTLE"
+    assert reconstructed["stage"] == "entry_confirmed"
+    assert reconstructed["stop_loss"] == 99.0
+    assert "trade_risk_pct" not in reconstructed
 
 
 def test_turtle_entry_candidates_do_not_add_broker_or_live_execution_fields() -> None:
@@ -87,6 +137,29 @@ def test_turtle_setup_risk_input_avoids_missing_trade_risk_rejection() -> None:
     assert outcome is None
     assert trade_risk_pct == Decimal("0.01")
     assert reason is None
+
+
+def test_persisted_reconstructed_turtle_setup_avoids_missing_trade_risk_rejection(
+    tmp_path: Path,
+) -> None:
+    signal = _generate_single_turtle_signal(_turtle_setup_df())
+    reconstructed = _persist_and_reconstruct_turtle_signal(tmp_path, signal)
+    paper_repo = SqliteCanonicalExecutionRepository(db_path=tmp_path / "paper.db")
+    worker = BoundedPaperExecutionWorker(
+        repository=paper_repo,
+        risk_profile=PaperExecutionRiskProfile(
+            max_total_exposure_pct=Decimal("1.00"),
+            max_strategy_exposure_pct=Decimal("1.00"),
+            max_symbol_exposure_pct=Decimal("1.00"),
+        ),
+    )
+
+    result = worker.process_signal(reconstructed)
+
+    assert result.outcome != "reject:missing_trade_risk_input"
+    assert result.outcome == "eligible", result.reason
+    assert result.decision_inputs is not None
+    assert Decimal(str(result.decision_inputs["trade_risk_pct"])) == Decimal("0.01")
 
 
 def test_turtle_entry_confirmed_stop_loss_avoids_missing_trade_risk_rejection() -> None:


### PR DESCRIPTION
Closes #1212

## Summary
- Persist signal.trade_risk_pct in the SQLite signal repository.
- Reconstruct trade_risk_pct on signal list/read paths.
- Preserve stop_loss/trade_risk_pct in reconstructed signal explanations.
- Add focused TURTLE persistence and paper-execution regression tests.

## Tests
- python -m pytest tests\strategies\test_turtle_paper_risk_input.py tests\test_signal_repository_sqlite.py tests\engine\test_paper_execution_worker.py tests\scripts\test_run_paper_execution_cycle_evidence.py -q
- python -m pytest -q

Note:
Full-suite failures are identical before and after the #1212 patch and are not introduced by this change.