### PR TITLE
Align RSI2 confirmed-entry contract

### DIFF
--- a/docs/governance/signal-quality-bounded-contract.md
+++ b/docs/governance/signal-quality-bounded-contract.md
@@ -187,6 +187,29 @@ Qualification output remains technical-only and must expose:
 - explicit missing criteria fields
 - explicit blocking-condition fields
 
+## RSI2 Setup and Confirmed-Entry Boundary
+
+RSI2 uses explicit, separate stage semantics:
+
+- `setup` = non-executable candidate
+- `entry_confirmed` = only executable RSI2 entry stage
+- `exit` = explicit separate exit stage
+
+RSI2 confirmation occurs only on a subsequent bar. The setup bar cannot confirm
+itself, and confirmation is evaluated without lookahead: evaluation at index
+`n` may use only rows `0..n`. A confirmed RSI2 long entry requires a prior setup,
+the current close above the setup/trigger bar high, and RSI2 no longer inside the
+oversold zone.
+
+Evaluation/backtest and bounded paper execution consume the same executable
+stage: `stage == "entry_confirmed"` with `direction == "long"`. A `setup` is
+available for analysis/ranking as a candidate but must not create a backtest or
+bounded paper entry.
+
+This technical alignment does not establish trader validation, profitability,
+operational readiness, broker readiness, live readiness, production readiness,
+or real-money safety.
+
 ## Stability Boundary
 
 Given equivalent fixture content, ranked output remains stable independent of input list order.

--- a/docs/testing/backtesting/strategy_comparison_harness.md
+++ b/docs/testing/backtesting/strategy_comparison_harness.md
@@ -54,10 +54,20 @@ Optional per-strategy configs are provided via `--strategy-config` as:
 Strategy output is translated into executable backtest signals with a fixed rule:
 
 - only `stage="entry_confirmed"` and `direction="long"` are executable
+- RSI2 `setup` is a non-executable candidate
+- RSI2 `entry_confirmed` is the only executable RSI2 entry stage
+- RSI2 `exit` is an explicit separate exit stage
 - executable signal becomes one deterministic `BUY` order with `quantity="1"`
 - maximum one open position per strategy in the harness flow
 
 This keeps strategy comparison deterministic and bounded.
+
+For RSI2, confirmation occurs on a subsequent bar without lookahead. At
+evaluation index `n`, strategy generation may use only rows `0..n`; a setup bar
+cannot confirm itself. Evaluation/backtest and bounded paper execution therefore
+consume the same executable RSI2 stage, `entry_confirmed`. This alignment is
+technical only and does not establish trader validation, profitability, or
+operational readiness.
 
 ## Output Contract
 
@@ -99,4 +109,3 @@ This guarantees the comparison harness stays aligned with existing backtesting a
 | `20` | Snapshot/config input invalid |
 | `30` | Strategy selection invalid |
 | `1` | Unexpected fallback error |
-

--- a/src/cilly_trading/engine/paper_execution_worker.py
+++ b/src/cilly_trading/engine/paper_execution_worker.py
@@ -143,6 +143,7 @@ OutcomeCode = Literal[
     "eligible:full_exit",
     "skip:score_below_threshold",
     "skip:exit_signal_not_entry_candidate",
+    "skip:entry_stage_not_confirmed",
     "skip:duplicate_entry",
     "skip:cooldown_active",
     "skip:entry_zone_not_reached",
@@ -1079,15 +1080,17 @@ class BoundedPaperExecutionWorker:
 
         Steps:
             1. Eligibility check (required fields)
-            2. Score threshold check
-            3. Duplicate-entry check
-            4. Cooldown check
-            5. Entry-bar fill check (if entry_bar provided)
-            6. Regime filter (if regime_state provided and allowed_regimes non-empty)
-            7. Drawdown guard (if drawdown_guard_enabled)
-            8. Trade sizing
-            9. Exposure and position-limit checks
-            10. Correlation risk check (if price_history provided and correlation_check_enabled)
+            2. Exit classification
+            3. Executable-stage validation
+            4. Score threshold check
+            5. Duplicate-entry check
+            6. Cooldown check
+            7. Entry-bar fill check (if entry_bar provided)
+            8. Regime filter (if regime_state provided and allowed_regimes non-empty)
+            9. Drawdown guard (if drawdown_guard_enabled)
+            10. Trade sizing
+            11. Exposure and position-limit checks
+            12. Correlation risk check (if price_history provided and correlation_check_enabled)
         """
         # Step 1: eligibility — required signal fields
         field_error = _validate_signal_fields(signal)
@@ -1111,6 +1114,24 @@ class BoundedPaperExecutionWorker:
                 decision_inputs=_build_signal_contract_evidence(
                     signal,
                     outcome="skip:exit_signal_not_entry_candidate",
+                    reason=reason,
+                    profile=self._risk_profile,
+                ),
+            )
+
+        is_rsi2_setup = strategy.upper() == "RSI2" and stage == "setup"
+        is_unsupported_stage = stage not in {"setup", "entry_confirmed"}
+        if is_rsi2_setup or is_unsupported_stage:
+            reason = (
+                "entry candidate stage must be entry_confirmed; "
+                f"got {stage!r}"
+            )
+            return SignalEvaluationResult(
+                outcome="skip:entry_stage_not_confirmed",
+                reason=reason,
+                decision_inputs=_build_signal_contract_evidence(
+                    signal,
+                    outcome="skip:entry_stage_not_confirmed",
                     reason=reason,
                     profile=self._risk_profile,
                 ),

--- a/src/cilly_trading/strategies/rsi2.py
+++ b/src/cilly_trading/strategies/rsi2.py
@@ -3,8 +3,8 @@
 Core idea (MVP):
 - Uses a very short RSI (default: 2 periods) as a rebound signal.
 - Emits a SETUP signal when RSI2 is strongly oversold.
+- Emits an ENTRY_CONFIRMED signal only when a later bar confirms that setup.
 - Emits an EXIT signal when RSI2 is overbought, indicating the rebound has played out.
-- Entry confirmation guidance is provided in the ``confirmation_rule`` field.
 
 The strategy evaluates only the last available bar in the DataFrame.
 """
@@ -12,14 +12,14 @@ The strategy evaluates only the last available bar in the DataFrame.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_HALF_UP
-from typing import List, Dict, Any
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any, Dict, List
 
 import pandas as pd
 
-from cilly_trading.models import Signal
 from cilly_trading.engine.core import BaseStrategy
 from cilly_trading.indicators.rsi import rsi
+from cilly_trading.models import Signal
 from cilly_trading.strategies._constants import PRICE_SCALE
 
 
@@ -32,7 +32,7 @@ class Rsi2Config:
     oversold_threshold:
         Threshold for "extremely oversold". Default: 10.
     overbought_threshold:
-        Threshold for "overbought" — triggers an exit signal. Default: 70.
+        Threshold for "overbought" - triggers an exit signal. Default: 70.
     min_score:
         Minimum score a signal must reach to be emitted.
         Filters out extremely weak signals.
@@ -44,6 +44,7 @@ class Rsi2Config:
     entry_zone_upper_factor:
         Upper bound of the entry zone relative to close. Default: 1.01.
     """
+
     rsi_period: int = 2
     oversold_threshold: float = 10.0
     overbought_threshold: float = 70.0
@@ -59,7 +60,7 @@ class Rsi2Strategy(BaseStrategy):
     Note:
     - Evaluates only the last bar in the DataFrame.
     - This avoids flooding the system with historical signals and is
-      sufficient for finding current setups and exit conditions.
+      sufficient for finding current setups, confirmations, and exit conditions.
     """
 
     name: str = "RSI2"
@@ -85,17 +86,22 @@ class Rsi2Strategy(BaseStrategy):
         if "close" not in df.columns:
             raise ValueError("DataFrame must contain a 'close' column for RSI2Strategy")
 
-        # Compute RSI series; only uses past data — no lookahead bias.
         rsi_series = rsi(df, period=cfg.rsi_period, price_column="close")
 
         last_idx = df.index[-1]
         last_close = float(df.loc[last_idx, "close"])
         last_rsi = float(rsi_series.loc[last_idx])
+        confirmation_rule = (
+            "Enter long when a subsequent bar closes above the high of the trigger bar "
+            "AND RSI2 is no longer in the oversold zone."
+        )
 
-        # EXIT: RSI is overbought — the mean-reversion move has likely played out.
         if last_rsi > cfg.overbought_threshold:
-            # Score: how far above the overbought threshold (0 = barely, 100 = RSI at 100).
-            raw_score = (last_rsi - cfg.overbought_threshold) / (100.0 - cfg.overbought_threshold) * 100.0
+            raw_score = (
+                (last_rsi - cfg.overbought_threshold)
+                / (100.0 - cfg.overbought_threshold)
+                * 100.0
+            )
             score = max(0.0, min(100.0, raw_score))
 
             exit_signal: Signal = {
@@ -110,47 +116,128 @@ class Rsi2Strategy(BaseStrategy):
             }
             return [exit_signal]
 
-        # SETUP: RSI is extremely oversold — potential mean-reversion entry.
-        if last_rsi < cfg.oversold_threshold:
-            # Score: deeper oversold → higher score.
-            raw_score = (cfg.oversold_threshold - last_rsi) / cfg.oversold_threshold * 100.0
-            score = max(0.0, min(100.0, raw_score))
+        if last_rsi >= cfg.oversold_threshold and len(df) > 1:
+            prior_setup = self._find_prior_setup(
+                df=df.iloc[:-1],
+                rsi_series=rsi_series.iloc[:-1],
+                cfg=cfg,
+            )
+            if prior_setup is not None and last_close > prior_setup["high"]:
+                return [
+                    self._entry_signal(
+                        score=prior_setup["score"],
+                        close=last_close,
+                        cfg=cfg,
+                        confirmation_rule=confirmation_rule,
+                    )
+                ]
 
+        if last_rsi < cfg.oversold_threshold:
+            score = self._setup_score(last_rsi, cfg)
             if score < cfg.min_score:
                 return []
 
-            confirmation_rule = (
-                "Enter long when a subsequent bar closes above the high of the trigger bar "
-                "AND RSI2 is no longer in the oversold zone."
-            )
-
-            setup_signal: Signal = {
-                "strategy": self.name,
-                "direction": "long",
-                "score": score,
-                "stage": "setup",
-                "confirmation_rule": confirmation_rule,
-                "entry_zone": {
-                    "from_": float(
-                        (
-                            Decimal(str(last_close))
-                            * Decimal(str(cfg.entry_zone_lower_factor))
-                        ).quantize(PRICE_SCALE, ROUND_HALF_UP)
-                    ),
-                    "to": float(
-                        (
-                            Decimal(str(last_close))
-                            * Decimal(str(cfg.entry_zone_upper_factor))
-                        ).quantize(PRICE_SCALE, ROUND_HALF_UP)
-                    ),
-                },
-                "stop_loss": float(
-                    (
-                        Decimal(str(last_close))
-                        * (Decimal("1") - Decimal(str(cfg.stop_loss_pct)))
-                    ).quantize(PRICE_SCALE, ROUND_HALF_UP)
-                ),
-            }
-            return [setup_signal]
+            return [
+                self._setup_signal(
+                    score=score,
+                    close=last_close,
+                    cfg=cfg,
+                    confirmation_rule=confirmation_rule,
+                )
+            ]
 
         return []
+
+    def _find_prior_setup(
+        self,
+        *,
+        df: pd.DataFrame,
+        rsi_series: pd.Series,
+        cfg: Rsi2Config,
+    ) -> dict[str, float] | None:
+        """Return the most recent prior setup using only supplied history."""
+
+        for idx in reversed(df.index):
+            candidate_rsi = float(rsi_series.loc[idx])
+            if candidate_rsi >= cfg.oversold_threshold:
+                continue
+
+            score = self._setup_score(candidate_rsi, cfg)
+            if score < cfg.min_score:
+                continue
+
+            setup_close = float(df.loc[idx, "close"])
+            setup_high = (
+                float(df.loc[idx, "high"])
+                if "high" in df.columns
+                else setup_close
+            )
+            return {"score": score, "high": setup_high}
+
+        return None
+
+    def _setup_score(self, rsi_value: float, cfg: Rsi2Config) -> float:
+        raw_score = (
+            (cfg.oversold_threshold - rsi_value)
+            / cfg.oversold_threshold
+            * 100.0
+        )
+        return max(0.0, min(100.0, raw_score))
+
+    def _setup_signal(
+        self,
+        *,
+        score: float,
+        close: float,
+        cfg: Rsi2Config,
+        confirmation_rule: str,
+    ) -> Signal:
+        return {
+            "strategy": self.name,
+            "direction": "long",
+            "score": score,
+            "stage": "setup",
+            "confirmation_rule": confirmation_rule,
+            "entry_zone": self._entry_zone(close, cfg),
+            "stop_loss": self._stop_loss(close, cfg),
+        }
+
+    def _entry_signal(
+        self,
+        *,
+        score: float,
+        close: float,
+        cfg: Rsi2Config,
+        confirmation_rule: str,
+    ) -> Signal:
+        return {
+            "strategy": self.name,
+            "direction": "long",
+            "score": score,
+            "stage": "entry_confirmed",
+            "confirmation_rule": confirmation_rule,
+            "entry_zone": self._entry_zone(close, cfg),
+            "stop_loss": self._stop_loss(close, cfg),
+        }
+
+    def _entry_zone(self, close: float, cfg: Rsi2Config) -> dict[str, float]:
+        return {
+            "from_": float(
+                (
+                    Decimal(str(close)) * Decimal(str(cfg.entry_zone_lower_factor))
+                ).quantize(PRICE_SCALE, ROUND_HALF_UP)
+            ),
+            "to": float(
+                (
+                    Decimal(str(close)) * Decimal(str(cfg.entry_zone_upper_factor))
+                ).quantize(PRICE_SCALE, ROUND_HALF_UP)
+            ),
+        }
+
+    def _stop_loss(self, close: float, cfg: Rsi2Config) -> float:
+        return float(
+            (
+                Decimal(str(close))
+                * (Decimal("1") - Decimal(str(cfg.stop_loss_pct)))
+            ).quantize(PRICE_SCALE, ROUND_HALF_UP)
+        )

--- a/tests/engine/test_paper_execution_risk_profile_contract.py
+++ b/tests/engine/test_paper_execution_risk_profile_contract.py
@@ -66,6 +66,6 @@ def test_same_profile_and_same_input_produce_same_outcome(tmp_path: Path) -> Non
     result_a = worker_a.process_signal(signal)
     result_b = worker_b.process_signal(signal)
 
-    assert result_a.outcome == "skip:score_below_threshold"
-    assert result_b.outcome == "skip:score_below_threshold"
+    assert result_a.outcome == "skip:entry_stage_not_confirmed"
+    assert result_b.outcome == "skip:entry_stage_not_confirmed"
     assert result_a.reason == result_b.reason

--- a/tests/engine/test_paper_execution_worker.py
+++ b/tests/engine/test_paper_execution_worker.py
@@ -61,7 +61,7 @@ def _make_signal(
     direction: str = "long",
     score: float = 75.0,
     timestamp: str = "2024-01-15T10:00:00Z",
-    stage: str = "setup",
+    stage: str = "entry_confirmed",
     trade_risk_pct: float = 0.20,
     signal_id: str | None = None,
 ) -> Signal:
@@ -122,7 +122,7 @@ def test_missing_symbol_returns_reject(worker: BoundedPaperExecutionWorker) -> N
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2024-01-15T10:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
     }
     result = worker.process_signal(signal)
     assert result.outcome == "reject:invalid_signal_fields"
@@ -136,7 +136,7 @@ def test_missing_strategy_returns_reject(worker: BoundedPaperExecutionWorker) ->
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2024-01-15T10:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
     }
     result = worker.process_signal(signal)
     assert result.outcome == "reject:invalid_signal_fields"
@@ -580,7 +580,7 @@ def test_missing_trade_risk_input_is_rejected_fail_closed(
         "reason": "trade_risk_pct or stop_loss is required for deterministic sizing",
         "symbol": "AAPL",
         "strategy": "rsi2",
-        "stage": "setup",
+        "stage": "entry_confirmed",
         "direction": "long",
         "sizing_method": "stop_distance",
         "risk_profile_contract_id": "paper-execution-risk-profile-v1",
@@ -648,6 +648,111 @@ def test_exit_signal_processed_as_entry_candidate_is_classified_before_sizing(
         "risk_profile_contract_id": "paper-execution-risk-profile-v1",
         "signal_id": "sig-entry-api-exit-stage",
     }
+
+
+def test_rsi2_setup_stage_is_rejected_before_score_gate(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    signal = _make_signal(
+        signal_id="sig-entry-api-setup-stage",
+        score=1.0,
+        stage="setup",
+        trade_risk_pct=0.05,
+    )
+    result = worker.process_signal(signal)
+    assert result.outcome == "skip:entry_stage_not_confirmed"
+    assert result.order_id is None
+    assert result.trade_id is None
+    assert result.reason == "entry candidate stage must be entry_confirmed; got 'setup'"
+    assert result.decision_inputs == {
+        "outcome": "skip:entry_stage_not_confirmed",
+        "reason": "entry candidate stage must be entry_confirmed; got 'setup'",
+        "symbol": "AAPL",
+        "strategy": "rsi2",
+        "stage": "setup",
+        "direction": "long",
+        "sizing_method": "stop_distance",
+        "risk_profile_contract_id": "paper-execution-risk-profile-v1",
+        "signal_id": "sig-entry-api-setup-stage",
+    }
+
+
+def test_unknown_entry_stage_is_rejected_before_score_gate(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    signal = _make_signal(
+        signal_id="sig-entry-api-unknown-stage",
+        score=1.0,
+        stage="watch",
+        trade_risk_pct=0.05,
+    )
+    result = worker.process_signal(signal)
+    assert result.outcome == "skip:entry_stage_not_confirmed"
+    assert result.order_id is None
+    assert result.trade_id is None
+    assert result.reason == "entry candidate stage must be entry_confirmed; got 'watch'"
+
+
+def test_entry_confirmed_low_score_reaches_score_gate(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    result = worker.process_signal(
+        _make_signal(
+            signal_id="sig-entry-api-confirmed-low-score",
+            score=1.0,
+            stage="entry_confirmed",
+            trade_risk_pct=0.05,
+        )
+    )
+    assert result.outcome == "skip:score_below_threshold"
+    assert result.reason == "score=1.0 < min_score_threshold=60.0"
+
+
+def test_turtle_setup_low_score_preserves_score_gate(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    result = worker.process_signal(
+        _make_signal(
+            strategy="TURTLE",
+            signal_id="sig-entry-api-turtle-setup-low-score",
+            score=1.0,
+            stage="setup",
+            trade_risk_pct=0.05,
+        )
+    )
+    assert result.outcome == "skip:score_below_threshold"
+    assert result.reason == "score=1.0 < min_score_threshold=60.0"
+
+
+def test_entry_confirmed_stage_reaches_normal_entry_gates(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    result = worker.process_signal(
+        _make_signal(
+            signal_id="sig-entry-api-confirmed-stage",
+            stage="entry_confirmed",
+            trade_risk_pct=0.05,
+        )
+    )
+    assert result.outcome == "eligible"
+    assert result.order_id is not None
+    assert result.trade_id is not None
+
+
+def test_turtle_setup_stage_preserves_existing_entry_path(
+    worker: BoundedPaperExecutionWorker,
+) -> None:
+    result = worker.process_signal(
+        _make_signal(
+            strategy="TURTLE",
+            signal_id="sig-entry-api-turtle-setup-stage",
+            stage="setup",
+            trade_risk_pct=0.05,
+        )
+    )
+    assert result.outcome == "eligible"
+    assert result.order_id is not None
+    assert result.trade_id is not None
 
 
 # ---------------------------------------------------------------------------
@@ -831,7 +936,7 @@ def _make_signal_with_stop_loss(
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 75.0,
         "timestamp": "2024-01-15T10:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "stop_loss": stop_loss,
         "entry_zone": {
             "from_": entry_low,
@@ -1045,7 +1150,7 @@ def _make_signal_with_entry_zone(
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 75.0,
         "timestamp": timestamp,
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "entry_zone": {"from_": entry_low, "to": entry_high},
         "signal_id": signal_id,
@@ -1229,7 +1334,7 @@ def test_atr_sizing_produces_notional_proportional_to_risk_budget(
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "atr": 2.0,
         "entry_zone": {"from_": 100.0, "to": 100.0},
     }
@@ -1252,7 +1357,7 @@ def test_atr_sizing_rejected_when_atr_not_provided(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         # no atr field
     }
     result = worker.process_signal(signal)
@@ -1270,7 +1375,7 @@ def test_fixed_sizing_uses_explicit_trade_risk_pct(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
     }
     result = worker.process_signal(signal)
@@ -1290,7 +1395,7 @@ def test_fixed_sizing_rejected_when_trade_risk_pct_missing(tmp_path: Path) -> No
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         # no trade_risk_pct
     }
     result = worker.process_signal(signal)
@@ -1309,7 +1414,7 @@ def test_atr_multiple_scales_position_size(tmp_path: Path) -> None:
             "direction": "long",  # type: ignore[typeddict-item]
             "score": 80.0,
             "timestamp": "2026-01-01T00:00:00Z",
-            "stage": "setup",  # type: ignore[typeddict-item]
+            "stage": "entry_confirmed",  # type: ignore[typeddict-item]
             "atr": 1.0,
             "entry_zone": {"from_": 100.0, "to": 100.0},
         }
@@ -1366,7 +1471,7 @@ def test_correlation_gate_blocks_entry_when_highly_correlated(tmp_path: Path) ->
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-corr-aapl",
     }
@@ -1380,7 +1485,7 @@ def test_correlation_gate_blocks_entry_when_highly_correlated(tmp_path: Path) ->
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-02T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-corr-msft",
     }
@@ -1403,7 +1508,7 @@ def test_correlation_gate_skipped_when_disabled(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-nc-aapl",
     }
@@ -1415,7 +1520,7 @@ def test_correlation_gate_skipped_when_disabled(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-02T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-nc-msft",
     }
@@ -1439,7 +1544,7 @@ def test_correlation_gate_passes_without_price_history(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-noph-aapl",
     }
@@ -1451,7 +1556,7 @@ def test_correlation_gate_passes_without_price_history(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-02T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-noph-msft",
     }
@@ -1568,7 +1673,7 @@ def test_drawdown_guard_blocks_entry_after_consecutive_losses(tmp_path: Path) ->
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-10T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-dg-block",
     })
@@ -1614,7 +1719,7 @@ def test_drawdown_guard_disabled_does_not_block(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-10T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-dg-nodisable",
     })
@@ -1681,7 +1786,7 @@ def test_drawdown_guard_blocks_on_equity_drawdown(tmp_path: Path) -> None:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-10T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "signal_id": "sig-dg-equity",
     })
@@ -1719,7 +1824,7 @@ def _entry_signal(signal_id: str, symbol: str = "AAPL") -> Signal:
         "direction": "long",  # type: ignore[typeddict-item]
         "score": 80.0,
         "timestamp": "2026-01-01T00:00:00Z",
-        "stage": "setup",  # type: ignore[typeddict-item]
+        "stage": "entry_confirmed",  # type: ignore[typeddict-item]
         "trade_risk_pct": 0.05,
         "entry_zone": {"from_": 100.0, "to": 100.0},
         "signal_id": signal_id,

--- a/tests/strategies/test_strategy_252bar_fixture.py
+++ b/tests/strategies/test_strategy_252bar_fixture.py
@@ -87,10 +87,10 @@ def test_rsi2_signal_schema_over_252bar_fixture(df_252: pd.DataFrame) -> None:
     signals = _rsi2_walk_forward(df_252)
     for s in signals:
         assert s["strategy"] == "RSI2"
-        assert s["stage"] in ("setup", "exit"), f"Unexpected stage: {s['stage']}"
+        assert s["stage"] in ("setup", "entry_confirmed", "exit"), f"Unexpected stage: {s['stage']}"
         assert s["direction"] == "long"
         assert 0.0 <= float(s["score"]) <= 100.0
-        if s["stage"] == "setup":
+        if s["stage"] in ("setup", "entry_confirmed"):
             ez = s.get("entry_zone", {})
             assert isinstance(ez, dict)
             assert float(ez["from_"]) < float(ez["to"])

--- a/tests/strategies/test_strategy_contracts_mvp.py
+++ b/tests/strategies/test_strategy_contracts_mvp.py
@@ -4,6 +4,8 @@ from typing import Any, Dict
 
 import pandas as pd
 
+from cilly_trading.models import compute_signal_id
+from cilly_trading.strategies.evaluation_harness import _to_executable_signals
 from cilly_trading.strategies.rsi2 import Rsi2Strategy
 from cilly_trading.strategies.turtle import TurtleStrategy
 
@@ -82,6 +84,248 @@ def test_rsi2_schema_if_signal_emitted() -> None:
         s = result[0]
         assert s["strategy"] == "RSI2"
         _assert_strategy_signal_schema(s)
+
+
+def test_rsi2_oversold_trigger_bar_emits_non_executable_setup() -> None:
+    strat = Rsi2Strategy()
+    df = pd.DataFrame(
+        {
+            "high": [100.0, 95.0, 90.0, 85.0],
+            "close": [100.0, 95.0, 90.0, 85.0],
+        }
+    )
+    result = strat.generate_signals(
+        df=df,
+        config={"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0},
+    )
+    assert len(result) == 1
+    assert result[0]["stage"] == "setup"
+    assert result[0]["direction"] == "long"
+
+
+def test_rsi2_setup_bar_does_not_confirm_itself() -> None:
+    strat = Rsi2Strategy()
+    df = pd.DataFrame(
+        {
+            "high": [100.0, 95.0, 90.0, 85.0],
+            "close": [100.0, 95.0, 90.0, 85.0],
+        }
+    )
+    result = strat.generate_signals(
+        df=df,
+        config={"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0},
+    )
+    assert [signal["stage"] for signal in result] == ["setup"]
+
+
+def test_rsi2_subsequent_bar_confirms_after_high_break_and_oversold_exit() -> None:
+    strat = Rsi2Strategy()
+    df = pd.DataFrame(
+        {
+            "high": [100.0, 95.0, 90.0, 85.0, 86.0],
+            "close": [100.0, 95.0, 90.0, 85.0, 86.0],
+        }
+    )
+    result = strat.generate_signals(
+        df=df,
+        config={"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0},
+    )
+    assert len(result) == 1
+    assert result[0]["stage"] == "entry_confirmed"
+    _assert_strategy_signal_schema(result[0])
+
+
+def test_rsi2_subsequent_bar_without_high_break_does_not_confirm() -> None:
+    strat = Rsi2Strategy()
+    df = pd.DataFrame(
+        {
+            "high": [100.0, 95.0, 90.0, 90.0, 86.0],
+            "close": [100.0, 95.0, 90.0, 85.0, 86.0],
+        }
+    )
+    result = strat.generate_signals(
+        df=df,
+        config={"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0},
+    )
+    assert result == []
+
+
+def test_rsi2_subsequent_bar_still_oversold_does_not_confirm() -> None:
+    strat = Rsi2Strategy()
+    df = pd.DataFrame(
+        {
+            "high": [100.0, 95.0, 90.0, 85.0, 84.0],
+            "close": [100.0, 95.0, 90.0, 85.0, 84.0],
+        }
+    )
+    result = strat.generate_signals(
+        df=df,
+        config={"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0},
+    )
+    assert len(result) == 1
+    assert result[0]["stage"] == "setup"
+
+
+def test_rsi2_confirmation_does_not_use_future_bar() -> None:
+    strat = Rsi2Strategy()
+    cfg = {"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0}
+    through_current = pd.DataFrame(
+        {
+            "high": [100.0, 95.0, 90.0, 90.0, 86.0],
+            "close": [100.0, 95.0, 90.0, 85.0, 86.0],
+        }
+    )
+    with_future = pd.concat(
+        [
+            through_current,
+            pd.DataFrame({"high": [91.0], "close": [91.0]}),
+        ],
+        ignore_index=True,
+    )
+    assert strat.generate_signals(through_current, cfg) == []
+    assert strat.generate_signals(with_future.iloc[: len(through_current)], cfg) == []
+    assert strat.generate_signals(with_future, cfg)[0]["stage"] == "entry_confirmed"
+
+
+def test_rsi2_no_setup_means_no_confirmation() -> None:
+    strat = Rsi2Strategy()
+    df = pd.DataFrame(
+        {
+            "high": [100.0, 101.0, 100.0, 100.0],
+            "close": [100.0, 101.0, 100.0, 100.0],
+        }
+    )
+    result = strat.generate_signals(
+        df=df,
+        config={"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0},
+    )
+    assert result == []
+
+
+def test_rsi2_score_minimum_remains_enforced_for_setup_and_confirmation() -> None:
+    strat = Rsi2Strategy()
+    cfg = {"rsi_period": 2, "oversold_threshold": 50.0, "min_score": 40.0}
+    setup_df = pd.DataFrame(
+        {
+            "high": [100.0, 105.0, 110.0, 100.0],
+            "close": [100.0, 105.0, 110.0, 100.0],
+        }
+    )
+    confirm_df = pd.concat(
+        [setup_df, pd.DataFrame({"high": [105.0], "close": [105.0]})],
+        ignore_index=True,
+    )
+    assert strat.generate_signals(setup_df, cfg) == []
+    assert strat.generate_signals(confirm_df, cfg) == []
+
+
+def test_rsi2_default_thresholds_and_presets_remain_unchanged() -> None:
+    from cilly_trading.strategies.rsi2 import Rsi2Config
+
+    cfg = Rsi2Config()
+    assert cfg.rsi_period == 2
+    assert cfg.oversold_threshold == 10.0
+    assert cfg.overbought_threshold == 70.0
+    assert cfg.min_score == 20.0
+    assert cfg.stop_loss_pct == 0.05
+    assert cfg.entry_zone_lower_factor == 0.97
+    assert cfg.entry_zone_upper_factor == 1.01
+
+
+def test_rsi2_identical_inputs_produce_identical_stages_and_signal_ids() -> None:
+    strat = Rsi2Strategy()
+    df = pd.DataFrame(
+        {
+            "high": [100.0, 95.0, 90.0, 85.0, 86.0],
+            "close": [100.0, 95.0, 90.0, 85.0, 86.0],
+        }
+    )
+    cfg = {"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0}
+    first = strat.generate_signals(df, cfg)
+    second = strat.generate_signals(df, cfg)
+    assert first == second
+    assert [s["stage"] for s in first] == [s["stage"] for s in second]
+    enriched_first = {**first[0], "symbol": "AAPL", "timestamp": "2024-01-05T00:00:00Z"}
+    enriched_second = {**second[0], "symbol": "AAPL", "timestamp": "2024-01-05T00:00:00Z"}
+    assert compute_signal_id(enriched_first) == compute_signal_id(enriched_second)
+
+
+def test_rsi2_setup_and_confirmed_entry_have_stage_distinct_signal_ids() -> None:
+    strat = Rsi2Strategy()
+    cfg = {"rsi_period": 2, "oversold_threshold": 10.0, "min_score": 0.0}
+    setup = strat.generate_signals(
+        pd.DataFrame(
+            {
+                "high": [100.0, 95.0, 90.0, 85.0],
+                "close": [100.0, 95.0, 90.0, 85.0],
+            }
+        ),
+        cfg,
+    )[0]
+    confirmed = strat.generate_signals(
+        pd.DataFrame(
+            {
+                "high": [100.0, 95.0, 90.0, 85.0, 86.0],
+                "close": [100.0, 95.0, 90.0, 85.0, 86.0],
+            }
+        ),
+        cfg,
+    )[0]
+    setup_identity = {**setup, "symbol": "AAPL", "timestamp": "2024-01-04T00:00:00Z"}
+    confirmed_identity = {
+        **confirmed,
+        "symbol": "AAPL",
+        "timestamp": "2024-01-05T00:00:00Z",
+    }
+    assert setup["stage"] == "setup"
+    assert confirmed["stage"] == "entry_confirmed"
+    assert compute_signal_id(setup_identity) != compute_signal_id(confirmed_identity)
+
+
+def test_evaluation_harness_rejects_setup_and_accepts_confirmed_long() -> None:
+    class StaticStrategy:
+        def __init__(self, stage: str) -> None:
+            self.stage = stage
+
+        def generate_signals(self, df: pd.DataFrame, config: dict[str, Any]) -> list[dict]:
+            return [
+                {
+                    "strategy": "RSI2",
+                    "symbol": "AAPL",
+                    "direction": "long",
+                    "score": 80.0,
+                    "stage": self.stage,
+                }
+            ]
+
+    frame = pd.DataFrame({"close": [100.0]})
+    snapshot = {"id": "snap-1", "symbol": "AAPL"}
+
+    setup = _to_executable_signals(
+        strategy_name="RSI2",
+        snapshot=snapshot,
+        strategy=StaticStrategy("setup"),
+        history_frame=frame,
+        strategy_config={},
+    )
+    confirmed = _to_executable_signals(
+        strategy_name="RSI2",
+        snapshot=snapshot,
+        strategy=StaticStrategy("entry_confirmed"),
+        history_frame=frame,
+        strategy_config={},
+    )
+    exit_signal = _to_executable_signals(
+        strategy_name="RSI2",
+        snapshot=snapshot,
+        strategy=StaticStrategy("exit"),
+        history_frame=frame,
+        strategy_config={},
+    )
+
+    assert setup == []
+    assert exit_signal == []
+    assert confirmed[0]["action"] == "BUY"
 
 
 # -------------------------


### PR DESCRIPTION
## Summary

Align RSI2 setup, confirmation, and executable-entry semantics across strategy generation, evaluation/backtest, and bounded paper execution.

Closes #1246

## Contract

- `setup` remains a non-executable RSI2 candidate.
- `entry_confirmed` is emitted only after subsequent-bar confirmation without lookahead.
- Evaluation/backtest continues to execute only `entry_confirmed` + `long`.
- Bounded paper execution rejects RSI2 `setup` and unsupported stages before score evaluation.
- `entry_confirmed` proceeds through the existing score, duplicate, cooldown, risk, and sizing gates.
- `exit` remains explicit and separate.
- TURTLE behavior and thresholds/defaults remain unchanged.

## Validation

- Strategy/exit focused tests: 44 passed
- Paper worker focused tests: 91 passed
- Related paper/runtime regressions: 45 passed
- `git diff --check`: passed
- Repository status: clean

## Full-suite baseline exception

Issue #1246 AC11 was formally amended to allow baseline comparison evidence.

- Clean baseline: 36 failed, 1619 passed, 1 skipped
- Issue branch: 36 failed, 1637 passed, 1 skipped
- Failed node IDs: identical
- Failure signatures: identical
- New Issue #1246 failures: none evidenced

Classification: `FULL-SUITE FAILURES BASELINE-IDENTICAL`

## Governance classification

- Technical implementation: technically good
- Trader relevance: not sufficiently evidenced
- Operational usefulness: technically good, but traderically weak
- Backtest / paper consistency: technically good
- Lookahead safety: technically good
- Determinism: technically good
- Overall evidence status: technically good, but traderically weak

Approved implementation commit: `9ef68b114d15163e8f0555ea84841651e1185473`

No profitability, trader-readiness, operational-readiness, broker-readiness, live-readiness, production-readiness, or real-money-safety claim is made.