### PR TITLE
[PAPER-RUNTIME][SIGNAL-SCOPE] Consume current-run paper execution signals only

### DIFF
--- a/scripts/run_daily_bounded_paper_runtime.py
+++ b/scripts/run_daily_bounded_paper_runtime.py
@@ -1723,6 +1723,7 @@ def run_daily_bounded_paper_runtime(
                     "ingestion_run_id": ingestion_run_id,
                 },
             )
+        analysis_run_id = str(analysis_payload.get("analysis_run_id", ""))
         steps_completed.append("analysis_signal_generation")
 
         # Step 3: bounded paper execution cycle
@@ -1733,6 +1734,10 @@ def run_daily_bounded_paper_runtime(
                 db_path,
                 "--evidence-dir",
                 execution_evidence_dir,
+                "--analysis-run-id",
+                analysis_run_id,
+                "--ingestion-run-id",
+                ingestion_run_id,
             ],
             run_command=run_command,
         )
@@ -1874,7 +1879,7 @@ def run_daily_bounded_paper_runtime(
             paper_state_freshness=paper_state_freshness,
         )
         summary_payload: dict[str, Any] = {
-            "analysis_run_id": str(analysis_payload.get("analysis_run_id", "")),
+            "analysis_run_id": analysis_run_id,
             "completed_at": completed_at.isoformat(),
             "ingestion_run_id": ingestion_run_id,
             "paper_state_freshness": paper_state_freshness,

--- a/scripts/run_paper_execution_cycle.py
+++ b/scripts/run_paper_execution_cycle.py
@@ -83,6 +83,16 @@ def _parse_args() -> argparse.Namespace:
         default=500,
         help="Maximum number of signals to read.  Default: 500.",
     )
+    parser.add_argument(
+        "--analysis-run-id",
+        default=None,
+        help="Scope signal reads to the current analysis run when provided.",
+    )
+    parser.add_argument(
+        "--ingestion-run-id",
+        default=None,
+        help="Scope signal reads to the current ingestion run when provided.",
+    )
     return parser.parse_args()
 
 
@@ -142,6 +152,42 @@ def _signal_value(signal: Any, field: str) -> Any:
 
 def _is_exit_signal(signal: Any) -> bool:
     return _signal_stage(signal) == "exit"
+
+
+def _clean_scope_id(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _signal_scope_metadata(
+    *,
+    analysis_run_id: str | None,
+    ingestion_run_id: str | None,
+    signals_read: int,
+) -> dict[str, Any]:
+    scope_filters: list[str] = []
+    if analysis_run_id is not None:
+        scope_filters.append("analysis_run_id")
+    if ingestion_run_id is not None:
+        scope_filters.append("ingestion_run_id")
+
+    if scope_filters:
+        selection_mode = "current_run_scope"
+        fallback_reason = None
+    else:
+        selection_mode = "latest_per_identity_fallback"
+        fallback_reason = "current_run_scope_unavailable"
+
+    return {
+        "analysis_run_id": analysis_run_id,
+        "fallback_reason": fallback_reason,
+        "ingestion_run_id": ingestion_run_id,
+        "scope_filters": scope_filters,
+        "selection_mode": selection_mode,
+        "signals_read": signals_read,
+    }
 
 
 def _build_missing_trade_risk_input_diagnostic(
@@ -225,10 +271,14 @@ def run_paper_execution_cycle(
     db_path: str,
     evidence_dir: str,
     signal_limit: int = 500,
+    analysis_run_id: str | None = None,
+    ingestion_run_id: str | None = None,
     ran_at: datetime | None = None,
 ) -> int:
     """Execute bounded paper execution cycle.  Returns exit code."""
     ran_at = ran_at or _utc_now()
+    analysis_run_id = _clean_scope_id(analysis_run_id)
+    ingestion_run_id = _clean_scope_id(ingestion_run_id)
     evidence_path = Path(evidence_dir)
     stamp = ran_at.strftime("%Y%m%dT%H%M%SZ")
 
@@ -236,7 +286,12 @@ def run_paper_execution_cycle(
         signal_repo = SqliteSignalRepository(db_path=Path(db_path))
         execution_repo = SqliteCanonicalExecutionRepository(db_path=Path(db_path))
 
-        signals = signal_repo.list_signals(limit=signal_limit)
+        signals = signal_repo.list_signals(
+            limit=signal_limit,
+            analysis_run_id=analysis_run_id,
+            ingestion_run_id=ingestion_run_id,
+            latest_per_identity=analysis_run_id is None and ingestion_run_id is None,
+        )
 
         risk_profile = DEFAULT_PAPER_EXECUTION_RISK_PROFILE
         worker = BoundedPaperExecutionWorker(
@@ -273,6 +328,11 @@ def run_paper_execution_cycle(
         "rejected": len(rejected),
         "results": [_result_to_dict(r) for r in results],
         "risk_profile": risk_profile.to_payload(),
+        "signal_scope": _signal_scope_metadata(
+            analysis_run_id=analysis_run_id,
+            ingestion_run_id=ingestion_run_id,
+            signals_read=len(signals),
+        ),
         "signals_read": len(signals),
         "skipped": len(skipped),
         "status": "pass" if eligible else "no_eligible",
@@ -298,6 +358,8 @@ def main() -> int:
         db_path=args.db_path,
         evidence_dir=args.evidence_dir,
         signal_limit=args.signal_limit,
+        analysis_run_id=args.analysis_run_id,
+        ingestion_run_id=args.ingestion_run_id,
     )
 
 

--- a/src/cilly_trading/repositories/signals_sqlite.py
+++ b/src/cilly_trading/repositories/signals_sqlite.py
@@ -190,37 +190,126 @@ class SqliteSignalRepository(BaseSqliteRepository, SignalRepository):
             )
             conn.commit()
 
-    def list_signals(self, limit: int = 100) -> List[Signal]:
+    def list_signals(
+        self,
+        limit: int = 100,
+        *,
+        analysis_run_id: Optional[str] = None,
+        ingestion_run_id: Optional[str] = None,
+        latest_per_identity: bool = False,
+    ) -> List[Signal]:
+        where_clauses: list[str] = []
+        params: list[object] = []
+        scope_clauses: list[str] = []
+        if analysis_run_id is not None:
+            scope_clauses.append("analysis_run_id = ?")
+            params.append(analysis_run_id)
+        if ingestion_run_id is not None:
+            scope_clauses.append("ingestion_run_id = ?")
+            params.append(ingestion_run_id)
+        if scope_clauses:
+            where_clauses.append(f"({' OR '.join(scope_clauses)})")
+        where_sql = self._compose_where_clause(where_clauses)
+        normalized_timestamp = "REPLACE(timestamp, 'Z', '+00:00')"
+
         with self._connection() as conn:
             cur = conn.cursor()
-            cur.execute(
-                """
-                SELECT
-                    id,
-                    signal_id,
-                    analysis_run_id,
-                    ingestion_run_id,
-                    symbol,
-                    strategy,
-                    direction,
-                    score,
-                    timestamp,
-                    stage,
-                    entry_zone_from,
-                    entry_zone_to,
-                    stop_loss,
-                    trade_risk_pct,
-                    confirmation_rule,
-                    timeframe,
-                    market_type,
-                    data_source,
-                    reasons_json
-                FROM signals
-                ORDER BY id DESC
-                LIMIT ?;
-                """,
-                (limit,),
-            )
+            if latest_per_identity:
+                dedupe_identity_sql = (
+                    "CASE "
+                    "WHEN signal_id IS NOT NULL THEN signal_id "
+                    "ELSE symbol || '|' || strategy || '|' || direction || '|' || "
+                    "CAST(score AS TEXT) || '|' || timestamp || '|' || stage || '|' || "
+                    "timeframe || '|' || market_type || '|' || data_source "
+                    "END"
+                )
+                cur.execute(
+                    f"""
+                    WITH ranked_signals AS (
+                        SELECT
+                            id,
+                            signal_id,
+                            analysis_run_id,
+                            ingestion_run_id,
+                            symbol,
+                            strategy,
+                            direction,
+                            score,
+                            timestamp,
+                            stage,
+                            entry_zone_from,
+                            entry_zone_to,
+                            stop_loss,
+                            trade_risk_pct,
+                            confirmation_rule,
+                            timeframe,
+                            market_type,
+                            data_source,
+                            reasons_json,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY {dedupe_identity_sql}
+                                ORDER BY {normalized_timestamp} DESC, id DESC
+                            ) AS dedupe_rank
+                        FROM signals
+                        {where_sql}
+                    )
+                    SELECT
+                        id,
+                        signal_id,
+                        analysis_run_id,
+                        ingestion_run_id,
+                        symbol,
+                        strategy,
+                        direction,
+                        score,
+                        timestamp,
+                        stage,
+                        entry_zone_from,
+                        entry_zone_to,
+                        stop_loss,
+                        trade_risk_pct,
+                        confirmation_rule,
+                        timeframe,
+                        market_type,
+                        data_source,
+                        reasons_json
+                    FROM ranked_signals
+                    WHERE dedupe_rank = 1
+                    ORDER BY {normalized_timestamp} DESC, id DESC
+                    LIMIT ?;
+                    """,
+                    [*params, limit],
+                )
+            else:
+                cur.execute(
+                    f"""
+                    SELECT
+                        id,
+                        signal_id,
+                        analysis_run_id,
+                        ingestion_run_id,
+                        symbol,
+                        strategy,
+                        direction,
+                        score,
+                        timestamp,
+                        stage,
+                        entry_zone_from,
+                        entry_zone_to,
+                        stop_loss,
+                        trade_risk_pct,
+                        confirmation_rule,
+                        timeframe,
+                        market_type,
+                        data_source,
+                        reasons_json
+                    FROM signals
+                    {where_sql}
+                    ORDER BY id DESC
+                    LIMIT ?;
+                    """,
+                    [*params, limit],
+                )
             rows = cur.fetchall()
 
         result: List[Signal] = []

--- a/tests/scripts/test_run_paper_execution_cycle_evidence.py
+++ b/tests/scripts/test_run_paper_execution_cycle_evidence.py
@@ -17,7 +17,15 @@ class _FakeSignalRepository:
     def __init__(self, db_path: Path) -> None:
         self.db_path = db_path
 
-    def list_signals(self, limit: int) -> list[dict[str, Any]]:
+    def list_signals(
+        self,
+        limit: int,
+        *,
+        analysis_run_id: str | None = None,
+        ingestion_run_id: str | None = None,
+        latest_per_identity: bool = False,
+    ) -> list[dict[str, Any]]:
+        del analysis_run_id, ingestion_run_id, latest_per_identity
         return self.signals[:limit]
 
 
@@ -132,4 +140,12 @@ def test_paper_execution_cycle_evidence_includes_diagnostics_and_decision_inputs
         "risk_input_rejected_entries": 1,
         "missing_trade_risk_input_count": 1,
         "missing_trade_risk_input_rejections": [missing_risk_evidence],
+    }
+    assert payload["signal_scope"] == {
+        "analysis_run_id": None,
+        "fallback_reason": "current_run_scope_unavailable",
+        "ingestion_run_id": None,
+        "scope_filters": [],
+        "selection_mode": "latest_per_identity_fallback",
+        "signals_read": 3,
     }

--- a/tests/test_run_daily_bounded_paper_runtime_script.py
+++ b/tests/test_run_daily_bounded_paper_runtime_script.py
@@ -89,6 +89,8 @@ def test_daily_runner_sends_current_manual_analysis_contract_and_reaches_executi
         if script_name == "run_paper_execution_cycle.py":
             assert "--db-path" in command
             assert command[command.index("--db-path") + 1] == str(db_path)
+            assert command[command.index("--analysis-run-id") + 1] == "analysis-contract-ok"
+            assert command[command.index("--ingestion-run-id") + 1] == ingestion_run_id
             return subprocess.CompletedProcess(
                 command,
                 2,

--- a/tests/test_run_paper_execution_cycle_script.py
+++ b/tests/test_run_paper_execution_cycle_script.py
@@ -115,3 +115,143 @@ def test_run_paper_execution_cycle_routes_exit_signals_to_worker(
     closed_trade = execution_repo.get_trade(entry_result.trade_id)
     assert closed_trade is not None
     assert closed_trade.status == "closed"
+
+
+def test_run_paper_execution_cycle_uses_current_run_scope_over_stale_turtle_rows(
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    db_path = tmp_path / "paper_execution_scope.db"
+    evidence_dir = tmp_path / "evidence"
+    signal_repo = SqliteSignalRepository(db_path=db_path)
+
+    signal_repo.save_signals(
+        [
+            {
+                "signal_id": "turtle-scope-signal",
+                "analysis_run_id": "analysis-stale",
+                "ingestion_run_id": "ingestion-stale",
+                "symbol": "WMT",
+                "strategy": "TURTLE",
+                "direction": "long",  # type: ignore[typeddict-item]
+                "score": 80.0,
+                "timestamp": "2026-05-27T12:00:00Z",
+                "stage": "setup",  # type: ignore[typeddict-item]
+                "entry_zone": {"from_": 100.0, "to": 100.0},
+                "timeframe": "D1",
+                "market_type": "stock",  # type: ignore[typeddict-item]
+                "data_source": "snapshot",  # type: ignore[typeddict-item]
+            },
+            {
+                "signal_id": "turtle-scope-signal",
+                "analysis_run_id": "analysis-current",
+                "ingestion_run_id": "ingestion-current",
+                "symbol": "WMT",
+                "strategy": "TURTLE",
+                "direction": "long",  # type: ignore[typeddict-item]
+                "score": 80.0,
+                "timestamp": "2026-05-28T12:00:00Z",
+                "stage": "setup",  # type: ignore[typeddict-item]
+                "entry_zone": {"from_": 100.0, "to": 100.0},
+                "stop_loss": 95.0,
+                "timeframe": "D1",
+                "market_type": "stock",  # type: ignore[typeddict-item]
+                "data_source": "snapshot",  # type: ignore[typeddict-item]
+            },
+        ]
+    )
+
+    exit_code = module.run_paper_execution_cycle(
+        db_path=str(db_path),
+        evidence_dir=str(evidence_dir),
+        signal_limit=10,
+        analysis_run_id="analysis-current",
+        ingestion_run_id="ingestion-current",
+        ran_at=datetime(2026, 5, 28, 13, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert exit_code == module.EXIT_CYCLE_PASS
+    evidence_file = evidence_dir / "paper-execution-pass-20260528T130000Z.json"
+    payload = json.loads(evidence_file.read_text(encoding="utf-8"))
+
+    assert payload["signals_read"] == 1
+    assert payload["signal_scope"] == {
+        "analysis_run_id": "analysis-current",
+        "fallback_reason": None,
+        "ingestion_run_id": "ingestion-current",
+        "scope_filters": ["analysis_run_id", "ingestion_run_id"],
+        "selection_mode": "current_run_scope",
+        "signals_read": 1,
+    }
+    assert payload["eligible"] == 1
+    assert payload["rejected"] == 0
+    assert payload["diagnostics_summary"]["missing_trade_risk_input_count"] == 0
+    assert payload["results"][0]["outcome"] == "eligible"
+    assert payload["results"][0]["decision_inputs"]["trade_risk_pct"] == "0.05"
+
+
+def test_run_paper_execution_cycle_fallback_uses_latest_signal_identity_with_risk(
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    db_path = tmp_path / "paper_execution_fallback.db"
+    evidence_dir = tmp_path / "evidence"
+    signal_repo = SqliteSignalRepository(db_path=db_path)
+
+    signal_repo.save_signals(
+        [
+            {
+                "signal_id": "turtle-fallback-signal",
+                "analysis_run_id": "analysis-old",
+                "ingestion_run_id": "ingestion-old",
+                "symbol": "COST",
+                "strategy": "TURTLE",
+                "direction": "long",  # type: ignore[typeddict-item]
+                "score": 80.0,
+                "timestamp": "2026-05-27T12:00:00Z",
+                "stage": "setup",  # type: ignore[typeddict-item]
+                "entry_zone": {"from_": 200.0, "to": 200.0},
+                "timeframe": "D1",
+                "market_type": "stock",  # type: ignore[typeddict-item]
+                "data_source": "snapshot",  # type: ignore[typeddict-item]
+            },
+            {
+                "signal_id": "turtle-fallback-signal",
+                "analysis_run_id": "analysis-new",
+                "ingestion_run_id": "ingestion-new",
+                "symbol": "COST",
+                "strategy": "TURTLE",
+                "direction": "long",  # type: ignore[typeddict-item]
+                "score": 80.0,
+                "timestamp": "2026-05-28T12:00:00Z",
+                "stage": "setup",  # type: ignore[typeddict-item]
+                "entry_zone": {"from_": 200.0, "to": 200.0},
+                "trade_risk_pct": 0.03,
+                "timeframe": "D1",
+                "market_type": "stock",  # type: ignore[typeddict-item]
+                "data_source": "snapshot",  # type: ignore[typeddict-item]
+            },
+        ]
+    )
+
+    exit_code = module.run_paper_execution_cycle(
+        db_path=str(db_path),
+        evidence_dir=str(evidence_dir),
+        signal_limit=10,
+        ran_at=datetime(2026, 5, 28, 14, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert exit_code == module.EXIT_CYCLE_PASS
+    evidence_file = evidence_dir / "paper-execution-pass-20260528T140000Z.json"
+    payload = json.loads(evidence_file.read_text(encoding="utf-8"))
+
+    assert payload["signals_read"] == 1
+    assert payload["signal_scope"]["selection_mode"] == "latest_per_identity_fallback"
+    assert payload["signal_scope"]["fallback_reason"] == "current_run_scope_unavailable"
+    assert payload["eligible"] == 1
+    assert payload["rejected"] == 0
+    assert payload["diagnostics_summary"]["missing_trade_risk_input_count"] == 0
+    assert payload["results"][0]["outcome"] == "eligible"
+    assert payload["results"][0]["decision_inputs"]["trade_risk_pct"] == "0.03"


### PR DESCRIPTION
Closes #1214

Summary:
- Pass current analysis_run_id and ingestion_run_id from daily bounded runtime into paper execution.
- Scope paper execution signal reads to current-run IDs when available.
- Add deterministic latest-per-identity fallback only when current-run scope is unavailable.
- Add signal_scope evidence metadata and focused stale-row regression coverage.

Tests:
- python -m pytest tests/test_run_paper_execution_cycle_script.py tests/scripts/test_run_paper_execution_cycle_evidence.py tests/test_run_daily_bounded_paper_runtime_script.py tests/test_signal_repository_sqlite.py
- python -m pytest

Note:
Full-suite failures are existing API/runtime contract failures outside #1214 scope.
Ruff was not executed because the local environment has no ruff module installed.