### PR TITLE
Add local OHLCV source for historical exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ htmlcov/
 runs/
 /.codex/issue-*-runtime/
 /data/artifacts/
+/data/local_ohlcv_cache*/
 
 # Local editor settings
 .vscode/

--- a/scripts/export_historical_snapshots.py
+++ b/scripts/export_historical_snapshots.py
@@ -32,6 +32,7 @@ Additional outputs (--annotate-signals mode):
 from __future__ import annotations
 
 import argparse
+import csv
 import hashlib
 import json
 import sys
@@ -58,6 +59,8 @@ _MIN_SCORE_THRESHOLD = 60.0
 _MAX_RISK_PER_TRADE_PCT = 0.01
 _RISK_PCT_SCALE = Decimal("0.00000001")
 _SCORE_BUCKETS = ("<50", "50-55", "55-60", "60-65", "65-70", "70+")
+_SOURCE_YFINANCE = "yfinance"
+_SOURCE_CSV_DIR = "csv-dir"
 
 # Default TurtleStrategy parameters (match TurtleConfig defaults).
 _TURTLE_DEFAULT_CONFIG: dict[str, Any] = {
@@ -148,6 +151,94 @@ def _fetch_symbol(symbol: str, start: date, end: date, *, session=None) -> list[
     return rows
 
 
+def _parse_local_csv_date(raw_value: str) -> datetime | None:
+    value = raw_value.strip()
+    if not value:
+        return None
+    try:
+        if "T" in value:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+        parsed_date = date.fromisoformat(value)
+        return datetime(parsed_date.year, parsed_date.month, parsed_date.day, tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _normalize_local_csv_number(raw_value: Any, *, integer: bool = False) -> str | None:
+    if raw_value is None:
+        return None
+    value = str(raw_value).strip()
+    if not value:
+        return None
+    try:
+        number = Decimal(value)
+    except Exception:
+        return None
+    if not number.is_finite():
+        return None
+    if integer:
+        return str(int(number))
+    return str(round(float(number), 6))
+
+
+def _fetch_symbol_from_csv_dir(
+    symbol: str,
+    start: date,
+    end: date,
+    *,
+    source_dir: Path,
+) -> tuple[list[dict[str, Any]], int]:
+    """Read deterministic OHLCV rows from <source_dir>/<SYMBOL>.csv."""
+    csv_path = source_dir / f"{symbol}.csv"
+    if not csv_path.exists():
+        return [], 0
+
+    rows: list[dict[str, Any]] = []
+    missing_ohlcv_rows = 0
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as fh:
+        reader = csv.DictReader(fh)
+        for raw in reader:
+            raw_timestamp = raw.get("timestamp") or raw.get("date") or ""
+            parsed_ts = _parse_local_csv_date(raw_timestamp)
+            open_value = _normalize_local_csv_number(raw.get("open"))
+            high_value = _normalize_local_csv_number(raw.get("high"))
+            low_value = _normalize_local_csv_number(raw.get("low"))
+            close_value = _normalize_local_csv_number(raw.get("close"))
+            volume_value = _normalize_local_csv_number(raw.get("volume"), integer=True)
+            if (
+                parsed_ts is None
+                or open_value is None
+                or high_value is None
+                or low_value is None
+                or close_value is None
+                or volume_value is None
+            ):
+                missing_ohlcv_rows += 1
+                continue
+
+            bar_date = parsed_ts.date()
+            if bar_date < start or bar_date > end:
+                continue
+
+            rows.append({
+                "id": _snapshot_id(symbol, bar_date),
+                "timestamp": parsed_ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "symbol": symbol,
+                "open": open_value,
+                "high": high_value,
+                "low": low_value,
+                "close": close_value,
+                "volume": volume_value,
+                "timeframe": "D1",
+            })
+
+    rows.sort(key=lambda r: (r["timestamp"], r["id"]))
+    return rows, missing_ohlcv_rows
+
+
 # ---------------------------------------------------------------------------
 # Build snapshot array + metadata
 # ---------------------------------------------------------------------------
@@ -159,15 +250,35 @@ def build_export(
     *,
     command: str,
     session=None,
+    source: str = _SOURCE_YFINANCE,
+    source_dir: Path | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Return (snapshots, metadata) for the given symbol universe and date range."""
     per_symbol: dict[str, list[dict[str, Any]]] = {}
+    missing_ohlcv_by_symbol: dict[str, int] = {}
     missing_symbols: list[str] = []
     actual_start: date | None = None
     actual_end: date | None = None
 
     for symbol in sorted(symbols):
-        rows = _fetch_symbol(symbol, start, end, session=session)
+        if source == _SOURCE_YFINANCE:
+            rows = _fetch_symbol(symbol, start, end, session=session)
+            missing_ohlcv_by_symbol[symbol] = sum(
+                1 for r in rows
+                if any(r.get(f) is None for f in ("open", "high", "low", "close", "volume"))
+            )
+        elif source == _SOURCE_CSV_DIR:
+            if source_dir is None:
+                raise ValueError("--source-dir is required when source='csv-dir'")
+            rows, missing_ohlcv_rows = _fetch_symbol_from_csv_dir(
+                symbol,
+                start,
+                end,
+                source_dir=source_dir,
+            )
+            missing_ohlcv_by_symbol[symbol] = missing_ohlcv_rows
+        else:
+            raise ValueError(f"unsupported source: {source!r}")
         per_symbol[symbol] = rows
         if not rows:
             missing_symbols.append(symbol)
@@ -204,15 +315,16 @@ def build_export(
         symbol_coverage[symbol] = {
             "snapshot_count": len(rows),
             "missing": len(rows) == 0,
-            "missing_ohlcv_rows": sum(
-                1 for r in rows
-                if any(r.get(f) is None for f in ("open", "high", "low", "close", "volume"))
-            ),
+            "missing_ohlcv_rows": missing_ohlcv_by_symbol.get(symbol, 0),
         }
 
     metadata: dict[str, Any] = {
         "artifact_type": "historical_multi_asset_snapshot_export",
-        "data_source": "yfinance",
+        "data_source": source,
+        "source": {
+            "type": source,
+            "path": str(source_dir) if source_dir is not None else None,
+        },
         "command": command,
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "requested_date_range": {
@@ -714,6 +826,20 @@ def _parse_args() -> argparse.Namespace:
         help="Output directory for generated artifacts.",
     )
     parser.add_argument(
+        "--source",
+        choices=(_SOURCE_YFINANCE, _SOURCE_CSV_DIR),
+        default=_SOURCE_YFINANCE,
+        help="OHLCV data source. Default: yfinance.",
+    )
+    parser.add_argument(
+        "--source-dir",
+        default=None,
+        help=(
+            "Local OHLCV CSV directory for --source csv-dir. "
+            "Expected files: <SYMBOL>.csv with date or timestamp, open, high, low, close, volume."
+        ),
+    )
+    parser.add_argument(
         "--annotate-signals",
         action="store_true",
         default=False,
@@ -744,6 +870,10 @@ def _build_command(args: argparse.Namespace) -> str:
         f"--end {args.end}",
         f"--out {args.out}",
     ]
+    if getattr(args, "source", _SOURCE_YFINANCE) != _SOURCE_YFINANCE:
+        parts.append(f"--source {args.source}")
+    if getattr(args, "source_dir", None):
+        parts.append(f"--source-dir {args.source_dir}")
     if getattr(args, "annotate_signals", False):
         parts.append("--annotate-signals")
     return " ".join(parts)
@@ -779,6 +909,10 @@ def main() -> int:
     if not symbols:
         print("No symbols specified.", file=sys.stderr)
         return 2
+    source_dir = Path(args.source_dir) if args.source_dir else None
+    if args.source == _SOURCE_CSV_DIR and source_dir is None:
+        print("--source-dir is required when --source csv-dir", file=sys.stderr)
+        return 2
 
     out_dir = Path(args.out)
     date_tag = f"{start.strftime(_SNAPSHOT_DATE_FMT)}_{end.strftime(_SNAPSHOT_DATE_FMT)}"
@@ -787,7 +921,18 @@ def main() -> int:
 
     command = _build_command(args)
     print(f"Fetching OHLCV data for: {', '.join(symbols)}", flush=True)
-    snapshots, metadata = build_export(symbols, start, end, command=command, session=yf_session)
+    print(f"Source : {args.source}", flush=True)
+    if source_dir is not None:
+        print(f"Source dir : {source_dir}", flush=True)
+    snapshots, metadata = build_export(
+        symbols,
+        start,
+        end,
+        command=command,
+        session=yf_session,
+        source=args.source,
+        source_dir=source_dir,
+    )
 
     _write_json(snapshots_path, snapshots)
     _write_json(meta_path, metadata)

--- a/tests/scripts/test_export_historical_snapshots.py
+++ b/tests/scripts/test_export_historical_snapshots.py
@@ -58,6 +58,7 @@ build_turtle_research_summary = _mod.build_turtle_research_summary
 _build_signals_array = _mod._build_signals_array
 _MIN_SCORE_THRESHOLD = _mod._MIN_SCORE_THRESHOLD
 _MAX_RISK_PER_TRADE_PCT = _mod._MAX_RISK_PER_TRADE_PCT
+_SOURCE_CSV_DIR = _mod._SOURCE_CSV_DIR
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +123,27 @@ def _make_trending_bars(symbol: str, n: int = 30) -> list[dict[str, Any]]:
             "timeframe": "D1",
         })
     return rows
+
+
+def _write_symbol_csv(source_dir: Path, symbol: str, rows: list[dict[str, Any]]) -> Path:
+    source_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = source_dir / f"{symbol}.csv"
+    lines = ["date,open,high,low,close,volume"]
+    for row in rows:
+        lines.append(
+            ",".join(
+                [
+                    row["timestamp"][:10],
+                    str(row["open"]),
+                    str(row["high"]),
+                    str(row["low"]),
+                    str(row["close"]),
+                    str(row["volume"]),
+                ]
+            )
+        )
+    csv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return csv_path
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +370,165 @@ def test_governed_symbol_universe_all_present():
     assert meta["total_snapshot_count"] == len(GOVERNED_SYMBOLS)
     for sym in GOVERNED_SYMBOLS:
         assert meta["symbol_coverage"][sym]["snapshot_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Local CSV source
+# ---------------------------------------------------------------------------
+
+def test_local_csv_source_parses_ohlcv_rows(tmp_path: Path):
+    _write_symbol_csv(
+        tmp_path,
+        "AAPL",
+        [
+            _make_bar("AAPL", "2023-01-03", px=150.0),
+            _make_bar("AAPL", "2023-01-04", px=151.0),
+        ],
+    )
+    snapshots, meta = build_export(
+        ("AAPL",),
+        date(2023, 1, 3),
+        date(2023, 1, 4),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    assert [snap["id"] for snap in snapshots] == ["AAPL_2023-01-03", "AAPL_2023-01-04"]
+    assert snapshots[0]["timestamp"] == "2023-01-03T00:00:00Z"
+    assert snapshots[0]["open"] == "150.0"
+    assert snapshots[0]["high"] == "151.0"
+    assert snapshots[0]["low"] == "149.0"
+    assert snapshots[0]["close"] == "150.0"
+    assert snapshots[0]["volume"] == "1000000"
+    assert meta["data_source"] == "csv-dir"
+
+
+def test_local_csv_source_required_ohlcv_fields_present(tmp_path: Path):
+    _write_symbol_csv(tmp_path, "MSFT", [_make_bar("MSFT", "2023-01-03")])
+    snapshots, _ = build_export(
+        ("MSFT",),
+        date(2023, 1, 3),
+        date(2023, 1, 3),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    for field in ("symbol", "timestamp", "open", "high", "low", "close", "volume"):
+        assert field in snapshots[0]
+
+
+def test_local_csv_source_six_symbol_coverage(tmp_path: Path):
+    for symbol in GOVERNED_SYMBOLS:
+        _write_symbol_csv(tmp_path, symbol, [_make_bar(symbol, "2023-01-03")])
+    snapshots, meta = build_export(
+        GOVERNED_SYMBOLS,
+        date(2023, 1, 3),
+        date(2023, 1, 3),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    assert meta["missing_symbols"] == []
+    assert meta["total_snapshot_count"] == len(GOVERNED_SYMBOLS)
+    assert {snap["symbol"] for snap in snapshots} == set(GOVERNED_SYMBOLS)
+
+
+def test_local_csv_source_missing_symbol_report(tmp_path: Path):
+    _write_symbol_csv(tmp_path, "AAPL", [_make_bar("AAPL", "2023-01-03")])
+    _, meta = build_export(
+        ("AAPL", "GS"),
+        date(2023, 1, 3),
+        date(2023, 1, 3),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    assert meta["missing_symbols"] == ["GS"]
+    assert meta["symbol_coverage"]["GS"]["missing"] is True
+    assert meta["symbol_coverage"]["GS"]["snapshot_count"] == 0
+
+
+def test_local_csv_source_missing_data_report(tmp_path: Path):
+    csv_path = tmp_path / "AAPL.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "date,open,high,low,close,volume",
+                "2023-01-03,100,101,99,100,1000000",
+                "2023-01-04,100,101,99,,1000000",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    snapshots, meta = build_export(
+        ("AAPL",),
+        date(2023, 1, 3),
+        date(2023, 1, 4),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    assert len(snapshots) == 1
+    assert meta["symbol_coverage"]["AAPL"]["missing_ohlcv_rows"] == 1
+
+
+def test_local_csv_source_deterministic_ordering(tmp_path: Path):
+    _write_symbol_csv(
+        tmp_path,
+        "AAPL",
+        [
+            _make_bar("AAPL", "2023-01-05"),
+            _make_bar("AAPL", "2023-01-03"),
+            _make_bar("AAPL", "2023-01-04"),
+        ],
+    )
+    snapshots, _ = build_export(
+        ("AAPL",),
+        date(2023, 1, 3),
+        date(2023, 1, 5),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    assert [snap["id"] for snap in snapshots] == [
+        "AAPL_2023-01-03",
+        "AAPL_2023-01-04",
+        "AAPL_2023-01-05",
+    ]
+
+
+def test_local_csv_source_metadata_records_source_type_and_path(tmp_path: Path):
+    _write_symbol_csv(tmp_path, "AAPL", [_make_bar("AAPL", "2023-01-03")])
+    _, meta = build_export(
+        ("AAPL",),
+        date(2023, 1, 3),
+        date(2023, 1, 3),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    assert meta["data_source"] == "csv-dir"
+    assert meta["source"] == {"type": "csv-dir", "path": str(tmp_path)}
+    assert meta["requested_date_range"] == {"start": "2023-01-03", "end": "2023-01-03"}
+    assert meta["actual_date_range"] == {"start": "2023-01-03", "end": "2023-01-03"}
+
+
+def test_local_csv_source_supports_turtle_annotation(tmp_path: Path):
+    rows = _make_trending_bars("AAPL", n=30)
+    _write_symbol_csv(tmp_path, "AAPL", rows)
+    snapshots, _ = build_export(
+        ("AAPL",),
+        date(2023, 1, 1),
+        date(2023, 1, 30),
+        command="test",
+        source=_SOURCE_CSV_DIR,
+        source_dir=tmp_path,
+    )
+    annotations = generate_turtle_signal_annotations({"AAPL": snapshots})
+    annotated = annotate_snapshots(snapshots, annotations)
+    assert len(annotated) == 30
+    assert any(snap["turtle_research"]["stage"] == "entry_confirmed" for snap in annotated)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Add deterministic local CSV directory source mode to the historical snapshot exporter.
- Preserve yfinance as the default source.
- Record source type and source path in export metadata.
- Add focused coverage for parsing, six-symbol coverage, missing symbol/data reporting, deterministic ordering, metadata, and TURTLE annotation compatibility.
- Ignore generated artifacts and local OHLCV cache directories.

## Validation
- python -m pytest tests/scripts/test_export_historical_snapshots.py -q
- python scripts/export_historical_snapshots.py --symbols AAPL,MSFT,NVDA,GS,WMT,COST --start 2024-01-02 --end 2024-01-31 --out data/artifacts/issue_1226_local_source_smoke --source csv-dir --source-dir data/local_ohlcv_cache_issue_1226 --annotate-signals
- python -m cilly_trading backtest --snapshots data/artifacts/issue_1226_local_source_smoke/historical_snapshots_2024-01-02_2024-01-31_turtle_annotated.json --strategy TURTLE --out data/artifacts/issue_1226_local_source_smoke/backtest_turtle --run-id issue-1226-local-source-smoke

Closes #1226